### PR TITLE
Add a 'new journal here' button

### DIFF
--- a/core/language/en-GB/Buttons.multids
+++ b/core/language/en-GB/Buttons.multids
@@ -40,6 +40,8 @@ NewHere/Caption: new here
 NewHere/Hint: Create a new tiddler tagged with this one
 NewJournal/Caption: new journal
 NewJournal/Hint: Create a new journal tiddler
+NewJournalHere/Caption: new journal here
+NewJournalHere/Hint: Create a new journal tiddler tagged with this one
 NewTiddler/Caption: new tiddler
 NewTiddler/Hint: Create a new tiddler
 Permalink/Caption: permalink

--- a/core/ui/PageControls/new-journal-here.tid
+++ b/core/ui/PageControls/new-journal-here.tid
@@ -1,0 +1,21 @@
+title: $:/core/ui/Buttons/new-journal-here
+tags: $:/tags/ViewToolbar
+caption: {{$:/core/images/new-journal-button}} {{$:/language/Buttons/NewJournalHere/Caption}}
+description: {{$:/language/Buttons/NewJournalHere/Hint}}
+
+\define journalButton()
+<$button tooltip={{$:/language/Buttons/NewJournalHere/Hint}} aria-label={{$:/language/Buttons/NewJournalHere/Caption}} class=<<tv-config-toolbar-class>>>
+<$action-sendmessage $message="tm-new-tiddler" title=<<now "$(journalTitleTemplate)$">> tags="[[$(currentTiddlerTag)$]] $(journalTags)$"/>
+<$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
+{{$:/core/images/new-journal-button}}
+</$list>
+<$list filter="[<tv-config-toolbar-text>prefix[yes]]">
+<$text text={{$:/language/Buttons/NewJournalHere/Caption}}/>
+</$list>
+</$button>
+\end
+<$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
+<$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
+<$set name="currentTiddlerTag" value=<<currentTiddler>>>
+<<journalButton>>
+</$set></$set></$set>

--- a/core/ui/PageControls/new-journal.tid
+++ b/core/ui/PageControls/new-journal.tid
@@ -5,7 +5,7 @@ description: {{$:/language/Buttons/NewJournal/Hint}}
 
 \define journalButton()
 <$button tooltip={{$:/language/Buttons/NewJournal/Hint}} aria-label={{$:/language/Buttons/NewJournal/Caption}} class=<<tv-config-toolbar-class>>>
-<$action-sendmessage $message="tm-new-tiddler" title=<<now "$(journalTitleTemplate)$">> tags={{$:/config/NewJournal/Tags}}/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<now "$(journalTitleTemplate)$">> tags="$(journalTags)$"/>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/new-journal-button}}
 </$list>
@@ -15,5 +15,6 @@ description: {{$:/language/Buttons/NewJournal/Hint}}
 </$button>
 \end
 <$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
+<$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
 <<journalButton>>
-</$set>
+</$set></$set>

--- a/core/wiki/config/ViewToolbarButtons.multids
+++ b/core/wiki/config/ViewToolbarButtons.multids
@@ -4,5 +4,6 @@ core/ui/Buttons/clone: hide
 core/ui/Buttons/close-others: hide
 core/ui/Buttons/more-tiddler-actions: hide
 core/ui/Buttons/new-here: hide
+core/ui/Buttons/new-journal-here: hide
 core/ui/Buttons/permalink: hide
 core/ui/Buttons/permaview: hide


### PR DESCRIPTION
The journal tiddler will be tagged with the name of the current
tiddler. This is similar to how the new here button works.

(Would have liked to reuse the journalButton code which is almost
identical between new-journal-here and new-journal, but I'm not
sure how to do it.)
