### PR TITLE
Add span wrapper around button caption text

### DIFF
--- a/core/ui/EditToolbar/cancel.tid
+++ b/core/ui/EditToolbar/cancel.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Cancel/Hint}}
 {{$:/core/images/cancel-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Cancel/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Cancel/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/EditToolbar/delete.tid
+++ b/core/ui/EditToolbar/delete.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Delete/Hint}}
 {{$:/core/images/delete-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Delete/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Delete/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/EditToolbar/save.tid
+++ b/core/ui/EditToolbar/save.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Save/Hint}}
 {{$:/core/images/done-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Save/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Save/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/PageControls/closeall.tid
+++ b/core/ui/PageControls/closeall.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/CloseAll/Hint}}
 {{$:/core/images/close-all-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/CloseAll/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/CloseAll/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/PageControls/controlpanel.tid
+++ b/core/ui/PageControls/controlpanel.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/ControlPanel/Hint}}
 {{$:/core/images/options-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/ControlPanel/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/ControlPanel/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/PageControls/encryption.tid
+++ b/core/ui/PageControls/encryption.tid
@@ -9,7 +9,7 @@ description: {{$:/language/Buttons/Encryption/Hint}}
 {{$:/core/images/locked-padlock}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Encryption/ClearPassword/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Encryption/ClearPassword/Caption}}/></span>
 </$list>
 </$button>
 </$reveal>
@@ -19,7 +19,7 @@ description: {{$:/language/Buttons/Encryption/Hint}}
 {{$:/core/images/unlocked-padlock}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Encryption/SetPassword/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Encryption/SetPassword/Caption}}/></span>
 </$list>
 </$button>
 </$reveal>

--- a/core/ui/PageControls/full-screen.tid
+++ b/core/ui/PageControls/full-screen.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/FullScreen/Hint}}
 {{$:/core/images/full-screen-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/FullScreen/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/FullScreen/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/PageControls/home.tid
+++ b/core/ui/PageControls/home.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Home/Hint}}
 {{$:/core/images/home-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Home/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Home/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/PageControls/import.tid
+++ b/core/ui/PageControls/import.tid
@@ -9,7 +9,7 @@ description: {{$:/language/Buttons/Import/Hint}}
 {{$:/core/images/import-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Import/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Import/Caption}}/></span>
 </$list>
 </$button>
 <$browse/>

--- a/core/ui/PageControls/language.tid
+++ b/core/ui/PageControls/language.tid
@@ -15,7 +15,7 @@ $(languagePluginTitle)$/icon
 </span>
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Language/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Language/Caption}}/></span>
 </$list>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/language">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/more-page-actions.tid
+++ b/core/ui/PageControls/more-page-actions.tid
@@ -11,7 +11,7 @@ $:/config/PageControlButtons/Visibility/$(listItem)$
 {{$:/core/images/down-arrow}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/More/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/More/Caption}}/></span>
 </$list>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/more">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/new-journal.tid
+++ b/core/ui/PageControls/new-journal.tid
@@ -10,7 +10,7 @@ description: {{$:/language/Buttons/NewJournal/Hint}}
 {{$:/core/images/new-journal-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/NewJournal/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/NewJournal/Caption}}/></span>
 </$list>
 </$button>
 \end

--- a/core/ui/PageControls/newtiddler.tid
+++ b/core/ui/PageControls/newtiddler.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/NewTiddler/Hint}}
 {{$:/core/images/new-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/NewTiddler/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/NewTiddler/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/PageControls/refresh.tid
+++ b/core/ui/PageControls/refresh.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Refresh/Hint}}
 {{$:/core/images/refresh-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Refresh/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Refresh/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/PageControls/savewiki.tid
+++ b/core/ui/PageControls/savewiki.tid
@@ -9,7 +9,7 @@ description: {{$:/language/Buttons/SaveWiki/Hint}}
 {{$:/core/images/save-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/SaveWiki/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/SaveWiki/Caption}}/></span>
 </$list>
 </span>
 </$button>

--- a/core/ui/PageControls/storyview.tid
+++ b/core/ui/PageControls/storyview.tid
@@ -13,7 +13,7 @@ $:/core/images/storyview-$(storyview)$
 </$set>
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/StoryView/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/StoryView/Caption}}/></span>
 </$list>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/storyview">> type="popup" position="below" animate="yes">

