### PR TITLE
syncer freeze fix

### DIFF
--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -514,6 +514,9 @@ Syncer.prototype.dispatchTask = function(task,callback) {
 				// Invoke the callback
 				callback(null);
 			});
+		} else {
+			this.logger.log(" Not Dispatching 'save' task:",task.title,"tiddler does not exist");
+			return callback(null);
 		}
 	} else if(task.type === "load") {
 		// Load the tiddler


### PR DESCRIPTION
If an edit is made in a draft tiddler and the tiddler is saved immediately, then it is possible for the syncer to try and save the edit to the draft after it is deleted (this leads to the syncer freezing).  This happens with the editboost plugin as a result of using 'on blur' events for  edit-updates within the edit-text widget. 

Test -
server a 508 tw and drag and drop the editboost plugin into it(from http://bjhacks.tiddlyspot.com/). create and edit some tiddlers until it is observed from the log output that the syncer freezes.
server this pull-request modified tw and repeat. no freeze should occur.
