### PR TITLE
Define operators via fields and a view template

### DIFF
--- a/editions/tw5.com/tiddlers/filters/FilterOperators.tid
+++ b/editions/tw5.com/tiddlers/filters/FilterOperators.tid
@@ -1,5 +1,5 @@
 created: 20140410103123179
-modified: 20150129133657000
+modified: 20150203183422000
 tags: Concepts Filters
 title: Filter Operators
 type: text/vnd.tiddlywiki
@@ -7,7 +7,7 @@ type: text/vnd.tiddlywiki
 \define .operator-rows(filter)
 <$list filter="$filter$"><tr>
 <td><$link to={{!!title}}>{{!!caption}}</$link></td>
-<td>{{!!purpose}} <$list filter="[all[current]tag[Common Operators]]">{{$:/core/images/done-button}}</$list></td>
+<td>{{!!op-purpose}} <$list filter="[all[current]tag[Common Operators]]">{{$:/core/images/done-button}}</$list></td>
 <td align="center"><$list filter="[all[current]tag[Negatable Operators]]">`!`</$list></td>
 </tr></$list>
 \end

--- a/editions/tw5.com/tiddlers/filters/addprefix.tid
+++ b/editions/tw5.com/tiddlers/filters/addprefix.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124172110000
+modified: 20150203181822000
 tags: [[Filter Operators]] [[String Operators]]
 title: addprefix Operator
 type: text/vnd.tiddlywiki
 caption: addprefix
-purpose: extend each input title with a prefix
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a string of characters"
-paramName="s"
-output="the input, but with <<.place s>> added to the start of each title"
-/>
+op-purpose: extend each input title with a prefix
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string of characters
+op-parameter-name: S
+op-output: the input, but with <<.place S>> added to the start of each title
 
 <<.operator-examples "addprefix">>

--- a/editions/tw5.com/tiddlers/filters/addsuffix.tid
+++ b/editions/tw5.com/tiddlers/filters/addsuffix.tid
@@ -1,16 +1,13 @@
 created: 20140828133830424
-modified: 20150124172115000
+modified: 20150203183207000
 tags: [[Filter Operators]] [[String Operators]]
 title: addsuffix Operator
 type: text/vnd.tiddlywiki
 caption: addsuffix
-purpose: extend each input title with a suffix
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a string of characters"
-paramName="s"
-output="the input, but with <<.place s>> added to the end of each title"
-/>
+op-purpose: extend each input title with a suffix
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string of characters
+op-parameter-name: S
+op-output: the input, but with <<.place S>> added to the end of each title
 
 <<.operator-examples "addsuffix">>

--- a/editions/tw5.com/tiddlers/filters/after.tid
+++ b/editions/tw5.com/tiddlers/filters/after.tid
@@ -1,18 +1,15 @@
 created: 20140512103123179
-modified: 20150124204353000
+modified: 20150203183205000
 tags: [[Filter Operators]] [[Order Operators]]
 title: after Operator
 type: text/vnd.tiddlywiki
 caption: after
-purpose: find which input title follows a specified one
+op-purpose: find which input title follows a specified one
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: one of those titles
+op-parameter-name: T
+op-output: the title that immediately follows <<.place T>> in the input
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="one of those titles"
-paramName="t"
-output="the title that immediately follows <<.place t>> in the input"
-/>
-
-If <<.place t>> is not present in the input, or is the last title there, then the output is empty.
+If <<.place T>> is not present in the input, or is the last title there, then the output is empty.
 
 <<.operator-examples "after">>

--- a/editions/tw5.com/tiddlers/filters/all.tid
+++ b/editions/tw5.com/tiddlers/filters/all.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150129133636000
+modified: 20150203183224000
 tags: [[Filter Operators]] [[Common Operators]] [[Selection Constructors]]
 title: all Operator
 type: text/vnd.tiddlywiki
 caption: all
-purpose: find all titles of a fundamental category
-
-<$macrocall $name=".operator-def"
-input="ignored, unless the parameter is empty"
-parameter="zero or more categories -- see below"
-output="the titles that belong to all the specified categories"
-/>
+op-purpose: find all titles of a fundamental category
+op-input: ignored, unless the parameter is empty
+op-parameter: zero or more categories
+op-output: the titles that belong to all the specified categories
 
 The parameter specifies zero or more fundamental categories using the following syntax:
 

--- a/editions/tw5.com/tiddlers/filters/backlinks.tid
+++ b/editions/tw5.com/tiddlers/filters/backlinks.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124200946000
+modified: 20150203183356000
 tags: [[Filter Operators]]
 title: backlinks Operator
 type: text/vnd.tiddlywiki
 caption: backlinks
-purpose: find the titles that link to each input title
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="none"
-output="any non-[[system|SystemTiddlers]] titles that contain [[hard links|Hard and Soft Links]] to the input titles"
-/>
+op-purpose: find the titles that link to each input title
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: none
+op-output: any non-[[system|SystemTiddlers]] titles that contain [[hard links|Hard and Soft Links]] to the input titles
 
 Each input title is processed in turn. The corresponding tiddler's list of backlinks is generated, sorted alphabetically by title, and then [[dominantly appended|Dominant Append]] to the operator's overall output.
 

--- a/editions/tw5.com/tiddlers/filters/before.tid
+++ b/editions/tw5.com/tiddlers/filters/before.tid
@@ -1,18 +1,15 @@
 created: 20140512103123179
-modified: 20150124164952000
+modified: 20150203191918000
 tags: [[Filter Operators]] [[Order Operators]]
 caption: before
 title: before Operator
 type: text/vnd.tiddlywiki
-purpose: find which input title precedes a specified one
+op-purpose: find which input title precedes a specified one
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: one of those titles
+op-parameter-name: T
+op-output: the title that immediately precedes <<.place T>> in the input
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="one of those titles"
-paramName="t"
-output="the title that immediately precedes <<.place t>> in the input"
-/>
-
-If <<.place t>> is not present in the input, or is the first title there, then the output is empty.
+If <<.place T>> is not present in the input, or is the first title there, then the output is empty.
 
 <<.operator-examples "before">>

--- a/editions/tw5.com/tiddlers/filters/bf.tid
+++ b/editions/tw5.com/tiddlers/filters/bf.tid
@@ -1,9 +1,7 @@
 created: 20140410103123179
-modified: 20150124200504000
+modified: 20150203183738000
 tags: [[Filter Operators]] [[Order Operators]]
 title: bf Operator
 type: text/vnd.tiddlywiki
 caption: bf
-purpose: same as <<.op rest>>
-
-<<.op bf>> is a synonym for <<.olink rest>>, also known as <<.olink butfirst>>.
+op-purpose: same as <<.olink rest>>

--- a/editions/tw5.com/tiddlers/filters/butfirst.tid
+++ b/editions/tw5.com/tiddlers/filters/butfirst.tid
@@ -1,9 +1,7 @@
 created: 20140410103123179
-modified: 20150124200507000
+modified: 20150203183733000
 tags: [[Filter Operators]] [[Order Operators]]
 title: butfirst Operator
 type: text/vnd.tiddlywiki
 caption: butfirst
-purpose: same as <<.op rest>>
-
-<<.op butfirst>> is a synonym for <<.olink rest>>, also known as <<.olink bf>>.
+op-purpose: same as <<.olink rest>>

--- a/editions/tw5.com/tiddlers/filters/butlast.tid
+++ b/editions/tw5.com/tiddlers/filters/butlast.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124172210000
+modified: 20150203191930000
 tags: [[Filter Operators]] [[Order Operators]]
 title: butlast Operator
 type: text/vnd.tiddlywiki
 caption: butlast
-purpose: discard the last <<.place n>> input titles
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="an integer, defaulting to 1"
-paramName="n"
-output="all but the last <<.place n>> input titles"
-/>
+op-purpose: discard the last <<.place N>> input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: an integer, defaulting to 1
+op-parameter-name: N
+op-output: all but the last <<.place N>> input titles
 
 <<.operator-examples "butlast">>

