### PR TITLE
Allow additional server paths

### DIFF
--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -200,6 +200,18 @@ var Command = function(params,commander,callback) {
 			response.end(text,"utf8");
 		}
 	});
+	for(var r in $tw.boot.wikiInfo.routes) {
+		var route = $tw.boot.wikiInfo.routes[r];
+		this.server.addRoute({
+			method: "GET",
+			path: new RegExp(route.path),
+			handler: function(request,response,state) {
+				response.writeHead(200, {"Content-Type": route.serveType});
+				var text = state.wiki.renderTiddler(route.renderType, route.rootTiddler)
+				response.end(text,"utf8");
+			}
+		});
+	}
 	this.server.addRoute({
 		method: "GET",
 		path: /^\/status$/,


### PR DESCRIPTION
Add additional routes to the basic server from a "routes" list in wiki info file.  Each item in the list is an object with a path, serveType, renderType, and rootTiddler.
