### PR TITLE
Adding recursive sort parameter to toc macro

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -10,7 +10,7 @@ tags: $:/tags/Macro
 <$view field="title"/>
 </$view>
 </$list>
-<$macrocall $name="toc" tag=<<currentTiddler>>/>
+<$macrocall $name="toc" tag=<<currentTiddler>> sort="$sort$"/>
 </li>
 </$list>
 </ol>


### PR DESCRIPTION
Unlike the selective(-expandable) versions, the basic toc macro isn't propagating the "sort" parameter during the recursive macrocall.

PS. This seem not an issue for this commit, but how do I update my repository to the current master branch? I must perform a new fork, or is there another method?