--- a/editions/tw5.com/tiddlers/filters/commands.tid
+++ b/editions/tw5.com/tiddlers/filters/commands.tid
@@ -1,15 +1,12 @@
 created: 20140410103123179
-modified: 20150129133643000
+modified: 20150203184154000
 tags: [[Filter Operators]] [[Special Operators]] [[Selection Constructors]]
 title: commands Operator
 type: text/vnd.tiddlywiki
 caption: commands
-purpose: select the titles of all the Node.js commands
-
-<$macrocall $name=".operator-def"
-input="ignored"
-parameter="none"
-output="the [[command words|Commands]] that can be given to [[TiddlyWiki on Node.js]]"
-/>
+op-purpose: select the titles of all the Node.js commands
+op-input: ignored
+op-parameter: none
+op-output: the [[command words|Commands]] that can be given to [[TiddlyWiki on Node.js]]
 
 <<.operator-examples "commands">>

--- a/editions/tw5.com/tiddlers/filters/each.tid
+++ b/editions/tw5.com/tiddlers/filters/each.tid
@@ -1,26 +1,23 @@
 created: 20140410103123179
-modified: 20150127202915000
+modified: 20150203184257000
 tags: [[Filter Operators]] [[Group Operators]]
 title: each Operator
 type: text/vnd.tiddlywiki
 caption: each
-purpose: select one of each group of input titles by field
+op-purpose: select one of each group of input titles by field
+op-input: a [[selection of titles|Title Selection]]
+op-suffix: optionally, `list`
+op-parameter: the name of a [[field|TiddlerFields]], defaulting to <<.field title>>
+op-parameter-name: F
+op-output: a selection containing the first input title encountered for each distinct value of field <<.place F>>
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-suffix="optionally, `list`"
-parameter="the name of a [[field|TiddlerFields]], defaulting to <<.field title>>"
-paramName="f"
-output="a selection containing the first input title encountered for each distinct value of field <<.place f>>"
-/>
-
-Each input title is processed in turn. The value of field <<.place f>> in the corresponding tiddler is examined.
+Each input title is processed in turn. The value of field <<.place F>> in the corresponding tiddler is examined.
 
 ;each
 :As long as the field's value has not been encountered before, the title is appended to the output.
 ;each:list
 :The value is treated as a [[title list|Title List]]. Each title in the list considered in turn. If it has not been encountered before, it is appended to the output.
 
-If a tiddler doesn't contain field <<.place f>>, it is treated as if the field's value was empty.
+If a tiddler doesn't contain field <<.place F>>, it is treated as if the field's value was empty.
 
 <<.operator-examples "each">>

--- a/editions/tw5.com/tiddlers/filters/eachday.tid
+++ b/editions/tw5.com/tiddlers/filters/eachday.tid
@@ -1,20 +1,17 @@
 created: 20140410103123179
-modified: 20150127202806000
+modified: 20150203184456000
 tags: [[Filter Operators]] [[Group Operators]] [[Date Operators]]
 title: eachday Operator
 type: text/vnd.tiddlywiki
 caption: eachday
-purpose: select one of each group of input titles by date
+op-purpose: select one of each group of input titles by date
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the name of a [[date field|Date Fields]]
+op-parameter-name: F
+op-output: a selection containing the first input title encountered for each distinct value (ignoring times of day) of field <<.place F>>
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="the name of a [[date field|Date Fields]]"
-paramName="f"
-output="a selection containing the first input title encountered for each distinct value (ignoring times of day) of field <<.place f>>"
-/>
+Each input title is processed in turn. The value of field <<.place F>> in the corresponding tiddler is examined, and as long as this indicates a date that has not been encountered before, the title is appended to the output.
 
-Each input title is processed in turn. The value of field <<.place f>> in the corresponding tiddler is examined, and as long as this indicates a date that has not been encountered before, the title is appended to the output.
-
-If a tiddler doesn't contain field <<.place f>>, it contributes nothing to the output.
+If a tiddler doesn't contain field <<.place F>>, it contributes nothing to the output.
 
 <<.operator-examples "eachday">>

--- a/editions/tw5.com/tiddlers/filters/editiondescription.tid
+++ b/editions/tw5.com/tiddlers/filters/editiondescription.tid
@@ -1,16 +1,13 @@
 created: 20150111145738451
-modified: 20150124165002000
+modified: 20150203184528000
 tags: [[Filter Operators]] [[Special Operators]]
 title: editiondescription Operator
 type: text/vnd.tiddlywiki
 caption: editiondescription
-purpose: select the descriptions of the input editions
-
-<$macrocall $name=".operator-def"
-input="a [[selection|Title Selection]] of edition names"
-parameter="none"
-output="the description string of each edition in the input"
-/>
+op-purpose: select the descriptions of the input editions
+op-input: a [[selection|Title Selection]] of edition names
+op-parameter: none
+op-output: the description string of each edition in the input
 
 Each input title is processed in turn, ignoring any that is not the name of a ~TiddlyWiki edition.
 

--- a/editions/tw5.com/tiddlers/filters/editions.tid
+++ b/editions/tw5.com/tiddlers/filters/editions.tid
@@ -1,15 +1,12 @@
 created: 20150111145738451
-modified: 20150129133647000
+modified: 20150203184604000
 tags: [[Filter Operators]] [[Special Operators]] [[Selection Constructors]]
 title: editions Operator
 type: text/vnd.tiddlywiki
 caption: editions
-purpose: select the names of all the ~TiddlyWiki editions
-
-<$macrocall $name=".operator-def"
-input="ignored"
-parameter="none"
-output="the name of each ~TiddlyWiki edition, in alphabetical order"
-/>
+op-purpose: select the names of all the ~TiddlyWiki editions
+op-input: ignored
+op-parameter: none
+op-output: the name of each ~TiddlyWiki edition, in alphabetical order
 
 <<.node-only-operator>>

--- a/editions/tw5.com/tiddlers/filters/field.tid
+++ b/editions/tw5.com/tiddlers/filters/field.tid
@@ -1,25 +1,22 @@
 created: 20140410103123179
-modified: 20150124201655000
+modified: 20150203184718000
 tags: [[Filter Operators]] [[Common Operators]] [[Field Operators]] [[Negatable Operators]]
 title: field Operator
 type: text/vnd.tiddlywiki
 caption: field
-purpose: filter the input by field
+op-purpose: filter the input by field
+op-input: a [[selection of titles|Title Selection]]
+op-suffix: the name of a [[field|TiddlerFields]]
+op-suffix-name: F
+op-parameter: a possible value of field <<.place F>>
+op-parameter-name: S
+op-output: those input tiddlers in which field <<.place F>> has the value <<.place S>>
+op-neg-output: those input tiddlers in which field <<.place F>> does <<.em not>> have the value <<.place S>>
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-suffix="the name of a [[field|TiddlerFields]]"
-suffixName="f"
-parameter="a possible value of field <<.place f>>"
-paramName="s"
-output="those input tiddlers in which field <<.place f>> has the value <<.place s>>"
-negationOutput="those input tiddlers in which field <<.place f>> does <<.em not>> have the value <<.place s>>"
-/>
+If <<.place S>> is empty, <<.op field>> will match both of the following:
 
-If <<.place s>> is empty, <<.op field>> will match both of the following:
-
-* tiddlers that don't contain field <<.place f>>
-* tiddlers in which field <<.place f>> exists but has an empty value
+* tiddlers that don't contain field <<.place F>>
+* tiddlers in which field <<.place F>> exists but has an empty value
 
 The syntax of a [[filter step|Filter Step]] treats any unrecognised [[filter operator|Filter Operators]] as if it was the suffix to the <<.op field>> operator. See the <<.operator-examples "field" "examples">>.
 

--- a/editions/tw5.com/tiddlers/filters/fields.tid
+++ b/editions/tw5.com/tiddlers/filters/fields.tid
@@ -1,16 +1,13 @@
 created: 20140924115616653
