### PR TITLE
make examples work and help texts more consistent and readable.

### DIFF
--- a/core/language/en-GB/Help/build.tid
+++ b/core/language/en-GB/Help/build.tid
@@ -9,3 +9,10 @@ Build the specified build targets for the current wiki. If no build targets are 
 
 Build targets are defined in the `tiddlywiki.info` file of a wiki folder.
 
+Example:
+
+```
+tiddlywiki ./editions/tw5.com --output ./output --build index 
+```
+
+Will create the index.html file in the ./output folder. The ./output folder, in the example, is relative to the currend directory.

--- a/core/language/en-GB/Help/build.tid
+++ b/core/language/en-GB/Help/build.tid
@@ -15,4 +15,4 @@ Example:
 tiddlywiki ./editions/tw5.com --output ./output --build index 
 ```
 
-Will create the index.html file in the ./output folder. The ./output folder, in the example, is relative to the curren directory.
+Will create the index.html file in the ./output folder. The ./output folder, in the example, is relative to the current directory.

--- a/core/language/en-GB/Help/build.tid
+++ b/core/language/en-GB/Help/build.tid
@@ -15,4 +15,4 @@ Example:
 tiddlywiki ./editions/tw5.com --output ./output --build index 
 ```
 
-Will create the index.html file in the ./output folder. The ./output folder, in the example, is relative to the currend directory.
+Will create the index.html file in the ./output folder. The ./output folder, in the example, is relative to the curren directory.

--- a/core/language/en-GB/Help/default.tid
+++ b/core/language/en-GB/Help/default.tid
@@ -8,10 +8,9 @@ usage: tiddlywiki [<wikifolder>] [--<command> [<args>...]...]
 ```
 
 Available commands:
-
 <ul>
 <$list filter="[commands[]sort[title]]" variable="command">
-<li><$link to=<<commandTitle>>><$macrocall $name="command" $type="text/plain" $output="text/plain"/></$link>: <$transclude tiddler=<<commandTitle>> field="description"/></li>
+<li><$link to=<<commandTitle>>><$macrocall $name="command" $type="text/plain" $output="text/plain"/></$link>:  - <$transclude tiddler=<<commandTitle>> field="description"/></li>
 </$list>
 </ul>
 

--- a/core/language/en-GB/Help/default.tid
+++ b/core/language/en-GB/Help/default.tid
@@ -10,7 +10,7 @@ usage: tiddlywiki [<wikifolder>] [--<command> [<args>...]...]
 Available commands:
 <ul>
 <$list filter="[commands[]sort[title]]" variable="command">
-<li><$link to=<<commandTitle>>><$macrocall $name="command" $type="text/plain" $output="text/plain"/></$link>:  - <$transclude tiddler=<<commandTitle>> field="description"/></li>
+<li><$link to=<<commandTitle>>><$macrocall $name="command" $type="text/plain" $output="text/plain"/></$link>  - <$transclude tiddler=<<commandTitle>> field="description"/></li>
 </$list>
 </ul>
 

--- a/core/language/en-GB/Help/help.tid
+++ b/core/language/en-GB/Help/help.tid
@@ -8,3 +8,11 @@ Displays help text for a command:
 ```
 
 If the command name is omitted then a list of available commands is displayed.
+
+Example: 
+
+```
+tiddlywiki --help server
+```
+
+This exapmle will display the help text for the `--server` command.

