### PR TITLE
A more selective way to improve editing speed

### DIFF
--- a/core/modules/startup.js
+++ b/core/modules/startup.js
@@ -203,7 +203,7 @@ exports.startup = function() {
 		$tw.utils.addClass($tw.pageContainer,"tw-page-container");
 		document.body.insertBefore($tw.pageContainer,document.body.firstChild);
 		$tw.pageWidgetNode.render($tw.pageContainer,null);
-		$tw.wiki.addEventListener("change",function(changes) {
+		$tw.wiki.addEventListener("refreshtree",function(changes) {
 			$tw.pageWidgetNode.refresh(changes,$tw.pageContainer,null);
 		});
 		// Fix up the link between the root widget and the page container

--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -46,6 +46,7 @@ EditWidget.prototype.execute = function() {
 	this.editIndex = this.getAttribute("index");
 	this.editClass = this.getAttribute("class");
 	this.editPlaceholder = this.getAttribute("placeholder");
+	this.onkeyupdate = this.getAttribute("onkeyupdate","no"); 
 	// Get the content type of the thing we're editing
 	var type;
 	if(this.editField === "text") {
@@ -65,7 +66,8 @@ EditWidget.prototype.execute = function() {
 			field: {type: "string", value: this.editField},
 			index: {type: "string", value: this.editIndex},
 			"class": {type: "string", value: this.editClass},
-			"placeholder": {type: "string", value: this.editPlaceholder}
+			"placeholder": {type: "string", value: this.editPlaceholder},
+			"onkeyupdate": {type: "string", value: this.onkeyupdate}
 		}
 	}]);
 };
@@ -75,7 +77,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 EditWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index|| changedAttributes.onkeyupdate) {
 		this.refreshSelf();
 		return true;
 	} else {

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -123,7 +123,7 @@ This method should be called after the changes it describes have been made to th
 	isDeleted: defaults to false (meaning the tiddler has been created or modified),
 		true if the tiddler has been created
 */
-exports.enqueueTiddlerEvent = function(title,isDeleted) {
+exports.enqueueTiddlerEvent = function(title,isDeleted,norefresh) {
 	// Record the touch in the list of changed tiddlers
 	this.changedTiddlers = this.changedTiddlers || {};
 	this.changedTiddlers[title] = this.changedTiddlers[title] || {};
@@ -144,6 +144,7 @@ exports.enqueueTiddlerEvent = function(title,isDeleted) {
 			self.changedTiddlers = {};
 			self.eventsTriggered = false;
 			self.dispatchEvent("change",changes);
+			if (!norefresh) self.dispatchEvent("refreshtree",changes);
 		});
 		this.eventsTriggered = true;
 	}
@@ -209,7 +210,7 @@ exports.isImageTiddler = function(title) {
 	}
 };
 
-exports.addTiddler = function(tiddler) {
+exports.addTiddler = function(tiddler,norefresh) {
 	// Check if we're passed a fields hashmap instead of a tiddler
 	if(!(tiddler instanceof $tw.Tiddler)) {
 		tiddler = new $tw.Tiddler(tiddler);
@@ -221,7 +222,7 @@ exports.addTiddler = function(tiddler) {
 		this.tiddlers[title] = tiddler;
 		this.clearCache(title);
 		this.clearGlobalCache();
-		this.enqueueTiddlerEvent(title);
+		this.enqueueTiddlerEvent(title,false,norefresh);
 	}
 };
 
@@ -619,7 +620,7 @@ title: title of tiddler
 data: object that can be serialised to JSON
 fields: optional hashmap of additional tiddler fields to be set
 */
-exports.setTiddlerData = function(title,data,fields) {
+exports.setTiddlerData = function(title,data,fields,setTiddlerData,norefresh) {
 	var existingTiddler = this.getTiddler(title),
 		newFields = {
 			title: title
@@ -630,7 +631,7 @@ exports.setTiddlerData = function(title,data,fields) {
 		newFields.type = "application/json";
 		newFields.text = JSON.stringify(data,null,$tw.config.preferences.jsonSpaces);
 	}
-	this.addTiddler(new $tw.Tiddler(existingTiddler,fields,newFields,this.getModificationFields()));
+	this.addTiddler(new $tw.Tiddler(existingTiddler,fields,newFields,this.getModificationFields()),norefresh);
 };
 
 /*

--- a/core/ui/EditTemplate/body.tid
+++ b/core/ui/EditTemplate/body.tid
@@ -14,7 +14,7 @@ tags: $:/tags/EditTemplate
 </div>
 
 <div class="tw-tiddler-preview-edit">
-<$edit field="text" class="tw-edit-texteditor" placeholder={{$:/language/EditTemplate/Body/Placeholder}}/>
+<$edit field="text" onkeyupdate="yes" class="tw-edit-texteditor" placeholder={{$:/language/EditTemplate/Body/Placeholder}}/>
 
 </div>
 
@@ -25,6 +25,6 @@ tags: $:/tags/EditTemplate
 <$reveal state="$:/ShowEditPreview" type="nomatch" text="yes">
 
 <em class="tw-edit"><<lingo Body/Hint>></em> <$button type="set" set="$:/ShowEditPreview" setTo="yes"><<lingo Body/Preview/Button/Show>></$button>
-<$edit field="text" class="tw-edit-texteditor" placeholder={{$:/language/EditTemplate/Body/Placeholder}}/>
+<$edit field="text" onkeyupdate="no" class="tw-edit-texteditor" placeholder={{$:/language/EditTemplate/Body/Placeholder}}/>
 
 </$reveal>

--- a/core/ui/SideBarLists.tid
+++ b/core/ui/SideBarLists.tid
@@ -2,7 +2,7 @@ title: $:/core/ui/SideBarLists
 
 <div class="tw-sidebar-lists">
 
-<div class="tw-search"><$edit-text tiddler="$:/temp/search" type="search" tag="input"/> <$reveal state="$:/temp/search" type="nomatch" text=""><$linkcatcher to="$:/temp/search"><$link to="" class="btn-invisible">{{$:/core/images/close-button}}</$link></$linkcatcher></$reveal><$reveal state="$:/temp/search" type="match" text=""> &nbsp;<$link to="$:/AdvancedSearch" class="btn-invisible">&hellip;</$link></$reveal></div>
+<div class="tw-search"><$edit-text onkeyupdate="yes" tiddler="$:/temp/search" type="search" tag="input"/> <$reveal state="$:/temp/search" type="nomatch" text=""><$linkcatcher to="$:/temp/search"><$link to="" class="btn-invisible">{{$:/core/images/close-button}}</$link></$linkcatcher></$reveal><$reveal state="$:/temp/search" type="match" text=""> &nbsp;<$link to="$:/AdvancedSearch" class="btn-invisible">&hellip;</$link></$reveal></div>
 
 <$reveal state="$:/temp/search" type="nomatch" text="">
 


### PR DESCRIPTION
The main idea here is to disable the refresh of the widget tree when it is not needed (ie during most editing) but still allow syncing to be preformed on a character by character basis.

the event "change" is fired from wiki.js, and in the original code a listener was set in  startup.js, to enable the refresh of the widget tree. In this change startup.js listens for a new event, "refreshtree". This is fired at the same time as "change" (in wiki.js) except when disabled (controlled by parameter norefresh). 
In edit-text.js a norefresh parameter is added to the update() function, and can be set by the "input" event handler so that "refreshtree" is not fired (but "change" is still fired). A "blur" handler is added that calls update() without setting norefresh to cause the refresh of the widget tree. 
This functionality is selectable by a option passed into the edit-widget.
