### PR TITLE
edit-tags filtering tags and titles

### DIFF
--- a/core/ui/Components/tag-link.tid
+++ b/core/ui/Components/tag-link.tid
@@ -1,0 +1,9 @@
+title: $:/core/ui/Components/tag-link
+
+<$link>
+<$set name="backgroundColor" value={{!!color}}>
+<span style=<<tag-styles>> class="tc-tag-label">
+<$view field="title" format="text"/>
+</span>
+</$set>
+</$link>

--- a/core/ui/EditTemplate/tags.tid
+++ b/core/ui/EditTemplate/tags.tid
@@ -27,14 +27,12 @@ background-color:$(backgroundColor)$;
 <$reveal state=<<qualify "$:/state/popup/tags-auto-complete">> type="nomatch" text="" default="">
 <div class="tc-block-dropdown">
 <$linkcatcher set="$:/temp/NewTagName" setTo="" message="tm-add-tag">
-<$list filter="[!is[shadow]tags[]search{$:/temp/NewTagName}sort[title]]">
-<$link>
-<$set name="backgroundColor" value={{!!color}}>
-<span style=<<tag-styles>> class="tc-tag-label">
-<$view field="title" format="text"/>
-</span>
-</$set>
-</$link>
+<$list filter="[tags[]search:title{$:/temp/NewTagName}sort[]]">
+{{||$:/core/ui/Components/tag-link}}
+</$list>
+<hr>
+<$list filter="[!is[system]search:title{$:/temp/NewTagName}sort[]]">
+{{||$:/core/ui/Components/tag-link}}
 </$list>
 </$linkcatcher>
 </div>


### PR DESCRIPTION
fixes #1333

extracts the tag-link into a component template...

**$:/core/ui/Components/tag-link**

...so as to split the list in two, having two filters that list tiddlers
in the add-tags popup to...

1. firstly, list matching used tags
2. secondly, list mathcing tiddler titles, thus availabe for tagging

Does away with searching content as it is irrelevant if not distracting
for tagging.

Why two lists? Consider wanting to tag a tiddler with "Filters"...
observe how the result would otherwise be way too far down because
existing tiddler titles get in the way.

Component templates are also desireable elsewhere, e.g. #1318