### PR TITLE
Proposal to allow creating a field and setting its value in one go

### DIFF
--- a/core/modules/widgets/fieldmangler.js
+++ b/core/modules/widgets/fieldmangler.js
@@ -73,7 +73,15 @@ FieldManglerWidget.prototype.handleRemoveFieldEvent = function(event) {
 FieldManglerWidget.prototype.handleAddFieldEvent = function(event) {
 	var tiddler = this.wiki.getTiddler(this.mangleTitle);
 	if(tiddler && typeof event.param === "string") {
-		var name = event.param.toLowerCase().trim();
+		var name = event.param;
+		var colon = name.indexOf(":");
+		var value = "";
+		if(colon>0) {
+			value = name.substr(colon+1).trim();
+			name= name.substr(0, colon).trim().toLowerCase();
+		} else {
+			name= name.toLowerCase().trim();
+		}
 		if(name !== "" && !$tw.utils.hop(tiddler.fields,name)) {
 			if(!$tw.utils.isValidFieldName(name)) {
 				alert($tw.language.getString(
@@ -85,7 +93,7 @@ FieldManglerWidget.prototype.handleAddFieldEvent = function(event) {
 				return true;
 			}
 			var addition = this.wiki.getModificationFields();
-			addition[name] = "";
+			addition[name] = value;
 			this.wiki.addTiddler(new $tw.Tiddler(tiddler,addition));
 		}
 	}


### PR DESCRIPTION
I always find it very tedious to first enter a field name, click "add" (could you add "Return" here as a shortcut?) and then to click the newly created field to enter the value. Especially when an instruction shows field and value like this: "field: value".

This proposal splits a field name at the first colon and sets the name to be the left and the new value to be the right part.