### PR TITLE
added support for xlink: attribute prefix

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -263,9 +263,15 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 			v = undefined;
 		}
 		if(v !== undefined) {
+			var b = a.split(":");
 			// Setting certain attributes can cause a DOM error (eg xmlns on the svg element)
 			try {
-				domNode.setAttributeNS(null,a,v);
+				if (b.length == 2 && b[0] == "xlink"){
+					domNode.setAttributeNS("http://www.w3.org/1999/xlink",b[1],v);
+				}
+				else {
+					domNode.setAttributeNS(null,a,v);
+				}
 			} catch(e) {
 			}
 		}


### PR DESCRIPTION
re-submitted

The 'xlink:' attribute prefix used with inline svg is not supported, it's use is described in the spec section 8.1.2.3 Attributes, see here:
http://www.w3.org/TR/html5/syntax.html#attributes-0

The bug is evident if you remove the $$$.svg block in the example tiddler "Making curved text with SVG" on tiddlywiki.com, to make it inline svg.

there is a demo of the fix here: http://xlink.tiddlyspot.com/
