### PR TITLE
Warning for non-existing tiddlywiki.info under node.js

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1559,6 +1559,7 @@ $tw.loadWikiTiddlers = function(wikiPath,parentPaths) {
 	if(fs.existsSync(wikiInfoPath)) {
 		wikiInfo = JSON.parse(fs.readFileSync(wikiInfoPath,"utf8"));
 	} else {
+		console.log("Warning: " + $tw.config.wikiInfo + " NOT exist in below location!!\n"	+ wikiInfoPath + "\n" );
 		return null;
 	}
 	// Load any parent wikis


### PR DESCRIPTION
not sure the proper error raising, but adding a warning would be better
than nothing.

in response to #864
Raise error if wiki folder not found under node.js
