### PR TITLE
update tagging filter tests

### DIFF
--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -33,13 +33,13 @@ describe("Filter tests", function() {
 				tiddler: new $tw.Tiddler({title: "TiddlerSeventh",
 					text: "",
 					list: "TiddlerOne [[Tiddler Three]] [[a fourth tiddler]] MissingTiddler",
-					tags: []
+					tags: ["one"]
 				}),
 			},
 			"Tiddler8": {
 				tiddler: new $tw.Tiddler({title: "Tiddler8",
 					text: "Tidd",
-					tags: [],
+					tags: ["one"],
 					"test-field": "JoeBloggs"
 				})
 			}
@@ -162,11 +162,11 @@ describe("Filter tests", function() {
 	});
 
 	it("should handle the tagging operator", function() {
-		expect(wiki.filterTiddlers("[[one]tagging[]sort[title]]").join(",")).toBe("Tiddler Three,TiddlerOne");
-		expect(wiki.filterTiddlers("[[one]tagging[]]").join(",")).toBe("Tiddler Three,TiddlerOne");
+		expect(wiki.filterTiddlers("[[one]tagging[]sort[title]]").join(",")).toBe("Tiddler Three,Tiddler8,TiddlerOne,TiddlerSeventh");
+		expect(wiki.filterTiddlers("[[one]tagging[]]").join(",")).toBe("Tiddler Three,TiddlerOne,Tiddler8,TiddlerSeventh");
 		expect(wiki.filterTiddlers("[[two]tagging[]sort[title]]").join(",")).toBe("$:/TiddlerFive,$:/TiddlerTwo,Tiddler Three");
 		var fakeWidget = {getVariable: function() {return "one";}};
-		expect(wiki.filterTiddlers("[all[current]tagging[]sort[title]]",fakeWidget).join(",")).toBe("Tiddler Three,TiddlerOne");
+		expect(wiki.filterTiddlers("[all[current]tagging[]]",fakeWidget).join(",")).toBe("Tiddler Three,TiddlerOne,Tiddler8,TiddlerSeventh");
 	});
 
 	it("should handle the untagged operator", function() {


### PR DESCRIPTION
tests for #1378

using a single test-filters.js is (becoming) a pain... I'd rather have a single test file per filter / module / function