### PR TITLE
Fix german typos

### DIFF
--- a/editions/de-AT/tiddlers/howto/TiddlyWiki und TiddlyDesktop.tid
+++ b/editions/de-AT/tiddlers/howto/TiddlyWiki und TiddlyDesktop.tid
@@ -9,7 +9,7 @@ TiddlyDesktop ist eine Programm für Windows, Mac OS X und Linux, mit der sie Ti
 
 # Installieren sie die aktuelle ~TiddlyDesktop Version von: from https://github.com/Jermolene/TiddlyDesktop/releases
 # Starten sie TiddlyDesktop
-# Verwenden sie den "browse button" um TiddlyWiki Datein zu öffnen.
+# Verwenden sie den "browse button" um TiddlyWiki Dateien zu öffnen.
 # Speicher der Änderungen funktioniert wie gewohnt. 
 
 -----

--- a/languages/de-DE/Buttons.multids
+++ b/languages/de-DE/Buttons.multids
@@ -25,7 +25,7 @@ Encryption/ClearPassword/Hint: Lösche das Passwort und speichere ohne Verschlü
 Encryption/SetPassword/Caption: aktiviere Passwort
 Encryption/SetPassword/Hint: Definiert ein Passwort, um dieses Wiki zu verschlüsseln
 FullScreen/Caption: Vollbild
-FullScreen/Hint: Aktivieren oder deaktivieren des Vollbild modus
+FullScreen/Hint: Aktivieren oder deaktivieren des Vollbild-modus
 Import/Caption: Import
 Import/Hint: Importiere Dateien
 Info/Caption: info
@@ -39,9 +39,9 @@ NewTiddler/Hint: Erstelle einen neuen Tiddler
 More/Caption: mehr
 More/Hint: Weitere Aktionen
 Permalink/Caption: permalink
-Permalink/Hint: Die Browser Addressleiste enthält einen Link zu diesem Tiddler
+Permalink/Hint: Die Browser Adressleiste enthält einen Link zu diesem Tiddler
 Permaview/Caption: permaview
-Permaview/Hint: Die Browser Addressleiste enthält einen Link zu allen offenen Tiddlern in dieser "Story"
+Permaview/Hint: Die Browser Adressleiste enthält einen Link zu allen offenen Tiddlern in dieser "Story"
 Refresh/Caption: aktualisieren
 Refresh/Hint: Die Seite wird neu in den Browser geladen
 Save/Caption: speichern
@@ -53,7 +53,7 @@ StoryView/Hint: Auswahl des Anzeige Modus für die "Story"
 HideSideBar/Caption: Sidebar ausblenden
 HideSideBar/Hint: Sidebar ausblenden
 ShowSideBar/Caption: Sidebar einblenden
-ShowSideBar/Hint: Sidebar eiblenden
+ShowSideBar/Hint: Sidebar einblenden
 TagManager/Caption: Tag Manager
 TagManager/Hint: Öffne den "Tag Manager"
 Theme/Caption: Thema

--- a/languages/de-DE/ControlPanel.multids
+++ b/languages/de-DE/ControlPanel.multids
@@ -26,7 +26,7 @@ EditorTypes/Type/Caption: MIME-Type
 Info/Caption: Info
 Info/Hint: Informationen über dieses TiddlyWiki
 LoadedModules/Caption: Geladene Module
-LoadedModules/Hint: Hier weden die geladenen Module und ihre Quelltext Komponenten angezeigt. Mit "italic" hervorgehobene Tiddler wurden während des Boot-Prozesses erstellt. Diese Tiddler haben keinen Quelltext.
+LoadedModules/Hint: Hier werden die geladenen Module und ihre Quelltext Komponenten angezeigt. Mit "italic" hervorgehobene Tiddler wurden während des Boot-Prozesses erstellt. Diese Tiddler haben keinen Quelltext.
 Palette/Caption: Palette
 Palette/Editor/Clone/Caption: Palette klonen
 Palette/Editor/Clone/Prompt: Es wird empfohlen, dass sie diese Schatten-Palette klonen, bevor sie sie bearbeiten. Der Name der Palette wird im Tiddler Feld "description" eingestellt.
