### PR TITLE
Fixed a problem for non-existing tiddler's title

### DIFF
--- a/core/modules/filters/field.js
+++ b/core/modules/filters/field.js
@@ -17,13 +17,14 @@ Export our filter function
 */
 exports.field = function(source,operator,options) {
 	var results = [],
-		fieldname = (operator.suffix || operator.operator).toLowerCase();
+		fieldname = (operator.suffix || operator.operator).toLowerCase(),
+		checkTitle = fieldname === "title";
 	// Function to check an individual title
 	function checkTiddler(title) {
-		var tiddler = options.wiki.getTiddler(title);
+		var tiddler = checkTitle ? title : options.wiki.getTiddler(title);
 		if(tiddler) {
 			var match,
-				text = tiddler.getFieldString(fieldname);
+				text = checkTitle ? title : tiddler.getFieldString(fieldname);
 			if(operator.regexp) {
 				match = !!operator.regexp.exec(text);
 			} else {


### PR DESCRIPTION
Non existing tiddlers (like those got with tags[]) don't have a title field (of course) but still have a title. This is one possible fix for it.
