### PR TITLE
fixes #282 the long standing jumpy toolbar.

### DIFF
--- a/themes/tiddlywiki/stickytitles/styles.tid
+++ b/themes/tiddlywiki/stickytitles/styles.tid
@@ -11,4 +11,5 @@ tags: [[$:/tags/Stylesheet]]
   position: sticky;
   top: 0px;
   background: #fff;
+  overflow: hidden;
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -602,6 +602,13 @@ button.tc-tag-label, span.tc-tag-label {
 	margin: 0;
 }
 
+/* fix jumpy titlebar */
+.tc-tiddler-title,
+.tc-titlebar {
+	overflow: hidden;
+}
+
+
 .tc-system-title-prefix {
 	color: <<colour muted-foreground>>;
 }


### PR DESCRIPTION
fixes #282 the long standing jumpy toolbar. thx a lot to @andrey013 and the folks from mozilla.

There is a short video for Jeremy:  http://youtu.be/pxKSxKoMeRY that shows the problem. 
The file tw contains the patch already. I hope there are no side effects.

There should be a second issue somewhere, that should be fixed now. I'll have to investigate. .. 
