### PR TITLE
Show site title when logging in

### DIFF
--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -95,8 +95,9 @@ SimpleServer.prototype.listen = function(port,host) {
 		if(username && password) {
 			// Check they match
 			if(self.checkCredentials(request,username,password) !== "ALLOWED") {
+				var servername = state.wiki.getTiddlerText("$:/SiteTitle") || "TiddlyWiki5";
 				response.writeHead(401,"Authentication required",{
-					"WWW-Authenticate": 'Basic realm="Please provide your username and password to login to TiddlyWiki5"'
+					"WWW-Authenticate": 'Basic realm="Please provide your username and password to login to ' + servername + '"'
 				});
 				response.end();
 				return;


### PR DESCRIPTION
I have several TW5 servers running on the same host and think it would be good, would the password prompt display the $:/SiteTitle
