### PR TITLE
Helping action-sendmessage to consider additional parameters

### DIFF
--- a/core/modules/widgets/action-sendmessage.js
+++ b/core/modules/widgets/action-sendmessage.js
@@ -55,23 +55,29 @@ SendMessageWidget.prototype.refresh = function(changedTiddlers) {
 Invoke the action associated with this widget
 */
 SendMessageWidget.prototype.invokeAction = function(triggeringWidget,event) {
-	// Get the parameter
+   
+   	// Get the parameter
 	var param = this.actionParam;
-	// If the parameter is missing then we'll assemble the attributes as a hashmap
+	
 	if(!param) {
-		param = Object.create(null);
-		var count = 0;
-		$tw.utils.each(this.attributes,function(attribute,name) {
-			if(name.charAt(0) !== "$") {
-				param[name] = attribute;
-				count++;
-			}
-		});
-		// Revert to an empty parameter if no values were found
-		if(!count) {
-			param = undefined;
-		}
+	  param = Object.create(null);
 	}
+	
+	// Merge all other attributes into the object to allow additional parameters
+	// if properties of actionParam get overriden, its the users explicit choice
+	var count = 0;
+	$tw.utils.each(this.attributes,function(attribute,name) {
+	  if(name.charAt(0) !== "$") {
+	    param[name] = attribute;
+	    count++;
+	  }
+	});
+	
+	// Revert to an empty parameter if param was originally empty and no parameters where added
+	if(!this.actionParam && count == 0) {
+	  param = undefined;
+	}
+	
 	// Dispatch the message
 	this.dispatchEvent({type: this.actionMessage, param: param, tiddlerTitle: this.getVariable("currentTiddler")});
 	return true; // Action was invoked


### PR DESCRIPTION
Hi,

It seems to me that many users really look for a feature to create a new tiddler with a chosen title via a message. Naturally they want to specify a template and add some variables.

Two plugins I know picked up this issue.

Stephan's plugin: https://groups.google.com/d/msg/tiddlywiki/EbTVXUrWss4/Wwg57Zmur2YJ
Matabele's plugin: https://groups.google.com/d/msg/tiddlywiki/sLYQCaTVRVA/hUqi9nx-c-YJ

However with the modification in the action-sendmessage.js it can be done very easily(!) without a plugin(!) and without much code change(!):

I can now do the following to create a new tiddler via a button and set some fields and a title:

```
Create a new tiddler named "helloworld!" and based on a tiddler called "skeleton" also give it a field "bla" with value "hi"

<$button>
<$action-sendmessage $message="tm-new-tiddler" $param="skeleton" title="test"  bla="hi" /> create a new tiddler!
</$button>
```
