### PR TITLE
Add 'tiddlers-path' config

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1502,7 +1502,11 @@ $tw.loadWikiTiddlers = function(wikiPath,parentPaths) {
 		$tw.wiki.addTiddler({title: "$:/config/OriginalTiddlerPaths", type: "application/x-tiddler-dictionary", text: output.join("")});
 	}
 	// Save the path to the tiddlers folder for the filesystemadaptor
-	$tw.boot.wikiTiddlersPath = path.resolve($tw.boot.wikiPath,$tw.config.wikiTiddlersSubDir);
+	if(wikiInfo.config && wikiInfo.config["tiddlers-path"]) {
+		$tw.boot.wikiTiddlersPath = path.resolve($tw.boot.wikiPath,wikiInfo.config["tiddlers-path"]);
+	} else {
+		$tw.boot.wikiTiddlersPath = path.resolve($tw.boot.wikiPath,$tw.config.wikiTiddlersSubDir);
+	}
 	// Load any plugins within the wiki folder
 	var wikiPluginsPath = path.resolve(wikiPath,$tw.config.wikiPluginsSubDir);
 	if(fs.existsSync(wikiPluginsPath)) {


### PR DESCRIPTION
There is the case that when dealing with mutiple editions that you may want to store the tiddlers in a different path then the default one. For example using the tw5.com-server edition any **new** content created via the filesystem sync will be placed in `tw5.com-server/tiddlers` and **not** the `tw5.com/tiddlers` folder which is the real storage folder for distribution.

This descrepency requires a manual copy from one edition to the other depending. In some cases it is desierable to avoid that and directly config the location of the tiddlers folder. For example in the `tw5.com-server/tiddlywiki.info` add the following config option:

```
"config": {
    "tiddlers-path": "../tw5.com/tiddlers"
}
```
