### PR TITLE
Tweak of the list-links macro in order to display caption fields if present

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -6,7 +6,9 @@ tags: $:/tags/Macro
 <$list filter="$filter$">
 <$subtype$>
 <$link to={{!!title}}>
+<$transclude field="caption">
 <$view field="title"/>
+</$transclude>
 </$link>
 </$subtype$>
 </$list>

--- a/editions/tw5.com/tiddlers/community/Examples.tid
+++ b/editions/tw5.com/tiddlers/community/Examples.tid
@@ -2,6 +2,7 @@ created: 20140320230543190
 modified: 20140916121854696
 tags: HelloThere Community
 title: Examples
+caption: Examples of ~TiddlyWiki being used in the wild
 type: text/vnd.tiddlywiki
 
 This collection showcases inspiring and interesting examples of TiddlyWiki being used in the wild.

--- a/editions/tw5.com/tiddlers/macros/ListMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/ListMacro.tid
@@ -7,7 +7,7 @@ The list macro is a family of macros that produce a list of tiddlers.
 
 There are several variants of the macro:
 
-* `<<list-links>>` produces a list of links to tiddlers that match a filter expression
+* `<<list-links>>` produces a list of links to tiddlers that match a filter expression. If the tiddler has a //caption// field, it is displayed in lieu of the //title// field.
 
 ! Parameters
 


### PR DESCRIPTION
Hope this isn't too bold. You might prefer to add a "display-field" parameter, or add a list-links-caption variant?

Regards,
--X.
