### PR TITLE
fixed an awful typo in the regexp

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -63,7 +63,7 @@ function parseFilterOperation(operators,filterString,p) {
 			nextBracketPos = filterString.indexOf(']',p);
 			break;
 		case '/': // regexp brackets
-			var rex = /^((?:[^\\\/]*|\\.))*\/(?:\(([mygi]+)\))?/g,
+			var rex = /^((?:[^\\\/]*|\\.)*)\/(?:\(([mygi]+)\))?/g,
 				rexMatch = rex.exec(filterString.substring(p));
 			if(rexMatch) {
 				operator.regexp = new RegExp(rexMatch[1], rexMatch[2]);


### PR DESCRIPTION
The regexp fails when backslashes are used in the search-regexp. The closing bracket was at the wrong position.
