### PR TITLE
small typo on WidgetMessage: tm-add-field

### DIFF
--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-add-field.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-add-field.tid
@@ -5,9 +5,9 @@ title: WidgetMessage: tm-add-field
 type: text/vnd.tiddlywiki
 caption: tm-add-field
 
-The `tm-add-field` message is handled by the FieldMangerWidget. It adds the specified field with a blank value if the field doesn't already exist.
+The `tm-add-field` message is handled by the FieldManglerWidget. It adds the specified field with a blank value if the field doesn't already exist.
 
 |!Name |!Description |
 |param |Name of field to add |
 
-The add field  message is usually generated with the ButtonWidget, and is handled by the FieldMangerWidget.
+The add field  message is usually generated with the ButtonWidget, and is handled by the FieldManglerWidget.


### PR DESCRIPTION
You can read FieldMangerWidget instead of FieldManglerWidget. A single L is missing, so the links are not working properly.
