### PR TITLE
Giving users of modal a chance to reference the underlying tiddler

### DIFF
--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -108,13 +108,8 @@ Modal.prototype.display = function(param,options) {
 	var bodyWidgetNode = this.wiki.makeTranscludeWidget(title,{
 		parentWidget: $tw.rootWidget,
 		document: document,
-		variables: param
+		variables: vars
 	});
-	// make variables accessible in the body
-	for(var prop in param) {
-    		bodyWidgetNode.setVariable(prop, param[prop]);
-  	}
-	
 	bodyWidgetNode.render(modalBody,null);
 	this.wiki.addEventListener("change",function(changes) {
 		bodyWidgetNode.refresh(changes,modalBody,null);
@@ -154,7 +149,7 @@ Modal.prototype.display = function(param,options) {
 		]}],
 		parentWidget: $tw.rootWidget,
 		document: document,
-		variables: param
+		variables: vars
 	});
 	footerWidgetNode.render(modalFooterButtons,null);
 	this.wiki.addEventListener("change",function(changes) {


### PR DESCRIPTION
To make it possible to reference the underlying tiddler from a modal the `currentTiddler` variable is set and made accessible in the `bodyWidgetNode`.

This way the user (programmer) gets a chance to access fields of the tiddler the modal is based on.
