### PR TITLE
Trying to fix tiddler title slash issue using double escaping in TW5 tiddlyweb plugin

### DIFF
--- a/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
+++ b/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
@@ -18,7 +18,7 @@ var CONFIG_HOST_TIDDLER = "$:/config/tiddlyweb/host",
 function TiddlyWebAdaptor(options) {
 	this.wiki = options.wiki;
 	this.host = this.getHost();
-	this.recipe = undefined;
+	this.recipe = "default";
 	this.logger = new $tw.utils.Logger("TiddlyWebAdaptor");
 }
 
@@ -135,7 +135,7 @@ Get an array of skinny tiddler fields from the server
 TiddlyWebAdaptor.prototype.getSkinnyTiddlers = function(callback) {
 	var self = this;
 	$tw.utils.httpRequest({
-		url: this.host + "recipes/" + this.recipe + "/tiddlers.json",
+		url: this.host + "recipes/" + encodeURIComponentWithSlashes(this.recipe) + "/tiddlers.json",
 		callback: function(err,data) {
 			// Check for errors
 			if(err) {
@@ -158,7 +158,7 @@ Save a tiddler and invoke the callback with (err,adaptorInfo,revision)
 TiddlyWebAdaptor.prototype.saveTiddler = function(tiddler,callback) {
 	var self = this;
 	$tw.utils.httpRequest({
-		url: this.host + "recipes/" + encodeURIComponent(this.recipe) + "/tiddlers/" + encodeURIComponent(tiddler.fields.title),
+		url: this.host + "recipes/" + encodeURIComponentWithSlashes(this.recipe) + "/tiddlers/" + encodeURIComponentWithSlashes(tiddler.fields.title),
 		type: "PUT",
 		headers: {
 			"Content-type": "application/json"
@@ -184,7 +184,7 @@ Load a tiddler and invoke the callback with (err,tiddlerFields)
 TiddlyWebAdaptor.prototype.loadTiddler = function(title,callback) {
 	var self = this;
 	$tw.utils.httpRequest({
-		url: this.host + "recipes/" + encodeURIComponent(this.recipe) + "/tiddlers/" + encodeURIComponent(title),
+		url: this.host + "recipes/" + encodeURIComponentWithSlashes(this.recipe) + "/tiddlers/" + encodeURIComponentWithSlashes(title),
 		callback: function(err,data,request) {
 			if(err) {
 				return callback(err);
@@ -209,7 +209,7 @@ TiddlyWebAdaptor.prototype.deleteTiddler = function(title,callback,options) {
 	}
 	// Issue HTTP request to delete the tiddler
 	$tw.utils.httpRequest({
-		url: this.host + "bags/" + encodeURIComponent(bag) + "/tiddlers/" + encodeURIComponent(title),
+		url: this.host + "bags/" + encodeURIComponentWithSlashes(bag) + "/tiddlers/" + encodeURIComponentWithSlashes(title),
 		type: "DELETE",
 		callback: function(err,data,request) {
 			if(err) {
@@ -308,6 +308,10 @@ TiddlyWebAdaptor.prototype.parseEtag = function(etag) {
 		};
 	}
 };
+
+function encodeURIComponentWithSlashes(uri) {
+	return encodeURIComponent(uri.replace(/\//g, "%2F"));
+}
 
 if($tw.browser && document.location.protocol.substr(0,4) === "http" ) {
 	exports.adaptorClass = TiddlyWebAdaptor;


### PR DESCRIPTION
I am experiencing issues saving tiddlers with slashes from TW5(5.1.5-prerelease be2a74d623b6cef4516bcd146d84ec82294c7ae6) to TiddlyWeb. 

I get 404 responses from the server.

I decided to use the hint from https://mail.python.org/pipermail/web-sig/2008-January/003135.html :

> If you really want PATH_INFO to have "%2F" instead of "/", then I suggest encoding the slashes as "%252F" or "$2F" or something else. Then your application will be portable.

I do not know if it is relevant anyhow, but I tried to solve my issue that way (escape the `/` twice) and it worked.

I use `twanager server` command to start the server (`wsgiref`) and do not use `tiddlywebwiki`

```
Python 2.7.8

This is TiddlyWeb version 2.3.0.
    The current store is: tiddlywebplugins.mysql3 (3.1.2).
System Plugins:
        tiddlywebplugins.status (0.8)
        tiddlywebplugins.logout (1.0)

MySQL-python==1.2.5
SQLAlchemy==0.8.7
html5lib==0.999
httpexceptor==1.3.1
pyparsing==1.5.7
python-mimeparse==0.1.4
resolver==0.2.1
selector==0.10.1
simplejson==3.6.5
six==1.8.0
tiddlyweb==2.3.0
tiddlywebplugins.logout==1.0
tiddlywebplugins.mysql3==3.1.2
tiddlywebplugins.sqlalchemy3==3.1.1
tiddlywebplugins.status==0.8
wsgiref==0.1.2
```