-modified: 20150124184835000
+modified: 20150203184828000
 tags: [[Filter Operators]] [[Field Operators]]
 title: fields Operator
 type: text/vnd.tiddlywiki
 caption: fields
-purpose: select all field names of the input titles
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="none"
-output="all the field names contained in the input tiddlers"
-/>
+op-purpose: select all field names of the input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: none
+op-output: all the field names contained in the input tiddlers
 
 Each input title is processed in turn. Its list of field names is retrieved (in no particular order) and then [[dominantly appended|Dominant Append]] to the operator's output.
 

--- a/editions/tw5.com/tiddlers/filters/first.tid
+++ b/editions/tw5.com/tiddlers/filters/first.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124161800000
+modified: 20150203191946000
 tags: [[Filter Operators]] [[Order Operators]]
 title: first Operator
 type: text/vnd.tiddlywiki
 caption: first
-purpose: select the first <<.place n>> input titles
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="an integer, defaulting to 1"
-paramName="n"
-output="the first <<.place n>> input titles"
-/>
+op-purpose: select the first <<.place N>> input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: an integer, defaulting to 1
+op-parameter-name: N
+op-output: the first <<.place N>> input titles
 
 <<.operator-examples "first">>

--- a/editions/tw5.com/tiddlers/filters/get.tid
+++ b/editions/tw5.com/tiddlers/filters/get.tid
@@ -1,20 +1,17 @@
 created: 20140426183123179
-modified: 20150124165013000
+modified: 20150203185001000
 tags: [[Filter Operators]] [[Field Operators]]
 title: get Operator
 type: text/vnd.tiddlywiki
 caption: get
-purpose: select all values of a field in the input titles
+op-purpose: select all values of a field in the input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the name of a [[field|TiddlerFields]]
+op-parameter-name: F
+op-output: the values of field <<.place F>> in each of the input titles
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="the name of a [[field|TiddlerFields]]"
-paramName="f"
-output="the values of field <<.place f>> in each of the input titles"
-/>
+Each input title is processed in turn. If the corresponding tiddler contains field <<.place F>>, and the value of this field is not empty, then its value is appended to the output.
 
-Each input title is processed in turn. If the corresponding tiddler contains field <<.place f>>, and the value of this field is not empty, then its value is appended to the output.
-
-Unlike most other [[Filter Operators]], the [[selection|Title Selection]] output by <<.op get>> can contain duplicates. To avoid duplicates, use `each[f]get[f]`.
+Unlike most other [[Filter Operators]], the [[selection|Title Selection]] output by <<.op get>> can contain duplicates. To avoid duplicates, use `each[F]get[F]`.
 
 <<.operator-examples "get">>

--- a/editions/tw5.com/tiddlers/filters/has.tid
+++ b/editions/tw5.com/tiddlers/filters/has.tid
@@ -1,18 +1,14 @@
 created: 20140410103123179
-modified: 20150124191952000
+modified: 20150203191843000
 tags: [[Filter Operators]] [[Common Operators]] [[Field Operators]] [[Negatable Operators]]
 title: has Operator
 type: text/vnd.tiddlywiki
 caption: has
-purpose: filter the input by field existence
-
-<$macrocall $name=".operator-def"
-syntax="has[f]"
-input="a [[selection of titles|Title Selection]]"
-parameter="the name of a [[field|TiddlerFields]]"
-paramName="f"
-output="those input tiddlers in which field <<.place f>> has a non-empty value"
-negationOutput="those input tiddlers in which field <<.place f>> does <<.em not>> exist or has an empty value"
-/>
+op-purpose: filter the input by field existence
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the name of a [[field|TiddlerFields]]
+op-parameter-name: F
+op-output: those input tiddlers in which field <<.place F>> has a non-empty value
+op-neg-output: those input tiddlers in which field <<.place F>> does <<.em not>> exist or has an empty value
 
 <<.operator-examples "has">>

--- a/editions/tw5.com/tiddlers/filters/indexes.tid
+++ b/editions/tw5.com/tiddlers/filters/indexes.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124184840000
+modified: 20150203185150000
 tags: [[Filter Operators]]
 title: indexes Operator
 type: text/vnd.tiddlywiki
 caption: indexes
-purpose: select all data properties of the input titles
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="none"
-output="all the property names or indices contained in the input data tiddlers"
-/>
+op-purpose: select all data properties of the input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: none
+op-output: all the property names or indices contained in the input data tiddlers
 
 Each input title is processed in turn, and is ignored if it does not denote a [[data tiddler|DataTiddlers]]. The list of property names is retrieved from the data tiddler (in no particular order) and then [[dominantly appended|Dominant Append]] to the operator's output.
 

--- a/editions/tw5.com/tiddlers/filters/is.tid
+++ b/editions/tw5.com/tiddlers/filters/is.tid
@@ -1,20 +1,17 @@
 created: 20140410103123179
-modified: 20150124202225000
+modified: 20150203185255000
 tags: [[Filter Operators]] [[Common Operators]] [[Negatable Operators]]
 title: is Operator
 type: text/vnd.tiddlywiki
 caption: is
-purpose: filter the input by fundamental category
+op-purpose: filter the input by fundamental category
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a category
+op-parameter-name: C
+op-output: those input tiddlers that belong to category <<.place C>>
+op-neg-output: those input tiddlers that do <<.em not>> belong to category <<.place C>>
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a category -- see below"
-paramName="c"
-output="those input tiddlers that belong to category <<.place c>>"
-negationOutput="those input tiddlers that do <<.em not>> belong to category <<.place c>>"
-/>
-
-The parameter <<.place c>> is one of the following fundamental categories:
+The parameter <<.place C>> is one of the following fundamental categories:
 
 |!Category |!Matches any tiddler that... |
 |^`current` |is the [[current tiddler|CurrentTiddler]] |
@@ -26,7 +23,7 @@ The parameter <<.place c>> is one of the following fundamental categories:
 |^`tag` |is in use as a tag |
 |^`tiddler` |exists as a non-shadow tiddler |
 
-If <<.place c>> is anything else, the output is an error message.
+If <<.place C>> is anything else, the output is an error message.
 
 `!is[tiddler]` is a synonym for `is[missing]`, and vice versa.
 

--- a/editions/tw5.com/tiddlers/filters/last.tid
+++ b/editions/tw5.com/tiddlers/filters/last.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124204508000
+modified: 20150203192036000
 tags: [[Filter Operators]] [[Order Operators]]
 title: last Operator
 type: text/vnd.tiddlywiki
 caption: last
-purpose: select the last <<.place n>> input titles
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="an integer, defaulting to 1"
-paramName="n"
-output="the last <<.place n>> input titles"
-/>
+op-purpose: select the last <<.place N>> input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: an integer, defaulting to 1
+op-parameter-name: N
+op-output: the last <<.place N>> input titles
 
 <<.operator-examples "last">>

--- a/editions/tw5.com/tiddlers/filters/limit.tid
+++ b/editions/tw5.com/tiddlers/filters/limit.tid
@@ -1,19 +1,16 @@
 created: 20140410103123179
-modified: 20150124204544000
+modified: 20150203185456000
 tags: [[Filter Operators]] [[Common Operators]] [[Order Operators]] [[Negatable Operators]]
 title: limit Operator
 type: text/vnd.tiddlywiki
 caption: limit
-purpose: select the first or last <<.place n>> input titles
+op-purpose: select the first or last <<.place N>> input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: an integer, defaulting to 0
+op-parameter-name: N
+op-output: the first <<.place N>> input titles
+op-neg-output: the last <<.place N>> input titles
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="an integer, defaulting to 0"
-paramName="n"
-output="the first <<.place n>> input titles"
-negationOutput="the last <<.place n>> input titles"
-/>
-
-`limit[n]` and `!limit[n]` are synonyms for `first[n]` and `last[n]` respectively.
+`limit[N]` and `!limit[N]` are synonyms for `first[N]` and `last[N]` respectively.
 
 <<.operator-examples "limit">>

