### PR TITLE
Fixes "ReferenceError: path is not defined" from filesystemadaptor

### DIFF
--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -14,6 +14,7 @@ A sync adaptor module for synchronising with the local filesystem via node.js AP
 
 // Get a reference to the file system
 var fs = !$tw.browser ? require("fs") : null;
+var path = !$tw.browser ? require("path") : null;
 
 
 function FileSystemAdaptor(syncer) {


### PR DESCRIPTION
This issue might pop up in other places, but this is the only one I've hit so far.
