### PR TITLE
Generate static output in RevealWidget

### DIFF
--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -164,7 +164,7 @@ RevealWidget.prototype.refresh = function(changedTiddlers) {
 			currentlyOpen = this.isOpen;
 		this.readState();
 		if(this.isOpen !== currentlyOpen) {
-			if(this.retain === "yes" || this.alwaysOpen) {
+			if(this.retain === "yes" || this.alwaysRender) {
 				this.updateState();
 			} else {
 				this.refreshSelf();

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -96,10 +96,16 @@ RevealWidget.prototype.execute = function() {
 	this.stateTitle = this.state;
 	this.readState();
 	// Construct the child widgets
-	var childNodes = this.isOpen ? this.parseTreeNode.children : [];
-	this.hasChildNodes = this.isOpen;
+	if(this.hasVariable("tv-static-output", "yes")) {
+		this.alwaysRender = true;
+	} else {
+		this.alwaysRender = false;
+	}
+	var childNodes = (this.alwaysRender || this.isOpen) ? this.parseTreeNode.children : [];
+	this.hasChildNodes = this.alwaysRender || this.isOpen;
 	this.makeChildWidgets(childNodes);
 };
+
 
 /*
 Read the state tiddler
@@ -158,7 +164,7 @@ RevealWidget.prototype.refresh = function(changedTiddlers) {
 			currentlyOpen = this.isOpen;
 		this.readState();
 		if(this.isOpen !== currentlyOpen) {
-			if(this.retain === "yes") {
+			if(this.retain === "yes" || this.alwaysOpen) {
 				this.updateState();
 			} else {
 				this.refreshSelf();


### PR DESCRIPTION
Added code to always generate the HTML if `tv-static-output` is set. This is a first step for the reveal widget. Almost nothing can be done with static HTML generation without this feature in place first. 
