### PR TITLE
Update instructions.tid to use one of the included addons

### DIFF
--- a/plugins/tiddlywiki/codemirror/instructions.tid
+++ b/plugins/tiddlywiki/codemirror/instructions.tid
@@ -13,11 +13,13 @@ For example:
       "$:/plugins/tiddlywiki/codemirror/mode/javascript/javascript.js",
       "$:/plugins/tiddlywiki/codemirror/addon/dialog/dialog.js",
       "$:/plugins/tiddlywiki/codemirror/addon/search/searchcursor.js",
+      "$:/plugins/tiddlywiki/codemirror/addon/edit/matchbrackets.js",
       "$:/plugins/tiddlywiki/codemirror/keymap/vim.js",
       "$:/plugins/tiddlywiki/codemirror/keymap/emacs.js"
   ],
   "configuration": {
       "keyMap": "vim",
+      "matchBrackets":true,
       "showCursorWhenSelecting": true
   }
 }


### PR DESCRIPTION
This addon is already included into the plugin, but is not used, neither mentioned how to use it. It is a very useful but lightweight addon. I consider it is better to include the full functionality of the current configuration in the config example.
