### PR TITLE
Enable custom output paths for static websites

### DIFF
--- a/core/modules/commands/rendertiddlers.js
+++ b/core/modules/commands/rendertiddlers.js
@@ -13,6 +13,7 @@ Command to render several tiddlers to a folder of files
 "use strict";
 
 var widget = require("$:/core/modules/widgets/widget.js");
+var link = require("$:/core/modules/widgets/link.js").link;
 
 exports.info = {
 	name: "rendertiddlers",
@@ -35,22 +36,33 @@ Command.prototype.execute = function() {
 		wiki = this.commander.wiki,
 		filter = this.params[0],
 		template = this.params[1],
-		pathname = path.resolve(this.commander.outputPath,this.params[2]),
+		outputPath = this.commander.outputPath,
+		pathParam = this.params[2],
+		rootPath = path.resolve(outputPath,pathParam),
 		type = this.params[3] || "text/html",
 		extension = this.params[4] || ".html",
 		deleteDirectory = (this.params[5] || "") != "noclean",
 		tiddlers = wiki.filterTiddlers(filter);
-	if(deleteDirectory){
-		$tw.utils.deleteDirectory(pathname);
+	var parser = wiki.parseTiddler(template),widgetNode = wiki.makeWidget(parser);
+	if(link.getExportFolder){
+		rootPath = link.getExportFolder(rootPath,outputPath,pathParam,null,null);
 	}
-	$tw.utils.createDirectory(pathname);
-	$tw.utils.each(tiddlers,function(title) {
+	if(deleteDirectory){
+		$tw.utils.deleteDirectory(rootPath);
+	}
+	$tw.utils.createDirectory(rootPath);
+	$tw.utils.each(tiddlers,function(title) {		
 		var parser = wiki.parseTiddler(template),
 			widgetNode = wiki.makeWidget(parser,{variables: {currentTiddler: title}});
 		var container = $tw.fakeDocument.createElement("div");
 		widgetNode.render(container,null);
 		var text = type === "text/html" ? container.innerHTML : container.textContent;
-		fs.writeFileSync(path.resolve(pathname,encodeURIComponent(title) + extension),text,"utf8");
+		var finalPath = path.resolve(rootPath,encodeURIComponent(title) + extension)
+		if(link.getExportFolder){
+			finalPath = link.getExportFolder(finalPath,outputPath,pathParam,title,extension);			
+			$tw.utils.createDirectory(path.dirname(finalPath));
+		}
+		fs.writeFileSync(finalPath,text,"utf8");
 	});
 	return null;
 };

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -77,6 +77,9 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 		wikiLinkTemplate = wikiLinkTemplateMacro ? wikiLinkTemplateMacro.trim() : "#$uri_encoded$",
 		wikiLinkText = wikiLinkTemplate.replace("$uri_encoded$",encodeURIComponent(this.to));
 	wikiLinkText = wikiLinkText.replace("$uri_doubleencoded$",encodeURIComponent(encodeURIComponent(this.to)));
+	if(this.getExportLink){
+		wikiLinkText = this.getExportLink(wikiLinkText);
+	}
 	domNode.setAttribute("href",wikiLinkText);
 	// Set the tooltip
 	// HACK: Performance issues with re-parsing the tooltip prevent us defaulting the tooltip to "<$transclude field='tooltip'><$transclude field='title'/></$transclude>"


### PR DESCRIPTION
Add hooks into render tiddlers and $:/core/modules/widgets/link.js to allow plugins to dictate where static pages will be output

most of the changes to rendertiddlers are cosmetic, if no plugin is supplied then the command should function as before. This is the same for core/modules/widgets/link.js