@@ -82,7 +82,7 @@ StoryView/Prompt: Ausgewählte Anzeige:
 Theme/Caption: Thema
 Theme/Prompt: Ausgewähltes Thema:
 TiddlerFields/Caption: Tiddler Felder
-TiddlerFields/Hint: Hier finden sie alle [[Felder|TiddlerFields]], die in diesem Wiki verwendet werden. Inklusive der Felder aus System-, exclusive Schatten-Tiddler. 
+TiddlerFields/Hint: Hier finden sie alle [[Felder|TiddlerFields]], die in diesem Wiki verwendet werden. Inklusive der Felder aus System-, exklusive Schatten-Tiddler. 
 Toolbars/Caption: Toolbar
 Toolbars/EditToolbar/Caption: Edit Toolbar
 Toolbars/EditToolbar/Hint: Auswählen, welche Buttons im "Edit Modus" angezeigt werden:
@@ -93,5 +93,5 @@ Toolbars/ViewToolbar/Caption: View Toolbar
 Toolbars/ViewToolbar/Hint: Auswählen, welche Buttons im "View Modus" angezeigt werden:
 Tools/Caption: Tools
 Tools/Download/Full/Caption: Herunterladen des ''gesamten Wikis''
-Tools/Export/AllAsStaticHTML/Caption: Alle Tiddler als "statische HTML" Datein speichern. 
+Tools/Export/AllAsStaticHTML/Caption: Alle Tiddler als "statische HTML" Dateien speichern. 
 Tools/Export/Heading: Export

--- a/languages/de-DE/Docs/PaletteColours.multids
+++ b/languages/de-DE/Docs/PaletteColours.multids
@@ -54,14 +54,14 @@ sidebar-tab-background: Seitenleiste Reiter Hintergrund
 sidebar-tab-border-selected: Seitenleiste Reiter Rahmen für selektierte Reiter
 sidebar-tab-border: Seitenleiste Reiter Rahmen
 sidebar-tab-divider: Seitenleiste Reiter Trennzeichen
-sidebar-tab-foreground-selected: Seitenleiste Reier Vordergrund für selectierte Reiter
+sidebar-tab-foreground-selected: Seitenleiste Reiter Vordergrund für selectierte Reiter
 sidebar-tab-foreground: Seitenleiste Reiter Vordergrund
 sidebar-tiddler-link-foreground-hover: Seitenleiste Tiddler Link Vordergrund (hover)
 sidebar-tiddler-link-foreground: Seitenleiste Tiddler Link Vordergrund
 static-alert-foreground: Statische Warnung Vordergrund
-tab-background-selected: Reier Hintergrund für selektierte Reiter
+tab-background-selected: Reiter Hintergrund für selektierte Reiter
 tab-background: Reiter Hintergrund
-tab-border-selected: Reiter Rahmen für selectierte Reiter
+tab-border-selected: Reiter Rahmen für selektierte Reiter
 tab-border: Reiter Rahmen
 tab-divider: Reiter Trennzeichen
 tab-foreground-selected: Reiter Vordergrund für selektierte Reiter
@@ -79,11 +79,11 @@ tiddler-controls-foreground: Tiddler Bedienelement Vordergrund
 tiddler-editor-background: Tiddler Editor Hintergrund
 tiddler-editor-border-image: Tiddler Editor Rahmen Bild
 tiddler-editor-border: Tiddler Editor Rahmen
-tiddler-editor-fields-even: Tiddler Editor Hintergrund geradzahlinge Felder in Tabelle
-tiddler-editor-fields-odd: Tiddler Editor Hintergrund un-geradzahlinge Felder in Tabelle
+tiddler-editor-fields-even: Tiddler Editor Hintergrund geradzahlige Felder in Tabelle
+tiddler-editor-fields-odd: Tiddler Editor Hintergrund un-geradzahlige Felder in Tabelle
 tiddler-info-background: Tiddler Info Bereich Hintergrund
 tiddler-info-border: Tiddler Info Bereich Rahmen
-tiddler-info-tab-background: Tiddler Info Breich Reiter Hintergrund
+tiddler-info-tab-background: Tiddler Info Bereich Reiter Hintergrund
 tiddler-link-background: Tiddler Link Hintergrund
 tiddler-link-foreground: Tiddler Link Vordergrund
 tiddler-subtitle-foreground: Tiddler Untertitel Vordergrund

