### PR TITLE
Update selectWidget example (the tag was deleted)

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/SelectWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SelectWidget.tid
@@ -74,10 +74,10 @@ Entries in the list can be grouped together with the `<optgroup>` element
 
 !! Generated Lists
 
-The ListWidget can be used to generate the options for a select widget. For example, here we combine a select widget listing all the tiddlers tagged ''introduction'' with a transclusion to display the text of the selected one.
+The ListWidget can be used to generate the options for a select widget. For example, here we combine a select widget listing all the tiddlers tagged ''TableOfContents'' with a transclusion to display the text of the selected one.
 
 <$macrocall $name="wikitext-example-without-html" src="<$select tiddler='$:/generated-list-demo-state'>
-<$list filter='[tag[introduction]]'>
+<$list filter='[tag[TableOfContents]]'>
 <option><$view field='title'/></option>
 </$list>
 </$select>


### PR DESCRIPTION
The generated lists example used the "introduction" tag that don't exist anymore. I've replaced it with "TableOfContents".
