### PR TITLE
Update GettingStarted.tid

### DIFF
--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
@@ -13,6 +13,10 @@ Instructions for getting started using TiddlyWiki on the different platforms and
 <$macrocall $name="tabs" state="$:/state/tabs/platform" tabsList="[prefix[GettingStarted - ]]" default=<<default-platform>> class="tc-vertical"/>
 </$set>
 
+Known Issues:
+
+* The Firefox add-on Linkification 1.3.8, http://yellow5.us/firefox/linkification/, interferes with proper TiddlyWiki operation.
+
 See also:
 
 * [[Encryption]] explains how to use TiddlyWiki's built-in encryption to protect your content with a password


### PR DESCRIPTION
The Firefox add-on Linkification 1.3.8, http://yellow5.us/firefox/linkification/, interferes with proper TiddlyWiki operation.

To reproduce the issue, install the Linkification plugin, then refresh the http://tiddlywiki.com page which will hang scripting operations until a timeout occurs which pops up a dialog box.
