### PR TITLE
list core descriptions for ModuleType

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/ModuleType.tid
+++ b/editions/tw5.com/tiddlers/concepts/ModuleType.tid
@@ -4,8 +4,15 @@ tags: Concepts
 title: ModuleType
 type: text/vnd.tiddlywiki
 
-The `module-type` field of a [[JavaScript module|Modules]] is a string that identifies the type of the module.
+\define describe() {{$:/language/Docs/ModuleTypes/$(type)$}}
 
-The module types used in this wiki are listed below.
+The `module-type` field of a [[JavaScript module|Modules]] is a string that identifies the type of the module. Here is a list of the module types used in this wiki:
 
-<<list-links "[moduletypes[]]">>
+<dl>
+<$list filter="[moduletypes[]]">
+<dt>{{!!title}}</dt>
+<$set name=type value=<<currentTiddler>>>
+<dd><<describe>></dd>
+</$set>
+</$list>
+</dl>


### PR DESCRIPTION
Changed dead links with descriptions.

These are still missing:
- $:/language/Docs/ModuleTypes/allfilteroperator
- $:/language/Docs/ModuleTypes/info
- $:/language/Docs/ModuleTypes/library
