### PR TITLE
Fix trailing semicolon in TIDDLYWIKI_EDITION_PATH

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1547,7 +1547,7 @@ $tw.getLibraryItemSearchPaths = function(libraryPath,envVar) {
 		env = process.env[envVar],
 		paths = [];
 	if(env) {
-		env.split(path.delimiter).map(function(item){
+		env.split(path.delimiter).map(function(item) {
 			if(item) {
 				paths.push(item)
 			}

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1544,15 +1544,13 @@ Returns an array of search paths
 */
 $tw.getLibraryItemSearchPaths = function(libraryPath,envVar) {
 	var pluginPaths = [path.resolve($tw.boot.corePath,libraryPath)],
-		env = process.env[envVar],
-		paths = [];
+		env = process.env[envVar];
 	if(env) {
 		env.split(path.delimiter).map(function(item) {
 			if(item) {
-				paths.push(item)
+				pluginPaths.push(item)
 			}
 		});
-		Array.prototype.push.apply(pluginPaths,paths);
 	}
 	return pluginPaths;
 };

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1544,9 +1544,15 @@ Returns an array of search paths
 */
 $tw.getLibraryItemSearchPaths = function(libraryPath,envVar) {
 	var pluginPaths = [path.resolve($tw.boot.corePath,libraryPath)],
-		env = process.env[envVar];
+		env = process.env[envVar],
+		paths = [];
 	if(env) {
-		Array.prototype.push.apply(pluginPaths,env.split(path.delimiter));
+		env.split(path.delimiter).map(function(item){
+			if(item) {
+				paths.push(item)
+			}
+		});
+		Array.prototype.push.apply(pluginPaths,paths);
 	}
 	return pluginPaths;
 };


### PR DESCRIPTION
fix problem if edition search path is TIDDLYWIKI_EDITION_PATH=c:\test; because the trailing semicolon creates an empty directory name.

see: https://github.com/Jermolene/TiddlyWiki5/issues/1187#issuecomment-65457756