### PR TITLE
Plain js source code tiddler support

### DIFF
--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -45,8 +45,8 @@ help() {
 	echo $'\t'-v .. Version
 	echo $'\t'-h .. Help
 	echo
-	echo Example 1 ./serve ./edition/tw5.com-server username
-	echo Example 2 ./serve ./edition/tw5.com-server \"\" \"\" localhost 9090
+	echo Example 1 ./serve ./editions/tw5.com-server username
+	echo Example 2 ./serve ./editions/tw5.com-server \"\" \"\" localhost 9090
 	echo .. Example 2 defines: empty username, empty password
 	echo
 }

--- a/core/modules/widgets/metafy.js
+++ b/core/modules/widgets/metafy.js
@@ -1,0 +1,124 @@
+/*\
+title: $:/core/modules/widgets/metafy.js
+type: application/javascript
+module-type: widget
+
+metafy widget
+
+Used to dump javascript tiddlers correctly as .js files as opposed to .js.tid
+files.
+
+widget attributes:
+* tiddler: defaults to the widget variable currentTiddler.
+* detect: regular expression detecting a meta data section (which may be
+    empty). Its parameter #2 indicates where to replace/insert meta data
+    when such a section is present. Otherwise, the template parameter will
+    be used instead. For instance, the following regular expression composed
+    of these elements:
+      "(^\/\*\\(?:\r?\n))"
+        -- the special comment marker at the section beginning on its own line.
+      "((?:^[^\r\n]+(?:\r?\n))*)"
+        -- matches all meta data field lines.
+      "(?:(?:^[^\r\n]*(?:\r?\n))*)"
+        -- matches a trailing normal comment text.
+      "(?:^\\\*\/(?:\r?\n)?)"
+        -- the special comment marker at the section end on its own line.
+* exclude: the fields to exclude; defaults to "text bag revision".
+* template: template to use to establish meta data section if not yet present.
+    $fields$ is used to indicate where to insert the fields (meta) data section of
+    "field: value\n" pairs. For instance, "/*\\\n$fields$\\*"+"/\n"
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+/*
+Constructor
+ */
+var MetafyWidget = function(parseTreeNode, options) {
+	this.initialise(parseTreeNode, options);
+};
+
+/*
+Inherit from the base widget class
+*/
+MetafyWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+MetafyWidget.prototype.render = function(parent, nextSibling) {
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
+	var textNode = this.document.createTextNode(this.text);
+	parent.insertBefore(textNode, nextSibling);
+	this.domNodes.push(textNode);
+};
+
+/*
+Compute the internal state of the widget
+*/
+MetafyWidget.prototype.execute = function() {
+	// Get parameters from our attributes
+	this.metafyTitle = this.getAttribute("tiddler", this.getVariable("currentTiddler"));
+	this.metafyDetect = this.getAttribute("match",
+		  "(^\\/\\*\\\\(?:\\r?\\n))" // special comment marker beginning
+		+ "((?:^[^\\r\\n]+(?:\\r?\\n))*)" // field name-value pairs
+		+ "(?:(?:^[^\\r\\n]*(?:\\r?\\n))*)" // remaining comment section
+		+ "(?:^\\\\\\*\\/(?:\\r?\\n)?)" // special comment marker end
+	);
+	var exclude = this.getAttribute("exclude", "text bag revision");
+	exclude = exclude.split(" ");
+	this.metafyExclude = exclude;
+	this.metafyTemplate = this.getAttribute("template", "/*\\\n$fields$\\*/\n");
+	
+	var tiddler = this.wiki.getTiddler(this.metafyTitle);
+	var text = "";
+	if (tiddler) {
+		text = this.wiki.getTiddlerText(this.metafyTitle);
+	}
+	
+	var fields = "";
+	for(var field in tiddler.fields) {
+		if (exclude.indexOf(field) === -1) {
+			fields += field + ": " + tiddler.getFieldString(field) + "\n";
+		}
+	}
+	
+	var match = new RegExp(this.metafyDetect, "mg").exec(text);
+	if (match) {
+		var start = match.index + match[1].length;
+		text = text.substr(0, start) + fields + text.substr(start + match[2].length);
+	} else {
+		console.log("no match");
+		text = this.metafyTemplate.replace("$fields$", fields) + text;
+	}
+	
+	this.text = text;
+};
+
+/*
+Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+*/
+MetafyWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if(changedAttributes.tiddler || changedAttributes.detect || changedAttributes.exclude || changedAttributes.template || changedTiddlers[this.viewTitle]) {
+		this.refreshSelf();
+		return true;
+	} else {
+		return false;
+	}
+};
+
+/*
+Export the metafy widget
+ */
+exports.metafy = MetafyWidget;
+
+})();

--- a/core/templates/plain-javascript-tiddler.tid
+++ b/core/templates/plain-javascript-tiddler.tid
@@ -1,0 +1,4 @@
+title: $:/core/templates/plain-javascript-tiddler
+type: text/vnd.tiddlywiki
+
+<$metafy/>

