### PR TITLE
Bugfix: Object.freeze() called on null

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -793,7 +793,7 @@ $tw.Tiddler = function(/* [fields,] fields */) {
 					value = src[t];
 				}
 				// Freeze the field to keep it immutable
-				if(typeof value === "object") {
+				if(value != null && typeof value === "object") {
 					Object.freeze(value);
 				}
 				this.fields[t] = value;


### PR DESCRIPTION
Hi @Jermolene 

For five minutes I stared at the following code...

    if(typeof value === "object") {
      Object.freeze(value);
    }

... and at the error message that led me to this code: `Object.freeze called on non-object`

And then I remembered that js treads null as object (http://www.ecma-international.org/ecma-262/5.1/#sec-11.4.3). This means the `typeof === "object"` will not discover null and freeze will throw an error...

So `value != null` will also work when value is undefined.

A hard to find bug ;)

**Edit**

Here is what happened:

1. I used `var fields = $tw.utils.deepCopy(tObj.fields);` on a tiddler's field to be able to manipulate a field value.
2. The `created` and `modified` fields (date objects) were getting destroyed at that point and became mere objects.
3. Saving the `fields` again via `$tw.wiki.addTiddler(new $tw.Tiddler(fields));` created the error then since in boot.js `src[t]` is not null or undefined but `fieldModule.parse.call(this,src[t]);` will create a null value.
4. This value is then overlooked by `typeof value === "object"`