### PR TITLE
Added blank lines to switch to block rendering in RevealWidget examples

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
@@ -38,8 +38,10 @@ Here's a simple example of showing and hiding content with buttons:
 <$button set="$:/SampleRevealState" setTo="hide">Hide me</$button>
 
 <$reveal type="match" state="$:/SampleRevealState" text="show">
+
 ! This is the revealed content
 And this is some text
+
 </$reveal>
 ```
 
@@ -49,8 +51,10 @@ It renders as:
 <$button set="$:/SampleRevealState" setTo="hide">Hide me</$button>
 
 <$reveal type="match" state="$:/SampleRevealState" text="show">
+
 ! This is the revealed content
 And this is some text
+
 </$reveal>
 
 !! Popup
@@ -62,8 +66,10 @@ Here is a simple example of a popup built with the RevealWidget:
 
 <$reveal type="popup" state="$:/SamplePopupState">
 <div class="tw-drop-down">
+
 ! This is the popup
 And this is some text
+
 </div>
 </$reveal>
 ```
@@ -74,7 +80,9 @@ It renders as:
 
 <$reveal type="popup" state="$:/SamplePopupState">
 <div class="tw-drop-down">
+
 ! This is the popup
 And this is some text
+
 </div>
 </$reveal>


### PR DESCRIPTION
In the Examples section, missing blank lines prevented the revealed text to display as a block when clicking on buttons.
