### PR TITLE
fix empty.html GettingStarted text input field widths

### DIFF
--- a/core/language/en-GB/GettingStarted.tid
+++ b/core/language/en-GB/GettingStarted.tid
@@ -7,8 +7,11 @@ Before you start storing important information in ~TiddlyWiki it is important to
 
 !! Set up this ~TiddlyWiki
 
+<div class="tc-control-panel">
+
 |<$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link> |<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
 |<$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link> |<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
 |<$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link> |<<lingo DefaultTiddlers/TopHint>><br> <$edit-text tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
+</div>
 
 See the [[control panel|$:/ControlPanel]] for more options.


### PR DESCRIPTION
empty.html GettingStarted input filed formatting is broken in 5.1.7 

This pull request uses a ´<div class = "tc-control-panel">´ wrapper, since the fields that are shown are the same as in the core ControlPanel.

