### PR TITLE
Fixed a bug in reveal.js, not refreshing tiddlers when referencing field...

### DIFF
--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -84,11 +84,11 @@ RevealWidget.prototype.execute = function() {
 	// Get our parameters
 	this.state = this.getAttribute("state");
 	if (this.state) {
-		this.tiddler= this.state;
+		this.tiddler = this.state;
 	} else {
 		this.field = this.getAttribute("field");
 		this.tiddler = this.getAttribute("tiddler") || this.getVariable("currentTiddler");
-		this.state= this.tiddler;
+		this.state = this.tiddler;
 		if (this.field) this.state+= '!!'+this.field;
 	}
 	this.type = this.getAttribute("type");


### PR DESCRIPTION
I introduced "field" and "tiddler" as an alternative to "state".

Only when "state" is missing will they be used so should be 100% compatible with the current usage.
