### PR TITLE
Make sure all "get" access to $tw.config.fileExtensionInfo goes through...

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -398,11 +398,19 @@ $tw.utils.registerFileType = function(type,encoding,extension,options) {
 };
 
 /*
+Given an extension, always access the $tw.config.fileExtensionInfo
+using a lowercase extension only.
+*/
+$tw.utils.getFileExtensionInfo = function(ext) {
+	return ext ? $tw.config.fileExtensionInfo[ext.toLowerCase()] : null;
+}
+
+/*
 Given an extension, get the correct encoding for that file.
 defaults to utf8
 */
 $tw.utils.getTypeEncoding = function(ext) {
-	var extensionInfo = $tw.config.fileExtensionInfo[ext],
+	var extensionInfo = $tw.util.getFileExtensionInfo(ext),
 		type = extensionInfo ? extensionInfo.type : null,
 		typeInfo = type ? $tw.config.contentTypeInfo[type] : null;
 	return typeInfo ? typeInfo.encoding : "utf8";
@@ -1137,9 +1145,9 @@ $tw.Wiki.prototype.deserializeTiddlers = function(type,text,srcFields) {
 	srcFields = srcFields || Object.create(null);
 	var deserializer = $tw.Wiki.tiddlerDeserializerModules[type],
 		fields = Object.create(null);
-	if(!deserializer && $tw.config.fileExtensionInfo[type]) {
+	if(!deserializer && $tw.utils.getFileExtensionInfo(type)) {
 		// If we didn't find the serializer, try converting it from an extension to a content type
-		type = $tw.config.fileExtensionInfo[type].type;
+		type = $tw.utils.getFileExtensionInfo(type).type;
 		deserializer = $tw.Wiki.tiddlerDeserializerModules[type];
 	}
 	if(!deserializer && $tw.config.contentTypeInfo[type]) {
@@ -1386,7 +1394,7 @@ Load the tiddlers contained in a particular file (and optionally extract fields 
 */
 $tw.loadTiddlersFromFile = function(filepath,fields) {
 	var ext = path.extname(filepath),
-		extensionInfo = $tw.config.fileExtensionInfo[ext],
+		extensionInfo = $tw.utils.getFileExtensionInfo(ext),
 		type = extensionInfo ? extensionInfo.type : null,
 		typeInfo = type ? $tw.config.contentTypeInfo[type] : null,
 		data = fs.readFileSync(filepath,typeInfo ? typeInfo.encoding : "utf8"),

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -761,8 +761,8 @@ exports.old_parseText = function(type,text,options) {
 	options = options || {};
 	// Select a parser
 	var Parser = $tw.Wiki.parsers[type];
-	if(!Parser && $tw.config.fileExtensionInfo[type]) {
-		Parser = $tw.Wiki.parsers[$tw.config.fileExtensionInfo[type].type];
+	if(!Parser && $tw.utils.getFileExtensionInfo(type)) {
+		Parser = $tw.Wiki.parsers[$tw.utils.getFileExtensionInfo(type).type];
 	}
 	if(!Parser) {
 		Parser = $tw.Wiki.parsers[options.defaultType || "text/vnd.tiddlywiki"];
@@ -1104,7 +1104,7 @@ exports.readFile = function(file,callback) {
 	if(type === "" || !type) {
 		var dotPos = file.name.lastIndexOf(".");
 		if(dotPos !== -1) {
-			var fileExtensionInfo = $tw.config.fileExtensionInfo[file.name.substr(dotPos)];
+			var fileExtensionInfo = $tw.utils.getFileExtensionInfo(file.name.substr(dotPos));
 			if(fileExtensionInfo) {
 				type = fileExtensionInfo.type;
 			}

--- a/plugins/tiddlywiki/classictools/modules/recipe.js
+++ b/plugins/tiddlywiki/classictools/modules/recipe.js
@@ -38,7 +38,7 @@ exports["text/vnd.tiddlywiki2-recipe"] = function(text,fields) {
 		},
 		loadTiddlersFromFile = function(sourcePath,prefix) {
 			var ext = path.extname(sourcePath),
-				extensionInfo = $tw.config.fileExtensionInfo[ext],
+				extensionInfo = $tw.utils.getFileExtensionInfo(ext),
 				typeInfo = extensionInfo ? $tw.config.contentTypeInfo[extensionInfo.type] : null,
 				data = fs.readFileSync(sourcePath,typeInfo ? typeInfo.encoding : "utf8"),
 				fields = {title: sourcePath},


### PR DESCRIPTION
...a `$tw.utils.getFileExtensionInfo` helper function that ensures the parameter is cast to lowercase. Fixes #1418. Also fixes another issue discovered while investigating where a TW that previously had a JPG file successfully imported with an uppercase extension wasn't reloading the tiddler correctly when running under node.