### PR TITLE
Minor: fix plugin name ThirdFlow

### DIFF
--- a/editions/tw5.com/tiddlers/community/resources/Plugins by TheDiveO.tid
+++ b/editions/tw5.com/tiddlers/community/resources/Plugins by TheDiveO.tid
@@ -7,7 +7,7 @@ url: http://thediveo.github.io
 
 A collection of plugins from TheDiveO.
 
-[[TheDiveO's Third Way|http://thediveo.github.io/ThirdFlow/]] plugin construction system:
+[[TheDiveO's Third Flow|http://thediveo.github.io/ThirdFlow/]] plugin construction system:
 
 <<<
 The ~ThirdFlow plugin brings to you another way to develop customization plugins for TiddlyWiki 5. It is not enforcing a specific development flow, it simply tries to help you. Otherwise, it tries to stay out of your way.


### PR DESCRIPTION
Just a minor textual fix: even if the icon may be slightly misleading it's not the Third Wave and instead the Third _Flow_. ;)