--- a/editions/tw5.com/tiddlers/filters/links.tid
+++ b/editions/tw5.com/tiddlers/filters/links.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124184844000
+modified: 20150203185545000
 tags: [[Filter Operators]] [[Common Operators]]
 title: links Operator
 type: text/vnd.tiddlywiki
 caption: links
-purpose: find the titles linked to by each input title
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="none"
-output="the titles to which the input tiddlers contain [[hard links|Hard and Soft Links]]"
-/>
+op-purpose: find the titles linked to by each input title
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: none
+op-output: the titles to which the input tiddlers contain [[hard links|Hard and Soft Links]]
 
 Each input title is processed in turn. The corresponding tiddler's list of links is generated, in the order in which they appear in the tiddler's text, and [[dominantly appended|Dominant Append]] to the operator's overall output.
 

--- a/editions/tw5.com/tiddlers/filters/list.tid
+++ b/editions/tw5.com/tiddlers/filters/list.tid
@@ -1,23 +1,20 @@
 created: 20140410103123179
-modified: 20150129133705000
+modified: 20150203192721000
 tags: [[Filter Operators]] [[Field Operators]] [[Selection Constructors]] [[Negatable Operators]]
 title: list Operator
 type: text/vnd.tiddlywiki
 caption: list
-purpose: select titles via a list field
+op-purpose: select titles via a list field
+op-input: ignored
+op-neg-input: a [[selection of titles|Title Selection]]
+op-parameter: a [[reference|TextReference]] to a [[field|TiddlerFields]] or [[property|DataTiddlers]] of a particular tiddler
+op-parameter-name: R
+op-output: the titles stored as a [[title list|Title List]] at <<.place R>>
+op-neg-output: those input titles that are <<.em not>> mentioned at <<.place R>>
 
-<$macrocall $name=".operator-def"
-input="ignored"
-negationInput="a [[selection of titles|Title Selection]]"
-parameter="a [[reference|TextReference]] to a [[field|TiddlerFields]] or [[property|DataTiddlers]] of a particular tiddler"
-paramName="r"
-output="the titles stored as a [[title list|Title List]] at <<.place r>>"
-negationOutput="those input titles that are <<.em not>> mentioned at <<.place r>>"
-/>
-
-<<.place r>> can reference either a field or a property. See [[TextReference]] for the syntax.
+<<.place R>> can reference either a field or a property. See [[TextReference]] for the syntax.
 
 * If neither is specified, the <<.field list>> field is used by default. So `[list[T]]` outputs the titles listed in the <<.field list>> of tiddler T.
-* If <<.place r>> consists of <<.em only>> a field or a property, the tiddler part of the reference defaults to the CurrentTiddler. So `[list[!!tags]]` outputs the titles listed in the <<.field tags>> field of the current tiddler.
+* If <<.place R>> consists of <<.em only>> a field or a property, the tiddler part of the reference defaults to the CurrentTiddler. So `[list[!!tags]]` outputs the titles listed in the <<.field tags>> field of the current tiddler.
 
 <<.operator-examples "list">>

--- a/editions/tw5.com/tiddlers/filters/listed.tid
+++ b/editions/tw5.com/tiddlers/filters/listed.tid
@@ -1,20 +1,17 @@
 created: 20140410103123179
-modified: 20150124203638000
+modified: 20150203185745000
 tags: [[Filter Operators]] [[Field Operators]]
 title: listed Operator
 type: text/vnd.tiddlywiki
 caption: listed
-purpose: find the titles that list the input titles
+op-purpose: find the titles that list the input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the name of a [[field|TiddlerFields]], defaulting to <<.field list>>
+op-parameter-name: F
+op-output: the titles in which field <<.place F>> mentions any of the input titles
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="the name of a [[field|TiddlerFields]], defaulting to <<.field list>>"
-paramName="f"
-output="the titles in which field <<.place f>> mentions any of the input titles"
-/>
+<<.field F>> is assumed to be a [[title list|Title List]].
 
-<<.field f>> is assumed to be a [[title list|Title List]].
-
-Each input title is processed in turn. A list of tiddlers whose <<.place f>> field mentions it is generated (in no particular order) and [[dominantly appended|Dominant Append]] to the operator's overall output.
+Each input title is processed in turn. A list of tiddlers whose <<.place F>> field mentions it is generated (in no particular order) and [[dominantly appended|Dominant Append]] to the operator's overall output.
 
 <<.operator-examples "listed">>

--- a/editions/tw5.com/tiddlers/filters/modules.tid
+++ b/editions/tw5.com/tiddlers/filters/modules.tid
@@ -1,15 +1,12 @@
 created: 20140410103123179
-modified: 20150124170624000
+modified: 20150203185838000
 tags: [[Filter Operators]] [[Special Operators]]
 title: modules Operator
 type: text/vnd.tiddlywiki
 caption: modules
-purpose: select the names of all modules of the input module types
-
-<$macrocall $name=".operator-def"
-input="a [[selection|Title Selection]] of module types"
-parameter="none"
-output="the title of each module with any of the input types"
-/>
+op-purpose: select the names of all modules of the input module types
+op-input: a [[selection|Title Selection]] of module types
+op-parameter: none
+op-output: the title of each module with any of the input types
 
 <<.operator-examples "modules">>

--- a/editions/tw5.com/tiddlers/filters/moduletypes.tid
+++ b/editions/tw5.com/tiddlers/filters/moduletypes.tid
@@ -1,15 +1,12 @@
 created: 20140410103123179
-modified: 20150129133709000
+modified: 20150203185903000
 tags: [[Filter Operators]] [[Special Operators]] [[Selection Constructors]]
 title: moduletypes Operator
 type: text/vnd.tiddlywiki
 caption: moduletypes
-purpose: select the names of all ~TiddlyWiki module types
-
-<$macrocall $name=".operator-def"
-input="ignored"
-parameter="none"
-output="the name of each known ~TiddlyWiki [[module type|ModuleType]], in alphabetical order"
-/>
+op-purpose: select the names of all ~TiddlyWiki module types
+op-input: ignored
+op-parameter: none
+op-output: the name of each known ~TiddlyWiki [[module type|ModuleType]], in alphabetical order
 
 <<.operator-examples "moduletypes">>

--- a/editions/tw5.com/tiddlers/filters/next.tid
+++ b/editions/tw5.com/tiddlers/filters/next.tid
@@ -1,17 +1,14 @@
 created: 20140410103123179
-modified: 20150124171754000
+modified: 20150203185954000
 tags: [[Filter Operators]] [[Field Operators]] [[Order Operators]]
 title: next Operator
 type: text/vnd.tiddlywiki
 caption: next
-purpose: find which titles in a <<.field list>> field follow the input ones
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a tiddler title"
-paramName="t"
-output="a selection containing each title that immediately follows each of the input titles in the <<.field list>> field of <<.place t>>"
-/>
+op-purpose: find which titles in a <<.field list>> field follow the input ones
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a tiddler title
+op-parameter-name: T
+op-output: a selection containing each title that immediately follows each of the input titles in the <<.field list>> field of <<.place T>>
 
 Each input title is processed in turn, and its successor is located in the <<.field list>> field and appended to the output. If a title is not listed in the field, or is the last title there, then it contributes nothing to the output.
 

--- a/editions/tw5.com/tiddlers/filters/nsort.tid
+++ b/editions/tw5.com/tiddlers/filters/nsort.tid
@@ -1,18 +1,15 @@
 created: 20140410103123179
-modified: 20150124205344000
+modified: 20150203190051000
 tags: [[Filter Operators]] [[Field Operators]] [[Order Operators]] [[Negatable Operators]]
 title: nsort Operator
 type: text/vnd.tiddlywiki
 caption: nsort
