### PR TITLE
Also fix timezone related eachday test failure

### DIFF
--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -41,7 +41,7 @@ describe("Filter tests", function() {
 		text: "The speed of sound in light\n\nThere is no TiddlerZero but TiddlerSix",
 		tags: ["one","two"],
 		modifier: "JohnDoe",
-		modified: "201304161643"});
+		modified: "201304162202"});
 	wiki.addTiddler({
 		title: "a fourth tiddler",
 		text: "The quality of mercy is not drained by [[Tiddler Three]]",


### PR DESCRIPTION
(An additional commit for issue #384)

At UTC +600 the modified timestmap for 'TiddlerOne' and 'Tiddler
Three' are on the same day hence the eachday test fails.

Similar to the fix commit 8487221, this just adjusts the timestamp
to ensure the test passes in any timezone.
