### PR TITLE
 Allowing to specify a template in the context of the new-tiddler event

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -389,7 +389,6 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 				  	if(p == "template") continue;
 					additionalFields[p] = event.param[p];
 				}
-				
 				// Override the default templateTiddler variable we created above.
 				// Also merge the additional fields provided in param to allow additional fields and overrides
 				templateTiddler = new $tw.Tiddler(tObj, additionalFields);


### PR DESCRIPTION
This request is a result of new insight gained in the discussion of #1050.
The proposed changes go well along with #429.

Excerpt from #1050 

---

It seems to me that many users really look for a feature to create a new tiddler with a chosen title via a message. Naturally they want to specify a template and add some variables.

Two plugins I know picked up this issue.

Stephan's plugin: https://groups.google.com/d/msg/tiddlywiki/EbTVXUrWss4/Wwg57Zmur2YJ
Matabele's plugin: https://groups.google.com/d/msg/tiddlywiki/sLYQCaTVRVA/hUqi9nx-c-YJ

---

What is changed by this new pull request?

1) If event.param is an object we look for a template property (this strategy is similar to where we look for a title property to use it as a title)
2) If the template exists, we use it and its fields as template
3) additional parameters may override or add fields

Try the following to see how it works

```
title: new-tiddler test
tags: displayonstartup

Create a new tiddler the standard way as it has been before
<$button>Click me!
<$action-sendmessage $message="tm-new-tiddler" title="My new tiddler" tags="mytag [[another tag]]" testfield="123" />
</$button>

Create a new tiddler with a template and some fields that may override the template's fields
<$button>Click me!
<$action-sendmessage $message="tm-new-tiddler" template="$:/SiteTitle" title="Look at my body!" tags="mytag [[another tag]]" testfield="123" />
</$button>


Create a new tiddler with a template property that does not refer to a tiddler and just gets discarded
<$button>Click me!
<$action-sendmessage $message="tm-new-tiddler" template="blabla23" title="I have no template" tags="mytag [[another tag]]" testfield="123" />
</$button>
```