--- a/core/language/en-GB/Help/help.tid
+++ b/core/language/en-GB/Help/help.tid
@@ -15,4 +15,4 @@ Example:
 tiddlywiki --help server
 ```
 
-This exapmle will display the help text for the `--server` command.
+This example will display the help text for the `--server` command.

--- a/core/language/en-GB/Help/init.tid
+++ b/core/language/en-GB/Help/init.tid
@@ -20,4 +20,4 @@ Note:
 * The init command will fail if the wiki folder is not empty
 * The init command removes any `includeWikis` definitions in the edition's `tiddlywiki.info` file
 * When multiple editions are specified, editions initialised later will overwrite any files shared with earlier editions (so, the final `tiddlywiki.info` file will be copied from the last edition)
-* `--help editions` - returns a list of available editions
+* "`--help editions`" - returns a list of available editions

--- a/core/language/en-GB/Help/init.tid
+++ b/core/language/en-GB/Help/init.tid
@@ -7,7 +7,7 @@ Initialise an empty [[WikiFolder|WikiFolders]] with a copy of the specified edit
 --init <edition> [<edition> ...]
 ```
 
-For example:
+Example:
 
 ```
 tiddlywiki ./MyWikiFolder --init empty
@@ -20,4 +20,4 @@ Note:
 * The init command will fail if the wiki folder is not empty
 * The init command removes any `includeWikis` definitions in the edition's `tiddlywiki.info` file
 * When multiple editions are specified, editions initialised later will overwrite any files shared with earlier editions (so, the final `tiddlywiki.info` file will be copied from the last edition)
-* `--help editions` returns a list of available editions
+* `--help editions` - returns a list of available editions

--- a/core/language/en-GB/Help/load.tid
+++ b/core/language/en-GB/Help/load.tid
@@ -7,10 +7,12 @@ Load tiddlers from 2.x.x TiddlyWiki files (`.html`), `.tiddler`, `.tid`, `.json`
 --load <filepath>
 ```
 
-To load tiddlers from an encrypted TiddlyWiki file you should first specify the password with the PasswordCommand. For example:
+To load tiddlers from an encrypted TiddlyWiki file you should first specify the password with the PasswordCommand.
+
+Example:
 
 ```
 tiddlywiki ./MyWiki --password pa55w0rd --load my_encrypted_wiki.html
 ```
 
-Note that TiddlyWiki will not load an older version of an already loaded plugin.
+Note: TiddlyWiki will not load an older version of an already loaded plugin.

--- a/core/language/en-GB/Help/output.tid
+++ b/core/language/en-GB/Help/output.tid
@@ -1,10 +1,16 @@
 title: $:/language/Help/output
 description: Set the base output directory for subsequent commands
 
-Sets the base output directory for subsequent commands. The default output directory is the `output` subdirectory of the edition directory.
+Sets the base output directory for subsequent commands. The default output directory is the `output` subdirectory of the edition directory. If the specified pathname is relative then it is resolved relative to the current working directory.
 
 ```
 --output <pathname>
 ```
 
-If the specified pathname is relative then it is resolved relative to the current working directory.
+Example:
+
+```
+tiddlywiki ./editions/tw5.com --output ./output --build index
+```
+
+The example will create the specified html file in the ./output folder. The ./output folder is relative to the currend working directory. The output filename is set in the editions "tiddlywiki.info" tiddler.

--- a/core/language/en-GB/Help/rendertiddler.tid
+++ b/core/language/en-GB/Help/rendertiddler.tid
@@ -10,3 +10,15 @@ Render an individual tiddler as a specified ContentType, defaults to `text/html`
 By default, the filename is resolved relative to the `output` subdirectory of the edition directory. The `--output` command can be used to direct output to a different directory.
 
 Any missing directories in the path to the filename are automatically created.
+
+Example:
+
+```
+tiddlywiki ./editions/tw5.com --output ./output --rendertiddler '$:/core/save/all' 'index.html' 'text/plain'
+```
+
+This command will create an index.html file in the ./output directory, relative to the currend working directory. The `$:/core/save/all` tiddler contains a filter, to build the whole TiddlyWiki file.
+
+Note: `'$:/core/save/all'` has to be enclosed in single quotes, otherwise the command line parser throws an error message, that it can't use `$:/` as a variable name.
+
+Also see the `--output` and `--build` command!

