### PR TITLE
add "noclean" parameter to rendertiddlers

### DIFF
--- a/core/language/en-GB/Help/rendertiddlers.tid
+++ b/core/language/en-GB/Help/rendertiddlers.tid
@@ -4,7 +4,7 @@ description: Render tiddlers matching a filter to a specified ContentType
 Render a set of tiddlers matching a filter to separate files of a specified ContentType (defaults to `text/html`) and extension (defaults to `.html`).
 
 ```
---rendertiddlers <filter> <template> <pathname> [<type>] [<extension>]
+--rendertiddlers <filter> <template> <pathname> [<type>] [<extension>] ["noclean"]
 ```
 
 For example:
@@ -15,4 +15,4 @@ For example:
 
 By default, the pathname is resolved relative to the `output` subdirectory of the edition directory. The `--output` command can be used to direct output to a different directory.
 
-Any files in the target directory are deleted. The target directory is recursively created if it is missing.
+Any files in the target directory are deleted unless the "noclean" parameter is specified. The target directory is recursively created if it is missing.

--- a/core/modules/commands/rendertiddlers.js
+++ b/core/modules/commands/rendertiddlers.js
@@ -38,8 +38,11 @@ Command.prototype.execute = function() {
 		pathname = path.resolve(this.commander.outputPath,this.params[2]),
 		type = this.params[3] || "text/html",
 		extension = this.params[4] || ".html",
+		deletedirectory = (this.params[5] || "") != "noclean",
 		tiddlers = wiki.filterTiddlers(filter);
-	$tw.utils.deleteDirectory(pathname);
+	if(deletedirectory){
+		$tw.utils.deleteDirectory(pathname);
+	}
 	$tw.utils.createDirectory(pathname);
 	$tw.utils.each(tiddlers,function(title) {
 		var parser = wiki.parseTiddler(template),

--- a/core/modules/commands/rendertiddlers.js
+++ b/core/modules/commands/rendertiddlers.js
@@ -38,9 +38,9 @@ Command.prototype.execute = function() {
 		pathname = path.resolve(this.commander.outputPath,this.params[2]),
 		type = this.params[3] || "text/html",
 		extension = this.params[4] || ".html",
-		deletedirectory = (this.params[5] || "") != "noclean",
+		deleteDirectory = (this.params[5] || "") != "noclean",
 		tiddlers = wiki.filterTiddlers(filter);
-	if(deletedirectory){
+	if(deleteDirectory){
 		$tw.utils.deleteDirectory(pathname);
 	}
 	$tw.utils.createDirectory(pathname);


### PR DESCRIPTION
Discussed here: https://groups.google.com/forum/#!topic/tiddlywikidev/m0QRODcm6mY

Deletes directory by default thus maintaining compatibility with existing uses of rendertiddlers.