### PR TITLE
tc-untagged-label doesn't work, because button.tc-tag-label is more specific 

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -339,7 +339,7 @@ button.tc-tag-label, span.tc-tag-label {
 	background: <<colour tab-divider>>;
 }
 
-.tc-untagged-label {
+button.tc-untagged-label {
 	background-color: <<colour untagged-background>>;
 }
 


### PR DESCRIPTION
`tc-untagged-label` doesn't work, because `button.tc-tag-label` is more specific and also defines the background-color.