--- a/core/language/en-GB/Help/rendertiddlers.tid
+++ b/core/language/en-GB/Help/rendertiddlers.tid
@@ -7,12 +7,31 @@ Render a set of tiddlers matching a filter to separate files of a specified Cont
 --rendertiddlers <filter> <template> <pathname> [<type>] [<extension>]
 ```
 
-For example:
-
-```
---rendertiddlers [!is[system]] $:/core/templates/static.tiddler.html ./static text/plain
-```
-
 By default, the pathname is resolved relative to the `output` subdirectory of the edition directory. The `--output` command can be used to direct output to a different directory.
 
 Any files in the target directory are deleted. The target directory is recursively created if it is missing.
+
+Example:
+
+```
+tiddlywiki ./editions/tw5.com --output ./output --rendertiddlers 'HelloThere GettingStarted' '$:/core/templates/static.tiddler.html' './static' 'text/plain'
+```
+
+This command creates 2 tiddlers HelloThere and GettingStarted in the `./output/static` directory. The CSS is missing! See the last example, how to create the CSS file.
+
+```
+tiddlywiki ./editions/tw5.com --output ./output --rendertiddlers '[!is[system]]' '$:/core/templates/static.tiddler.html' './static' 'text/plain'
+```
+
+This command writes all tiddlers of the wiki into a ./static directory as single html files. If you view them in the browser, you'll see, they are not formatted, since the static.css is missing.
+
+Use the following command to create it: 
+
+```
+tiddlywiki ./editions/tw5.com --output ./output --rendertiddler '$:/core/templates/static.template.css' 'static/static.css' 'text/plain'
+
+```
+
+Note: The system tiddlers starting with `$:/` have to be enclosed in single quotes, otherwise the command line parser throws an error message, that it can't use `$:/` as a variable name.
+
+Also see the `--output` and `--rendertiddler` command!

--- a/core/language/en-GB/Help/rendertiddlers.tid
+++ b/core/language/en-GB/Help/rendertiddlers.tid
@@ -7,7 +7,7 @@ Render a set of tiddlers matching a filter to separate files of a specified Cont
 --rendertiddlers <filter> <template> <pathname> [<type>] [<extension>]
 ```
 
-By default, the pathname is resolved relative to the `output` subdirectory of the edition directory. The `--output` command can be used to direct output to a different directory.
+By default, the pathname is resolved relative to the `output` subdirectory of the wiki folder. The `--output` command can be used to direct output to a different directory.
 
 Any files in the target directory are deleted. The target directory is recursively created if it is missing.
 
@@ -34,4 +34,4 @@ tiddlywiki ./editions/tw5.com --output ./output --rendertiddler '$:/core/templat
 
 Note: The system tiddlers starting with `$:/` have to be enclosed in single quotes, otherwise the command line parser throws an error message, that it can't use `$:/` as a variable name.
 
-Also see the `--output` and `--rendertiddler` command!
+Also see the `--output` and `--rendertiddler` command

--- a/core/language/en-GB/Help/savetiddler.tid
+++ b/core/language/en-GB/Help/savetiddler.tid
@@ -1,7 +1,7 @@
 title: $:/language/Help/savetiddler
 description: Saves a raw tiddler to a file
 
