### PR TITLE
Improvement on warnings for importation

### DIFF
--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -1,7 +1,7 @@
 title: $:/language/Import/
 
 Listing/Cancel/Caption: Cancel
-Listing/Hint: These tiddlers are ready to import:
+Listing/Hint: These tiddlers are ready to import (remember to __save and refresh__ after import) :
 Listing/Import/Caption: Import
 Listing/Select/Caption: Select
 Listing/Status/Caption: Status


### PR DESCRIPTION
Especially when importing plugins it is important to remind the user that, in order to work as expected (like creating the needed shadow tiddlers) tiddlywiki must be refreshed.

I think there is better ways to achieve it (like a tooltip for example) so feel free to adapt !