### PR TITLE
allows to cancel dropzone

### DIFF
--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -27,14 +27,14 @@ DropZoneWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 DropZoneWidget.prototype.render = function(parent,nextSibling) {
-	var self = this;
+	var cancel,domNode,self = this;
 	// Remember parent
 	this.parentDomNode = parent;
 	// Compute attributes and execute state
 	this.computeAttributes();
 	this.execute();
 	// Create element
-	var domNode = this.document.createElement("div");
+	domNode = this.document.createElement("div");
 	domNode.className = "tc-dropzone";
 	// Add event handlers
 	$tw.utils.addEventListeners(domNode,[
@@ -46,6 +46,14 @@ DropZoneWidget.prototype.render = function(parent,nextSibling) {
 	]);
 	domNode.addEventListener("click",function (event) {
 	},false);
+	// Create cancel button
+	cancel = this.document.createElement("button");
+	cancel.className = "tc-dropzone-cancel tc-btn-invisible";
+	cancel.innerHTML = "x";
+	cancel.addEventListener("click",function (event) {
+		$tw.utils.removeClass(this.parentNode,"tc-dragover");
+	},false);
+	domNode.appendChild(cancel);
 	// Insert element
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -241,6 +241,18 @@ a.tc-tiddlylink-external:hover {
 	content: "<<lingo DropMessage>>";
 }
 
+.tc-dropzone-cancel {
+	display:none;
+	position:absolute;
+	top:0;
+	right:10px;
+	z-index:10001;
+}
+
+.tc-dragover .tc-dropzone-cancel {
+	display:block;
+}
+
 /*
 ** Buttons
 */


### PR DESCRIPTION
Unless #686 is no longer an issue, this provides a button to hide the dropzone by clicking an x in the top-right corner of the dropzone.