### PR TITLE
some doc updates

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/Upgrading.tid
+++ b/editions/tw5.com/tiddlers/howtos/Upgrading.tid
@@ -1,5 +1,5 @@
 created: 20131202102427114
-modified: 20140919154634754
+modified: 20141009004937229
 tags: Features [[Working with TiddlyWiki]]
 title: Upgrading
 type: text/vnd.tiddlywiki
@@ -13,17 +13,19 @@ The process described here is for upgrading standalone TiddlyWiki files. There i
 <<<
 When upgrading, please remember the [[The First Rule of Using TiddlyWiki]]:
 
-//Backup your data!//
+//You are responsible for looking after your own data; take care to make backups, especially when upgrading the ~TiddlyWiki core//
 <<<
 
 ! Online upgrading
 
 This process will work on most desktop browsers. Note that none of your personal data leaves your browser with this process.
 
-# Visit the new version tiddywiki in http://tiddlywiki.com/upgrade.html in your browser
+# Locate your TiddlyWiki file in the file system (ie using Windows Explorer, the Finder on Mac OS X, or your file manager on Linux)
+# Visit http://tiddlywiki.com/upgrade.html in your browser
+
 # Drag your old TiddlyWiki HTML file into the browser window
 #* If the file is encrypted you will be prompted for the password
-# Click ''Upgrade''
+# Review the list of tiddlers that will be upgradedck ''Upgrade''
 # Save changes to save the new version
 
 This will download a file called ''upgrade.html'' to your computer. This file is the upgrade of your old file. You may need to open the location where ''upgrade.html'' was downloaded, rename ''upgrade.html'' with the name of the old file you are upgrading, and replace the old file by moving the new file in its place.
@@ -33,6 +35,20 @@ This will download a file called ''upgrade.html'' to your computer. This file is
 You can also download http://tiddlywiki.com/upgrade.html locally and perform the same drag-and-drop procedure to upgrade your files.
 
 ! Problems with Upgrades
+
+In case you run into this error with the upgrader, upon confirming the upgrade selection :
+
+<<<
+Error while saving:
+
+Error:NS_ERROR_DOM_BAD_URI: Access to restricted URI denied
+<<<
+
+* The upgrading script triggers a security restriction in Firefox, we suggest using Chrome instead until this can be resolved.<br><br>
+
+*# Use Chrome to open http://tiddlywiki.com/upgrade.html, then drag your local TiddlyWiki html file to be upgraded into the upgrader window, as described above in ''Online upgrading''.<br><br>
+*#After you've saved your upgraded file, you should be able to open it in Firefox and [[save using TiddlyFox|Saving with TiddlyFox]] again.<br><br>  
+* //See also : [[Saving on TiddlySpot]]//
 
 It is possible for a customisation applied in a previous version to break when upgraded to the latest version. There are two techniques you can use to help track down issues:
 

--- a/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
@@ -1,5 +1,5 @@
 created: 20130825213500000
-modified: 20140912141002181
+modified: 20141009010050619
 tags: Saving
 title: Saving on TiddlySpot
 type: text/vnd.tiddlywiki
@@ -14,14 +14,30 @@ You can upload an existing TiddlyWiki document from your local disc to TiddlySpo
 # Click the "Save Changes" button. You should get a confirmation notification at the top right saying ''Saved wiki''. Saving can take several seconds if you're on a slow connection or working with a large wiki.
 # Navigate to your TiddlySpot URL at http://{wikiname}.tiddlyspot.com/
 
-Note that this procedure does not work in Firefox.
-
-!! TiddlySpot Security
-
-Your password is sent unencrypted when using TiddlySpot. From http://faq.tiddlyspot.com/:
+Note that your password is sent unencrypted when using TiddlySpot. From http://faq.tiddlyspot.com/:
 
 <<<
 ''Is Tiddlyspot secure?''
 
 No. Tiddlyspot does not use SSL/https. Your password is sent in clear text when uploading and when authenticating to access a private site. This means that your Tiddlyspot is vulnerable to packet sniffing and your password could be discovered by a malicious third party. Also your data is transmitted unencrypted when you view your site, even if it is a private site. For this reason please don't put sensitive information such as banking details in your Tiddlyspot and don't use a password that you use for other high security sites.
 <<<
+! Problems with saving on TiddlySpot
+
+In case you run into this error when uploading a new or freshly upgraded local TiddlyWiki to TiddlySpot :
+
+<<<
+Error while saving:
+
+Error:NS_ERROR_DOM_BAD_URI: Access to restricted URI denied
+<<<
+
+* The upgrading script triggers a security restriction in Firefox, we suggest using Chrome instead until this can be resolved.<br><br>
+
+*# Use Chrome to open the local TiddlyWiki document you want to upload to TiddlySpot and follow the steps 1 through 5 described above..<br><br>
+
+*# Once you've checked the TiddlySpot-hosted TiddlyWiki loads properly in Chrome, you should be able to access, edit and [[save using TiddlyFox|Saving with TiddlyFox]] again.<br><br>  
+
+* After you've uploaded your local document once, further editing and saving of the online version hosted on TiddlySpot should work with any modern browser of your choice.<br><br>  
+** Don't forget to fill in the TiddlySpot wikiname and password in your TiddlySpot TiddlyWiki control panel for any new browser you want to save changes with !<br><br>
+
+* //See also : [[Upgrading]]//


### PR DESCRIPTION
Edited the 'Upgrading' and 'Saving on TiddlySpot' tids to document the issue and workaround of DOM security exceptions triggered on Firefox when uploading to the online upgrader or to TiddlySpot (short version, use Chrome to upload).
