### PR TITLE
Allow widget actions to propagate to children

### DIFF
--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -3,7 +3,7 @@ title: $:/core/modules/widgets/select.js
 type: application/javascript
 module-type: widget
 
-Select widget:
+Select widget (NG mod):
 
 ```
 <$select tiddler="MyTiddler" field="text">

--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -53,7 +53,6 @@ Handle a change event
 SelectWidget.prototype.handleChangeEvent = function(event) {
 	var value = this.getSelectDomNode().value;
 	this.wiki.setText(this.selectTitle,this.selectField,this.selectIndex,value);
-	this.invokeActions(event);
 };
 
 /*

--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -3,7 +3,7 @@ title: $:/core/modules/widgets/select.js
 type: application/javascript
 module-type: widget
 
-Select widget (NG mod):
+Select widget:
 
 ```
 <$select tiddler="MyTiddler" field="text">
@@ -53,6 +53,7 @@ Handle a change event
 SelectWidget.prototype.handleChangeEvent = function(event) {
 	var value = this.getSelectDomNode().value;
 	this.wiki.setText(this.selectTitle,this.selectField,this.selectIndex,value);
+	this.invokeActions(event);
 };
 
 /*

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -476,13 +476,23 @@ Widget.prototype.removeChildDomNodes = function() {
 };
 
 /*
-Invoke any action widgets that are immediate children of this widget
+Invoke any action widgets that are descendants of this widget.
 */
 Widget.prototype.invokeActions = function(event) {
+	return this.invokeActionCall(this, event);
+};
+
+/*
+Recursively search through descendants, invoking all actions encountered.
+*/
+Widget.prototype.invokeActionCall = function(here, event) {
 	var handled = false;
-	for(var t=0; t<this.children.length; t++) {
-		var child = this.children[t];
+	for(var t=0; t<here.children.length; t++) {
+		var child = here.children[t];
 		if(child.invokeAction && child.invokeAction(this,event)) {
+			handled = true;
+		}
+		if(this.invokeActionCall(child, event)) {
 			handled = true;
 		}
 	}


### PR DESCRIPTION
Modified invokeActions() in widget.js to recursively propagate action trigger event to all descendants.  Maintains compatibility with call from button widget.

Modified select.js to add action triggering capability.  Requires the widget.js modification to work.