### PR TITLE
unix symbolic links cause a problem with git for windows. 

### DIFF
--- a/licenses/copyright.md
+++ b/licenses/copyright.md
@@ -1,0 +1,4 @@
+Copyright
+=======
+
+The copyright.tid is part of the TiddlyWiki5/core, and can be found there.

--- a/licenses/copyright.tid
+++ b/licenses/copyright.tid
@@ -1,1 +1,0 @@
-../core/copyright.tid


### PR DESCRIPTION
The function to handle them is not implemented and probably will not be implemented at all. So the link is replaced by an info file.

---

This pull request was created with a "vagrant ubuntu box" running as a guest on windows 7. see: https://github.com/pmario/tw5-vagrant for more infos.
