### PR TITLE
Catch syntax errors in regexp filters

### DIFF
--- a/core/modules/filters/regexp.js
+++ b/core/modules/filters/regexp.js
@@ -41,7 +41,11 @@ exports.regexp = function(source,operator,options) {
 			regexpString = regexpString.substr(0,regexpString.length - match[0].length);
 		}
 	}
-	regexp = new RegExp(regexpString,flags);
+	try {
+		regexp = new RegExp(regexpString,flags);
+	} catch(e) {
+		return ["" + e];
+	}
 	// Process the incoming tiddlers
 	if(operator.prefix === "!") {
 		source(function(tiddler,title) {


### PR DESCRIPTION
This makes it possible to type a `regexp` filter character by character into the Advanced Search Filter tab or into a tiddler with the preview visible, without being bombarded with JavaScript exceptions. The exception message is instead returned as the filter's output.