### PR TITLE
Update GettingStarted.tid

### DIFF
--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
@@ -18,4 +18,5 @@ See also:
 * [[Encryption]] explains how to use TiddlyWiki's built-in encryption to protect your content with a password
 * [[Saving on TiddlySpot]], a free service that lets you use TiddlyWiki online
 * Saving on TiddlyDesktop, a custom desktop application for working with TiddlyWiki
-* You can also download this full TiddlyWiki including all the documentation: <a href="http://tiddlywiki.com/index.html" download="index.html">~http://tiddlywiki.com/index.html</a>
+* You can also download this full TiddlyWiki including all the documentation by clicking this button:
+{{$:/snippets/download-wiki-button}}


### PR DESCRIPTION
1) Clicking the link for the full version does not work as expected. You have to right click the link and 'Save link as ...'
2) A green button makes it more visible how to download the full version (In 5.0.18-beta the Download tiddler with 2 buttons for both versions disappeared).
