### PR TITLE
Improve description of railroad plugin

### DIFF
--- a/plugins/tiddlywiki/railroad/plugin.info
+++ b/plugins/tiddlywiki/railroad/plugin.info
@@ -1,6 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/railroad",
-	"description": "Plugin for generating SVG railroad diagrams",
+	"description": "Railroad diagram generator",
 	"author": "Astrid Elocson",
 	"plugin-type": "plugin",
 	"list": "readme syntax example"


### PR DESCRIPTION
TiddlyWiki lists plugins in alphabetical order of description, so it's better for "railroad" to be the first word of the description of this plugin. All the more so with the advent of the plugin library.