### PR TITLE
Releases.tid now switches to the newest releast per default

### DIFF
--- a/editions/tw5.com/tiddlers/releasenotes/Releases.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Releases.tid
@@ -8,4 +8,6 @@ Here are the details of recent releases of TiddlyWiki5. See [[TiddlyWiki5 Versio
 
 (BetaReleases and AlphaReleases are listed separately).
 
-<<tabs "[tag[ReleaseNotes]!sort[created]]" "Release 5.1.7" "$:/state/tab2" "tc-vertical" "ReleaseTemplate">>
+<$list filter="[tag[ReleaseNotes]!sort[created]limit[1]]">
+  <$macrocall $name="tabs" tabsList="[tag[ReleaseNotes]!sort[created]]"default={{!!title}} class="tc-vertical" template="ReleaseTemplate" />
+</$list>


### PR DESCRIPTION
@Jermolene, I am using your approach to display versions and release notes (see http://bit.ly/tiddlymap) and I noticed that changing the default every time is a step that could be automated...

-Felix