### PR TITLE
make deserializing a bit more robust

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -376,11 +376,28 @@ $tw.utils.checkVersions = function(versionStringA,versionStringB) {
 
 /*
 Register file type information
-flags: "image" for image types
+options: {flags: flags,deserializertype: deserializertype}
+	flags:"image" for image types
+	deserializertype: defaults to type if not specified
 */
-$tw.utils.registerFileType = function(type,encoding,extension,flags) {
-	$tw.config.fileExtensionInfo[extension] = {type: type};
-	$tw.config.contentTypeInfo[type] = {encoding: encoding, extension: extension, flags: flags || []};
+$tw.utils.registerFileType = function(type,encoding,extension,options) {
+	$tw.config.fileExtensionInfo[extension] = {type: type};	
+	$tw.config.contentTypeInfo[type] = {encoding: encoding, extension: extension};
+	if(options){
+		$tw.config.contentTypeInfo[type].flags = options.flags || [];
+		$tw.config.contentTypeInfo[type].deserializertype = options.deserializertype || type;
+	}
+};
+
+/*
+Given an extension, get the correct encoding for that file.
+defaults to utf8
+*/
+$tw.utils.getTypeEncoding = function(ext) {
+	var extensionInfo = $tw.config.fileExtensionInfo[ext],
+		type = extensionInfo ? extensionInfo.type : null,
+		typeInfo = type ? $tw.config.contentTypeInfo[type] : null;
+	return typeInfo ? typeInfo.encoding : "utf8";
 };
 
 /*
@@ -1042,6 +1059,11 @@ $tw.Wiki.prototype.deserializeTiddlers = function(type,text,srcFields) {
 		type = $tw.config.fileExtensionInfo[type].type;
 		deserializer = $tw.Wiki.tiddlerDeserializerModules[type];
 	}
+	if(!deserializer && $tw.config.contentTypeInfo[type]) {
+		// see if this type has a different deserializer registered with it
+		type = $tw.config.contentTypeInfo[type].deserializertype;
+		deserializer = $tw.Wiki.tiddlerDeserializerModules[type];
+	}
 	if(!deserializer) {
 		// If we still don't have a deserializer, treat it as plain text
 		deserializer = $tw.Wiki.tiddlerDeserializerModules["text/plain"];
@@ -1600,14 +1622,15 @@ $tw.boot.startup = function(options) {
 	$tw.utils.registerFileType("text/plain","utf8",".txt");
 	$tw.utils.registerFileType("text/css","utf8",".css");
 	$tw.utils.registerFileType("text/html","utf8",".html");
+	$tw.utils.registerFileType("application/hta","utf16le",".hta",{deserializertype:"text/html"});
 	$tw.utils.registerFileType("application/javascript","utf8",".js");
 	$tw.utils.registerFileType("application/json","utf8",".json");
-	$tw.utils.registerFileType("application/pdf","base64",".pdf",["image"]);
-	$tw.utils.registerFileType("image/jpeg","base64",".jpg",["image"]);
-	$tw.utils.registerFileType("image/png","base64",".png",["image"]);
-	$tw.utils.registerFileType("image/gif","base64",".gif",["image"]);
-	$tw.utils.registerFileType("image/svg+xml","utf8",".svg",["image"]);
-	$tw.utils.registerFileType("image/x-icon","base64",".ico",["image"]);
+	$tw.utils.registerFileType("application/pdf","base64",".pdf",{flags:["image"]});
+	$tw.utils.registerFileType("image/jpeg","base64",".jpg",{flags:["image"]});
+	$tw.utils.registerFileType("image/png","base64",".png",{flags:["image"]});
+	$tw.utils.registerFileType("image/gif","base64",".gif",{flags:["image"]});
+	$tw.utils.registerFileType("image/svg+xml","utf8",".svg",{flags:["image"]});
+	$tw.utils.registerFileType("image/x-icon","base64",".ico",{flags:["image"]});
 	$tw.utils.registerFileType("application/font-woff","base64",".woff");
 	// Create the wiki store for the app
 	$tw.wiki = new $tw.Wiki();

--- a/core/modules/commands/load.js
+++ b/core/modules/commands/load.js
@@ -30,8 +30,9 @@ Command.prototype.execute = function() {
 	if(this.params.length < 1) {
 		return "Missing filename";
 	}
-	fs.readFile(this.params[0],"utf8",function(err,data) {
-		if(err) {
+	var ext = path.extname(self.params[0]);
+	fs.readFile(this.params[0],$tw.utils.getTypeEncoding(ext),function(err,data) {
+		if (err) {
 			self.callback(err);
 		} else {
 			var fields = {title: self.params[0]},


### PR DESCRIPTION
load.js references the encoding set in boot.js when loading a file.
boot.js can now register file type with different deserialization from
their actual type
