### PR TITLE
avoid runtime errors in presence of broken plugin tiddlers

### DIFF
--- a/core/modules/filters/plugintiddlers.js
+++ b/core/modules/filters/plugintiddlers.js
@@ -19,7 +19,7 @@ exports.plugintiddlers = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
 		var pluginInfo = options.wiki.getPluginInfo(title) || options.wiki.getTiddlerData(title,{tiddlers:[]});
-		if(pluginInfo) {
+		if(pluginInfo && pluginInfo.tiddlers) {
 			$tw.utils.each(pluginInfo.tiddlers,function(fields,title) {
 				results.push(title);
 			});

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -570,7 +570,7 @@ exports.sortByList = function(array,listTitle) {
 
 exports.getSubTiddler = function(title,subTiddlerTitle) {
 	var bundleInfo = this.getPluginInfo(title) || this.getTiddlerData(title);
-	if(bundleInfo) {
+	if(bundleInfo && bundleInfo.tiddlers) {
 		var subTiddler = bundleInfo.tiddlers[subTiddlerTitle];
 		if(subTiddler) {
 			return new $tw.Tiddler(subTiddler);


### PR DESCRIPTION
This patch set increases robustness of the TW5 core in the presence of broken plugin tiddlers. Broken plugins in this context are especially those that lack the tiddlers field in their JSON text body. This patch avoids runtime errors otherwise caused by broken plugins when trying to access subtiddlers inside a (broken) tiddler and when using the plugintiddlers filter operator on a broken plugin.
