### PR TITLE
Fix up jasmine-plugin for Modules/1.1 patches

### DIFF
--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -27,6 +27,7 @@ exports.startup = function() {
 			clearInterval: clearInterval,
 			setTimeout: setTimeout,
 			clearTimeout: clearTimeout,
+			exports: {},
 			$tw: $tw
 	});
 	// Prepare the Jasmine environment


### PR DESCRIPTION
Provides an exports object in the context for `evalSandboxed`, fixes test.sh crash with Modules/1.1 patches in place.

Looking at the jasmine call site for `evalSandboxed` I feel like evalSandbox should be changed to return the return value of the code, instead of sandbox.exports as this would more closely match eval and runInNewContext API.

Soon, with Node 0.12, we will probably want to replace any usage of the 'vm' module with the upcoming contextify model anyway, so these portions of code are likely to change again.
