### PR TITLE
Update navigator.js

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -323,10 +323,11 @@ NavigatorWidget.prototype.handleCancelTiddlerEvent = function(event) {
 NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 	// Get the story details
 	var storyList = this.getStoryList();
+	var newTiddlerTitle = event.param || "New Tiddler";
 	// Get the template tiddler if there is one
-	var templateTiddler = this.wiki.getTiddler(event.param);
+	var templateTiddler = this.wiki.getTiddler(newTiddlerTitle);
 	// Create the new tiddler
-	var title = this.wiki.generateNewTitle((templateTiddler && templateTiddler.fields.title) || "New Tiddler");
+	var title = this.wiki.generateNewTitle((templateTiddler && templateTiddler.fields.title) || newTiddlerTitle);
 	var tiddler = new $tw.Tiddler(this.wiki.getCreationFields(),{
 		text: "Newly created tiddler",
 		title: title


### PR DESCRIPTION
As described here: https://groups.google.com/d/msg/tiddlywikidev/AWvXz7RMIC4/gFF5crN2UJoJ

Providing a name for the new tiddler message only works if a skeleton tiddler already exists. If not, "New Tiddler" is taken. This change fixes that in that the provided name is taken even if there is no skeleton.
