### PR TITLE
right menue SiteTitle and SiteSubtitle decoupled 

### DIFF
--- a/core/ui/PageTemplate/sidebar.tid
+++ b/core/ui/PageTemplate/sidebar.tid
@@ -7,8 +7,8 @@ tags: $:/tags/PageTemplate
 
 <$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes">
 
-<div class="titlebar">{{$:/SiteTitle}}</div>
-<div class="tw-subtitle">{{$:/SiteSubtitle}}</div>
+<div class="tw-site-title">{{$:/SiteTitle}}</div>
+<div class="tw-site-subtitle">{{$:/SiteSubtitle}}</div>
 
 <div class="tw-page-controls">
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -527,6 +527,7 @@ a.tw-tiddlylink-external:hover {
 	}
 }
 
+.tw-site-title,
 .titlebar {
 	font-weight: 300;
 	font-size: 2.35em;


### PR DESCRIPTION
right menue SiteTitle and SiteSubtitle decoupled from tiddler title and tiddler subtitle.

Otherwise it is not possible to modify the tiddler title styling, without affecting the site title. This is important for new themes. 
