### PR TITLE
Deleted overridden shadow tiddlers on language change.

### DIFF
--- a/core/modules/pluginswitcher.js
+++ b/core/modules/pluginswitcher.js
@@ -60,29 +60,10 @@ PluginSwitcher.prototype.switchPlugins = function() {
 	accumulatePlugin(selectedPluginTitle);
 	// Unregister any existing theme tiddlers
 	var unregisteredTiddlers = $tw.wiki.unregisterPluginTiddlers(this.pluginType);
-	// Accumulate the titles of shadow tiddlers that have changed as a result of this switch
-	var changedTiddlers = {};
-	this.wiki.eachShadow(function(tiddler,title) {
-		var source = self.wiki.getShadowSource(title);
-		if(unregisteredTiddlers.indexOf(source) !== -1) {
-			changedTiddlers[title] = true; // isDeleted?
-		}
-	});
 	// Register any new theme tiddlers
 	var registeredTiddlers = $tw.wiki.registerPluginTiddlers(this.pluginType,plugins);
 	// Unpack the current theme tiddlers
 	$tw.wiki.unpackPluginTiddlers();
-	// Accumulate the affected shadow tiddlers
-	this.wiki.eachShadow(function(tiddler,title) {
-		var source = self.wiki.getShadowSource(title);
-		if(registeredTiddlers.indexOf(source) !== -1) {
-			changedTiddlers[title] = false; // isDeleted?
-		}
-	});
-	// Issue change events for the modified tiddlers
-	$tw.utils.each(changedTiddlers,function(status,title) {
-		self.wiki.enqueueTiddlerEvent(title,status);
-	});
 };
 
 exports.PluginSwitcher = PluginSwitcher;


### PR DESCRIPTION
I am trying to understand why are there `enqueueTiddlerEvent` calls for shadow tiddlers.

I have an issue concerning automatically deleted overridden shadow tiddlers on language change.

Way to reproduce:
- start `tiddlywiki mywiki --server`

```
"TiddlyWebAdaptor:" "Getting status"
"TiddlyWebAdaptor:" "Status:" "{"space":{"recipe":"default"},"tiddlywiki_version":"5.1.5-prerelease"}"
"syncer-browser:" "Retrieving skinny tiddler list"
```
- _Language is English (British) by default_
- Set `$:/SiteTitle` to `Whatever`

```
"syncer-browser:" "Dispatching 'save' task:" "$:/SiteTitle"
"syncer-browser:" "Retrieving skinny tiddler list"
```
- Set language to e.g. Russian

```
"syncer-browser:" "Dispatching 'save' task:" "$:/language"
"syncer-browser:" "Dispatching 'save' task:" "$:/SiteTitle"
"syncer-browser:" "Retrieving skinny tiddler list"
```
- Set language back into English

```
"syncer-browser:" "Dispatching 'delete' task:" "$:/SiteTitle"
"syncer-browser:" "Dispatching 'save' task:" "$:/language"
```
- Hit F5 and `$:/SiteTitle` is lost forever

After modification - same actions:

```
"TiddlyWebAdaptor:" "Getting status"
"TiddlyWebAdaptor:" "Status:" "{"space":{"recipe":"default"},"tiddlywiki_version":"5.1.5-prerelease"}"
"syncer-browser:" "Retrieving skinny tiddler list"
"syncer-browser:" "Dispatching 'save' task:" "$:/SiteTitle"
"syncer-browser:" "Retrieving skinny tiddler list"
"syncer-browser:" "Dispatching 'save' task:" "$:/language"
"syncer-browser:" "Retrieving skinny tiddler list"
"syncer-browser:" "Dispatching 'save' task:" "$:/language"
```
