### PR TITLE
changed word-break break-all to normal for pre / signed CLA

### DIFF
--- a/licenses/cla-individual.md
+++ b/licenses/cla-individual.md
@@ -110,3 +110,5 @@ Contributors
 Mario Pietsch, @pmario, 2013/09/21
 
 David Johnston, @Brennall, 2013/09/21
+
+Tobias Beer, @tobibeer, 2013/09/21

--- a/themes/tiddlywiki/snowwhite/base.tid
+++ b/themes/tiddlywiki/snowwhite/base.tid
@@ -96,7 +96,7 @@ pre {
 	display: block;
 	padding: 14px;
 	margin: 0 0 14px;
-	word-break: break-all;
+	word-break: normal;
 	word-wrap: break-word;
 	white-space: pre;
 	white-space: pre-wrap;


### PR DESCRIPTION
was breaking words arbitrarily in code blocks arbitrarily — really ugly

now on a branch, instead of master ;-)
