### PR TITLE
New serve sh with some help texts

### DIFF
--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -35,10 +35,10 @@ help() {
 	echo Optional parameters
 	echo
 	echo $'\t'\$1 .. editions directory .. full path or relative to current directory
-	echo $'\t'\$2 .. username for signing edits - can be empty like this: ""
-	echo $'\t'\$3 .. password - can be empty like this: ""
-	echo $'\t'\$4 .. IP address or HOST name .. defaults to "localhost"
-	echo $'\t'\$5 .. PORT .. defaults to 8080
+	echo $'\t'\$2 .. username for signing edits - can be empty like this: \"\"
+	echo $'\t'\$3 .. password - can be empty like this: \"\"
+	echo $'\t'\$4 .. IP address or HOST name .. defaults to: localhost
+	echo $'\t'\$5 .. PORT .. defaults to: 8080
 	echo
 	echo $'\t'-v .. Version
 	echo $'\t'-h .. Help


### PR DESCRIPTION
`serve.sh -h` shows the following text

```
serve.sh, TiddlyWiki serve script version 0.0.1

Usage:  serve.sh [edition dir] [username] [password] [host] [port]

Optional parameters

        $1 .. editions directory .. full path or relative to current directory
        $2 .. username for signing edits - can be empty like this:
        $3 .. password - can be empty like this:
        $4 .. IP address or HOST name .. defaults to localhost
        $5 .. PORT .. defaults to 8080

        -v .. Version
        -h .. Help

Example 1 ./serve ./edition/tw5.com-server username
Example 2 ./serve ./edition/tw5.com-server "" "" localhost 9090
.. Example 2 defines: empty username, empty password

```

---

There is some room for improvements, because it doesn't work well if the script is used in a VM or docker. 
All parameters should be environment variables. ... but that's a later pull request. 
