### PR TITLE
exposes paramString as variable in macro scope

### DIFF
--- a/core/modules/parsers/wikiparser/rules/macrocallblock.js
+++ b/core/modules/parsers/wikiparser/rules/macrocallblock.js
@@ -53,6 +53,7 @@ exports.parse = function() {
 		type: "macrocall",
 		name: macroName,
 		params: params,
+		paramString: paramString,
 		isBlock: true
 	}];
 };

--- a/core/modules/parsers/wikiparser/rules/macrocallinline.js
+++ b/core/modules/parsers/wikiparser/rules/macrocallinline.js
@@ -52,7 +52,8 @@ exports.parse = function() {
 	return [{
 		type: "macrocall",
 		name: macroName,
-		params: params
+		params: params,
+		paramString: paramString
 	}];
 };
 

--- a/core/modules/widgets/macrocall.js
+++ b/core/modules/widgets/macrocall.js
@@ -42,6 +42,9 @@ MacroCallWidget.prototype.execute = function() {
 	this.renderOutput = this.getAttribute("$output","text/html");
 	// Merge together the parameters specified in the parse tree with the specified attributes
 	var params = this.parseTreeNode.params ? this.parseTreeNode.params.slice(0) : [];
+	// set paramString variable
+	this.setVariable("paramString",this.parseTreeNode.paramString);
+
 	$tw.utils.each(this.attributes,function(attribute,name) {
 		if(name.charAt(0) !== "$") {
 			params.push({name: name, value: attribute});			


### PR DESCRIPTION
implements #1373

useful in js macros that do their own parsing, if any

demo: http://tbdemo.tiddlyspot.com/#paramString