### PR TITLE
Add direct link to github ribbon plugin

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/How to put the last modification date in a banner.tid
+++ b/editions/tw5.com/tiddlers/howtos/How to put the last modification date in a banner.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 
 Here's how to display the last modification date of a wiki in a banner in the corner of the window:
 
-# Copy the plugin $:/plugins/tiddlywiki/github-fork-ribbon (labelled "GitHub-style ribbon in pure CSS") to your TiddlyWiki
+# Copy the plugin [[$:/plugins/tiddlywiki/github-fork-ribbon]] to your TiddlyWiki
 # Save and reload your wiki
 # Create a new tiddler called [[$:/_MyRibbon]] tagged [[$:/tags/PageControls]] and containing:<div>
 


### PR DESCRIPTION
The former documentation referenced a plugin but left no easy way to link to it. Also, the misleading text claiming a title also confused me. I had to do some creative greping the git files to hunt it down.

Adding a TiddlyWiki link around the plugin links to the actual tiddler that a reader could easily copy. This also deprecated the need for the misleading title.
