### PR TITLE
Revert "Add navigation support to the edit template"

### DIFF
--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -3,7 +3,7 @@ title: $:/core/ui/EditTemplate
 \define frame-classes()
 tc-tiddler-frame tc-tiddler-edit-frame $(missingTiddlerClass)$ $(shadowTiddlerClass)$ $(systemTiddlerClass)$
 \end
-<$link tag="div" draggable="no" tabindex="1" class=<<frame-classes>>>
+<div class=<<frame-classes>>>
 <$set name="storyTiddler" value=<<currentTiddler>>>
 <$keyboard key="escape" message="tm-cancel-tiddler">
 <$keyboard key="ctrl+enter" message="tm-save-tiddler">
@@ -13,4 +13,4 @@ tc-tiddler-frame tc-tiddler-edit-frame $(missingTiddlerClass)$ $(shadowTiddlerCl
 </$keyboard>
 </$keyboard>
 </$set>
-</$link>
+</div>


### PR DESCRIPTION
For some reason this is causing the focus to be repeatedly set to
the title field when editing a tiddler's text. Let's revert it for
now.

See Issue #1527.

This reverts commit fdc635007b70588fe17c06ff018e5bce824f4949.