-purpose: sort the input by number field
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="the name of a [[field|TiddlerFields]], defaulting to <<.field title>>"
-paramName="f"
-output="the input, sorted into ascending order by field <<.field f>>, treating field values as numbers"
-negationOutput="the input, likewise sorted into descending order"
-/>
+op-purpose: sort the input by number field
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the name of a [[field|TiddlerFields]], defaulting to <<.field title>>
+op-parameter-name: F
+op-output: the input, sorted into ascending order by field <<.field F>>, treating field values as numbers
+op-neg-output: the input, likewise sorted into descending order
 
 Non-numeric values are treated as having a higher value than any number, and the difference between capital and lowercase letters is ignored. Compare <<.olink nsortcs>>.
 

--- a/editions/tw5.com/tiddlers/filters/nsortcs.tid
+++ b/editions/tw5.com/tiddlers/filters/nsortcs.tid
@@ -1,18 +1,15 @@
 created: 20140410103123179
-modified: 20150124205339000
+modified: 20150203190202000
 tags: [[Filter Operators]] [[Field Operators]] [[Order Operators]] [[Negatable Operators]]
 title: nsortcs Operator
 type: text/vnd.tiddlywiki
 caption: nsortcs
-purpose: sort the input titles by number field, ignoring case
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="the name of a [[field|TiddlerFields]], defaulting to <<.field title>>"
-paramName="f"
-output="the input, sorted into ascending order by field <<.field f>>, treating field values as numbers"
-negationOutput="the input, likewise sorted into descending order"
-/>
+op-purpose: sort the input titles by number field, ignoring case
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the name of a [[field|TiddlerFields]], defaulting to <<.field title>>
+op-parameter-name: F
+op-output: the input, sorted into ascending order by field <<.place F>>, treating field values as numbers
+op-neg-output: the input, likewise sorted into descending order
 
 Non-numeric values are treated as having a higher value than any number, and capital and lowercase letters are treated as different. Compare <<.olink nsort>>.
 

--- a/editions/tw5.com/tiddlers/filters/nth.tid
+++ b/editions/tw5.com/tiddlers/filters/nth.tid
@@ -1,18 +1,15 @@
 created: 20150122204111000
-modified: 20150124204959000
+modified: 20150203192048000
 tags: [[Filter Operators]] [[Order Operators]]
 title: nth Operator
 type: text/vnd.tiddlywiki
 caption: nth
-purpose: select the <<.place n>>th input title
+op-purpose: select the <<.place N>>th input title
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: an integer, defaulting to 1
+op-parameter-name: N
+op-output: the <<.place N>>th input title
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="an integer, defaulting to 1"
-paramName="n"
-output="the <<.place n>>th input title"
-/>
-
-<<.place n>> is one-based. In other words, `nth[1]` has the same effect as the <<.olink first>> operator.
+<<.place N>> is one-based. In other words, `nth[1]` has the same effect as the <<.olink first>> operator.
 
 <<.operator-examples "nth">>

--- a/editions/tw5.com/tiddlers/filters/plugintiddlers.tid
+++ b/editions/tw5.com/tiddlers/filters/plugintiddlers.tid
@@ -1,15 +1,12 @@
 created: 20140410103123179
-modified: 20150124200549000
+modified: 20150203190350000
 tags: [[Filter Operators]] [[Special Operators]]
 title: plugintiddlers Operator
 type: text/vnd.tiddlywiki
 caption: plugintiddlers
-purpose: select all shadow titles in the input plugins
-
-<$macrocall $name=".operator-def"
-input="a [[selection|Title Selection]] of plugin tiddler titles"
-parameter="none"
-output="all shadow titles contained in the input plugins"
-/>
+op-purpose: select all shadow titles in the input plugins
+op-input: a [[selection|Title Selection]] of plugin tiddler titles
+op-parameter: none
+op-output: all shadow titles contained in the input plugins
 
 <<.operator-examples "plugintiddlers">>

--- a/editions/tw5.com/tiddlers/filters/prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/prefix.tid
@@ -1,18 +1,15 @@
 created: 20140410103123179
-modified: 20150124192023000
+modified: 20150203192735000
 tags: [[Filter Operators]] [[String Operators]] [[Negatable Operators]]
 title: prefix Operator
 type: text/vnd.tiddlywiki
 caption: prefix
-purpose: filter the input titles by how they start
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a string of characters"
-paramName="s"
-output="those input titles that start with <<.place s>>"
-negationOutput="those input tiddlers that do <<.em not>> start with <<.place s>>"
-/>
+op-purpose: filter the input titles by how they start
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string of characters
+op-parameter-name: S
+op-output: those input titles that start with <<.place S>>
+op-neg-output: those input tiddlers that do <<.em not>> start with <<.place S>>
 
 <<.s-matching-is-case-sensitive>>
 

--- a/editions/tw5.com/tiddlers/filters/previous.tid
+++ b/editions/tw5.com/tiddlers/filters/previous.tid
@@ -1,17 +1,14 @@
 created: 20140410103123179
-modified: 20150124171748000
+modified: 20150203190515000
 tags: [[Filter Operators]] [[Field Operators]] [[Order Operators]]
 title: previous Operator
 type: text/vnd.tiddlywiki
 caption: previous
-purpose: find which titles in a <<.field list>> field precede the input ones
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a tiddler title"
-paramName="t"
-output="a selection containing each title that immediately precedes each of the input titles in the <<.field list>> field of <<.place t>>"
-/>
+op-purpose: find which titles in a <<.field list>> field precede the input ones
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a tiddler title
+op-parameter-name: T
+op-output: a selection containing each title that immediately precedes each of the input titles in the <<.field list>> field of <<.place T>>
 
 Each input title is processed in turn, and its predecessor is located in the <<.field list>> field and appended to the output. If a title is not listed in the field, or is the first item there, then it contributes nothing to the output.
 

--- a/editions/tw5.com/tiddlers/filters/regexp.tid
+++ b/editions/tw5.com/tiddlers/filters/regexp.tid
@@ -1,31 +1,28 @@
 created: 20140909134102102
-modified: 20150124203736000
+modified: 20150203190626000
 tags: [[Filter Operators]] [[Field Operators]] [[Negatable Operators]]
 title: regexp Operator
 type: text/vnd.tiddlywiki
 caption: regexp
-purpose: filter the input by pattern-matched field
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-suffix="the name of a [[field|TiddlerFields]]"
-suffixName="f"
-parameter="a regular expression"
-paramName="x"
-output="those input tiddlers in which field <<.place f>> matches <<.place x>>"
-negationOutput="those input tiddlers in which field <<.place f>> does <<.em not>> match <<.place x>>"
-/>
+op-purpose: filter the input by pattern-matched field
+op-input: a [[selection of titles|Title Selection]]
+op-suffix: the name of a [[field|TiddlerFields]]
+op-suffix-name: F
+op-parameter: a regular expression
+op-parameter-name: X
+op-output: those input tiddlers in which field <<.place F>> matches <<.place X>>
+op-neg-output: those input tiddlers in which field <<.place F>> does <<.em not>> match <<.place X>>
 
 <<.def "Regular expressions">> are concise strings of characters that denote patterns of text to search for. The format used in ~TiddlyWiki is fully defined in [[this Mozilla reference|https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions]].
 
 The [[filter syntax|Filter Run]] makes it impossible to directly specify a regular expression that contains square brackets. The solution is to store the expression in a [[variable|Variables]]. See the <<.operator-examples "regexp" "examples">>.
 
-The parameter <<.place x>> can optionally start or end with a string of flags:
+The parameter <<.place X>> can optionally start or end with a string of flags:
 
 <$railroad text=""" "(?" { ("i"|"m"|:"g") } ")" """/>
 
 Only the `i` flag is generally useful: it forces the different between capital and lowercase letters to be ignored.
 
-If <<.place x>> is empty, <<.op regexp>> will match all of the input tiddlers.
+If <<.place X>> is empty, <<.op regexp>> will match all of the input tiddlers.
 
 <<.operator-examples "regexp">>

--- a/editions/tw5.com/tiddlers/filters/removeprefix.tid
+++ b/editions/tw5.com/tiddlers/filters/removeprefix.tid
@@ -1,17 +1,14 @@
 created: 20140410103123179
