### PR TITLE
Added support for the $:/tags/StartupActions tag

### DIFF
--- a/core/modules/startup/startup-actions.js
+++ b/core/modules/startup/startup-actions.js
@@ -1,0 +1,66 @@
+/*\
+title: $:/core/modules/startup/startup-actions.js
+type: application/javascript
+module-type: startup
+
+This runs startup action scripts
+
+\*/
+(function () {
+
+	/*jslint node: true, browser: true */
+	/*global $tw: false */
+	"use strict";
+
+	// Export name and synchronous status
+	exports.name = "startup-actions";
+	exports.platforms = ["browser"];
+	exports.after = ["rootwidget"];
+	exports.synchronous = true;
+
+	exports.startup = function() {
+		// Do all actions on startup.
+		var tiddlersFilter = "[tag[$:/tags/StartupAction]!has[draft.of]]";
+		var expressionTiddlerList = $tw.wiki.filterTiddlers(tiddlersFilter);
+		if(expressionTiddlerList.length !== 0) {
+			for (var j = 0; j < expressionTiddlerList.length; j++) {
+				var expressionTiddler = $tw.wiki.getTiddler(expressionTiddlerList[j]);
+				if(expressionTiddler) {
+					evaluateExpression(expressionTiddler);
+				}
+			}
+		}
+	};
+
+	function evaluateExpression(expressionTiddler) {
+		if(expressionTiddler) {
+			// Import all the variables because the widget isn't part of the main tiddlywiki story so the global macros and similar things aren't loaded by default.
+			var stringPassed = "<$importvariables filter='[[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]] [[" + expressionTiddler.getFieldString("title") + "]]'>"+expressionTiddler.getFieldString("text")+"</$importvariables>";
+			var parsed = $tw.wiki.parseText("text/vnd.tiddlywiki", stringPassed, {});
+			var widgets = $tw.wiki.makeWidget(parsed, {parentWidget:$tw.rootWidget});
+			var container = $tw.fakeDocument.createElement("div");
+
+			// If a filter is given for the action tiddlers do the actions in each returned tiddler in sequence.
+			if(expressionTiddler.getFieldString("action_filter")) {
+				var actionTiddlerList = $tw.wiki.filterTiddlers(expressionTiddler.getFieldString("action_filter"));
+				for (var k = 0; k < actionTiddlerList.length; k++) {
+					performAction(actionTiddlerList[k], widgets, container);
+				}
+			} else {
+				// If no filter for the action tiddlers is given just evaluate the expressions.
+				var expressionTiddlerTitle = expressionTiddler.getFieldString("title");
+				performAction(expressionTiddlerTitle, widgets, container);
+			}
+		}
+	}
+
+	// Invoke the action(s).
+	function performAction(tiddler, widgets, container) {
+		widgets.setVariable("currentTiddler", tiddler);
+		widgets.render(container, null);
+		if(widgets) {
+			widgets.invokeActions({});
+		}
+	}
+
+})();

--- a/editions/tw5.com/tiddlers/widgets/ActionWidgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionWidgets.tid
@@ -19,3 +19,5 @@ Click me!
 The following action widgets are provided:
 
 <<list-links "[tag[ActionWidgets]]">>
+
+Action widgets can be used with the `$:/tags/StartupAction` tag to create [[scripts that run when the wiki is loaded|Startup Actions]].

--- a/editions/tw5.com/tiddlers/widgets/Startup Actions
+++ b/editions/tw5.com/tiddlers/widgets/Startup Actions
@@ -7,7 +7,7 @@ Any WikiText markup is allowed, so transclusions and macros work as expected.
 
 !Example
 
-The following script, if put in the text field of a tiddler tagged with `$:/tags/StartupAction`, would change the title of a wiki to `title1` if it is not already `title1`, and if the title of the wiki is `title1` it will change the title to `title2`. This is done using the [[reveal widget|RevealWidget]].
+The following WikiText, if put in the text field of a tiddler tagged with `$:/tags/StartupAction`, would change the title of a wiki to `title1` if it is not already `title1`, and if the title of the wiki is `title1` it will change the title to `title2`. This is done using the [[reveal widget|RevealWidget]].
 
 ```
 <$reveal state='$:/SiteTitle' type='nomatch' text='title1'>

--- a/editions/tw5.com/tiddlers/widgets/Startup Actions
+++ b/editions/tw5.com/tiddlers/widgets/Startup Actions
@@ -1,0 +1,19 @@
+tags: ActionWidgets
+title: Startup Actions
+
+Any tiddler that is tagged with `$:/tags/StartupAction` will have the contents of its text field evaluated as though it were triggered by a button widget. That is, any [[action widgets|ActionWidgets]] will be invoked.
+
+Any WikiText markup is allowed, so transclusions and macros work as expected.
+
+!Example
+
+The following script, if put in the text field of a tiddler tagged with `$:/tags/StartupAction`, would change the title of a wiki to `title1` if it is not already `title1`, and if the title of the wiki is `title1` it will change the title to `title2`. This is done using the [[reveal widget|RevealWidget]].
+
+```
+<$reveal state='$:/SiteTitle' type='nomatch' text='title1'>
+<$action-setfield $tiddler='$:/SiteTitle' text=title1/>
+</$reveal>
+<$reveal state='$:/SiteTitle' type='match' text='title1'>
+<$action-setfield $tiddler='$:/SiteTitle' text=title2/>
+</$reveal>
+```


### PR DESCRIPTION
This allows you to make startup scripts using action widgets by tagging tiddlers with $:/tags/StartupActions, any wikitext in the text field of the tagged tiddler(s) will be triggered the same as if it were in a button widget that got pressed.

A demo site is here http://ooktech.com/jed/ExampleWikis/StartupActions/
