### PR TITLE
Stop using obsoleted "-moz-border-radius" and "-webkit-border-radius" pr...

### DIFF
--- a/boot/boot.css.tid
+++ b/boot/boot.css.tid
@@ -19,8 +19,6 @@ Error message and password prompt
     left: 50%;
     margin-left: -144px; /* - width/2 - paddingHorz/2 - border */
 	padding: 16px 16px 16px 16px;
-	-webkit-border-radius: 8px;
-	-moz-border-radius: 8px;
 	border-radius: 8px;
 }
 

--- a/core/ui/PageStylesheet.tid
+++ b/core/ui/PageStylesheet.tid
@@ -6,13 +6,6 @@ title: $:/core/ui/PageStylesheet
 \define color(name)
 <<colour $name$>>
 \end
-\define border-radius(radius)
-```
-  -webkit-border-radius: $radius$;
-     -moz-border-radius: $radius$;
-          border-radius: $radius$;
-```
-\end
 \define box-shadow(shadow)
 ```
   -webkit-box-shadow: $shadow$;

--- a/editions/tw5.com/tiddlers/howtos/Using Stylesheets.tid
+++ b/editions/tw5.com/tiddlers/howtos/Using Stylesheets.tid
@@ -28,7 +28,7 @@ If you wish to use macros and transclusions in your stylesheets you should inste
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline
 
 body.tw-body pre {
-	<<border-radius 7px>>
+	<<box-shadow "inset 0 1px 0 #fff">>
 }
 ```
 
@@ -39,7 +39,6 @@ The `\rules` pragma at the top of the tiddler restricts the WikiText to just all
 Several globally available macros are provided that are helpful in constructing stylesheets. See [[$:/core/ui/PageStylesheet]] for the definitions of these macros.
 
 * `<<colour name>>` and `<<color name>>` retrieve named colours from the current [[colour palette|ColourPalettes]]
-* `<<border-radius radius>>` specify a border-radius
 * `<<box-shadow shadow>>` specify a box-shadow
 * `<<filter filter>>` specify a CSS filter
 * `<<transition transition>>` specify a CSS transition

--- a/themes/tiddlywiki/snowwhite/base.tid
+++ b/themes/tiddlywiki/snowwhite/base.tid
@@ -54,12 +54,12 @@ canvas.tw-edit-bitmapeditor  {
 }
 
 .tw-drop-down {
-	<<border-radius 4px>>
+	border-radius: 4px;
 	<<box-shadow "2px 2px 10px rgba(0, 0, 0, 0.5)">>
 }
 
 .tw-block-dropdown {
-	<<border-radius 4px>>
+	border-radius: 4px;
 	<<box-shadow "2px 2px 10px rgba(0, 0, 0, 0.5)">>
 }
 
@@ -68,23 +68,23 @@ canvas.tw-edit-bitmapeditor  {
 }
 
 .modal {
-	<<border-radius 6px>>
+	border-radius: 6px;
 	<<box-shadow "0 3px 7px rgba(0,0,0,0.3)">>
 }
 
 .modal-footer {
-	<<border-radius "0 0 6px 6px">>
+	border-radius: 0 0 6px 6px;
 	<<box-shadow "inset 0 1px 0 #fff">>;
 }
 
 
 .tw-alert {
-	<<border-radius 6px>>
+	border-radius: 6px;
 	<<box-shadow "0 3px 7px rgba(0,0,0,0.6)">>
 }
 
 .tw-notification {
-	<<border-radius 6px>>
+	border-radius: 6px;
 	<<box-shadow "0 3px 7px rgba(0,0,0,0.3)">>
 	text-shadow: 0 1px 0 rgba(255,255,255, 0.8);
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -52,7 +52,7 @@ pre {
 	background-color: <<colour pre-background>>;
 	border: 1px solid <<colour pre-border>>;
 	padding: 0 3px 2px;
-	<<border-radius 3px>>
+	border-radius: 3px;
 }
 
 code {
@@ -61,7 +61,7 @@ code {
 	border: 1px solid <<colour code-border>>;
     white-space: pre-wrap;
 	padding: 0 3px 2px;
-	<<border-radius 3px>>
+	border-radius: 3px;
 }
 
 blockquote {
@@ -193,7 +193,7 @@ a.tw-tiddlylink-external:hover {
 	white-space: nowrap;
 	vertical-align: baseline;
 	background-color: <<colour dragger-background>>;
-	<<border-radius 20px>>
+	border-radius: 20px;
 }
 
 .tw-tiddler-dragger-cover {
@@ -295,7 +295,7 @@ a.tw-tiddlylink-external:hover {
 	white-space: nowrap;
 	vertical-align: baseline;
 	background-color: <<colour tag-background>>;
-	<<border-radius 8px>>
+	border-radius: 8px;
 }
 
 .tw-untagged-label {


### PR DESCRIPTION
Submitting fix for issue #480. (Is there a smarter way to link a pull request to an issue number?)

One thing I'm not 100% sure about is if replacing `<<border-radius 7px>>` with `<<box-shadow "inset 0 1px 0 #fff">>` in [Using Stylesheets](https://github.com/nameanyone/TiddlyWiki5/blob/bf8ad1e2947348dc1609281a35efa01714839153/editions/tw5.com/tiddlers/howtos/Using%20Stylesheets.tid#L31) makes for a good, sensible example. Please come up with a better one as you see fit.
