### PR TITLE
Add support for including wikified html markup

### DIFF
--- a/core/templates/tiddlywiki5.html.tid
+++ b/core/templates/tiddlywiki5.html.tid
@@ -18,10 +18,8 @@ title: $:/core/templates/tiddlywiki5.html
 <title>{{$:/core/wiki/title}}</title>
 <!--~~ This is a Tiddlywiki file. The points of interest in the file are marked with this pattern ~~-->
 
-<!--~~ User defined plain text meta tags ~~-->
-{{{ [all[shadows+tiddlers]tag[$:/tags/MetaTag]] ||$:/core/templates/plain-text-tiddler}}}
-<!--~~ User defined wikified meta tags ~~-->
-{{{ [all[shadows+tiddlers]tag[$:/tags/MetaTagWikified]] ||$:/core/templates/wikified-tiddler-visible-code}}}
+<!--~~ Wikified Markup ~~-->
+{{{ [all[shadows+tiddlers]tag[$:/tags/WikifiedMarkup]] ||$:/core/templates/html-tiddler}}}
 <!--~~ Raw markup ~~-->
 {{{ [all[shadows+tiddlers]tag[$:/core/wiki/rawmarkup]] [all[shadows+tiddlers]tag[$:/tags/RawMarkup]] ||$:/core/templates/plain-text-tiddler}}}
 </head>

--- a/core/templates/tiddlywiki5.html.tid
+++ b/core/templates/tiddlywiki5.html.tid
@@ -18,6 +18,10 @@ title: $:/core/templates/tiddlywiki5.html
 <title>{{$:/core/wiki/title}}</title>
 <!--~~ This is a Tiddlywiki file. The points of interest in the file are marked with this pattern ~~-->
 
+<!--~~ User defined plain text meta tags ~~-->
+{{{ [all[shadows+tiddlers]tag[$:/tags/MetaTag]] ||$:/core/templates/plain-text-tiddler}}}
+<!--~~ User defined wikified meta tags ~~-->
+{{{ [all[shadows+tiddlers]tag[$:/tags/MetaTagWikified]] ||$:/core/templates/wikified-tiddler-visible-code}}}
 <!--~~ Raw markup ~~-->
 {{{ [all[shadows+tiddlers]tag[$:/core/wiki/rawmarkup]] [all[shadows+tiddlers]tag[$:/tags/RawMarkup]] ||$:/core/templates/plain-text-tiddler}}}
 </head>

--- a/core/templates/wikified-tiddler-visible-code.tid
+++ b/core/templates/wikified-tiddler-visible-code.tid
@@ -1,0 +1,3 @@
+title: $:/core/templates/wikified-tiddler-visible-code
+
+<$view format='htmlwikified'/>

--- a/core/templates/wikified-tiddler-visible-code.tid
+++ b/core/templates/wikified-tiddler-visible-code.tid
@@ -1,3 +1,0 @@
-title: $:/core/templates/wikified-tiddler-visible-code
-
-<$view format='htmlwikified'/>

--- a/editions/tw5.com/tiddlers/concepts/SystemTags.tid
+++ b/editions/tw5.com/tiddlers/concepts/SystemTags.tid
@@ -38,6 +38,7 @@ These are the available system tags
 * {{$:/tags/TopRightBar||$:/core/ui/TagTemplate}} for the top right bar
 * {{$:/tags/ViewTemplate||$:/core/ui/TagTemplate}} for the view template
 * {{$:/tags/ViewToolbar||$:/core/ui/TagTemplate}} for the view mode tiddler toolbar
+* {{$:/tags/WikifiedMarkup||$:/core/ui/TagTemplate}} for markup that is wikified before being included in the generated HTML file
 
 ! System tags in use
 


### PR DESCRIPTION
Edit: This just adds support for $:/tags/WikifiedMarkup that wikifies tiddler content and places the result in the head element of the wikis html. This complements the existing $:/tags/RawMarkup tag that places the text of a tiddler in the head element with no processing.
