### PR TITLE
added preferred-editor fields to tiddler to allow per tiddler choice of ...

### DIFF
--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -67,7 +67,11 @@ EditWidget.prototype.getEditorType = function() {
 	if(this.editField === "text") {
 		var tiddler = this.wiki.getTiddler(this.editTitle);
 		if(tiddler) {
-			type = tiddler.fields.type;
+			if (tiddler.fields["preferred-editor"]) {
+				return tiddler.fields["preferred-editor"];
+			} else {
+				type = tiddler.fields.type;
+			}
 		}
 	}
 	type = type || "text/vnd.tiddlywiki";


### PR DESCRIPTION
...editor

I've put a demo here 
http://preferrededitor.tiddlyspot.com/

The result doesn't give a great user experience - when you type the name of the editor into the 'preferred-editor' field the first char get saved immediately causing the edit template to change the editor (which give an unknow editor message).
Maybe we can provide a drop down list next to the type list (when there is a preferred-editor field) giving the available editors to choose from?
