### PR TITLE
Support per-user configuration

### DIFF
--- a/core/modules/savers/upload.js
+++ b/core/modules/savers/upload.js
@@ -25,7 +25,7 @@ UploadSaver.prototype.save = function(text,method,callback) {
 	// Get the various parameters we need
 	var backupDir = this.wiki.getTextReference("$:/UploadBackupDir") || ".",
 		username = this.wiki.getTextReference("$:/UploadName"),
-		password = $tw.utils.getPassword("upload"),
+		password = $tw.utils.getBrowserVariable("password-upload"),
 		uploadDir = this.wiki.getTextReference("$:/UploadDir") || ".",
 		uploadFilename = this.wiki.getTextReference("$:/UploadFilename") || "index.html",
 		url = this.wiki.getTextReference("$:/UploadURL");

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -96,7 +96,7 @@ exports.getBoundingPageRect = function(element) {
 Saves a named password in the browser
 */
 exports.saveBrowserVariable = function(name,value) {
-	if(window.localStorage) {
+	if(typeof localStorage !== "undefined") {
 		localStorage.setItem("tw5-" + name,value);
 	}
 };
@@ -105,7 +105,7 @@ exports.saveBrowserVariable = function(name,value) {
 Retrieve a named password from the browser
 */
 exports.getBrowserVariable = function(name) {
-	return window.localStorage ? localStorage.getItem("tw5-" + name) : "";
+	return (typeof localStorage !== "undefined") ? localStorage.getItem("tw5-" + name) : "";
 };
 
 /*

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -95,17 +95,17 @@ exports.getBoundingPageRect = function(element) {
 /*
 Saves a named password in the browser
 */
-exports.savePassword = function(name,password) {
+exports.saveBrowserVariable = function(name,value) {
 	if(window.localStorage) {
-		localStorage.setItem("tw5-password-" + name,password);
+		localStorage.setItem("tw5-" + name,value);
 	}
 };
 
 /*
 Retrieve a named password from the browser
 */
-exports.getPassword = function(name) {
-	return window.localStorage ? localStorage.getItem("tw5-password-" + name) : "";
+exports.getBrowserVariable = function(name) {
+	return window.localStorage ? localStorage.getItem("tw5-" + name) : "";
 };
 
 /*

--- a/core/modules/widgets/browser-variable.js
+++ b/core/modules/widgets/browser-variable.js
@@ -1,9 +1,9 @@
 /*\
-title: $:/core/modules/widgets/password.js
+title: $:/core/modules/widgets/browser-variable.js
 type: application/javascript
 module-type: widget
 
-Password widget
+Browser-variable widget
 
 \*/
 (function(){
@@ -14,31 +14,31 @@ Password widget
 
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
-var PasswordWidget = function(parseTreeNode,options) {
+var BrowserVariableWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
 /*
 Inherit from the base widget class
 */
-PasswordWidget.prototype = new Widget();
+BrowserVariableWidget.prototype = new Widget();
 
 /*
 Render this widget into the DOM
 */
-PasswordWidget.prototype.render = function(parent,nextSibling) {
+BrowserVariableWidget.prototype.render = function(parent,nextSibling) {
 	// Save the parent dom node
 	this.parentDomNode = parent;
 	// Compute our attributes
 	this.computeAttributes();
 	// Execute our logic
 	this.execute();
-	// Get the current password
-	var password = $tw.browser ? $tw.utils.getBrowserVariable("password-" + this.passwordName) || "" : "";
+	// Get the current value
+	var value = $tw.browser ? $tw.utils.getBrowserVariable(this.variableName) || "" : "";
 	// Create our element
 	var domNode = this.document.createElement("input");
-	domNode.setAttribute("type","password");
-	domNode.setAttribute("value",password);
+	domNode.setAttribute("type","text");
+	domNode.setAttribute("value",value);
 	// Add a click event handler
 	$tw.utils.addEventListeners(domNode,[
 		{name: "change", handlerObject: this, handlerMethod: "handleChangeEvent"}
@@ -49,17 +49,17 @@ PasswordWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(domNode);
 };
 
-PasswordWidget.prototype.handleChangeEvent = function(event) {
-	var password = this.domNodes[0].value;
-	return $tw.utils.saveBrowserVariable("password-" + this.passwordName,password);
+BrowserVariableWidget.prototype.handleChangeEvent = function(event) {
+	var value = this.domNodes[0].value;
+	return $tw.utils.saveBrowserVariable(this.variableName,value);
 };
 
 /*
 Compute the internal state of the widget
 */
-PasswordWidget.prototype.execute = function() {
+BrowserVariableWidget.prototype.execute = function() {
 	// Get the parameters from the attributes
-	this.passwordName = this.getAttribute("name","");
+	this.variableName = this.getAttribute("name","");
 	// Make the child widgets
 	this.makeChildWidgets();
 };
@@ -67,7 +67,7 @@ PasswordWidget.prototype.execute = function() {
 /*
 Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 */
-PasswordWidget.prototype.refresh = function(changedTiddlers) {
+BrowserVariableWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.name) {
 		this.refreshSelf();
@@ -77,6 +77,6 @@ PasswordWidget.prototype.refresh = function(changedTiddlers) {
 	}
 };
 
-exports.password = PasswordWidget;
+exports["browser-variable"] = BrowserVariableWidget;
 
 })();

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -219,7 +219,7 @@ exports.getCreationFields = function() {
 	var fields = {
 			created: new Date()
 		},
-		creator = this.getTiddlerText(USER_NAME_TITLE);
+		creator = $tw.utils.getBrowserVariable("wiki-username") || this.getTiddlerText(USER_NAME_TITLE);
 	if(creator) {
 		fields.creator = creator;
 	}
@@ -231,7 +231,7 @@ Return a hashmap of the fields that should be set when a tiddler is modified
 */
 exports.getModificationFields = function() {
 	var fields = Object.create(null),
-		modifier = this.getTiddlerText(USER_NAME_TITLE);
+		modifier = $tw.utils.getBrowserVariable("wiki-username") || this.getTiddlerText(USER_NAME_TITLE);
 	fields.modified = new Date();
 	if(modifier) {
 		fields.modifier = modifier;

--- a/core/ui/ControlPanel/Basics.tid
+++ b/core/ui/ControlPanel/Basics.tid
@@ -6,7 +6,7 @@ caption: {{$:/language/ControlPanel/Basics/Caption}}
 |<<lingo Version/Prompt>> |''<<version>>'' |
 |<$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link> |<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
 |<$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link> |<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
-|<$link to="$:/status/UserName"><<lingo Username/Prompt>></$link> |<$edit-text tiddler="$:/status/UserName" default="" tag="input"/> |
+|<<lingo Username/Prompt>> |<$browser-variable name="wiki-username"/> |
 |<$link to="$:/config/AnimationDuration"><<lingo AnimDuration/Prompt>></$link> |<$edit-text tiddler="$:/config/AnimationDuration" default="" tag="input"/> |
 |<$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link> |<<lingo DefaultTiddlers/TopHint>><br> <$edit-text tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
 |<<lingo Language/Prompt>> |{{$:/snippets/minilanguageswitcher}} |


### PR DESCRIPTION
I'm attempting to get TiddlyWiki more useful for multi-person collaboration.  As part of that, this patch addresses one of the first things that I noticed when I attempted to share one with someone - which happened to be on TiddlySpot, but it doesn't appear that the breakage was specific to them.  Specifically, because our usernames for signing edits were stored in a tiddler, they were saved and synced along with everything else.  So we literally couldn't have individual ones!

I noticed that passwords already have the non-syncing property that would be great here, so I looked into how they did it, and generalized the mechanism.  I realize it will break compatibility with saver plugins, but I did rename $tw.utils.{get|save}Password to $tw.utils.{get|save}BrowserVariable; I also moved the "password-" portion of the key it's stored under to be specified only in the places where the variable actually holds a password.  I somewhat expect that you may want to preserve compatibility by making wrapper functions having the old interface, but since my own tendency is against and it's easy enough, I'll leave that for you. :)

I also forked off widgets/password into widgets/browser-variable - in this case, leaving the old one in place too, since the primary difference is that they use a different type of <input> tag, which still needs to be different and there were too many stylistic decisions to be made in trying to keep them unified.

Finally, I did look at backwards compatibility.  This should have it.  Passwords are expected in exactly the same place under the patch as before.  Usernames have of course moved, but they fall back to the old place for contexts where browser functionality isn't available, in particular for Node.

I guess it would have been possible to extend the browser-variable widget to actually store into the first place available - that is, either into browser local-storage or into a tiddler - leaving the other one alone; that would have provided halfway-decent semantics for the idea that the browser can have tiny pieces of state which override the tiddlers.  But I didn't do that; it's both a little annoying to implement, and cognitively complex for users to understand.

Okay!  I think that's it!  Hopefully you like it. :)
