### PR TITLE
added fix for issue #94 for horizontal rules, tables and typed block

### DIFF
--- a/core/modules/parsers/wikiparser/rules/horizrule.js
+++ b/core/modules/parsers/wikiparser/rules/horizrule.js
@@ -22,7 +22,7 @@ exports.types = {block: true};
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /-{3,}\r?\n/mg;
+	this.matchRegExp = /-{3,}\r?(?:\n|$)/mg;
 };
 
 exports.parse = function() {

--- a/core/modules/parsers/wikiparser/rules/table.js
+++ b/core/modules/parsers/wikiparser/rules/table.js
@@ -18,11 +18,11 @@ exports.types = {block: true};
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^\|(?:[^\n]*)\|(?:[fhck]?)\r?\n/mg;
+	this.matchRegExp = /^\|(?:[^\n]*)\|(?:[fhck]?)\r?(?:\n|$)/mg;
 };
 
 var processRow = function(prevColumns) {
-	var cellRegExp = /(?:\|([^\n\|]*)\|)|(\|[fhck]?\r?\n)/mg,
+	var cellRegExp = /(?:\|([^\n\|]*)\|)|(\|[fhck]?\r?(?:\n|$))/mg,
 		cellTermRegExp = /((?:\x20*)\|)/mg,
 		tree = [],
 		col = 0,
@@ -107,8 +107,8 @@ var processRow = function(prevColumns) {
 exports.parse = function() {
 	var rowContainerTypes = {"c":"caption", "h":"thead", "":"tbody", "f":"tfoot"},
 		table = {type: "element", tag: "table", children: []},
-		rowRegExp = /^\|([^\n]*)\|([fhck]?)\r?\n/mg,
-		rowTermRegExp = /(\|(?:[fhck]?)\r?\n)/mg,
+		rowRegExp = /^\|([^\n]*)\|([fhck]?)\r?(?:\n|$)/mg,
+		rowTermRegExp = /(\|(?:[fhck]?)\r?(?:\n|$))/mg,
 		prevColumns = [],
 		currRowType,
 		rowContainer,

--- a/core/modules/parsers/wikiparser/rules/typedblock.js
+++ b/core/modules/parsers/wikiparser/rules/typedblock.js
@@ -40,7 +40,7 @@ exports.init = function(parser) {
 };
 
 exports.parse = function() {
-	var reEnd = /\r?\n\$\$\$\r?\n/mg;
+	var reEnd = /\r?\n\$\$\$\r?(?:\n|$)/mg;
 	// Save the type
 	var parseType = this.match[1],
 		renderType = this.match[2];


### PR DESCRIPTION
I just fixed those 3 as all the other rules seem to be unaffected by a missing newline.

May I note that it seems that the rules are a bit inconsistent?

I can elaborate on that, but I think we should check all of them and think about changing something. In most cases where we have now \r?(?:\n|$) I think a simple $ should be sufficient. except of course, that the newline wouldn't be "eaten". 