--- a/core/ui/PageControls/tag-button.tid
+++ b/core/ui/PageControls/tag-button.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/TagManager/Hint}}
 {{$:/core/images/tag-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/TagManager/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/TagManager/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/PageControls/theme.tid
+++ b/core/ui/PageControls/theme.tid
@@ -8,7 +8,7 @@ description: {{$:/language/Buttons/Theme/Hint}}
 {{$:/core/images/theme-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Theme/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Theme/Caption}}/></span>
 </$list>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/theme">> type="popup" position="below" animate="yes">

--- a/core/ui/ViewToolbar/clone.tid
+++ b/core/ui/ViewToolbar/clone.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Clone/Hint}}
 {{$:/core/images/clone-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Clone/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Clone/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/ViewToolbar/close-others.tid
+++ b/core/ui/ViewToolbar/close-others.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/CloseOthers/Hint}}
 {{$:/core/images/close-others-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/CloseOthers/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/CloseOthers/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/ViewToolbar/close.tid
+++ b/core/ui/ViewToolbar/close.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Close/Hint}}
 {{$:/core/images/close-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Close/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Close/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/ViewToolbar/edit.tid
+++ b/core/ui/ViewToolbar/edit.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Edit/Hint}}
 {{$:/core/images/edit-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Edit/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Edit/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/ViewToolbar/info.tid
+++ b/core/ui/ViewToolbar/info.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Info/Hint}}
 {{$:/core/images/info-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Info/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Info/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/ViewToolbar/more-tiddler-actions.tid
+++ b/core/ui/ViewToolbar/more-tiddler-actions.tid
@@ -11,7 +11,7 @@ $:/config/ViewToolbarButtons/Visibility/$(listItem)$
 {{$:/core/images/down-arrow}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/More/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/More/Caption}}/></span>
 </$list>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/more">> type="popup" position="below" animate="yes">

--- a/core/ui/ViewToolbar/new-here.tid
+++ b/core/ui/ViewToolbar/new-here.tid
@@ -13,7 +13,7 @@ description: {{$:/language/Buttons/NewHere/Hint}}
 {{$:/core/images/new-here-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/NewHere/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/NewHere/Caption}}/></span>
 </$list>
 </$button>
 \end

--- a/core/ui/ViewToolbar/new-journal-here.tid
+++ b/core/ui/ViewToolbar/new-journal-here.tid
@@ -13,7 +13,7 @@ description: {{$:/language/Buttons/NewJournalHere/Hint}}
 {{$:/core/images/new-journal-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/NewJournalHere/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/NewJournalHere/Caption}}/></span>
 </$list>
 </$button>
 \end

--- a/core/ui/ViewToolbar/permalink.tid
+++ b/core/ui/ViewToolbar/permalink.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Permalink/Hint}}
 {{$:/core/images/permalink-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Permalink/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Permalink/Caption}}/></span>
 </$list>
 </$button>

--- a/core/ui/ViewToolbar/permaview.tid
+++ b/core/ui/ViewToolbar/permaview.tid
@@ -8,6 +8,6 @@ description: {{$:/language/Buttons/Permaview/Hint}}
 {{$:/core/images/permaview-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
-<$text text={{$:/language/Buttons/Permaview/Caption}}/>
+<span class="tc-btn-text"><$text text={{$:/language/Buttons/Permaview/Caption}}/></span>
 </$list>
 </$button>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -260,6 +260,11 @@ button svg, button img {
 	fill: <<colour muted-foreground>>;
 }
 
+.tc-btn-text {
+	padding: 0;
+	margin: 0;
+}
+
 .tc-btn-big-green {
 	padding: 8px;
 	margin: 4px 8px 4px 8px;


### PR DESCRIPTION
Reasons:
- can show or hide the button text with CSS (assuming
  tv-config-toolbar-text is yes).
- can have different looking buttons in the page controls versus the
  view toolbar, etc
- more flexibility styling the button appearance, for example you
  can change the text size compared to the icon size
- button appearance is more themeable
