### PR TITLE
Fix issue deleting non-existent tiddler

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -208,8 +208,11 @@ NavigatorWidget.prototype.handleDeleteTiddlerEvent = function(event) {
 	var title = event.param || event.tiddlerTitle,
 		tiddler = this.wiki.getTiddler(title),
 		storyList = this.getStoryList(),
-		originalTitle = tiddler.fields["draft.of"],
+		originalTitle = tiddler ? tiddler.fields["draft.of"] : 0,
 		confirmationTitle;
+	if(!tiddler) {
+		return false;
+	}
 	// Check if the tiddler we're deleting is in draft mode
 	if(originalTitle) {
 		// If so, we'll prompt for confirmation referencing the original tiddler


### PR DESCRIPTION
Currently **tm-delete-tiddler** throws a red error box:

```
<$button>
<$action-sendmessage $message="tm-delete-tiddler" $param="DoesntExist"/>
delete non-existing
</$button>
```

**Uncaught TypeError: Cannot read property 'fields' of undefined**