### PR TITLE
make serve.cmd useful for everyone out of the box.

### DIFF
--- a/bin/serve.cmd
+++ b/bin/serve.cmd
@@ -1,6 +1,14 @@
 :: This file uses the default settings for Jeremy and 
 :: provides some help and more parameters for the rest of us.
 
+:: This script allows you to serve different TiddlyWiki editions. 
+:: It respects the TIDDLYWIKI_EDITION_PATH variable described
+:: at: # http://tiddlywiki.com/#Environment%20Variables%20on%20Node.js
+::
+:: Be sure your server tiddlywiki.info configuration contains the plugins:
+::   - "tiddlywiki/tiddlyweb" and the "tiddlywiki/filesystem"
+::   - Otherwise saving is not possible. 
+
 @echo off
 echo.
 


### PR DESCRIPTION
make serve.cmd useful for everyone and use sensible defaults, so it works for different editions out of the box.

Hi Jeremy, 
.\serve.cmd now supports a help question ... `serve help` now prints: 

```
Serve TiddlyWiki5 over HTTP

Optional parameters
 - %1 .. editions directory .. full path or relative to current directory
 - %2 .. username for signing edits - can be empty like this: '""'
 - %3 .. password - can be empty like this: '""'
 - %4 .. IP address or HOST name .. defaults to localhost
 - %5 .. PORT .. defaults to 8080

Example 1 .\serve .\edition\tw5.com-server username
Example 2 .\serve .\edition\tw5.com-server '""' '""' localhost 9090
.. Example 2 defines: empty username, empty password
```

So now I can say: `serve .\editions\de-AT-DE-server pmario` and it will start a dev server for the german editon.

If you just type `server` it will start your setting, so there are no changes for your workflow, but everyone else can use the script now, without the need to modify it. 

---

I'd like to change the `serve.sh` file in a similar way but there will be a bit more `bash magic` to make it happen. 
