### PR TITLE
Pass content-type to codemirror mode option for syntax highlight

### DIFF
--- a/plugins/tiddlywiki/codemirror/codemirroreditor.js
+++ b/plugins/tiddlywiki/codemirror/codemirroreditor.js
@@ -59,6 +59,10 @@ EditTextWidget.prototype.postRender = function() {
 			lineWrapping: true,
 			lineNumbers: true
 		};
+	var tid = $tw.wiki.getTiddler(this.editTitle);
+	if(tid && tid.fields.type) {
+		cm_opts.mode = tid.fields.type
+	}
 
 	if($tw.browser && window.CodeMirror && this.editTag === "textarea") {
 		if(EditTextWidget.configuration) {


### PR DESCRIPTION
Look up existing type field for current tiddler and pass as mode option to CodeMirror constructor