-Saves an individual tiddler in its raw text or binary format to the specified filename. 
+Saves an individual tiddler in its raw text or binary format to the specified filename.
 
 ```
 --savetiddler <title> <filename>
@@ -10,3 +10,11 @@ Saves an individual tiddler in its raw text or binary format to the specified fi
 By default, the filename is resolved relative to the `output` subdirectory of the edition directory. The `--output` command can be used to direct output to a different directory.
 
 Any missing directories in the path to the filename are automatically created.
+
+Example:
+
+```
+tiddlywiki ./editions/tw5.com --output ./output --savetiddler '$:/favicon.ico' 'favicon.ico'
+```
+
+Note: The system tiddler starting with `$:/` have to be enclosed in single quotes, otherwise the command line parser throws an error message, that it can't use `$:/` as a variable name.

--- a/core/language/en-GB/Help/savetiddlers.tid
+++ b/core/language/en-GB/Help/savetiddlers.tid
@@ -10,3 +10,11 @@ Saves a group of tiddlers in their raw text or binary format to the specified di
 By default, the pathname is resolved relative to the `output` subdirectory of the edition directory. The `--output` command can be used to direct output to a different directory.
 
 Any missing directories in the pathname are automatically created.
+
+Example: 
+
+```
+tiddlywiki ./editions/tw5.com --output ./output --savetiddlers "[tag[external-image]]" "images"
+```
+
+This command will save all image tiddlers tagged "external-image" into the `./output/images` directory.

--- a/core/language/en-GB/Help/server.tid
+++ b/core/language/en-GB/Help/server.tid
@@ -22,16 +22,20 @@ The parameters are:
 
 If the password parameter is specified then the browser will prompt the user for the username and password. Note that the password is transmitted in plain text so this implementation isn't suitable for general use.
 
-For example:
+Examples:
 
 ```
---server 8080 $:/core/save/all text/plain text/html MyUserName passw0rd
+tiddlywiki ./editions/tw5.com-server --server 8080 '$:/core/save/all' text/plain text/html MyUserName passw0rd
 ```
 
-The username and password can be specified as empty strings if you need to set the hostname or pathprefix and don't want to require a password:
+The username and password can be specified as empty strings if you need to set the hostname or pathprefix and don't want to require a password. 
+
+IMPORTANT: With Windows you have to set empty name or password like this: `'""'`
 
 ```
---server 8080 $:/core/save/all text/plain text/html "" "" 192.168.0.245
+tiddlywiki ./editions/tw5.com-server --server 8080 '$:/core/save/all' text/plain text/html "" "" 192.168.0.245
 ```
 
 To run multiple TiddlyWiki servers at the same time you'll need to put each one on a different port.
+
+Note: The system tiddlers starting with `$:/` have to be enclosed in single quotes, otherwise the command line parser throws an error message, that it can't use `$:/` as a variable name.

--- a/core/language/en-GB/Help/verbose.tid
+++ b/core/language/en-GB/Help/verbose.tid
@@ -1,7 +1,7 @@
 title: $:/language/Help/verbose
 description: Triggers verbose output mode
 
-Triggers verbose output, useful for debugging 
+Triggers verbose output, useful for debugging
 
 ```
 --verbose

--- a/core/language/en-GB/Help/version.tid
+++ b/core/language/en-GB/Help/version.tid
@@ -1,8 +1,14 @@
 title: $:/language/Help/version
 description: Displays the version number of TiddlyWiki
 
-Displays the version number of TiddlyWiki.
+Displays the version number of TiddlyWiki
 
 ```
 --version
+```
+
+Example:
+
+```
+tiddlywiki --version
 ```

--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -206,7 +206,10 @@ Object.defineProperty(TW_Element.prototype, "formattedTextContent", {
 				b.push("\n");
 			}
 			if(this.tag === "li") {
-				b.push("* ");
+				b.push("    ");
+			}
+			if(this.tag === "pre") {
+				b.push("    ");
 			}
 			$tw.utils.each(this.children,function(node) {
 				b.push(node.formattedTextContent);


### PR DESCRIPTION
This pull request should make: 
 * the CLI command examples work
 * CLI help texts more consistent 
 * and readable

This pull request changes: `core/modules/utils/fakedom.js` `formattedTextContent` handler.
Since it is only used to create command line output, there should be no side effects. 

`pre` and `li` now create an indentation with 4 spaces, which imo makes the help texts much more readable. The formatting in the TW output is not affected. 

see the difference with: 

```
node tiddlywiki.js --help     ... new
tiddlywiki --help              ... old if tiddlywiki is installed globally
or
node tiddlywiki.js --help server
tiddlywiki --help server
...
```