### PR TITLE
Move the title display into a macro so that it can be globally overridden

### DIFF
--- a/core/wiki/macros/timeline.tid
+++ b/core/wiki/macros/timeline.tid
@@ -1,6 +1,16 @@
-title: $:/core/macros/timeline
+created: 20141212105914482
+modified: 20141212110330815
 tags: $:/tags/Macro
+title: $:/core/macros/timeline
+type: text/vnd.tiddlywiki
 
+\define timeline-title()
+<!-- Override this macro with a global macro 
+     of the same name if you need to change 
+     how titles are displayed on the timeline 
+     -->
+<$view field="title"/>
+\end
 \define timeline(limit:"100",format:"DDth MMM YYYY",subfilter:"",dateField:"modified")
 <div class="tc-timeline">
 <$list filter="[!is[system]$subfilter$has[$dateField$]!sort[$dateField$]limit[$limit$]eachday[$dateField$]]">
@@ -9,7 +19,7 @@ tags: $:/tags/Macro
 <$list filter="[sameday{!!$dateField$}!is[system]$subfilter$!sort[$dateField$]]">
 <div class="tc-menu-list-subitem">
 <$link to={{!!title}}>
-<$view field="title"/>
+<<timeline-title>>
 </$link>
 </div>
 </$list>


### PR DESCRIPTION
Copy the idea behind 5b38c21a417d2e5e2b85aed8010c88af32420e24 so that we can replace depencies on overridden core tiddlers with mere macro overriding.

A typical use case is localised documentation, where we could add such a global timeline-title() macro whithout overriding the core timeline macro:

```
\define timeline-title()
<$view field="fr-title">
<$view field="title"/>
</$view>
\end
```