-modified: 20150124173431000
+modified: 20150203190709000
 tags: [[Filter Operators]] [[String Operators]]
 title: removeprefix Operator
 type: text/vnd.tiddlywiki
 caption: removeprefix
-purpose: filter the input titles by how they start, deleting that prefix
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a string of characters"
-paramName="s"
-output="those input titles that start with <<.place s>>, but with those characters discarded"
-/>
+op-purpose: filter the input titles by how they start, deleting that prefix
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string of characters
+op-parameter-name: S
+op-output: those input titles that start with <<.place S>>, but with those characters discarded
 
 <<.s-matching-is-case-sensitive>>
 

--- a/editions/tw5.com/tiddlers/filters/removesuffix.tid
+++ b/editions/tw5.com/tiddlers/filters/removesuffix.tid
@@ -1,17 +1,14 @@
 created: 20140828133830424
-modified: 20150124173434000
+modified: 20150203190744000
 tags: [[Filter Operators]] [[String Operators]]
 title: removesuffix Operator
 type: text/vnd.tiddlywiki
 caption: removesuffix
-purpose: filter the input titles by how they end, deleting that suffix
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a string of characters"
-paramName="s"
-output="those input titles that end with <<.place s>>, but with those characters discarded"
-/>
+op-purpose: filter the input titles by how they end, deleting that suffix
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string of characters
+op-parameter-name: S
+op-output: those input titles that end with <<.place S>>, but with those characters discarded
 
 <<.s-matching-is-case-sensitive>>
 

--- a/editions/tw5.com/tiddlers/filters/rest.tid
+++ b/editions/tw5.com/tiddlers/filters/rest.tid
@@ -1,17 +1,14 @@
 created: 20140410103123179
-modified: 20150124191714000
+modified: 20150203190822000
 tags: [[Filter Operators]] [[Order Operators]]
 title: rest Operator
 type: text/vnd.tiddlywiki
 caption: rest
-purpose: discard the first <<.place n>> input titles
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="an integer, defaulting to 1"
-paramName="n"
-output="all but the first <<.place n>> input titles"
-/>
+op-purpose: discard the first <<.place N>> input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: an integer, defaulting to 1
+op-parameter-name: N
+op-output: all but the first <<.place N>> input titles
 
 <<.olink butfirst>> and <<.olink bf>> are synonyms for <<.op rest>>.
 

--- a/editions/tw5.com/tiddlers/filters/reverse.tid
+++ b/editions/tw5.com/tiddlers/filters/reverse.tid
@@ -1,15 +1,12 @@
 created: 20140410103123179
-modified: 20150124205130000
+modified: 20150203190852000
 tags: [[Filter Operators]] [[Order Operators]]
 title: reverse Operator
 type: text/vnd.tiddlywiki
 caption: reverse
-purpose: reverse the order of the input titles
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="none"
-output="the input, in reverse order"
-/>
+op-purpose: reverse the order of the input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: none
+op-output: the input, in reverse order
 
 <<.operator-examples "reverse">>

--- a/editions/tw5.com/tiddlers/filters/sameday.tid
+++ b/editions/tw5.com/tiddlers/filters/sameday.tid
@@ -1,22 +1,19 @@
 created: 20140410103123179
-modified: 20150124214612000
+modified: 20150203190959000
 tags: [[Filter Operators]] [[Date Operators]]
 title: sameday Operator
 type: text/vnd.tiddlywiki
 caption: sameday
-purpose: filter the input by date
+op-purpose: filter the input by date
+op-input: a [[selection of titles|Title Selection]]
+op-suffix: the name of a [[date field|Date Fields]], defaulting to <<.field modified>>
+op-suffix-name: F
+op-parameter: a date, in the [[format|DateFormat]] `YYYYMMDD`
+op-parameter-name: D
+op-output: those input tiddlers in which field <<.place F>> has the value <<.place D>>, ignoring time
 
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-suffix="the name of a [[date field|Date Fields]], defaulting to <<.field modified>>"
-suffixName="f"
-parameter="a date, in the [[format|DateFormat]] `YYYYMMDD`"
-paramName="d"
-output="those input tiddlers in which field <<.place f>> has the value <<.place d>>, ignoring time"
-/>
+If <<.place D>> is not a valid date, the output is empty.
 
-If <<.place d>> is not a valid date, the output is empty.
-
-<<.place d>> may include a time of day, but this is ignored.
+<<.place D>> may include a time of day, but this is ignored.
 
 <<.operator-examples "sameday">>

--- a/editions/tw5.com/tiddlers/filters/search.tid
+++ b/editions/tw5.com/tiddlers/filters/search.tid
@@ -1,19 +1,16 @@
 created: 20140410103123179
-modified: 20150124204023000
+modified: 20150203191048000
 tags: [[Filter Operators]] [[Common Operators]] [[Field Operators]] [[Negatable Operators]]
 title: search Operator
 type: text/vnd.tiddlywiki
 caption: search
-purpose: filter the input by searching tiddler content
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-suffix="optionally, the name of a [[field|TiddlerFields]]"
-suffixName="f"
-parameter="one or more search terms, separated by spaces"
-output="those input tiddlers in which <<.em all>> of the search terms can be found in the value of field <<.place f>>"
-negationOutput="those input tiddlers in which <<.em not>> all of the search terms can be so found"
-/>
+op-purpose: filter the input by searching tiddler content
+op-input: a [[selection of titles|Title Selection]]
+op-suffix: optionally, the name of a [[field|TiddlerFields]]
+op-suffix-name: F
+op-parameter: one or more search terms, separated by spaces
+op-output: those input tiddlers in which <<.em all>> of the search terms can be found in the value of field <<.place F>>
+op-neg-output: those input tiddlers in which <<.em not>> all of the search terms can be so found
 
 When used with a suffix, the <<.op search>> operator is similar to <<.olink regexp>> but less powerful.
 

--- a/editions/tw5.com/tiddlers/filters/shadowsource.tid
+++ b/editions/tw5.com/tiddlers/filters/shadowsource.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124210534000
+modified: 20150203191120000
 tags: [[Filter Operators]] [[Special Operators]]
 title: shadowsource Operator
 type: text/vnd.tiddlywiki
 caption: shadowsource
-purpose: select the plugin titles that contain the input shadows
-
-<$macrocall $name=".operator-def"
-input="a [[selection|Title Selection]] of [[shadow titles|ShadowTiddlers]]"
-parameter="none"
-output="the [[plugins|Plugins]] that contain the input tiddlers"
-/>
+op-purpose: select the plugin titles that contain the input shadows
+op-input: a [[selection|Title Selection]] of [[shadow titles|ShadowTiddlers]]
+op-parameter: none
+op-output: the [[plugins|Plugins]] that contain the input tiddlers
 
 Each input title is processed in turn. If it denotes a shadow tiddler, the title of its plugin tiddler is [[dominantly appended|Dominant Append]] to the output. Non-shadow tiddlers contribute nothing to the output.
 

--- a/editions/tw5.com/tiddlers/filters/sort.tid
+++ b/editions/tw5.com/tiddlers/filters/sort.tid
@@ -1,18 +1,15 @@
 created: 20140410103123179
-modified: 20150124205350000
+modified: 20150203191228000
 tags: [[Filter Operators]] [[Common Operators]] [[Field Operators]] [[Order Operators]] [[Negatable Operators]]
 title: sort Operator
 type: text/vnd.tiddlywiki
 caption: sort
-purpose: sort the input by text field
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="the name of a [[field|TiddlerFields]], defaulting to <<.field title>>"
-paramName="f"
-output="the input, sorted into ascending order by field <<.field f>>, treating field values as text"
-negationOutput="the input, likewise sorted into descending order"
-/>
+op-purpose: sort the input by text field
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the name of a [[field|TiddlerFields]], defaulting to <<.field title>>
+op-parameter-name: F
+op-output: the input, sorted into ascending order by field <<.field F>>, treating field values as text
+op-neg-output: the input, likewise sorted into descending order
 
 The difference between capital and lowercase letters is ignored. Compare <<.olink sortcs>>.
 

