### PR TITLE
Use Blob api to generate data links in download saver

### DIFF
--- a/core/modules/savers/download.js
+++ b/core/modules/savers/download.js
@@ -22,7 +22,12 @@ DownloadSaver.prototype.save = function(text) {
 	// Set up the link
 	var link = document.createElement("a");
 	link.setAttribute("target","_blank");
-	link.setAttribute("href","data:text/html," + encodeURIComponent(text));
+	if(Blob != undefined) {
+		var blob = new Blob([encodeURIComponent(text)], {type: "text/html"});
+		link.setAttribute("href", URL.createObjectURL(blob));
+	} else {
+		link.setAttribute("href","data:text/html," + encodeURIComponent(text));
+	}
 	link.setAttribute("download","tiddlywiki.html");
 	document.body.appendChild(link);
 	link.click();


### PR DESCRIPTION
This should fix crashing on large wikis under chrome
  see chrome bug: https://code.google.com/p/chromium/issues/detail?id=103234
This should also speed up generating the download html by a couple of seconds
  it avoids repeatedly marshalling the base64 encoded href string across the sandbox boundary
  it avoids some time and memory consumed by "large" dom manipulation
  major remaining delay is in encodeURIComponent
    TODO: consider using iconv on the server
    TODO: consider async invocation of regular expressions to avoid client "lockup"
