### PR TITLE
Let checkbox, link, radio and select widgets tigger action widgets.

### DIFF
--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -90,7 +90,8 @@ CheckboxWidget.prototype.handleChangeEvent = function(event) {
 		tiddler = this.wiki.getTiddler(this.checkboxTitle),
 		fallbackFields = {text: ""},
 		newFields = {title: this.checkboxTitle},
-		hasChanged = false;
+		hasChanged = false,
+		handled;
 	// Set the tag if specified
 	if(this.checkboxTag && (!tiddler || tiddler.hasTag(this.checkboxTag) !== checked)) {
 		newFields.tags = tiddler ? (tiddler.fields.tags || []).slice(0) : [];
@@ -113,6 +114,10 @@ CheckboxWidget.prototype.handleChangeEvent = function(event) {
 	}
 	if(hasChanged) {
 		this.wiki.addTiddler(new $tw.Tiddler(fallbackFields,tiddler,newFields,this.wiki.getModificationFields()));
+	}
+	// Invoke any actions
+	if(this.invokeActions(event)) {
+		handled = true;
 	}
 };
 

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -1,5 +1,5 @@
 /*\
-title: $:/core/modules/widgets/link.js
+title: $:/plugins/inmysocsk/WidgetsInvokeActions/link-invoke-actions.js
 type: application/javascript
 module-type: widget
 
@@ -14,19 +14,19 @@ Link widget
 
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
-var LinkWidget = function(parseTreeNode,options) {
+var LinkWidgetInvokeActions = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
 /*
 Inherit from the base widget class
 */
-LinkWidget.prototype = new Widget();
+LinkWidgetInvokeActions.prototype = new Widget();
 
 /*
 Render this widget into the DOM
 */
-LinkWidget.prototype.render = function(parent,nextSibling) {
+LinkWidgetInvokeActions.prototype.render = function(parent,nextSibling) {
 	// Save the parent dom node
 	this.parentDomNode = parent;
 	// Compute our attributes
@@ -51,15 +51,10 @@ LinkWidget.prototype.render = function(parent,nextSibling) {
 /*
 Render this widget into the DOM
 */
-LinkWidget.prototype.renderLink = function(parent,nextSibling) {
+LinkWidgetInvokeActions.prototype.renderLink = function(parent,nextSibling) {
 	var self = this;
-	// Sanitise the specified tag
-	var tag = this.linkTag;
-	if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-		tag = "a";
-	}
 	// Create our element
-	var domNode = this.document.createElement(tag);
+	var domNode = this.document.createElement("a");
 	// Assign classes
 	var classes = [];
 	if(this.linkClasses) {
@@ -82,11 +77,7 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 		wikiLinkTemplate = wikiLinkTemplateMacro ? wikiLinkTemplateMacro.trim() : "#$uri_encoded$",
 		wikiLinkText = wikiLinkTemplate.replace("$uri_encoded$",encodeURIComponent(this.to));
 	wikiLinkText = wikiLinkText.replace("$uri_doubleencoded$",encodeURIComponent(encodeURIComponent(this.to)));
-	wikiLinkText = this.getVariable("tv-get-export-link",{params: [{name: "to",value: this.to}],defaultValue: wikiLinkText});
-	if(tag === "a") {
-		domNode.setAttribute("href",wikiLinkText);		
-	}
-	domNode.setAttribute("tabindex",this.tabIndex);
+	domNode.setAttribute("href",wikiLinkText);
 	// Set the tooltip
 	// HACK: Performance issues with re-parsing the tooltip prevent us defaulting the tooltip to "<$transclude field='tooltip'><$transclude field='title'/></$transclude>"
 	var tooltipWikiText = this.tooltip || this.getVariable("tv-wikilink-tooltip");
@@ -106,20 +97,21 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	// Add a click event handler
 	$tw.utils.addEventListeners(domNode,[
 		{name: "click", handlerObject: this, handlerMethod: "handleClickEvent"},
+		{name: "dragstart", handlerObject: this, handlerMethod: "handleDragStartEvent"},
+		{name: "dragend", handlerObject: this, handlerMethod: "handleDragEndEvent"}
 	]);
-	if(this.draggable === "yes") {
-		$tw.utils.addEventListeners(domNode,[
-			{name: "dragstart", handlerObject: this, handlerMethod: "handleDragStartEvent"},
-			{name: "dragend", handlerObject: this, handlerMethod: "handleDragEndEvent"}
-		]);
-	}
 	// Insert the link into the DOM and render any children
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);
 	this.domNodes.push(domNode);
 };
 
-LinkWidget.prototype.handleClickEvent = function(event) {
+LinkWidgetInvokeActions.prototype.handleClickEvent = function(event) {
+	var handled;
+	// Invoke any actions
+	if(this.invokeActions(event)) {
+		handled = true;
+	}
 	// Send the click on its way as a navigate event
 	var bounds = this.domNodes[0].getBoundingClientRect();
 	this.dispatchEvent({
@@ -131,17 +123,14 @@ LinkWidget.prototype.handleClickEvent = function(event) {
 		},
 		navigateSuppressNavigation: event.metaKey || event.ctrlKey || (event.button === 1)
 	});
-	if(this.domNodes[0].hasAttribute("href")) {
-		event.preventDefault();
-		event.stopPropagation();
-		return false;
-	}
+	event.preventDefault();
+	event.stopPropagation();
+	return false;
 };
 
-LinkWidget.prototype.handleDragStartEvent = function(event) {
+LinkWidgetInvokeActions.prototype.handleDragStartEvent = function(event) {
 	if(event.target === this.domNodes[0]) {
 		if(this.to) {
-			$tw.dragInProgress = true;
 			// Set the dragging class on the element being dragged
 			$tw.utils.addClass(event.target,"tc-tiddlylink-dragging");
 			// Create the drag image elements
@@ -176,9 +165,9 @@ LinkWidget.prototype.handleDragStartEvent = function(event) {
 			if(!$tw.browser.isIE) {
 				dataTransfer.setData("text/vnd.tiddler",jsonData);
 				dataTransfer.setData("text/plain",title);
-				dataTransfer.setData("text/x-moz-url","data:text/vnd.tiddler," + encodeURIComponent(jsonData));
+				dataTransfer.setData("text/x-moz-url","data:text/vnd.tiddler," + encodeURI(jsonData));
 			}
-			dataTransfer.setData("URL","data:text/vnd.tiddler," + encodeURIComponent(jsonData));
+			dataTransfer.setData("URL","data:text/vnd.tiddler," + encodeURI(jsonData));
 			dataTransfer.setData("Text",title);
 			event.stopPropagation();
 		} else {
@@ -187,9 +176,8 @@ LinkWidget.prototype.handleDragStartEvent = function(event) {
 	}
 };
 
-LinkWidget.prototype.handleDragEndEvent = function(event) {
+LinkWidgetInvokeActions.prototype.handleDragEndEvent = function(event) {
 	if(event.target === this.domNodes[0]) {
-		$tw.dragInProgress = false;
 		// Remove the dragging class on the element being dragged
 		$tw.utils.removeClass(event.target,"tc-tiddlylink-dragging");
 		// Delete the drag image element
@@ -202,15 +190,14 @@ LinkWidget.prototype.handleDragEndEvent = function(event) {
 /*
 Compute the internal state of the widget
 */
-LinkWidget.prototype.execute = function() {
-	// Pick up our attributes
+LinkWidgetInvokeActions.prototype.execute = function() {
+	// Get the target tiddler title
 	this.to = this.getAttribute("to",this.getVariable("currentTiddler"));
+	// Get the link title and aria label
 	this.tooltip = this.getAttribute("tooltip");
 	this["aria-label"] = this.getAttribute("aria-label");
+	// Get the link classes
 	this.linkClasses = this.getAttribute("class");
-	this.tabIndex = this.getAttribute("tabindex");
-	this.draggable = this.getAttribute("draggable","yes");
-	this.linkTag = this.getAttribute("tag","a");
 	// Determine the link characteristics
 	this.isMissing = !this.wiki.tiddlerExists(this.to);
 	this.isShadow = this.wiki.isShadowTiddler(this.to);
@@ -221,7 +208,7 @@ LinkWidget.prototype.execute = function() {
 /*
 Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 */
-LinkWidget.prototype.refresh = function(changedTiddlers) {
+LinkWidgetInvokeActions.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.to || changedTiddlers[this.to] || changedAttributes["aria-label"] || changedAttributes.tooltip) {
 		this.refreshSelf();
@@ -230,6 +217,6 @@ LinkWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-exports.link = LinkWidget;
+exports.linkInvokeActions = LinkWidgetInvokeActions;
 
 })();

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -120,6 +120,11 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 };
 
 LinkWidget.prototype.handleClickEvent = function(event) {
+	var handled;
+	// Invoke any actions
+	if(this.invokeActions(event)) {
+		handled = true;
+	}
 	// Send the click on its way as a navigate event
 	var bounds = this.domNodes[0].getBoundingClientRect();
 	this.dispatchEvent({

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -120,11 +120,6 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 };
 
 LinkWidget.prototype.handleClickEvent = function(event) {
-	var handled;
-	// Invoke any actions
-	if(this.invokeActions(event)) {
-		handled = true;
-	}
 	// Send the click on its way as a navigate event
 	var bounds = this.domNodes[0].getBoundingClientRect();
 	this.dispatchEvent({

--- a/core/modules/widgets/radio.js
+++ b/core/modules/widgets/radio.js
@@ -59,6 +59,7 @@ RadioWidget.prototype.render = function(parent,nextSibling) {
 	this.labelDomNode.appendChild(this.inputDomNode);
 	this.spanDomNode = this.document.createElement("span");
 	this.labelDomNode.appendChild(this.spanDomNode);
+	this.setVariable("currentOption", this.radioValue);
 	// Add a click event handler
 	$tw.utils.addEventListeners(this.inputDomNode,[
 		{name: "change", handlerObject: this, handlerMethod: "handleChangeEvent"}
@@ -84,8 +85,13 @@ RadioWidget.prototype.setValue = function() {
 };
 
 RadioWidget.prototype.handleChangeEvent = function(event) {
+	var handled;
 	if(this.inputDomNode.checked) {
 		this.setValue();
+	}
+	// Invoke any actions
+	if(this.invokeActions(event)) {
+		handled = true;
 	}
 };
 

--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -54,7 +54,27 @@ SelectWidget.prototype.handleChangeEvent = function(event) {
 	var value = this.getSelectDomNode().value;
 	this.wiki.setText(this.selectTitle,this.selectField,this.selectIndex,value);
 
-	this.activeChild = 2*(this.getSelectDomNode().selectedIndex)+1;
+	for(var k = 0; k < this.parseTreeNode.children.length; k++) {
+		if(this.parseTreeNode.children[k].attributes){
+			if(this.parseTreeNode.children[k].attributes.value) {
+				if(this.parseTreeNode.children[k].attributes.value.value === this.getSelectDomNode().value) {
+					this.activeChild = k;
+					break;
+				}
+			} else {
+				for(var l = 0; l < this.parseTreeNode.children[k].children.length; l++) {
+					if(this.parseTreeNode.children[k].children[l].text) {
+						if(this.parseTreeNode.children[k].children[l].text === this.getSelectDomNode().value) {
+							this.activeChild = k;
+							break;
+						}
+					}
+				}
+			}
+		} 
+	}
+
+	if(this.activeChild){
 	var widgets = $tw.wiki.makeWidget(this.parseTreeNode.children[this.activeChild], {parentWidget:this});
 	widgets.parseTreeNode = this.parseTreeNode;
 	widgets.parseTreeNode.children = [this.parseTreeNode.children[this.activeChild]];
@@ -63,6 +83,9 @@ SelectWidget.prototype.handleChangeEvent = function(event) {
 	widgets.render(container, null);
 	if(widgets) {
 		widgets.invokeActions({});
+	}
+	} else {
+//		console.log("no active child");
 	}
 };
 

--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -53,6 +53,17 @@ Handle a change event
 SelectWidget.prototype.handleChangeEvent = function(event) {
 	var value = this.getSelectDomNode().value;
 	this.wiki.setText(this.selectTitle,this.selectField,this.selectIndex,value);
+
+	this.activeChild = 2*(this.getSelectDomNode().selectedIndex)+1;
+	var widgets = $tw.wiki.makeWidget(this.parseTreeNode.children[this.activeChild], {parentWidget:this});
+	widgets.parseTreeNode = this.parseTreeNode;
+	widgets.parseTreeNode.children = [this.parseTreeNode.children[this.activeChild]];
+	var container = $tw.fakeDocument.createElement("div");
+	widgets.setVariable("currentTiddler", this.getVariable("currentTiddler"));
+	widgets.render(container, null);
+	if(widgets) {
+		widgets.invokeActions({});
+	}
 };
 
 /*


### PR DESCRIPTION
The link and checkbox widgets treat action-widgets the same way as the button widget does, so a reveal widget has to be used to change what happens when checking vs unchecking a checkbox.

The radio widget evaluates the action widgets before the field being affected updates, so I added the currentOption variable that contains the value being switched to so that is available to to the action widgets.

The select widget only triggers the action widgets contained in side the <option> and </option> tags for the option being selected. Unlike the radio widget, the select widget does use the updated value of whatever field is being changed, so it is the previous value that is unavailable.
