### PR TITLE
First fixes to the fr-FR empty wiki generation

### DIFF
--- a/editions/fr-FR/tiddlers/system/download-empty-button.tid
+++ b/editions/fr-FR/tiddlers/system/download-empty-button.tid
@@ -1,0 +1,6 @@
+title: $:/editions/fr-FR/snippets/download-empty-button
+
+<$button class="tc-btn-big-green">
+<$action-sendmessage $message="tm-download-file" $param="$:/editions/fr-FR/download-empty" filename="empty_fr.html"/>
+Télécharger un wiki vide {{$:/core/images/save-button}}
+</$button>

--- a/editions/fr-FR/tiddlers/system/download-empty.tid
+++ b/editions/fr-FR/tiddlers/system/download-empty.tid
@@ -1,0 +1,10 @@
+title: $:/editions/fr-FR/download-empty
+type: text/vnd.tiddlywiki
+
+\define saveTiddlerFilter()
+[[$:/core]] [[$:/isEncrypted]] [[$:/themes/tiddlywiki/snowwhite]] [[$:/themes/tiddlywiki/vanilla]] [[$:/languages/fr-FR]] [[$:/language]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]]
+\end
+\define savingEmpty()
+yes
+\end
+{{$:/core/templates/tiddlywiki5.html}}

--- a/editions/fr-FR/tiddlers/system/language.tid
+++ b/editions/fr-FR/tiddlers/system/language.tid
@@ -1,0 +1,3 @@
+title: $:/language
+
+$:/languages/fr-FR

--- a/editions/fr-FR/tiddlywiki.info
+++ b/editions/fr-FR/tiddlywiki.info
@@ -18,6 +18,14 @@
     ],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","fr-fr-demo.html","text/plain"]
+			"--rendertiddler","$:/core/save/all","fr-fr-demo.html","text/plain"],
+		"empty": [
+			"--rendertiddler","$:/editions/fr-FR/download-empty","empty_fr.html","text/plain",
+			"--rendertiddler","$:/editions/fr-FR/download-empty","empty_fr.hta","text/plain"],
+		"static": [
+			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
+			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
 	}
 }


### PR DESCRIPTION
The `tiddlywiki.info` file of the fr-FR edition didn't even mention an empty build target :-) This commit is inspired by *tw5.com* and *de-AT*, but it only partly solves #1442. Notably, fr-FR language has to be manually switched after load, eventhough a **$:/language** tiddler has been added in hope that it would override the default **$:/language**.