--- a/languages/de-DE/EditTemplate.multids
+++ b/languages/de-DE/EditTemplate.multids
@@ -9,8 +9,8 @@ Fields/Add/Button: ok
 Fields/Add/Name/Placeholder: Feld Name
 Fields/Add/Prompt: Feld einfügen:
 Fields/Add/Value/Placeholder: Feld Text / Wert
-Shadow/Warning: Dies ist ein Schatten-Tiddler. Jede Änderung überschreibt die "standard" Version.
-Shadow/OverriddenWarning: Dies ist ein veränderter Tiddler. Um zur "standard" Version zurück zu kehren, löschen sie diesen Tiddler.
+Shadow/Warning: Dies ist ein Schatten-Tiddler. Jede Änderung überschreibt die Standardversion.
+Shadow/OverriddenWarning: Dies ist ein veränderter Tiddler. Um zur Standardversion zurück zu kehren, löschen sie diesen Tiddler.
 Tags/Add/Button: ok
 Tags/Add/Placeholder: neuer Tag
 Type/Placeholder: Tiddler Format

--- a/languages/de-DE/Fields.multids
+++ b/languages/de-DE/Fields.multids
@@ -11,7 +11,7 @@ creator: Name des Erstellers dieses Tiddlers.
 dependents: Listet die Abhängigkeiten bei "plugins" auf.
 description: Die Beschreibung für ein "plugin" oder einen "modalen" Dialog.
 draft.of: Entwurf von - enthält den Titel des Tiddlers, zu dem dieser Entwurf-Tiddler gehört.
-draft.title: Entwurd Titel - enthält den neuen Titel, wenn der Entwurf-Tiddler gespeichert wird. 
+draft.title: Entwurf Titel - enthält den neuen Titel, wenn der Entwurf-Tiddler gespeichert wird. 
 footer: Der Fußnoten Text bei einem "~Wizard-Dialog"
 hack-to-give-us-something-to-compare-against: Ein temporäres Feld, verwendet in [[$:/core/templates/static.content]]
 icon: Der Titel eines ~Icon-Tiddlers, der mit diesem Tiddler verbunden ist.
@@ -32,4 +32,4 @@ tags: Eine Liste von "Tags" für diesen Tiddler.
 text: Der Haupttext eines Tiddlers.
 title: Ein individueller einmaliger Name eines Tiddlers.
 type: Legt den Typ eines Tiddlers fest (aka MIME-type).
-version: Versions Information eines "plugins".
+version: Versions-Information eines "plugins".

--- a/languages/de-DE/Help/makelibrary.tid
+++ b/languages/de-DE/Help/makelibrary.tid
@@ -3,7 +3,7 @@ description: Erstellt die "Upgrade Bibliothek", die vom upgrade Prozess benötig
 
 Erstellt den tiddler: `$:/UpgradeLibrary`, der vom upgrade Prozess benötigt wird.
 
-Die "Upgrade Bibliothek" ist ein "normales" Plugin, vom Typ: `library`. Es enthält eine Kopie jedes Plugins, Themas und Sprachpacketes, das im TiddlyWiki5 Archiv enthalten ist.
+Die "Upgrade Bibliothek" ist ein "normales" Plugin, vom Typ: `library`. Es enthält eine Kopie jedes Plugins, Themas und Sprachpacketes, das im TiddlyWiki Archiv enthalten ist.
 
 Dieser Befehl ist ein "interner" Befehl! Er ist nur relevant für Benutzer, die einen spezifischen "Upgrade Prezess" erstellen müssen. zB: Umwandeln von einem Tiddler in mehrere Tiddler, um Inkompatibilitäten zu vermeiden.
 

