### PR TITLE
"Manually create an external image" instructions do not work 5.0.14-prerelease

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/ExternalImages.tid
+++ b/editions/tw5.com/tiddlers/concepts/ExternalImages.tid
@@ -16,6 +16,8 @@ An external image is an ordinary image tiddler that has a ''_canonical_uri'' fie
 
 To manually create an external image just create the tiddler with the appropriate image content type, and add a ''_canonical_uri'' field with a URI pointing to the actual image location.
 
+''IMPORTANT:'' Double-check your spelling. ``_canonical_uri`` is spelled [[URI|https://en.wikipedia.org/wiki/URI#The_relationship_between_URIs.2C_URLs.2C_and_URNs]], not URL.
+
 ! Creating external images under Node.js
 
 The following steps are used to create a static HTML file version of a wiki accompanied by an ''images'' folder containing the referenced external images:


### PR DESCRIPTION
In revision e3dc00573d9ea4db61e619b8f101168d1b4920a5, the following instructions for manually creating external images in the [ExternalImages](http://tiddlywiki.com/#ExternalImages) tiddler seem to not work.

> To manually create an external image just create the tiddler with the appropriate image content type, and add a _canonical_uri field with a URI pointing to the actual image location.
### Steps to reproduce:
1. Copy the image file into place as "Page Composition.svg".
2. Open up the "TiddlyWiki Architecture.svg" tiddler
3. Create a new Tiddler
4. Manually enter the tags from TiddlyWiki Architecture.svg into the new Tiddler.
5. Manually create a `_canonical_url` field, copy the value from TiddlyWiki Architecture.svg, and edit the value to `./images/Page%2520Composition.svg` (confimed as correct by this snip of Python code in a shell one-liner:
   
   ```
   % python <<< "import urllib, os; print os.path.isfile(urllib.unquote(urllib.unquote('./images/TiddlyWiki%2520Architecture.svg'))), os.path.isfile(urllib.unquote(urllib.unquote('./images/Page%2520Composition.svg')))"
   True True
   ```
6. Set the type to `image/svg+xml`
7. Name the new tiddler "Page Composition.svg"
8. Click "Save this tiddler"
### Expected result:

The saved tiddler should show the image and, when edited again, should reproduce TiddlyWiki Architecture.svg's "This is an external tiddler..." form of the content box.
### Actual result:

The tiddler renders as empty and re-editing it reproduces the same "internal text tiddler" content view that it started with.
