### PR TITLE
Reword documentation regarding tid-time function.

### DIFF
--- a/editions/tw5.com/tiddlers/tips/Editing Tiddlers with Emacs.tid
+++ b/editions/tw5.com/tiddlers/tips/Editing Tiddlers with Emacs.tid
@@ -1,10 +1,10 @@
 created: 20140406210404245
-modified: 20140406210649764
+modified: 20140407105002664
 tags: tips
 title: Editing Tiddlers with Emacs
 type: text/vnd.tiddlywiki
 
-This [[Emacs|http://www.gnu.org/software/emacs/]] macro from Michael Fogleman simplifies editing tiddlers in `*.tid` files by automatically updating the `modified` field:
+This [[Emacs|http://www.gnu.org/software/emacs/]] function from Michael Fogleman simplifies editing tiddlers in `*.tid` files by automatically updating the `modified` field:
 
 ```
 (defun tid-time ()


### PR DESCRIPTION
tid-time is a function, not a macro. This is a pretty trivial, but I thought I'd fork the repository so I could update this code if need be, and also maybe look at the other parts of TW5.

Incidentally, I called the tid-time function when editing this. You might want a different time, not sure. (I'm in India.) 

Finally, I have a local commit signing the Contributer's license, if that's a necessary prerequisite for docs changes.