--- a/languages/de-DE/Help/output.tid
+++ b/languages/de-DE/Help/output.tid
@@ -7,4 +7,4 @@ Setzt das Basis Ausgabeverzeichnis für die folgenden Befehle. Das Standard Verz
 --output <pathname>
 ```
 
-Ist das spezifizierte Verzeichnis "relative", dann wird es relativ zum bestehenden Arbeitsverzeichnis angelegt. 
+Ist das spezifizierte Verzeichnis "relativ", dann wird es relativ zum bestehenden Arbeitsverzeichnis angelegt. 

--- a/languages/de-DE/Help/rendertiddlers.tid
+++ b/languages/de-DE/Help/rendertiddlers.tid
@@ -1,7 +1,7 @@
 title: $:/language/Help/rendertiddlers
 description: Gefilterte Ausgabe von Tiddlern, in einem spezifizierten Format.
 
-Gefilterte Ausgabe mehrerer Tiddler, in ein angegebenes Dateiformat (standard: `text/html`) mit spezifischer Erweiterung (standard: `.html`).
+Gefilterte Ausgabe mehrerer Tiddler, in ein angegebenes Dateiformat (standard: `text/html`) mit spezifischer Erweiterung (Standard: `.html`).
 
 ```
 --rendertiddlers <filter> <template> <pathname> [<type>] [<extension>]

--- a/languages/de-DE/Help/server.tid
+++ b/languages/de-DE/Help/server.tid
@@ -1,9 +1,9 @@
 title: $:/language/Help/server
 description: Stellt einen HTTP server für TiddlyWiki zur Verfügung.
 
-TiddlyWiki bringt einen sehr einfachen Web-Server mit. Dieser ist zwar kompatibel mit dem TiddlyWeb Protokoll, ist jeoch nicht ausgereift genug, um im produktiven Einsatz im Netz eingesetzt zu werden. 
+TiddlyWiki bringt einen sehr einfachen Web-Server mit. Dieser ist zwar kompatibel mit dem TiddlyWeb Protokoll, ist jedoch nicht ausgereift genug, um im produktiven Einsatz im Netz eingesetzt zu werden. 
 
