### PR TITLE
Prevent the body from being scrolled when modal is open

### DIFF
--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -48,6 +48,8 @@ Modal.prototype.display = function(title,options) {
 		modalFooter = document.createElement("div"),
 		modalFooterHelp = document.createElement("span"),
 		modalFooterButtons = document.createElement("span");
+	// Prevent background from scrolling when inside a modal
+	document.body.style.overflow = "hidden";
 	// Up the modal count and adjust the body class
 	this.modalCount++;
 	this.adjustPageClass();
@@ -155,6 +157,8 @@ Modal.prototype.display = function(title,options) {
 			if(wrapper.parentNode) {
 				// Remove the modal message from the DOM
 				document.body.removeChild(wrapper);
+				// Reset style to allow the body to scroll
+			        document.body.style.overflow = null;
 			}
 		},duration);
 		// Don't let anyone else handle the tm-close-tiddler message


### PR DESCRIPTION
Hi @Jermolene 

it is really distracting to see the story river scrolling when being inside a modal and using the mouse wheel. A simple addition to the modal code fixes this.

-Felix