--- a/editions/test/tiddlers/tests/test-metafy.js
+++ b/editions/test/tiddlers/tests/test-metafy.js
@@ -1,0 +1,57 @@
+/*\
+title: test-metafy.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests the metafy mechanism.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+describe("Metafy tests", function() {
+
+	// Create a new and independent wiki
+	var wiki = new $tw.Wiki();
+	
+	// need to copy over the core tiddlers under test
+	wiki.addTiddler($tw.wiki.getTiddler("$:/core/templates/plain-javascript-tiddler"));
+	wiki.addTiddler($tw.wiki.getTiddler("$:/core/modules/widgets/metafy.js"));
+	
+	// establish the test-bed
+	wiki.addTiddler({
+		title: "UncommentedJavaScript.js",
+		text: "return;",
+		type: "application/javascript"
+	});
+	
+	wiki.addTiddler({
+		title: "CommentedJavaScript.js",
+		text: "/*\\\ntoast-field: Toast!\n\nSome comments, please!\n\\*/\nreturn;",
+		type: "application/javascript",
+		modifier: "JamesDoe42"
+	});
+	
+	wiki.addTiddler({
+		title: "render-uncommented",
+		text: "<$tiddler tiddler=\"UncommentedJavaScript.js\"><$transclude tiddler=\"$:/core/templates/plain-javascript-tiddler\" mode=\"block\"/></$tiddler>"
+	});
+
+	wiki.addTiddler({
+		title: "render-commented",
+		text: "<$tiddler tiddler=\"CommentedJavaScript.js\"><$transclude tiddler=\"$:/core/templates/plain-javascript-tiddler\" mode=\"block\"/></$tiddler>"
+	});
+	
+	it("should render uncommented javascript with a default meta section", function() {
+		expect(wiki.renderTiddler("text/plain", "render-uncommented")).toBe("/*\\\ntitle: UncommentedJavaScript.js\ntype: application/javascript\n\\*/\nreturn;");
+	});
+	
+	it("should render commented javascript with a replaced meta section", function() {
+		expect(wiki.renderTiddler("text/plain", "render-commented")).toBe("/*\\\ntitle: CommentedJavaScript.js\ntype: application/javascript\nmodifier: JamesDoe42\n\nSome comments, please!\n\\*/\nreturn;");
+	});
+});
+
+})();

--- a/editions/tw5.com/tiddlers/widgets/MetafyWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/MetafyWidget.tid
@@ -1,0 +1,21 @@
+title: MetafyWidget
+tags: Widgets
+caption: metafy
+
+! Introduction
+
+The metafy widget renders the contents of another tiddler while simultaneously inserting a missing meta-data comment section or replacing an existing meta-data comment section. This is different from the ViewWidget that albeit can display a tiddler's contents in a variety of formats, it cannot modify the tiddler's contents in itself during the formatting process. Also, while the FieldsWidget also renders tiddler meta-data it cannot insert its output into other content whereby replacing any old meta-data.
+
+This widget is used when rendering JavaScript tiddlers directly as plain JavaScript source code with tiddler meta-data embedded into the source code itself. A suitable template for rendering plain JavaScript source code with embedded meta-data is [[$:/core/templates/plain-javascript-tiddler]].
+
+It is thus possible to store plain JavaScript source code as ordinary `.js` files without the need for either separate `.meta` files or resorting to the general `.tid` tiddler storage format.
+
+! Content and Attributes
+
+The content of the `<$metafy>` widget is ignored.
+
+|!Attribute|!Description|
+|tiddler|The title of the tiddler to transclude (defaults to the current tiddler)|
+|detect|regular expression detecting a meta-data comment section. Its parameter #2 indicates where to replace or insert meta-data when such a meta-data comment section actually is present in the tiddler's contents. If no such section is present, then the `template` parameter will be evaluated instead. This parameter defaults to a regular expression suitable for JavaScript TiddlyWiki meta-data comment sections.|
+|exclude|The tiddler fields to exclude. This parameter defaults to `text bag revision`.|
+|template|The meta-data comment section template to use to correctly insert meta-data when no such meta-data comment section was found according to the `detect` regular expression. The string `$fields$` in the template indicates where the meta-data has to be inserted. This parameter defaults to a suitable template to be used with JavaScript plain source code. Please note that it is no possible to control the field name and value formatting as this is fixed in the TiddlyWiki core.|

--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -35,11 +35,16 @@ $tw.config.typeInfo = {
 	},
 	"image/jpeg" : {
 		hasMetaFile: true
+	},
+	"application/javascript": {
+		fileType: "application/javascript",
+		extension: ""
 	}
 };
 
 $tw.config.typeTemplates = {
-	"application/x-tiddler": "$:/core/templates/tid-tiddler"
+	"application/x-tiddler": "$:/core/templates/tid-tiddler",
+	"application/javascript": "$:/core/templates/plain-javascript-tiddler"
 };
 
 FileSystemAdaptor.prototype.getTiddlerFileInfo = function(tiddler,callback) {


### PR DESCRIPTION
Hi @Jermolene, this change set adds support for saving _plain_ JavaScript source code files with embedded meta-data comments sections. No more `.js.tid`, `.meta` sidekicks, `tiddlywiki.files`, ... for those that want to create their TW5 modules from within TW5.

I've also thrown in tests for the new `<$metafy>` widget and the associated `plain-javascript-tiddler` template. And last but not least you even get tw5.com documentation for the `<$metafy>` widget on top. Enjoy.