-Der Server kann spezifische Tiddler im angegebnen Format anzeigen (rendern). Zudem können einzelne, oder mehrere Tiddler im JSON Format übertragen werden. Die unterstützten HTTP Funktionen sind: `GET`, `PUT` und `DELETE`
+Der Server kann spezifische Tiddler im angegebenen Format anzeigen (rendern). Zudem können einzelne, oder mehrere Tiddler im JSON Format übertragen werden. Die unterstützten HTTP Funktionen sind: `GET`, `PUT` und `DELETE`
 
 ```
 --server <port> <roottiddler> <rendertype> <servetype> <username> <password> <host>
@@ -11,15 +11,15 @@ Der Server kann spezifische Tiddler im angegebnen Format anzeigen (rendern). Zud
 
 Die Parameter sind: 
 
-* ''port'' - Port Nummer mit der kommuniziert werden soll (standard: "8080").
-* ''roottiddler'' - Der Tiddler, der als ~Basis-Tiddler verwendet werden soll ( standard: "$:/core/save/all").
-* ''rendertype'' -  MIME-Type, zu dem der ~Basis-Tiddler "gerendert" werden soll ( standard: "text/plain").
-* ''servetype'' - MIME-Type, mit dem der Basis-Tiddler ausgeliefert werden soll ( standard: "text/html").
-* ''username'' - Benutzer Name, mit dem verändete Tiddler signiert werden.
+* ''port'' - Port Nummer mit der kommuniziert werden soll (Standard: "8080").
+* ''roottiddler'' - Der Tiddler, der als ~Basis-Tiddler verwendet werden soll ( Standard: "$:/core/save/all").
+* ''rendertype'' -  MIME-Type, zu dem der ~Basis-Tiddler "gerendert" werden soll ( Standard: "text/plain").
+* ''servetype'' - MIME-Type, mit dem der Basis-Tiddler ausgeliefert werden soll ( Standard: "text/html").
+* ''username'' - Benutzer Name, mit dem veränderte Tiddler signiert werden.
 * ''password'' - Passwort mit dem eine sehr "simple" Zugangsbeschränkung aufgebaut werden kann.
-* ''host'' - ~Host-Name von dem ausgeliefert werden soll. Host ist optional ( standard: "127.0.0.1" oder auch "localhost").
+* ''host'' - ~Host-Name von dem ausgeliefert werden soll. Host ist optional ( Standard: "127.0.0.1" oder auch "localhost").
 
-Wenn bem Server start ein Passwort angegeben wird, dann wird der Benutzer aufgefordert den Benutzernamen und das Passwort einzugeben, bevor ein Wiki angezeigt wird. ACHTUNG: Das Passwort wird im Klartext übertragen. Diese Vorgehensweise ist nicht für den Einsatz im Netz geeignet.
+Wenn beim Serverstart ein Passwort angegeben wird, dann wird der Benutzer aufgefordert den Benutzernamen und das Passwort einzugeben, bevor ein Wiki angezeigt wird. ACHTUNG: Das Passwort wird im Klartext übertragen. Diese Vorgehensweise ist nicht für den Einsatz im Netz geeignet.
 
 Beispiel:
 

--- a/languages/de-DE/Modals/Download.tid
+++ b/languages/de-DE/Modals/Download.tid
@@ -10,4 +10,4 @@ Um das geänderte Wiki zu speichern, machen sie einen "rechts klick" auf den fol
 
 //Sie können den Vorgang etwas beschleunigen, indem sie die "Control-Taste" (Windows) oder die "Options/Alt-Taste" (Max OS X) drücken. Es wird kein "Speichern Dialog" erscheinen. Jedoch wird bei einigen Browsern die Datei einen zufälligen Namen bekommen. Sie müssen die Datei eventuell umbenennen, um sie öffnen zu können.//
 
-Bei "smartphones", die das Speichern von Dateien nicht erlauben, können sie ein Lesezeichen erstellen, dass mit ihrem PC synchronisiert wird. Dort können sie die Datein dann wie gewohnt speichern. 
+Bei "Smartphones", die das Speichern von Dateien nicht erlauben, können sie ein Lesezeichen erstellen, dass mit ihrem PC synchronisiert wird. Dort können sie die Dateien dann wie gewohnt speichern. 

--- a/languages/de-DE/Modals/SaveInstructions.tid
+++ b/languages/de-DE/Modals/SaveInstructions.tid
@@ -12,12 +12,12 @@ Ihre Änderungen sollen als ~TiddlyWiki HTML Datei gespeichert werden.
 # Wählen sie den Dateinamen und das Verzeichnis. 
 
 #* Bei einigen Browsern müssen sie das Format explizit angeben. Zb: ''Webseite, nur HTML'' oder ähnliches.
-# Den Browser-tab schließen.
+# Den Browser-Tab schließen.
 
 !!! Smartphone Browser
 
 # Erstellen sie ein "Lesezeichen"
 #* Wenn sie "iCloud" oder "Google Sync" verwenden, dann werden ihre Daten automatisch mit dem Desktop PC synchronisiert. Dort können sie wie oben beschrieben fortfahren. 
-# Den Browser-tab schließen.
+# Den Browser-Tab schließen.
 
 //Wenn sie das Lesezeichen mit "Mobile Safari" öffnen, dann wird diese Meldung erneut angezeigt. Klicken sie ''Schließen'' um fort zu fahren.//

--- a/languages/de-DE/TiddlerInfo.multids
+++ b/languages/de-DE/TiddlerInfo.multids
@@ -13,9 +13,9 @@ Fields/Caption: Felder
 List/Caption: Liste
 List/Empty: Dieser Tiddler hat kein "list" Feld.
 Listed/Caption: Gelisted
-Listed/Empty: Dieser Tiddler wird nicht von anderen Tiddlern gelisted.
+Listed/Empty: Dieser Tiddler wird nicht von anderen Tiddlern gelistet.
 References/Caption: Referenzen
 References/Empty: Kein Tiddler linkt zu Diesem.
 Tagging/Caption: Tagging
-Tagging/Empty: Kein Tiddler ist mit diesem "getagged".
+Tagging/Empty: Kein Tiddler ist mit diesem "getaggt".
 Tools/Caption: Tools


### PR DESCRIPTION
So this is just a fix for de-AT / de-DE/   index.html and empty.html
The typos don't influence the functionality, but they are "ugly" ... I got the mail, that pointed to them yesterday at 22:50. Which is 21:50 your time :) ... first commit.

---

I found some more :) second commit.

---

How fast can we update tiddlywiki.com ... will we need something like a "sub version number" for these fixes?
