### PR TITLE
#371 focus title field on edit

### DIFF
--- a/core/modules/widgets/edit-text.js
+++ b/core/modules/widgets/edit-text.js
@@ -71,6 +71,13 @@ EditTextWidget.prototype.render = function(parent,nextSibling) {
 	}
 	// Fix height
 	this.fixHeight();
+
+	// Focus field
+	if(this.editFocus === "true") {
+		domNode.focus();
+		domNode.select();
+	}
+
 };
 
 /*
@@ -140,6 +147,8 @@ EditTextWidget.prototype.execute = function() {
 	this.editAutoHeight = this.getAttribute("autoHeight","yes") === "yes";
 	this.editMinHeight = this.getAttribute("minHeight",DEFAULT_MIN_TEXT_AREA_HEIGHT);
 	this.editFocusPopup = this.getAttribute("focusPopup");
+	this.editFocus = this.getAttribute("focus");
+
 	// Get the editor element tag and type
 	var tag,type;
 	if(this.editField === "text") {

--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -1,4 +1,4 @@
 title: $:/core/ui/EditTemplate/title
 tags: $:/tags/EditTemplate
 
-<$edit-text field="draft.title" class="tc-titlebar tc-edit-texteditor"/>
+<$edit-text field="draft.title" class="tc-titlebar tc-edit-texteditor" focus="true"/>


### PR DESCRIPTION
- enhanced edit-text widget with `focus="true"` attribute
- modified title template to make it `focus()` and `select()` by default

![focus_and_select](https://cloud.githubusercontent.com/assets/97566/5182280/785a0d66-74a0-11e4-865f-a9d60ef1e182.gif)