--- a/editions/tw5.com/tiddlers/filters/sortcs.tid
+++ b/editions/tw5.com/tiddlers/filters/sortcs.tid
@@ -1,18 +1,15 @@
 created: 20140410103123179
-modified: 20150124205353000
+modified: 20150203191308000
 tags: [[Filter Operators]] [[Field Operators]] [[Order Operators]] [[Negatable Operators]]
 title: sortcs Operator
 type: text/vnd.tiddlywiki
 caption: sortcs
-purpose: sort the input by text field, ignoring case
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="the name of a [[field|TiddlerFields]], defaulting to <<.field title>>"
-paramName="f"
-output="the input, sorted into ascending order by field <<.field f>>, treating field values as text"
-negationOutput="the input, likewise sorted into descending order"
-/>
+op-purpose: sort the input by text field, ignoring case
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the name of a [[field|TiddlerFields]], defaulting to <<.field title>>
+op-parameter-name: F
+op-output: the input, sorted into ascending order by field <<.field F>>, treating field values as text
+op-neg-output: the input, likewise sorted into descending order
 
 Capital and lowercase letters are treated as different. Compare <<.olink sort>>.
 

--- a/editions/tw5.com/tiddlers/filters/splitbefore.tid
+++ b/editions/tw5.com/tiddlers/filters/splitbefore.tid
@@ -1,22 +1,19 @@
 created: 20150126142522000
-modified: 20150126143945000
+modified: 20150203192107000
 tags: [[Filter Operators]] [[String Operators]]
 title: splitbefore Operator
 type: text/vnd.tiddlywiki
 caption: splitbefore
-purpose: select a delimited prefix from each input title
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a string of characters marking the end of the prefix"
-paramName="s"
-output="the prefix, up to and including <<.place S>>, of each input title"
-/>
+op-purpose: select a delimited prefix from each input title
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string of characters marking the end of the prefix
+op-parameter-name: S
+op-output: the prefix, up to and including <<.place S>>, of each input title
 
 Each input title is processed in turn.
 
-* A title that contains <<.place s>> contributes everything up to and including <<.place s>>.
-* A title that doesn't contain <<.place s>> simply contributes itself to the output.
+* A title that contains <<.place S>> contributes everything up to and including <<.place S>>.
+* A title that doesn't contain <<.place S>> simply contributes itself to the output.
 
 Contributions are [[dominantly appended|Dominant Append]] to the output.
 

--- a/editions/tw5.com/tiddlers/filters/storyviews.tid
+++ b/editions/tw5.com/tiddlers/filters/storyviews.tid
@@ -1,16 +1,13 @@
 created: 20150126141718000
-modified: 20150126142035000
+modified: 20150203191420000
 tags: [[Filter Operators]] [[Special Operators]]
 title: storyviews Operator
 type: text/vnd.tiddlywiki
 caption: storyviews
-purpose: select the names of all the story views
-
-<$macrocall $name=".operator-def"
-input="ignored"
-parameter="none"
-output="the name of each story view"
-/>
+op-purpose: select the names of all the story views
+op-input: ignored
+op-parameter: none
+op-output: the name of each story view
 
 The names are those exported by [[modules|Modules]] whose <<.field module-type>> is <<.value storyview>>.
 

--- a/editions/tw5.com/tiddlers/filters/suffix.tid
+++ b/editions/tw5.com/tiddlers/filters/suffix.tid
@@ -1,18 +1,15 @@
 created: 20140828133830424
-modified: 20150124192043000
+modified: 20150203192738000
 tags: [[Filter Operators]] [[String Operators]] [[Negatable Operators]]
 title: suffix Operator
 type: text/vnd.tiddlywiki
 caption: suffix
-purpose: filter the input titles by how they end
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="a string of characters"
-paramName="s"
-output="those input titles that end with <<.place p>>"
-negationOutput="those input tiddlers that do <<.em not>> end with <<.place p>>"
-/>
+op-purpose: filter the input titles by how they end
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string of characters
+op-parameter-name: S
+op-output: those input titles that end with <<.place S>>
+op-neg-output: those input tiddlers that do <<.em not>> end with <<.place S>>
 
 <<.s-matching-is-case-sensitive>>
 

--- a/editions/tw5.com/tiddlers/filters/tag.tid
+++ b/editions/tw5.com/tiddlers/filters/tag.tid
@@ -1,21 +1,18 @@
 created: 20140410103123179
-modified: 20150124205948000
+modified: 20150203191853000
 tags: [[Filter Operators]] [[Common Operators]] [[Tag Operators]] [[Negatable Operators]]
 title: tag Operator
 type: text/vnd.tiddlywiki
 caption: tag
-purpose: filter the input by tag
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="the title of a [[tag|Tagging]]"
-paramName="t"
-output="those input tiddlers that have tag <<.place t>>"
-negationOutput="those input tiddlers that do <<.em not>> have tag <<.place t>>"
-/>
+op-purpose: filter the input by tag
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the title of a [[tag|Tagging]]
+op-parameter-name: T
+op-output: those input tiddlers that have tag <<.place T>>
+op-neg-output: those input tiddlers that do <<.em not>> have tag <<.place T>>
 
 The output is [[sorted|Order of Tagged Tiddlers]] using the tag's <<.field list>> field and the tiddlers' <<.field list-before>> and <<.field list-after>> fields.
 
-If <<.place t>> is empty, the output of `tag` is empty, and the output of `!tag` is a copy of the input.
+If <<.place T>> is empty, the output of `tag` is empty, and the output of `!tag` is a copy of the input.
 
 <<.operator-examples "tag">>

--- a/editions/tw5.com/tiddlers/filters/tagging.tid
+++ b/editions/tw5.com/tiddlers/filters/tagging.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124205941000
+modified: 20150203191620000
 tags: [[Filter Operators]] [[Tag Operators]]
 title: tagging Operator
 type: text/vnd.tiddlywiki
 caption: tagging
-purpose: find the tiddlers that have the input tags
-
-<$macrocall $name=".operator-def"
-input="a [[selection|Title Selection]] of [[tags|Tagging]]"
-parameter="none"
-output="the titles of any tiddlers that carry the input tags"
-/>
+op-purpose: find the tiddlers that have the input tags
+op-input: a [[selection|Title Selection]] of [[tags|Tagging]]
+op-parameter: none
+op-output: the titles of any tiddlers that carry the input tags
 
 Each input tag is processed in turn. The list of tiddlers carrying that tag is generated, [[sorted|Order of Tagged Tiddlers]], and then [[dominantly appended|Dominant Append]] to the operator's overall output.
 

--- a/editions/tw5.com/tiddlers/filters/tags.tid
+++ b/editions/tw5.com/tiddlers/filters/tags.tid
@@ -1,16 +1,13 @@
 created: 20140410103123179
-modified: 20150124210613000
+modified: 20150203191657000
 tags: [[Filter Operators]] [[Tag Operators]]
 title: tags Operator
 type: text/vnd.tiddlywiki
 caption: tags
-purpose: select all tags of the input tiddlers
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="none"
-output="all the tags carried by the input tiddlers"
-/>
+op-purpose: select all tags of the input tiddlers
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: none
+op-output: all the tags carried by the input tiddlers
 
 Each input title is processed in turn. The corresponding tiddler's tags are retrieved (in order of appearance in the <<.field tags>> field) and then [[dominantly appended|Dominant Append]] to the operator's output.
 

--- a/editions/tw5.com/tiddlers/filters/title.tid
+++ b/editions/tw5.com/tiddlers/filters/title.tid
@@ -1,19 +1,16 @@
 created: 20140410103123179
-modified: 20150129133732000
+modified: 20150203191749000
 tags: [[Filter Operators]] [[Common Operators]] [[Selection Constructors]] [[Negatable Operators]]
 title: title Operator
 type: text/vnd.tiddlywiki
 caption: title
