### PR TITLE
Update WidgetMessage_ tm-remove-tag.tid

### DIFF
--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-remove-tag.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-remove-tag.tid
@@ -8,6 +8,6 @@ caption: tm-remove-tag
 The `tm-remove-tag` message is handled by the FieldManglerWidget. It removes the specified tag.
 
 |!Name |!Description |
-|param |Name of tag to remove |
+|$param |Name of tag to remove |
 
 The remove tag message is usually generated with the ButtonWidget, and is handled by the FieldManglerWidget.


### PR DESCRIPTION
When removing a tag $param is used instead of param, isn't it.