### PR TITLE
Newtiddler

### DIFF
--- a/plugins/skeeve/newtiddler.js
+++ b/plugins/skeeve/newtiddler.js
@@ -74,7 +74,25 @@ NewtiddlerWidget.prototype.handleClickEvent = function(event) {
 		skeletonClone[modificationField] = created[creationField];
 	}
 	this.wiki.addTiddler(skeletonClone);
-	this.dispatchEvent({type: "tw-edit-tiddler", tiddlerTitle: title});
+	switch(this.newtiddlerEdit) {
+	case "yes":
+		var bounds = this.domNodes[0].getBoundingClientRect();
+		this.dispatchEvent({
+			type: "tw-navigate",
+			navigateTo: title,
+			navigateFromTitle: this.getVariable("currentTiddler"),
+			navigateFromNode: this,
+			navigateFromClientRect: { top: bounds.top, left: bounds.left, width: bounds.width, right: bounds.right, bottom: bounds.bottom, height: bounds.height
+			}
+		});
+		this.dispatchEvent({type: "tw-edit-tiddler", tiddlerTitle: title});
+		break;
+	case "no":
+		break;
+	case "inline":
+		// not implemented yet
+		break;
+	}
 };
 
 
@@ -85,6 +103,7 @@ NewtiddlerWidget.prototype.execute = function() {
 	// Get attributes
 	this.newtiddlerTitle = this.getAttribute("title");
 	this.newtiddlerSkeleton = this.getAttribute("skeleton");
+	this.newtiddlerEdit = this.getAttribute("edit", "yes");
 	this.newtiddlerClass = this.getAttribute("class","");
 	this.newtiddlerStyle = this.getAttribute("style");
 	if(this.newtiddlerClass != "") {


### PR DESCRIPTION
http://skeeve.tiddlyspot.com/#test%20newtiddler

This is a test for the highly experimental New-Tiddler-Button.

The New-Tiddler-Button expects 2 parameters:

```
Parameter |  Mandatory | Explanation
title     |  yes       | the title of the new tiddler. Will get numbers appended
skeleton  |  yes       | an existing tiddler which may contain variable placeholders
edit      |  no        | This defines wether to open the new tiddler in edit mode.
                       | Must be one of "yes", "no" or (not implemented yet) "inline
```

The most important part lies in the skeleton! TiddlyWiki already can clone tiddlers, but you can't really prefill data of the newly created tiddler.

With <$newtiddler> you can put placeholders of the form $(variable)$ anywhere in the tiddler and they will be replaced by the values of the variables set with the <$set> or <$let> widget. Please note: The placeholders can be anywhere! In the tiddlers body, in fields, types, you name it…

The example skeleton used here looks like this:

```
   Property  | Content
   title     | skeleton 1
   text      | This is some test: $(placeholder)$
   tags      | $(tag1)$
   field1    | $(f1)$
   field2    | $(f2)$
```

If we now put this into our tiddler:

```
<$let f1=<<uuid>> f2="field-2" placeholder="pl1" tag1="testtag">
<$newtiddler title="test" skeleton="skeleton 1">Create</$newtiddler>
</$let>
```

We get (Create) a button.

Clicking it, will open a new tiddler with some values pre-filled.
