### PR TITLE
No "Internals" tab in control panel

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/ModuleType.tid
+++ b/editions/tw5.com/tiddlers/concepts/ModuleType.tid
@@ -6,4 +6,6 @@ type: text/vnd.tiddlywiki
 
 The `module-type` field of a [[JavaScript module|Modules]] is a string that identifies the type of the module.
 
-See the ''Internals'' tab of the [[control panel|$:/ControlPanel]] for a list of the module types used in this wiki.
+The module types used in this wiki are listed below.
+
+<<list-links "[moduletypes[]]">>


### PR DESCRIPTION
ModuleType.tid refers to a non-existing "Internals" tab in the control panel for a list of module types used in this wiki.  I propose listing these directly in this tiddler as an alternative.
