### PR TITLE
austrian flag now preserves aspect ratio in page toolbar button

### DIFF
--- a/languages/de-AT/Flag.tid
+++ b/languages/de-AT/Flag.tid
@@ -2,7 +2,7 @@ title: $:/language/Flag
 type: image/svg+xml
 
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600">
-<rect fill="#ed2939" width="900" height="600"/>
-<rect fill="#fff" y="200" width="900" height="200"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 9 6">
+<rect fill="#ef3340" width="9" height="6"/>
+<rect fill="#fff" y="2" width="9" height="2"/>
 </svg>


### PR DESCRIPTION
Austrian flag now preserves aspect ratio in page toolbar button.
Also change the colour according to Austrian rules.
