### PR TITLE
extended search filter

### DIFF
--- a/core/modules/filters/search.js
+++ b/core/modules/filters/search.js
@@ -16,19 +16,14 @@ Filter operator for searching for the text in the operand tiddler
 Export our filter function
 */
 exports.search = function(source,operator,options) {
-	var invert = operator.prefix === "!";
-	if(operator.suffix) {
-		return options.wiki.search(operator.operand,{
-			source: source,
-			invert: invert,
-			field: operator.suffix
-		});
-	} else {
-		return options.wiki.search(operator.operand,{
-			source: source,
-			invert: invert
-		});
-	}
+	var result = [],
+		invert = operator.prefix === "!",
+		fields = (operator.suffix || "").split(":");
+	return options.wiki.search(operator.operand,{
+		source: source,
+		invert: invert,
+		field: fields[0] ? fields : undefined
+	});
 };
 
 })();

--- a/core/modules/tiddler.js
+++ b/core/modules/tiddler.js
@@ -27,7 +27,7 @@ standard text fields:
 
 exports.getFieldNames = function(which) {
 	var core,f,result = [];
-	switch (which){
+	switch (which) {
 		case "$text":
 		case "$standard":
 			core = $tw.wiki.getFieldNames(which);
@@ -43,7 +43,7 @@ exports.getFieldNames = function(which) {
 	} else {
 		core = $tw.wiki.getFieldNames();
 		for (f in this.fields){
-			if($tw.utils.hop(this.fields,f) && ("$all" === which || 0 > core.indexOf(f))) {
+			if($tw.utils.hop(this.fields,f) && (which === "$all" || 0 > core.indexOf(f))) {
 				result.push(f);
 			}
 		}

--- a/core/modules/tiddler.js
+++ b/core/modules/tiddler.js
@@ -13,7 +13,7 @@ Extension methods for the $tw.Tiddler object (constructor and methods required a
 "use strict";
 
 /*
-returns names of tiddler fields
+Returns names of tiddler fields.
 
 default: the current tiddler's custom fields, or via...
   => listFields("$custom")
@@ -26,16 +26,24 @@ standard text fields:
 */
 
 exports.listFields = function(which) {
-	var f, result = [],
+	var core = [],f,result = [],
 		text = ["title","text","tags","modifier","creator","list"],
 		standard = text.concat("color","created","modified");
-	switch (which) {
-	case "$text":
-		result = text;
-	case "$standard":
-		result = standard;
-		break
-	default :
+	if("$text" === which) {
+		core = text;
+	}
+	if("$standard" === which) {
+		core = standard;
+	}
+	//$text or $standard
+	if(core.length) {
+		for(f=0; f<core.length; f++){
+			if($tw.utils.hop(this.fields,core[f])) {
+				result.push(core[f]);
+			}
+		}
+	// $all or $custom
+	} else {
 		for (f in this.fields){
 			if($tw.utils.hop(this.fields,f) && ("$all" === which || 0 > standard.indexOf(f))) {
 				result.push(f);

--- a/core/modules/tiddler.js
+++ b/core/modules/tiddler.js
@@ -28,7 +28,7 @@ standard text fields:
 exports.listFields = function(which) {
 	var f, result = [],
 		text = ["title","text","tags","modifier","creator","list"],
-		standard = text.concat("modified","created");
+		standard = text.concat("color","created","modified");
 	switch (which) {
 	case "$text":
 		result = text;

--- a/core/modules/tiddler.js
+++ b/core/modules/tiddler.js
@@ -12,6 +12,39 @@ Extension methods for the $tw.Tiddler object (constructor and methods required a
 /*global $tw: false */
 "use strict";
 
+/*
+returns names of tiddler fields
+
+default: the current tiddler's custom fields, or via...
+  => listFields("$custom")
+all fields:
+  => listFields("$all")	
+standard fields:
+  => listFields("$standard")
+standard text fields:
+  => listFields("$text")
+*/
+
+exports.listFields = function(which) {
+	var f, result = [],
+		text = ["title","text","tags","modifier","creator","list"],
+		standard = text.concat("modified","created");
+	switch (which) {
+	case "$text":
+		result = text;
+	case "$standard":
+		result = standard;
+		break
+	default :
+		for (f in this.fields){
+			if($tw.utils.hop(this.fields,f) && ("$all" === which || 0 > standard.indexOf(f))) {
+				result.push(f);
+			}
+		}
+	}
+	return result;
+};
+
 exports.hasTag = function(tag) {
 	return this.fields.tags && this.fields.tags.indexOf(tag) !== -1;
 };

--- a/core/modules/tiddler.js
+++ b/core/modules/tiddler.js
@@ -16,27 +16,24 @@ Extension methods for the $tw.Tiddler object (constructor and methods required a
 Returns names of tiddler fields.
 
 default: the current tiddler's custom fields, or via...
-  => listFields("$custom")
+  => getFieldNames("$custom")
 all fields:
-  => listFields("$all")	
+  => getFieldNames("$all")	
 standard fields:
-  => listFields("$standard")
+  => getFieldNames("$standard")
 standard text fields:
-  => listFields("$text")
+  => getFieldNames("$text")
 */
 
-exports.listFields = function(which) {
-	var core = [],f,result = [],
-		text = ["title","text","tags","modifier","creator","list"],
-		standard = text.concat("color","created","modified");
-	if("$text" === which) {
-		core = text;
-	}
-	if("$standard" === which) {
-		core = standard;
+exports.getFieldNames = function(which) {
+	var core,f,result = [];
+	switch (which){
+		case "$text":
+		case "$standard":
+			core = $tw.wiki.getFieldNames(which);
 	}
 	//$text or $standard
-	if(core.length) {
+	if(core) {
 		for(f=0; f<core.length; f++){
 			if($tw.utils.hop(this.fields,core[f])) {
 				result.push(core[f]);
@@ -44,8 +41,9 @@ exports.listFields = function(which) {
 		}
 	// $all or $custom
 	} else {
+		core = $tw.wiki.getFieldNames();
 		for (f in this.fields){
-			if($tw.utils.hop(this.fields,f) && ("$all" === which || 0 > standard.indexOf(f))) {
+			if($tw.utils.hop(this.fields,f) && ("$all" === which || 0 > core.indexOf(f))) {
 				result.push(f);
 			}
 		}

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -185,6 +185,16 @@ exports.generateNewTitle = function(baseTitle,options) {
 	return title;
 };
 
+exports.getFieldNames = function(which){
+	//$text
+	var result = ["title","text","tags","list","modifier","creator"];
+	if(!which || "$text" !== which){
+		//$standard
+		result = result.concat("modified","created","color");
+	}
+	return result;
+}
+
 exports.isSystemTiddler = function(title) {
 	return title.indexOf("$:/") === 0;
 };
@@ -1014,7 +1024,7 @@ exports.search = function(text,options) {
 			if(field) {
 				if('[object Array]' == Object.prototype.toString.call(field)) {
 					$tw.utils.each(field, function(f){
-						f = 0 === f.indexOf("$") ? tiddler.listFields(f) : f;
+						f = 0 === f.indexOf("$") ? tiddler.getFieldNames(f) : f;
 						$tw.utils.pushTop(fields, f);
 					});
 				} else {

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1001,7 +1001,9 @@ exports.search = function(text,options) {
 		if(!searchTermsRegExps) {
 			return true;
 		}
-		var tiddler = self.getTiddler(title);
+		var field = options.field,
+			fields=[],
+			tiddler = self.getTiddler(title);
 		if(!tiddler) {
 			tiddler = new $tw.Tiddler({title: title, text: "", type: "text/vnd.tiddlywiki"});
 		}
@@ -1009,8 +1011,21 @@ exports.search = function(text,options) {
 			match;
 		for(var t=0; t<searchTermsRegExps.length; t++) {
 			match = false;
-			if(options.field) {
-				match = searchTermsRegExps[t].test(tiddler.getFieldString(options.field));
+			if(field) {
+				if('[object Array]' == Object.prototype.toString.call(field)) {
+					$tw.utils.each(field, function(f){
+						f = 0 === f.indexOf("$") ? tiddler.listFields(f) : f;
+						$tw.utils.pushTop(fields, f);
+					});
+				} else {
+					fields = [field];
+				}
+				$tw.utils.each(fields, function(field) {
+					match = searchTermsRegExps[t].test(tiddler.getFieldString(field));
+					if(match){
+						return false;
+					}
+				});
 			} else {
 				// Search title, tags and body
 				if(contentTypeInfo.encoding === "utf8") {


### PR DESCRIPTION
Extends search and search filter, implementing #1195. Allows...
- `[search:foo:bar:title[baz]]`
  - search custom fields foo & bar and title field
- `[search:$custom[foo]]`
  - search all custom fields
- `[search:$standard[foo]]`
  - search all standard fields
- `[search:$text[foo]]`
  - search all standard text fields — the above minus color / created / modified
- `[search:$all[foo]]`
  - search all fields