-purpose: select a single title
-
-<$macrocall $name=".operator-def"
-input="ignored"
-negationInput="a [[selection of titles|Title Selection]]"
-parameter="a tiddler title"
-paramName="t"
-output="a selection containing only <<.place t>>"
-negationOutput="the input, but with tiddler <<.place t>> filtered out if it exists in the wiki"
-/>
+op-purpose: select a single title
+op-input: ignored
+op-neg-input: a [[selection of titles|Title Selection]]
+op-parameter: a tiddler title
+op-parameter-name: T
+op-output: a selection containing only <<.place T>>
+op-neg-output: the input, but with tiddler <<.place T>> filtered out if it exists in the wiki
 
 `[title[An Example]]` can be shortened to `[[An Example]]`, because <<.op title>> is the default filter operator.
 

--- a/editions/tw5.com/tiddlers/filters/untagged.tid
+++ b/editions/tw5.com/tiddlers/filters/untagged.tid
@@ -1,17 +1,14 @@
 created: 20140410103123179
-modified: 20150124192055000
+modified: 20150203191821000
 tags: [[Filter Operators]] [[Tag Operators]] [[Negatable Operators]]
 title: untagged Operator
 type: text/vnd.tiddlywiki
 caption: untagged
-purpose: discard any input titles that have tags
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="none"
-output="those input tiddlers that have no tags"
-negationOutput="those input tiddlers that have at least one tag"
-/>
+op-purpose: discard any input titles that have tags
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: none
+op-output: those input tiddlers that have no tags
+op-neg-output: those input tiddlers that have at least one tag
 
 A tiddler is deemed to have no tags if it:
 

--- a/editions/tw5.com/tiddlers/macros/if-macro.js
+++ b/editions/tw5.com/tiddlers/macros/if-macro.js
@@ -20,6 +20,7 @@ exports.params = [
 exports.run = function(cond, then, elze) {
 	then = then || "";
 	elze = elze || "";
+console.log('Condition:', cond);
 	return cond ? then : elze;
 };
 

--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -1,5 +1,5 @@
 created: 20150117152612000
-modified: 20150126091948000
+modified: 20150203183335000
 title: $:/editions/tw5.com/doc-styles
 tags: $:/tags/Stylesheet
 
@@ -30,7 +30,6 @@ tags: $:/tags/Stylesheet
 	color: <<color very-muted-foreground>>;
 	font-style: normal;
 	font-weight: bold;
-	text-transform: uppercase;
 }
 
 .doc-button,
@@ -120,4 +119,8 @@ td svg {
 tr.doc-table-subheading {
 	height: 2em;
 	vertical-align: middle;
+}
+
+.doc-table.before-tiddler-body {
+	margin-top: 2em;
 }

--- a/editions/tw5.com/tiddlers/system/operator-macros.tid
+++ b/editions/tw5.com/tiddlers/system/operator-macros.tid
@@ -1,29 +1,7 @@
 created: 20150117152607000
-modified: 20150127203427000
+modified: 20150203190441000
 title: $:/editions/tw5.com/operator-macros
 tags: $:/tags/Macro
-
-\define .operator-suffix-name(suffixName)
-<$macrocall $name=".if" cond="""$suffixName$""" then="<<.place '$suffixName$'>> = " else=""/>
-\end
-
-\define .operator-def(input,negationInput,suffix,suffixName,parameter,paramName,output,negationOutput)
-<table class="doc-table">
-<tr><th align="left">purpose</th><td>{{!!purpose}}</td></tr>
-<tr><th align="left">[[input|Filter Syntax]]</th><td>$input$</td></tr>
-<$macrocall $name=".if" cond="""$negationInput$"""
-then="""<tr><th align="left">`!` input</th><td>$negationInput$</td></tr>"""
-else=""/>
-<$macrocall $name=".if" cond="""$suffix$"""
-then="""<tr><th align="left">[[suffix|Filter Step]]</th><td><<.operator-suffix-name "$suffixName$">>$suffix$</td></tr>"""
-else=""/>
-<tr><th align="left">[[parameter|Filter Parameter]]</th><td><$macrocall $name=".if" cond="""$paramName$""" then="<<.place '$paramName$'>> = " else=""/>$parameter$</td></tr>
-<tr><th align="left">output</th><td>$output$</td></tr>
-<$macrocall $name=".if" cond="""$negationOutput$"""
-then="""<tr><th align="left">`!` output</th><td>$negationOutput$</td></tr>"""
-else=""/>
-</table>
-\end
 
 \define .operator-examples(op,text:"Examples") <$link to="$op$ Operator (Examples)">$text$</$link>
 
@@ -50,7 +28,7 @@ else=""/>
 
 \define .this-is-operator-example() This example tiddler is used to illustrate some of the [[Filter Operators]].
 \define .using-days-of-week() These examples make use of the [[Days of the Week]] tiddler.
-\define .s-matching-is-case-sensitive() In looking for matches for <<.place s>>, capital and lowercase letters are treated as different.
+\define .s-matching-is-case-sensitive() In looking for matches for <<.place S>>, capital and lowercase letters are treated as different.
 
 \define .node-only-operator()
 

--- a/editions/tw5.com/tiddlers/system/operator-template.tid
+++ b/editions/tw5.com/tiddlers/system/operator-template.tid
@@ -1,0 +1,77 @@
+created: 20150203173506000
+modified: 20150203181725000
+title: $:/editions/tw5.com/operator-template
+tags: $:/tags/ViewTemplate
+list-before: $:/core/ui/ViewTemplate/body
+
+\define .op-place()
+<$macrocall $name=".if"
+  cond="""$(op-name)$"""
+  then="<<.place '$(op-name)$'>> = "
+  else=""/>
+\end
+
+\define .op-row()
+<$macrocall $name=".if"
+  cond="""$(op-body)$"""
+  then="""<tr><th align="left">$(op-head)$</th><td><<.op-place>>$(op-body)$</td></tr>"""
+  else=""/>
+\end
+
+<$set name="op-head" value="">
+<$set name="op-body" value="">
+<$set name="op-name" value="">
+<$list filter="[all[current]tag[Filter Operators]]">
+<table class="doc-table before-tiddler-body">
+<!-->
+<$set name="op-head" value="purpose">
+<$set name="op-body" value={{!!op-purpose}}>
+<<.op-row>>
+</$set>
+</$set>
+<!-->
+<$set name="op-head" value="[[input|Filter Syntax]]">
+<$set name="op-body" value={{!!op-input}}>
+<<.op-row>>
+</$set>
+</$set>
+<!-->
+<$set name="op-head" value="`!` input">
+<$set name="op-body" value={{!!op-neg-input}}>
+<<.op-row>>
+</$set>
+</$set>
+<!-->
+<$set name="op-head" value="[[suffix|Filter Step]]">
+<$set name="op-body" value={{!!op-suffix}}>
+<$set name="op-name" value={{!!op-suffix-name}}>
+<<.op-row>>
+</$set>
+</$set>
+</$set>
+<!-->
+<$set name="op-head" value="[[parameter|Filter Parameter]]">
+<$set name="op-body" value={{!!op-parameter}}>
+<$set name="op-name" value={{!!op-parameter-name}}>
+<<.op-row>>
+</$set>
+</$set>
+</$set>
+<!-->
+<$set name="op-head" value="output">
+<$set name="op-body" value={{!!op-output}}>
+<<.op-row>>
+</$set>
+</$set>
+<!-->
+<$set name="op-head" value="`!` output">
+<$set name="op-body" value={{!!op-neg-output}}>
+<<.op-row>>
+</$set>
+</$set>
+<!-->
+</table>
+</$list>
+</$set>
+</$set>
+</$set>


### PR DESCRIPTION
The table at the start of the tiddler for each filter operator is now generated by means of a conditional view template instead of the clumsy `.operator-def` macro. The fields that are used to populate this view template have names with the prefix `op-`.

I've also taken the opportunity to fix #1453.