### PR TITLE
Use the toc-caption() utility macro in Tabbed ToCs as well

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -167,7 +167,7 @@ tags: $:/tags/Macro
 <div class="tc-tabbed-table-of-contents-content">
 <$reveal state="""$selectedTiddler$""" type="nomatch" text="">
 <$transclude mode="block" tiddler="$template$">
-<h1><$transclude field="caption"><$view field="title"/></$transclude></h1>
+<h1><<toc-caption>></h1>
 <$transclude mode="block">$missingText$</$transclude>
 </$transclude>
 </$reveal>


### PR DESCRIPTION
Thus allowing overrides to toc-caption() to also take effect on tiddler titles displayed in Tabbed ToCs.