### PR TITLE
german video links for saving with chrome, firefox, ie

### DIFF
--- a/editions/de-AT/tiddlers/howto/Speichern mit Chrome.tid
+++ b/editions/de-AT/tiddlers/howto/Speichern mit Chrome.tid
@@ -10,7 +10,7 @@ Diese Methode ist etwas umständlich, da man Einstellungen immer wieder manuell 
 
 !! Video
 
-<iframe width="560" height="315" src="//www.youtube.com/embed/LcoZ7hQCuFI" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="http://www.youtube.com/embed/LcoZ7hQCuFI" frameborder="0" allowfullscreen></iframe>
 
 !! Speichern mit Chrome
 

--- a/editions/de-AT/tiddlers/howto/Speichern mit TiddlyFox.tid
+++ b/editions/de-AT/tiddlers/howto/Speichern mit TiddlyFox.tid
@@ -12,7 +12,7 @@ Wenn Sie "Firefox for Android" verwenden, dann beachten sie: [[Speichern mit Tid
 
 !! Video (de)
 
-<iframe width="560" height="315" src="//www.youtube.com/embed/bsWE7jXPbb0" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="http://www.youtube.com/embed/bsWE7jXPbb0" frameborder="0" allowfullscreen></iframe>
 
 !! Speichern mit TiddlyFox
 # Stellen Sie sicher, dass Sie die [[aktuelle Version von Firefox|http://getfirefox.com]] verwenden.

--- a/editions/de-AT/tiddlers/howto/Speichern mit TiddlyIE.tid
+++ b/editions/de-AT/tiddlers/howto/Speichern mit TiddlyIE.tid
@@ -8,7 +8,7 @@ type: text/vnd.tiddlywiki
 
 !! Video
 
-<iframe width="560" height="315" src="//www.youtube.com/embed/OrWuvjs3Ly0" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="http://www.youtube.com/embed/OrWuvjs3Ly0" frameborder="0" allowfullscreen></iframe>
 
 !! Speichern mit TiddlyIE
 

--- a/editions/de-AT/tiddlers/howto/Windows HTA Hack.tid
+++ b/editions/de-AT/tiddlers/howto/Windows HTA Hack.tid
@@ -14,6 +14,6 @@ TW wird standardmäßig im UTF-8 Format gespeichert. Wird die Datei wieder mit e
 
 Hier ist ein Video von Mario Pietsch, dass den Umgang IE, HTA und TiddlyWiki zeigt.
 
-<iframe width="560" height="315" src="//www.youtube.com/embed/OrWuvjs3Ly0" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="http://www.youtube.com/embed/OrWuvjs3Ly0" frameborder="0" allowfullscreen></iframe>
 
 Siehe Wikipedia (englisch): http://en.wikipedia.org/wiki/HTML_Application

--- a/editions/tw5.com/tiddlers/community/TiddlyWiki Hangouts.tid
+++ b/editions/tw5.com/tiddlers/community/TiddlyWiki Hangouts.tid
@@ -8,4 +8,4 @@ The TiddlyWiki community holds regular Google Hangouts, usually every Tuesday fr
 
 Past Hangouts are archived in this YouTube playlist:
 
-<iframe width="560" height="315" src="//www.youtube.com/embed/videoseries?list=PLVT_2PPd-1p34gGCQ5qpwC8QdykxVAI3u" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="http://www.youtube.com/embed/videoseries?list=PLVT_2PPd-1p34gGCQ5qpwC8QdykxVAI3u" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
german video links for saving with chrome, firefox, ie
