### PR TITLE
Fixed the description of the operator

### DIFF
--- a/editions/tw5.com/tiddlers/filters/FilterOperator nth.tid
+++ b/editions/tw5.com/tiddlers/filters/FilterOperator nth.tid
@@ -5,7 +5,7 @@ caption: nth
 title: FilterOperator: nth
 type: text/vnd.tiddlywiki
 
-Without an operand, the ''nth'' filter operator returns the first entry in the current list. The optional operand specifies the number of entries to return.
+Without an operand, the ''nth'' filter operator returns the first entry in the current list. The optional operand specifies the position of the entry in the list.
 
 For example:
 


### PR DESCRIPTION
the previous description was erroneous: the operand is not the number of entries to return, but the position of the entry to select.
