### PR TITLE
Fix on tiddler sorting

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -204,8 +204,8 @@ exports.getTiddlers = function(sortField,excludeTag) {
 		}
 	}
 	tiddlers.sort(function(a,b) {
-		var aa = a.fields[sortField].toLowerCase() || "",
-			bb = b.fields[sortField].toLowerCase() || "";
+		var aa = (a.fields[sortField] || "").toLowerCase(),
+			bb = (b.fields[sortField] || "").toLowerCase();
 		if(aa < bb) {
 			return -1;
 		} else {


### PR DESCRIPTION
Hi,

encountered a problem when I created the first tiddler running clientserver edition. The server refused to start the second time. I guess some expected fields where missing in the tiddler when it tried to sort them. Anyway I saw the opportunity to make the sort a bit more robust. The server runs fine after this.
