### PR TITLE
Only import newer tiddlers

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -211,6 +211,9 @@ exports.importTiddler = function(tiddler) {
 			return false;
 		}
 	}
+	if(tiddler && tiddler.hasField("modified") && existingTiddler && existingTiddler.hasField("modified") && tiddler.fields.modified <= existingTiddler.fields.modified){
+  	    return false;
+  	    }
 	// Fall through to adding the tiddler
 	this.addTiddler(tiddler);
 	return true;


### PR DESCRIPTION
When importing a wiki file just import those tiddlers that are not pressent in the importing wiki or those which are newer than the existing ones.
