### PR TITLE
#1129 — hide static and github links for any system tiddlers prefixed "$:/" on tw.com

### DIFF
--- a/editions/tw5.com/tiddlers/system/Sources.tid
+++ b/editions/tw5.com/tiddlers/system/Sources.tid
@@ -16,7 +16,7 @@ https://github.com/Jermolene/TiddlyWiki5/blob/master/editions/tw5.com/tiddlers/$
 <a href=<<makeGitHubLink>> class="tc-tiddlylink-external" target="_blank"><$text text=<<makeGitHubLink>>/></a>
 </$set>
 \end
-<$list filter="[all[current]!prefix[$:/]!is[shadow]]">
+<$list filter="[all[current]!is[system]!is[shadow]]">
 
 A static HTML representation of this tiddler is available at the URL:
 


### PR DESCRIPTION
Remedies #1129 byremoving the content of sources from the TiddlerInfo for system tiddlers.

Also added underlined format for other tiddlers to make the "link" it at least stand out a little, even if not a link.
