### PR TITLE
Handle case-insensitive file systems.

### DIFF
--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -92,16 +92,17 @@ Given a tiddler title and an array of existing filenames, generate a new legal f
 */
 FileSystemAdaptor.prototype.generateTiddlerFilename = function(title,extension,existingFilenames) {
 	// First remove any of the characters that are illegal in Windows filenames
-	var baseFilename = title.replace(/<|>|\:|\"|\/|\\|\||\?|\*|\^|\s/g,"_");
+	var baseFilename = transliterate(title.replace(/<|>|\:|\"|\/|\\|\||\?|\*|\^|\s/g,"_"));
 	// Truncate the filename if it is too long
 	if(baseFilename.length > 200) {
 		baseFilename = baseFilename.substr(0,200);
 	}
 	// Start with the base filename plus the extension
-	var filename = transliterate(baseFilename) + extension,
+	var filename = baseFilename + extension,
 		count = 1;
-	// Add a discriminator if we're clashing with an existing filename
-	while(existingFilenames.indexOf(filename) !== -1) {
+	// Add a discriminator if we're clashing with an existing filename while
+	// handling case-insensitive filesystems (NTFS, FAT/FAT32, etc.)
+	while(existingFilenames.some(function(value) {return value.toLocaleLowerCase() === filename.toLocaleLowerCase();})) {
 		filename = baseFilename + " " + (count++) + extension;
 	}
 	return filename;


### PR DESCRIPTION
Hopefully you think this is cleaner. Tested as follows:
1. Create tiddler *f*, saved as *f.tid*
2. Create tiddler *F*, saved as *F 1.tid*
3. Create tiddler *foo*, saved as *foo.tid*
4. Create tiddler *Foo*, saved as *Foo 1.tid*
5. Create tiddler *FOO*, saved as *FOO 2.tid*
6. Delete tiddler *Foo*, deleted *Foo 1.tid*
7. Create tiddler *fOo*, saved as *fOo 1.tid*