### PR TITLE
Update TiddlyWiki 5 vis.js plug-in.tid

### DIFF
--- a/editions/tw5.com/tiddlers/community/resources/TiddlyWiki 5 vis.js plug-in.tid
+++ b/editions/tw5.com/tiddlers/community/resources/TiddlyWiki 5 vis.js plug-in.tid
@@ -16,3 +16,4 @@ This plug-in has been testing on OS X with Safari, Chrome and Firefox, but shoul
 
 Also, the plug-in has been designed to work off-line, enabling it to be used without a wireless connection on an iPad/iPhone using TWEdit
 <<<
+


### PR DESCRIPTION
I think you have to delete this tiddler.
Although it was (or maybe is?) a nice plugin, it does not work anymore.
As far as I know it did not work anymore after TW5.0.10-beta. My timeline TW (today upgraded to 5.0.18-beta) with this plugin gives a Javascript error with 'TypeError: vis is undefined'. After clicking 'close' of this error, you cannot do anything: buttons and tabs do not react (only save works!).
emkay did not react in the group. His latest activity at https://github.com/emkayonline/tw5visjs is from 6 month ago.
