### PR TITLE
Correct WikiText in the upgrade wizard

### DIFF
--- a/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
+++ b/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
@@ -1,3 +1,4 @@
+created: 20150228154208000
 title: $:/UpgradeWizard
 tags: $:/tags/AboveStory
 
@@ -49,10 +50,10 @@ For help and support, visit [[the TiddlyWiki discussion forum|http://groups.goog
 
 version <<version>>
 
-//Your data will not leave your browser. <a href="http://tiddlywiki.com/upgrade.html" download="upgrade.html">Download</a> this upgrader to use it offline
+//Your data will not leave your browser. <a href="http://tiddlywiki.com/upgrade.html" download="upgrade.html">Download</a> this upgrader to use it offline//
 
-If clicking the link doesn't work save this link.
+//If clicking the link doesn't work, right-click the link and save it that way.//
 
-Your browser may ask you to accept the download before it begins.//
+//Your browser may ask you to accept the download before it begins.//
 
 </div>


### PR DESCRIPTION
Three separate paragraphs were being displayed as one, because the single `//` around all three was causing them to be parsed inline.

I've also made one bit of the wording slightly clearer.