### PR TITLE
Links and transclusions in railroad diagrams

### DIFF
--- a/core/modules/parsers/wikiparser/rules/prettylink.js
+++ b/core/modules/parsers/wikiparser/rules/prettylink.js
@@ -27,18 +27,13 @@ exports.init = function(parser) {
 	this.matchRegExp = /\[\[(.*?)(?:\|(.*?))?\]\]/mg;
 };
 
-var isLinkExternal = function(to) {
-	var externalRegExp = /(?:file|http|https|mailto|ftp|irc|news|data|skype):[^\s<>{}\[\]`|'"\\^~]+(?:\/|\b)/i;
-	return externalRegExp.test(to);
-};
-
 exports.parse = function() {
 	// Move past the match
 	this.parser.pos = this.matchRegExp.lastIndex;
 	// Process the link
 	var text = this.match[1],
 		link = this.match[2] || text;
-	if(isLinkExternal(link)) {
+	if($tw.utils.isLinkExternal(link)) {
 		return [{
 			type: "element",
 			tag: "a",

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -439,6 +439,12 @@ exports.escapeRegExp = function(s) {
     return s.replace(/[\-\/\\\^\$\*\+\?\.\(\)\|\[\]\{\}]/g, '\\$&');
 };
 
+// Checks whether a link target is external, i.e. not a tiddler title
+exports.isLinkExternal = function(to) {
+	var externalRegExp = /(?:file|http|https|mailto|ftp|irc|news|data|skype):[^\s<>{}\[\]`|'"\\^~]+(?:\/|\b)/i;
+	return externalRegExp.test(to);
+};
+
 exports.nextTick = function(fn) {
 /*global window: false */
 	if(typeof process === "undefined") {

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -106,8 +106,8 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	this.domNodes.push(domNode);
 };
 
-LinkWidget.prototype.handleClickEvent = function (event) {
-	// Send the click on it's way as a navigate event
+LinkWidget.prototype.handleClickEvent = function(event) {
+	// Send the click on its way as a navigate event
 	var bounds = this.domNodes[0].getBoundingClientRect();
 	this.dispatchEvent({
 		type: "tm-navigate",

--- a/plugins/tiddlywiki/railroad/components.js
+++ b/plugins/tiddlywiki/railroad/components.js
@@ -89,13 +89,13 @@ Component.prototype.debug = function(output,indent) {
 Component.prototype.debugArray = function(array,output,indent) {
 	for(var i=0; i<array.length; i++) {
 		var item = array[i];
-		// Choice content is a special case: an array of arrays
+		// Choice content is a special case: we number the branches
 		if(item.isChoiceBranch) {
 			output.push(indent);
 			output.push("(");
 			output.push(i);
 			output.push(")\n");
-			item.debug(output,"  " +indent);
+			item.debug(output,"  "+indent);
 		} else {
 			item.debug(output,indent);
 		}
@@ -205,6 +205,27 @@ Repeated.prototype.toSvg = function() {
 	return railroad.OneOrMore(this.child.toSvg(),separatorSvg);
 }
 
+var Link = function(content,options) {
+	this.initialiseWithChild("Link",content);
+	this.options = options;
+};
+
+Link.prototype = new Component();
+
+Link.prototype.toSvg = function() {
+	return railroad.Link(this.child.toSvg(),this.options);
+}
+
+var Transclusion = function(content) {
+	this.initialiseWithChild("Transclusion",content);
+};
+
+Transclusion.prototype = new Component();
+
+Transclusion.prototype.toSvg = function() {
+	return this.child.toSvg();
+}
+
 /////////////////////////// Components with an array of children
 
 var Root = function(content) {
@@ -252,13 +273,15 @@ exports.components = {
 	Choice: Choice,
 	Comment: Comment,
 	Dummy: Dummy,
+	Link: Link,
 	Nonterminal: Nonterminal,
 	Optional: Optional,
 	OptionalRepeated: OptionalRepeated,
 	Repeated: Repeated,
 	Root: Root,
 	Sequence: Sequence,
-	Terminal: Terminal
+	Terminal: Terminal,
+	Transclusion: Transclusion
 };
 
 })();

--- a/plugins/tiddlywiki/railroad/doc/example-source.tid
+++ b/plugins/tiddlywiki/railroad/doc/example-source.tid
@@ -5,5 +5,5 @@ title: $:/plugins/tiddlywiki/railroad/example-source
 type: text/plain
 
 ["+"]
-({digit} | "#" <'escape sequence'>)
+({ [[digit|GettingStarted]] } | "#" <'escape sequence'>)
 [{("@" name-char | :"--" )}]

--- a/plugins/tiddlywiki/railroad/doc/example.tid
+++ b/plugins/tiddlywiki/railroad/doc/example.tid
@@ -8,7 +8,7 @@ title: $:/plugins/tiddlywiki/railroad/example
 ```
 <$railroad text="""
 ["+"]
-({digit} | "#" <'escape sequence'>)
+({ [[digit|GettingStarted]] } | "#" <'escape sequence'>)
 [{("@" name-char | :"--" )}]
 """/>
 ```

--- a/plugins/tiddlywiki/railroad/doc/readme.tid
+++ b/plugins/tiddlywiki/railroad/doc/readme.tid
@@ -2,7 +2,7 @@ created: 20150102163222184
 modified: 20150102172016663
 title: $:/plugins/tiddlywiki/railroad/readme
 
-This plugin provides a `<$railroad>` widget for generating railroad syntax diagrams as SVG images. It is based on [[a library by Tab Atkins|https://github.com/tabatkins/railroad-diagrams]].
+This plugin provides a `<$railroad>` widget for generating railroad syntax diagrams as SVG images. It is based on [[a library by Tab Atkins|https://github.com/tabatkins/railroad-diagrams]], and has been extended to allow components of a diagram to function as links.
 
 The content of the `<$railroad>` widget is ignored.
 
@@ -10,8 +10,10 @@ The content of the `<$railroad>` widget is ignored.
 |text |Text in a special syntax that defines the diagram's layout |
 |mode |If set to `debug`, the diagram will display its internal tree structure. The default mode is `svg` |
 
-The `text` can be transcluded from another tiddler:
+The entire `text` can be transcluded from another tiddler:
 
 ```
 <$railroad tiddler={{diagram}}>
 ```
+
+Alternatively, the diagram syntax allows specific parts of the `text` to be transcluded from other tiddlers.

--- a/plugins/tiddlywiki/railroad/doc/syntax.tid
+++ b/plugins/tiddlywiki/railroad/doc/syntax.tid
@@ -2,9 +2,11 @@ created: 20150103184022184
 modified: 20150103184022184
 title: $:/plugins/tiddlywiki/railroad/syntax
 
-The railroad widget constructs a diagram from the components defined below.
+The railroad widget uses a special ''diagram syntax'' to construct the components defined below.
 
 `x` and `y` here stand for any component.
+
+Names (as opposed to quoted strings) are available when a value starts with a letter and contains only letters, digits, underscores, dots and hyphens.
 
 ---
 
@@ -52,7 +54,6 @@ The railroad widget constructs a diagram from the components defined below.
 ; nonterminal
 : <$railroad text=""" (name | "<" string ">") """/>
 * A nonterminal component, i.e. the name of another diagram
-* The simple `name` option is available when the text starts with a letter and contains only letters, digits, underscores, dots and hyphens
 
 ---
 
@@ -65,3 +66,15 @@ The railroad widget constructs a diagram from the components defined below.
 ; dummy
 : <$railroad text=""" "-" """/>
 * The absence of a component
+
+---
+
+; link
+: <$railroad text=""" "[[" x "|" (name|string) "]]" """/>
+* A link to the tiddler title or URI given by the string or name
+
+---
+
+; transclusion
+: <$railroad text=""" "{{" (name|string) "}}" """/>
+* Treats the content of another tiddler as diagram syntax and transcludes it into the current diagram

--- a/plugins/tiddlywiki/railroad/files/railroad-diagrams.js
+++ b/plugins/tiddlywiki/railroad/files/railroad-diagrams.js
@@ -467,15 +467,16 @@ var temp = (function(options) {
 	}
 	
 /* TiddlyWiki: added linking ability */
-	function Link(target, item) {
-		if(!(this instanceof Link)) return new Link(target, item);
-		FakeSVG.call(this, 'a', {'xlink:href': target});
+	function Link(item,options) {
+		if(!(this instanceof Link)) return new Link(item,options);
+		FakeSVG.call(this,'a',options);
 		this.item = item;
 		this.width = item.width;
 		this.up = item.up;
 		this.down = item.down;
 	}
 	subclassOf(Link, FakeSVG);
+	Link.prototype.needsSpace = true;
 	Link.prototype.format = function(x, y, width) {
 		this.item.format(x,y,width).addTo(this);
 		return this;

--- a/plugins/tiddlywiki/railroad/wrapper.js
+++ b/plugins/tiddlywiki/railroad/wrapper.js
@@ -38,22 +38,71 @@ RailroadWidget.prototype.render = function(parent,nextSibling) {
 	var div = this.document.createElement("div");
 	try {
 		// Parse the source
-		var parser = new Parser(source);
+		var parser = new Parser(this,source);
+		// Generate content into the div
 		if(this.getAttribute("mode","svg") === "debug") {
-			var output = ["<pre>"];
-			parser.root.debug(output, "");
-			output.push("</pre>");
-			div.innerHTML = output.join("");
+			this.renderDebug(parser,div);
 		} else {
-			div.innerHTML = parser.root.toSvg();
+			this.renderSvg(parser,div);
 		}
 	} catch(ex) {
 		div.className = "tc-error";
 		div.textContent = ex;
 	}
-	// Insert it into the DOM
+	// Insert the div into the DOM
 	parent.insertBefore(div,nextSibling);
 	this.domNodes.push(div);
+};
+
+RailroadWidget.prototype.renderDebug = function(parser,div) {
+	var output = ["<pre>"];
+	parser.root.debug(output, "");
+	output.push("</pre>");
+	div.innerHTML = output.join("");
+};
+
+RailroadWidget.prototype.renderSvg = function(parser,div) {
+	// Generate a model of the diagram
+	var fakeSvg = parser.root.toSvg();
+	// Render the model into a tree of SVG DOM nodes
+	var svg = fakeSvg.toSVG();
+	// Fill in the remaining attributes of any link nodes
+	this.patchLinks(svg);
+	// Insert the SVG tree into the div
+	div.appendChild(svg);
+};
+
+RailroadWidget.prototype.patchLinks = function(node) {
+	var self = this;
+	if(node.hasChildNodes()) {
+		var children = node.childNodes;
+		for(var i=0; i<children.length; i++) {
+			var child = children[i];
+			var attributes = child.attributes;
+			if(attributes) {
+				// Find each element that has a data-tw-target attribute
+				var target = child.attributes["data-tw-target"];
+				if(target !== undefined) {
+					target = target.value;
+					if(child.attributes["data-tw-external"]) {
+						// External links are straightforward
+						child.setAttribute("target","_blank");
+					} else {
+						// Each internal link gets its own onclick handler, capturing its own copy of target
+						(function(myTarget) {
+							child.onclick = function(event) {
+								self.dispatchLink(myTarget,event);
+								return false;
+							}
+						})(target);
+						target = "#" + target;
+					}
+					child.setAttributeNS("http://www.w3.org/1999/xlink","href",target);
+				}
+			}
+			this.patchLinks(child);
+		}
+	}
 };
 
 RailroadWidget.prototype.refresh = function(changedTiddlers) {
@@ -63,6 +112,23 @@ RailroadWidget.prototype.refresh = function(changedTiddlers) {
 		return true;
 	}
 	return false;	
+};
+
+RailroadWidget.prototype.dispatchLink = function(to,event) {
+	// Send the click on its way as a navigate event
+	var bounds = this.domNodes[0].getBoundingClientRect();
+	this.dispatchEvent({
+		type: "tm-navigate",
+		navigateTo: to,
+		navigateFromTitle: this.getVariable("storyTiddler"),
+		navigateFromNode: this,
+		navigateFromClientRect: { top: bounds.top, left: bounds.left, width: bounds.width, right: bounds.right, bottom: bounds.bottom, height: bounds.height
+		},
+		navigateSuppressNavigation: event.metaKey || event.ctrlKey || (event.button === 1)
+	});
+	event.preventDefault();
+	event.stopPropagation();
+	return false;
 };
 
 exports.railroad = RailroadWidget;


### PR DESCRIPTION
Any component of a diagram can now be made to serve as a link to another tiddler or a URI.
Diagram fragments can be transcluded from other tiddlers.
I've promoted isExternalLink() from prettylink.js to be a method of $tw.utils to avoid duplicating it.