### PR TITLE
added a fix for issue #186

### DIFF
--- a/core/modules/parsers/wikiparser/rules/codeinline.js
+++ b/core/modules/parsers/wikiparser/rules/codeinline.js
@@ -7,6 +7,7 @@ Wiki text inline rule for code runs. For example:
 
 ```
 	This is a `code run`.
+	This is another ``code run``
 ```
 
 \*/
@@ -22,13 +23,13 @@ exports.types = {inline: true};
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /`/mg;
+	this.matchRegExp = /(``?)/mg;
 };
 
 exports.parse = function() {
 	// Move past the match
 	this.parser.pos = this.matchRegExp.lastIndex;
-	var reEnd = /`/mg;
+	var reEnd = new RegExp(this.match[1], "mg");
 	// Look for the end marker
 	reEnd.lastIndex = this.parser.pos;
 	var match = reEnd.exec(this.parser.source),


### PR DESCRIPTION
Fixed it by adding an optional second backtick.

The only problem might be code runs containing a backtick as last character. I hope that it's sufficient to tell in such a case to add an additional space.

So this example:

``````
``dir=`ls -al```
``````

needs to be written as

```
``dir=`ls -al` ``
```

in order to be displayed (almost) correctly. We could change L32 to read:

```
var reEnd = new RegExp(" ?" + this.match[1], "mg");
```

in which case one blank preceeding the terminating `` would silently be "eaten".

But I don't know whether this seems appropriate.
