### PR TITLE
Prevent long no-space field values from overflowing

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -594,6 +594,7 @@ button.tc-untagged-label {
 }
 
 .tc-view-field-value {
+	word-break: break-all;
 }
 
 @media (max-width: {{$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint}}) {


### PR DESCRIPTION
The pictures contain complete dummy json data

After the fix

![selection_513](https://cloud.githubusercontent.com/assets/4307137/6442214/5444c99e-c0ee-11e4-9504-29784ecf671b.png)

Without the fix

![selection_514](https://cloud.githubusercontent.com/assets/4307137/6442216/568b010a-c0ee-11e4-962e-67cce0f2e11b.png)
