### PR TITLE
Added tw-active-focus to prevent editor refreshing. 

### DIFF
--- a/core/modules/widgets/edit-text.js
+++ b/core/modules/widgets/edit-text.js
@@ -61,6 +61,7 @@ EditTextWidget.prototype.render = function(parent,nextSibling) {
 	// Add an input event handler
 	$tw.utils.addEventListeners(domNode,[
 		{name: "focus", handlerObject: this, handlerMethod: "handleFocusEvent"},
+		{name: "blur", handlerObject: this, handlerMethod: "handleBlurEvent"},
 		{name: "input", handlerObject: this, handlerMethod: "handleInputEvent"}
 	]);
 	// Insert the element into the DOM
@@ -235,6 +236,10 @@ EditTextWidget.prototype.handleInputEvent = function(event) {
 };
 
 EditTextWidget.prototype.handleFocusEvent = function(event) {
+	// tell the parent widgets that we currently have the focus
+	this.dispatchEvent({type: "tw-active-focus", param: "true", tiddlerTitle: this.getVariable("currentTiddler")});
+
+	// trigger an eventual popup
 	if(this.editFocusPopup) {
 		$tw.popup.triggerPopup({
 			domNode: this.domNodes[0],
@@ -245,6 +250,11 @@ EditTextWidget.prototype.handleFocusEvent = function(event) {
 	}
 	return true;
 };
+
+EditTextWidget.prototype.handleBlurEvent = function(event) {
+	//inform the parent widgets that we lost the focus
+	this.dispatchEvent({type: "tw-active-focus", param: "false", tiddlerTitle: this.getVariable("currentTiddler")});
+}
 
 EditTextWidget.prototype.saveChanges = function(text) {
 	var editInfo = this.getEditInfo();

--- a/core/modules/widgets/tiddler.js
+++ b/core/modules/widgets/tiddler.js
@@ -16,6 +16,8 @@ var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var TiddlerWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
+	this.addEventListener("tw-active-focus", "handleFocusEvent");
+	this.activeState = false;
 };
 
 /*
@@ -65,12 +67,24 @@ TiddlerWidget.prototype.getTagClasses = function() {
 	}
 };
 
+
+TiddlerWidget.prototype.handleFocusEvent = function(event) {
+	//check event and set our active state
+	if(event.type == "tw-active-focus") {
+		this.activeState = (event.param == "false") ? false : true;
+		// don't propagate any further
+		return false;
+	}
+
+	return true;
+}
+
 /*
 Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 */
 TiddlerWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedTiddlers[this.tiddlerTitle]) {
+	if(changedAttributes.tiddler || (changedTiddlers[this.tiddlerTitle] && !this.activeState)) {
 		this.refreshSelf();
 		return true;
 	} else {

--- a/plugins/tiddlywiki/codemirror/edit-codemirror.js
+++ b/plugins/tiddlywiki/codemirror/edit-codemirror.js
@@ -88,6 +88,15 @@ EditCodeMirrorWidget.prototype.render = function(parent,nextSibling) {
 	cm.on("change",function() {
 		self.saveChanges(cm.getValue());
 	});
+
+	//add events to tell parent widgets whether the editor is active or not
+	cm.on("focus", function() {
+		self.dispatchEvent({type: "tw-active-focus", param: "true", tiddlerTitle: self.getVariable("currentTiddler")});
+	});
+
+	cm.on("blur", function() {
+		self.dispatchEvent({type: "tw-active-focus", param: "false", tiddlerTitle: self.getVariable("currentTiddler")});
+	});
 	this.codeMirrorInstance = cm;
 };
 


### PR DESCRIPTION
Hi, 

In Issue #744 the problem is that a tiddler widget might refresh its contents, which causes an active editor contained within the widget to lose its focus.

This fix introduces a Widget-Message which is emitted by an active editor and processed by the tiddler widget so that it won't refresh as long as the editor got the focus.
