### PR TITLE
moved the text shadow from .tw-sidebar-lists a.tw-tiddlylink:hover since...

### DIFF
--- a/themes/tiddlywiki/snowwhite/base.tid
+++ b/themes/tiddlywiki/snowwhite/base.tid
@@ -160,7 +160,6 @@ a.tw-tiddlylink {
 }
 
 .tw-sidebar-lists a.tw-tiddlylink:hover {
-	color: #444;
 }
 
 a.tw-tiddlylink:hover {
@@ -302,7 +301,6 @@ a.tw-tiddlylink-external {
 
 .sidebar-header {
 	color: #acacac;
-	text-shadow: 0 1px 0 rgba(255,255,255, 0.8);
 }
 
 .sidebar-header .title a.tw-tiddlylink-resolves {
@@ -478,6 +476,8 @@ a.tw-tiddlylink-external {
 	font-size: 2.35em;
 	line-height: 1.2em;
 	color: #182955;
+	
+	/* text-shadow: 0 1px 0 rgba(255,255,255, 0.8); */
 }
 
 .titlebar img {


### PR DESCRIPTION
... it effects too many elements. moved it too .titlebar as a comment. I think shadows influence readability

open: right sidebar: more: tags: "tagpill" hover an item to see the difference. 
