### PR TITLE
Sidebar remove p tags and adjust css

### DIFF
--- a/core/ui/PageMacros.tid
+++ b/core/ui/PageMacros.tid
@@ -3,30 +3,31 @@ title: $:/core/ui/PageMacros
 \define colour(name)
 <$transclude tiddler={{$:/palette}} index="$name$"/>
 \end
+
 \define color(name)
 <<colour $name$>>
 \end
+
 \define tabs(tabsList,default,state:"$:/state/tab")
 <div class="tw-tab-buttons">
-<$list filter="$tabsList$" variable="currentTab">
-<$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" selectedClass="tw-tab-selected">
-<$transclude tiddler=<<currentTab>> field="caption">
-<$macrocall $name="currentTab" $type="text/plain" $output="text/plain"/>
-</$transclude> </$button>
-</$list>
+	<$list filter="$tabsList$" variable="currentTab">
+		<$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" selectedClass="tw-tab-selected">
+			<$transclude tiddler=<<currentTab>> field="caption">
+			<$macrocall $name="currentTab" $type="text/plain" $output="text/plain"/>
+			</$transclude>
+		</$button>
+	</$list>
 </div>
 <div class="tw-tab-divider"/>
 <div class="tw-tab-content">
-
-<$list filter="$tabsList$" variable="currentTab">
-<$reveal type="match" state=<<qualify "$state$">> text=<<currentTab>> default="$default$">
-
-<$transclude tiddler=<<currentTab>>/>
-
-</$reveal>
-</$list>
+	<$list filter="$tabsList$" variable="currentTab">
+		<$reveal type="match" state=<<qualify "$state$">> text=<<currentTab>> default="$default$">
+			<$transclude tiddler=<<currentTab>> mode="block"/>
+		</$reveal>
+	</$list>
 </div>
 \end
+
 \define wikitext-example(src)
 ```
 $src$
@@ -43,6 +44,7 @@ $src$
 $$$
 
 \end
+
 \define wikitext-example-without-html(src)
 ```
 $src$
@@ -53,9 +55,11 @@ Renders as:
 $src$
 
 \end
+
 \define lingo-base()
 $:/lingo/
 \end
+
 \define lingo(title)
 {{$(lingo-base)$$title$}}
 \end

--- a/core/ui/PageTemplate/sidebar.tid
+++ b/core/ui/PageTemplate/sidebar.tid
@@ -2,24 +2,15 @@ title: $:/core/ui/PageTemplate/sidebar
 tags: $:/tags/PageTemplate
 
 <$scrollable fallthrough="no" class="tw-sidebar-scrollable">
-
-<div class="sidebar-header">
-
-<$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes">
-
-<div class="tw-site-title">{{$:/SiteTitle}}</div>
-<div class="tw-site-subtitle">{{$:/SiteSubtitle}}</div>
-
-<div class="tw-page-controls">
-
-<$list filter="[all[tiddlers+shadows]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem"><$transclude tiddler=<<listItem>>/></$list>
-
-</div>
-
-{{$:/core/ui/SideBarLists}}
-
-</$reveal>
-
-</div>
-
+	<div class="sidebar-header">
+		<$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes">
+			<div class="tw-site-title">{{$:/SiteTitle}}</div>
+			<div class="tw-site-subtitle">{{$:/SiteSubtitle}}</div>
+			<div class="tw-page-controls">
+				<$list filter="[all[tiddlers+shadows]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">						<$transclude tiddler=<<listItem>>/>
+				</$list>
+			</div>
+			{{$:/core/ui/SideBarLists}}
+		</$reveal>
+	</div>
 </$scrollable>

--- a/core/ui/SideBarLists.tid
+++ b/core/ui/SideBarLists.tid
@@ -1,32 +1,24 @@
 title: $:/core/ui/SideBarLists
 
 <div class="tw-sidebar-lists">
-
-<div class="tw-search">
-<$edit-text tiddler="$:/temp/search" type="search" tag="input"/> <$reveal state="$:/temp/search" type="nomatch" text="">
-<$linkcatcher to="$:/temp/search">
-<$link to="" class="btn-invisible">{{$:/core/images/close-button}}</$link>
-</$linkcatcher>
-</$reveal>
-<$reveal state="$:/temp/search" type="match" text=""> &nbsp;<$link to="$:/AdvancedSearch" class="btn-invisible">&hellip;</$link>
-</$reveal>
-</div>
-
-<$reveal state="$:/temp/search" type="nomatch" text="">
-
-<div class="tw-search-results">
-
-{{$:/language/Search/Matches}}
-
-<$list filter="[!is[system]search{$:/temp/search}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
-
-</div>
-
-</$reveal>
-
-<$reveal state="$:/temp/search" type="match" text="">
-
-<<tabs "[all[tiddlers+shadows]tag[$:/tags/SideBar]!has[draft.of]]" "$:/core/ui/SideBar/Open" "$:/state/tab/sidebar">>
-
-</$reveal>
+	<div class="tw-search">
+		<$edit-text tiddler="$:/temp/search" type="search" tag="input"/>
+		<$reveal state="$:/temp/search" type="nomatch" text="">
+			<$linkcatcher to="$:/temp/search">
+				<$link to="" class="btn-invisible">{{$:/core/images/close-button}}</$link>
+			</$linkcatcher>
+		</$reveal>
+		<$reveal state="$:/temp/search" type="match" text=""> &nbsp;
+			<$link to="$:/AdvancedSearch" class="btn-invisible">&hellip;</$link>
+		</$reveal>
+	</div>
+	<$reveal state="$:/temp/search" type="nomatch" text="">
+		<div class="tw-search-results">
+			{{$:/language/Search/Matches}}
+			<$list filter="[!is[system]search{$:/temp/search}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+		</div>
+	</$reveal>
+	<$reveal state="$:/temp/search" type="match" text="">
+		<<tabs "[all[tiddlers+shadows]tag[$:/tags/SideBar]!has[draft.of]]" "$:/core/ui/SideBar/Open" "$:/state/tab/sidebar">>
+	</$reveal>
 </div>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -368,6 +368,10 @@ a.tw-tiddlylink-external:hover {
 	width: 60%;
 }
 
+.tw-search {
+	padding-top: .5em;
+}
+
 .tw-search a svg {
 	height: 0.75em;
 }
@@ -449,7 +453,7 @@ a.tw-tiddlylink-external:hover {
 		overflow-x: auto;
 		-webkit-overflow-scrolling: touch;
 		margin: 0 0 0 -42px;
-		padding: 70px 0 28px 42px;
+		padding: 99px 0 28px 42px;
 	}
 
 	.story-river {


### PR DESCRIPTION
This PR replaces PR  #527
- These changes remove most of the <p> tags from the right sidebar, without changing the layout too much.
- The tab buttons are a little bit higher but this will be adjusted with the next CSS tweaks.
