### PR TITLE
make checkVersions consider build version

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -375,8 +375,7 @@ $tw.utils.checkVersions = function(versionStringA,versionStringB) {
 	];
 	return (diff[0] > 0) ||
 		(diff[0] === 0 && diff[1] > 0) ||
-		(diff[0] === 0 && diff[1] === 0 && diff[2] > 0) ||
-		(diff[0] === 0 && diff[1] === 0 && diff[2] === 0 && !versionB.prerelease);
+		(diff[0] === 0 && diff[1] === 0 && diff[2] > 0);
 };
 
 /*


### PR DESCRIPTION
Hi @Jermolene,

Currently, the build version is extracted by the regex (by `parseVersion`) but not used in the version check.

See this discussion.
https://groups.google.com/d/topic/tiddlywikidev/-WgmkTyeIM0/discussion

The patch solves this.

I tested the patch dragging my plugin 0.6.0+75 to a wiki with plugin version 0.6.0+74 and vice versa.

Regards
Felix
