### PR TITLE
Missing advice in Contributing.tid 

### DIFF
--- a/editions/tw5.com/tiddlers/community/Contributing.tid
+++ b/editions/tw5.com/tiddlers/community/Contributing.tid
@@ -36,6 +36,9 @@ eg: `Jeremy Ruston, @Jermolene, 2011/11/22`
 
 //The CLA documents used for this project were created using [[Harmony Project Templates|http://www.harmonyagreements.org]]. "HA-CLA-I-LIST Version 1.0" for "CLA-individual" and "HA-CLA-E-LIST Version 1.0" for "CLA-entity".//
 
-! When you do not own the Copyright in the entire work of authorship
+Remarks
+-------
+
+**When not owning the copyright in the entire work of authorship**
 
 In this case, please clearly state so, since otherwise we assume that you are the legal copyright holder of the contributed work! Please provide links and additional information that clarify under which license the rest of the code is distributed.

--- a/editions/tw5.com/tiddlers/community/Contributing.tid
+++ b/editions/tw5.com/tiddlers/community/Contributing.tid
@@ -35,3 +35,7 @@ eg: `Jeremy Ruston, @Jermolene, 2011/11/22`
 ---
 
 //The CLA documents used for this project were created using [[Harmony Project Templates|http://www.harmonyagreements.org]]. "HA-CLA-I-LIST Version 1.0" for "CLA-individual" and "HA-CLA-E-LIST Version 1.0" for "CLA-entity".//
+
+! When you do not own the Copyright in the entire work of authorship
+
+In this case, please clearly state so, since otherwise we assume that you are the legal copyright holder of the contributed work! Please provide links and additional information that clarify under which license the rest of the code is distributed.


### PR DESCRIPTION
Hi @Jermolene,

I am adding CLAs to my project as well and I noticed the following:

In the CLAs it says

> If You do not own the Copyright in the entire work of authorship, please follow the instructions in contributing.md, which is in the root directory of the project repository.

However as for TiddlyWiki5, there is no advice given on how to handle such situation in the `contribution`.md

Hence this pull request.

-Felix