### PR TITLE
renamed filename for downloading empty wiki on tw5.com

### DIFF
--- a/editions/tw5.com/tiddlers/system/download-empty-button.tid
+++ b/editions/tw5.com/tiddlers/system/download-empty-button.tid
@@ -1,3 +1,7 @@
 title: $:/editions/tw5.com/snippets/download-empty-button
 
-<$button message="tm-download-file" param="$:/editions/tw5.com/download-empty" class="tc-btn-big-green">Download Empty {{$:/core/images/save-button}}</$button>
+\define buildEmptyFilename()
+tiddlywiki-$(version)$-empty.html
+\end
+
+<$button class="tc-btn-big-green"><$action-sendmessage $message="tm-download-file" $param="$:/editions/tw5.com/download-empty" filename=<<buildEmptyFilename>> />Download Empty {{$:/core/images/save-button}}</$button>


### PR DESCRIPTION
This changes the filename when clicking the `Download Empty` button to `tiddlywiki-$(version)$-empty.html`. I tested this in Firefox as well as chrome and it seems to work okay. This fixes #1234.

Note: This does not fix the `cryptic filename` bug (see #1231) and it does not change the download filenames of the `Download full wiki` button or any other button for that matter. Also note that the macro is not reusable and should not be put into the general macro tiddlers.

/Andreas
