### PR TITLE
removes the p-tags for the tag edit dropdown in tiddler edit mode

### DIFF
--- a/core/ui/EditTemplate/tags.tid
+++ b/core/ui/EditTemplate/tags.tid
@@ -24,11 +24,8 @@ background-color:$(backgroundColor)$;
 </div>
 
 <div class="tc-block-dropdown-wrapper">
-
 <$reveal state=<<qualify "$:/state/popup/tags-auto-complete">> type="nomatch" text="" default="">
-
 <div class="tc-block-dropdown">
-
 <$linkcatcher set="$:/temp/NewTagName" setTo="" message="tm-add-tag">
 <$list filter="[!is[shadow]tags[]search{$:/temp/NewTagName}sort[title]]">
 <$link>
@@ -40,9 +37,7 @@ background-color:$(backgroundColor)$;
 </$link>
 </$list>
 </$linkcatcher>
-
 </div>
-
 </$reveal>
 </div>
 </$fieldmangler>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -932,7 +932,7 @@ canvas.tc-edit-bitmapeditor  {
 	min-width: 280px;
 	border: 1px solid <<colour dropdown-border>>;
 	background-color: <<colour dropdown-background>>;
-	padding: 0 0 0 0;
+	padding: 7px 0;
 	margin: 4px 0 0 0;
 	white-space: nowrap;
 	z-index: 1000;


### PR DESCRIPTION
- removes the p-tags for the tag edit dropdown in tiddler edit mode
- it also effects the type-selector, since it uses the same css.
  - but there is no visual difference.
