### PR TITLE
add some info tiddlers, that can be used by list and reveal widget

### DIFF
--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -4,6 +4,7 @@
 		"tiddlywiki/googleanalytics",
 		"tiddlywiki/nodewebkitsaver",
 		"tiddlywiki/github-fork-ribbon",
+		"tiddlywiki/document-location",
 		"tiddlywiki/browser-sniff"
 	],
 	"themes": [

--- a/plugins/tiddlywiki/document-location/advanced.tid
+++ b/plugins/tiddlywiki/document-location/advanced.tid
@@ -1,0 +1,60 @@
+title: $:/plugins/tiddlywiki/document-location/advanced
+
+\define infoTid()
+info-$(currentTiddler)$
+\end
+
+!! Be Careful!
+
+The path of a TiddlyWiki is very likely to change. So be sure, that you use elements, where you know, that they never change. Otherwise your code may break!
+
+!! Extended Info Tiddlers
+
+Depending on the content of the [[$:/info/doc/location/filepath]] tiddler, several tiddlers with the content "yes" will be created. These tiddlers can be used by the reveal widget. eg:
+
+* If the filepath is: `languages/de-DE/` there will be the following shadow tiddlers: 
+** `$:/info/doc/location/filepath/is/languages` and
+** `$:/info/doc/location/filepath/is/de-DE`
+
+Both tiddlers contain the text "yes", so the reveal widget can compare this value with "match" or "nomatch". The extended shadow tiddlers are dynamic. Depending on where the TiddlyWiki file is saved. So ''never ever'' modify those tiddlers!
+
+This Tiddlywiki has the following extended info tiddlers:
+
+<<list-links "[all[shadows]tag[$:/tags/filepath/]]">>
+
+!! Extended Tags
+The tiddler [[$:/info/doc/location/filepath]] will be tagged with the path elements. These tags can be used as filter inputs for the list- or the reveal-widget.
+
+* So if the filepath is eg: `languages/de-DE/` the tiddler will have the following tags: 
+** `$:/tags/filepath/languages` and
+** `$:/tags/filepath/de-DE`
+
+!! How to use the $:/tags/filepath tags
+
+Copy this code into a tiddler and play with it. The transclude widget will do nothing, until you create the "info-xxx" tiddlers.
+Important: At the moment you need to remove the additional empty lines if you copy paste the code :/
+For the widget documentation visit: http://tiddlywiki.com#Widgets
+
+```
+\define infoTid()
+info-$(currentTiddler)$
+\end
+
+<ul>
+<$list filter="[[$:/info/doc/location/filepath]tags[]]">
+<li><$link to=<<infoTid>> ><<infoTid>></$link></li>
+<$reveal type="nomatch" state=<<currentTiddler>> >
+<$transclude tiddler=<<infoTid>> mode="block" />
+</$reveal>
+</$list>
+</ul>
+```
+
+<ul>
+<$list filter="[[$:/info/doc/location/filepath]tags[]]">
+<li><$link to=<<infoTid>> ><<infoTid>></$link></li>
+<$reveal type="nomatch" state=<<currentTiddler>> >
+<$transclude tiddler=<<infoTid>> mode="block" />
+</$reveal>
+</$list>
+</ul>

--- a/plugins/tiddlywiki/document-location/filename-detection.tid
+++ b/plugins/tiddlywiki/document-location/filename-detection.tid
@@ -1,0 +1,43 @@
+title: $:/plugins/tiddlywiki/document-location/filename
+
+!! Filename detection
+
+The filename detection mechanism can handle the following `document.location.pathname` paterns:
+
+* `/D:/git/tiddly/tiddlywiki/jermolene.github.com/index.html`
+** filedomain: `D:/`
+** filepath: `git/tiddly/tiddlywiki/jermolene.github.com/`
+** filename: `index.html`
+----
+* `/D:/index.html`
+** filedomain: `D:/`
+** filepath: - empty -
+** filename: `index.html`
+----
+* `///b2d.lan/index.html`
+** filedomain: `b2d.lan/`
+** filepath: - empty -
+** filename: `index.html`
+----
+* `///b2d.lan/data/index.html`
+** filedomain: `b2d.lan/`
+** filepath: `data/`
+** filename: `index.html`
+----
+* `///10.0.0.6/data/index.html`
+** filedomain: `10.0.0.6/`
+** filepath: `data/`
+** filename: `index.html`
+----
+* `/`
+** filedomain: - empty -
+** filepath: - empty -
+** filename: - empty -
+----
+* `/index.html`
+** filedomain: - empty -
+** filepath: - empty -
+** filename: `index.html`
+----
+* `/test/index.html`
+* `/languages/de-DE/index.html`

--- a/plugins/tiddlywiki/document-location/global-macros.tid
+++ b/plugins/tiddlywiki/document-location/global-macros.tid
@@ -1,0 +1,50 @@
+title: $:/plugins/tiddlywiki/document-location/global-macros
+tags: $:/tags/Macro
+
+\define document-filedomain()
+{{$:/info/doc/location/filedomain}}
+\end
+
+\define document-filepath()
+{{$:/info/doc/location/filepath}}
+\end
+
+\define document-filename()
+{{$:/info/doc/location/filename}}
+\end
+
+\define document-hash()
+{{$:/info/doc/location/hash}}
+\end
+
+\define document-host()
+{{$:/info/doc/location/host}}
+\end
+
+\define document-hostname()
+{{$:/info/doc/location/hostname}}
+\end
+
+\define document-origin()
+{{$:/info/doc/location/origin}}
+\end
+
+\define document-port()
+{{$:/info/doc/location/port}}
+\end
+
+\define document-protocol()
+{{$:/info/doc/location/protocol}}
+\end
+
+\define document-search()
+{{$:/info/doc/location/search}}
+\end
+
+\define document-href()
+{{$:/info/doc/location/href}}
+\end
+
+\define document-pathname()
+{{$:/info/doc/location/pathname}}
+\end

--- a/plugins/tiddlywiki/document-location/info.js
+++ b/plugins/tiddlywiki/document-location/info.js
@@ -1,0 +1,82 @@
+/*\
+title: $:/plugins/tiddlywiki/document-location/info.js
+type: application/javascript
+module-type: info
+
+Initialise $:/info/doc/location tiddlers
+
+# Additional info for the path detection regexp:
+#
+# It's important, that the match[3] matches the filename without leading or trailing slashes.
+# trailing slashes for domain and path are ok.
+# match[1] .. filedomain
+# match[2] .. filepath
+# match[3] .. filename
+
+Tests:
+
+/D:/git/tiddly/tiddlywiki/jermolene.github.com/index.html
+/D:/index.html
+///b2d.lan/data/index.html
+///b2d.lan/index.html
+///10.0.0.6/data/index.html
+///10.0.0.6/index.html
+/
+/index.html
+/test/index.html
+/languages/de-DE/index.html
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.getInfoTiddlerFields = function() {
+	var match, 
+		filepath = "",
+		filedomain = "",
+		filename = "",
+		pathname, infoTiddlerFields = [], tags = [];
+	// Basics
+	if($tw.browser) {
+		infoTiddlerFields.push({title: "$:/info/doc/location/hash", text: document.location.hash});
+		infoTiddlerFields.push({title: "$:/info/doc/location/host", text: document.location.host});
+		infoTiddlerFields.push({title: "$:/info/doc/location/hostname", text: document.location.hostname});
+		infoTiddlerFields.push({title: "$:/info/doc/location/origin", text: document.location.origin});
+		infoTiddlerFields.push({title: "$:/info/doc/location/port", text: document.location.port});
+		infoTiddlerFields.push({title: "$:/info/doc/location/protocol", text: document.location.protocol});
+		infoTiddlerFields.push({title: "$:/info/doc/location/search", text: document.location.search});
+		infoTiddlerFields.push({title: "$:/info/doc/location/href", text: document.location.href});
+
+		pathname = document.location.pathname;
+		infoTiddlerFields.push({title: "$:/info/doc/location/pathname", text: pathname, tags: tags});
+
+		match = pathname.match(/^\/?\/?\/?([\-A-Z0-9.]+:?\/)?([\-A-Z0-9\/%._]*\/)?([\-A-Z0-9\/%._]*$)/i);
+		if (match !== null) {
+			filename = match[3] || "";
+			filepath = match[2] || "";
+			filedomain = match [1] || "";
+			
+			// fill the tags with elements. Exclude empty elements with map()
+			filepath.split("/").map( function(el){
+						if (el) {
+							// create a tag for tiddler: $:/info/doc/location/filepath
+							tags.push("$:/tags/filepath/" + el);
+							// create some tiddlers, that can be used with reveal
+							infoTiddlerFields.push({title: "$:/info/doc/location/filepath/is/" + el, text: "yes", tags: ["$:/tags/filepath/"]});
+						}
+					});
+		} else {
+			// Match attempt failed
+		}
+		infoTiddlerFields.push({title: "$:/info/doc/location/filedomain", text: filedomain});
+		infoTiddlerFields.push({title: "$:/info/doc/location/filepath", text: filepath, tags: tags});
+		infoTiddlerFields.push({title: "$:/info/doc/location/filename", text: filename});
+	}
+	console.log("fields: ", infoTiddlerFields);
+	return infoTiddlerFields;
+};
+
+})();

--- a/plugins/tiddlywiki/document-location/plugin.info
+++ b/plugins/tiddlywiki/document-location/plugin.info
@@ -1,0 +1,7 @@
+{
+	"title": "$:/plugins/tiddlywiki/document-location",
+	"description": "Document Information for TiddlyWiki",
+	"author": "MarioPietsch aka pmario",
+	"core-version": ">=5.0.0",
+	"list": "readme system filename advanced"
+}

--- a/plugins/tiddlywiki/document-location/readme.tid
+++ b/plugins/tiddlywiki/document-location/readme.tid
@@ -1,0 +1,23 @@
+title: $:/plugins/tiddlywiki/document-location/readme
+
+!! Global Macros
+
+[[The document-location plugin|$:/plugins/tiddlywiki/document-location]] defines several global macros, to simplify typing.
+
+''Important:'' For the background info, read the "plugin:system" tab! For advanced usage have a look at the "plugin:advanced" tab!
+
+There are "Actual values", that are empty. Values vary, if the TW is a "file" TW, if it is hosted from a server or if it is shared on a network drive.
+
+|Macro Name |Actual Value|h
+|`<<document-filedomain>>` |<<document-filedomain>> |
+|`<<document-filepath>>` |<<document-filepath>> |
+|`<<document-filename>>` |<<document-filename>> |
+|`<<document-hash>>` |<<document-hash>> |
+|`<<document-host>>` |<<document-host>> |
+|`<<document-hostname>>` |<<document-hostname>> |
+|`<<document-origin>>` |<<document-origin>> |
+|`<<document-port>>` |<<document-port>> |
+|`<<document-protocol>>` |<<document-protocol>> |
+|`<<document-search>>` |<<document-search>> |
+|`<<document-href>>` |<<document-href>> |
+|`<<document-pathname>>` |<<document-pathname>> |

--- a/plugins/tiddlywiki/document-location/system.tid
+++ b/plugins/tiddlywiki/document-location/system.tid
@@ -1,0 +1,26 @@
+title: $:/plugins/tiddlywiki/document-location/system
+
+This plugin adds a number of `$:/info/` tiddlers containing information about the current TiddlyWiki document.
+
+!! Information Tiddlers
+
+!!! Information derived from "document.location"
+
+|Title |Description |h
+|[[$:/info/doc/location/host]] |Name of the document host and port if different to 80. eg: `localhost:8080` |
+|[[$:/info/doc/location/hostname]] |Name of the document host, without the port. eg: `localhost` |
+|[[$:/info/doc/location/pathname]] |Full path name of the document. This may be slash `/`, if the server is configured to use a default file. So the real name is unknown. Most of the time index.html will fit. |
+|[[$:/info/doc/location/href]] |Full URL encoded path name of the document. This may contain elements like `%20` for spaces |
+|[[$:/info/doc/location/protocol]] |The protocol used to display. (`file: http: https: ..`) |
+|[[$:/info/doc/location/origin]] |Name of the document origin. eg: `http://tiddlywiki.com` Also contains the port if not default |
+|[[$:/info/doc/location/hash]] |Hash, if there is one. eg: `#GettingStarted:GettingStarted` |
+|[[$:/info/doc/location/search]] |Search string, if there is one. eg: `?something` ... not supported by TW atm |
+|[[$:/info/doc/location/port]] |HTTP port, where the document comes from. 80 will be an empty string |
+
+!!! Information derived from "document.location.pathname"
+
+|Title |Description |h
+|[[$:/info/doc/location/filename]] |Name of the document: eg: `index.html` |
+|[[$:/info/doc/location/filedomain]] |Name of the document domain. eg: `D:/` or `xyz.lan/` if mounted from a network drive |
+|[[$:/info/doc/location/filepath]] |Name of the document path. This may be empty. |
+


### PR DESCRIPTION
This plugin provides users with the possibilities, that otherwise just devs have.
With the plugin TiddlyWiki has the possibility to check information about "itself".

It implements several global macros. Those macros are just wrappers for the `$:/info/doc/location/xxxx` tiddlers. The global macros can be easily used by users to show info about the TW.

eg: 
- `<<document-filename>>` was requested in the group. Mainly for documentation reasons in a teaching context.
- `<<document-protocol>>` gives you the possibility to display different content if served from "file:  http:  https:" ...

The main info is done with `$:/info/doc/location/xxx` tiddlers. See documentation tiddlers in the plugin.

`$:/info/doc/location/filepath` is special, since depending on the path of the TW, it is extended to 

eg: If the filepath is: `languages/de-DE/` there will be the following shadow tiddlers:
- `$:/info/doc/location/filepath/is/languages` and
- `$:/info/doc/location/filepath/is/de-DE`

These tiddlers can be used with the reveal widget, to display special content, depending on the path. ... 
