### PR TITLE
set url to current tiddler on tw.com

### DIFF
--- a/editions/tw5.com/tiddlers/system/UpdateAddressBar.tid
+++ b/editions/tw5.com/tiddlers/system/UpdateAddressBar.tid
@@ -1,0 +1,3 @@
+title $:/config/Navigation/UpdateAddressBar
+
+permalink


### PR DESCRIPTION
I can't say how often I had to look for the **# permalink** button just because it wouldn't be set automatically