### PR TITLE
Fix for #317

### DIFF
--- a/core/modules/widgets/edit-text.js
+++ b/core/modules/widgets/edit-text.js
@@ -37,11 +37,12 @@ EditTextWidget.prototype.render = function(parent,nextSibling) {
 	// Execute our logic
 	this.execute();
 	// Create our element
+	var editInfo = this.getEditInfo();
 	var domNode = this.document.createElement(this.editTag);
 	if(this.editType) {
 		domNode.setAttribute("type",this.editType);
 	}
-	if(this.editPlaceholder) {
+	if(editInfo.value === "" && this.editPlaceholder) {
 		domNode.setAttribute("placeholder",this.editPlaceholder);
 	}
 	// Assign classes
@@ -49,7 +50,6 @@ EditTextWidget.prototype.render = function(parent,nextSibling) {
 		domNode.className = this.editClass;
 	}
 	// Set the text
-	var editInfo = this.getEditInfo();
 	if(this.editTag === "textarea") {
 		domNode.appendChild(this.document.createTextNode(editInfo.value));
 	} else {


### PR DESCRIPTION
Unfortunately with IE not supporting the placeholder attribute in a sane way, I'm not sure if there is a better solution other than to not set the placeholder when the field has data like this. I believe that the only side affect will be that if an existing Tiddler is edited and all the test is removed, then there will be no placeholder to show. For new empty Tiddlers, the placeholder works as expected.
