### PR TITLE
help panel css changes.

### DIFF
--- a/plugins/tiddlywiki/help/styles.tid
+++ b/plugins/tiddlywiki/help/styles.tid
@@ -8,7 +8,7 @@ tags: [[$:/tags/Stylesheet]]
 	top: 2.5em;
 	bottom: 0;
 	right: 0;
-	width: 310px;
+	width: 25%;
 	overflow: scroll;
 	-webkit-overflow-scrolling: touch;
 	<<box-shadow "0px 0px 5px rgba(0, 0, 0, 0.3)">>
@@ -16,6 +16,7 @@ tags: [[$:/tags/Stylesheet]]
 	background: <<colour tiddler-background>>;
 	padding: 1em;
 	margin: 0.5em;
+	overflow: auto;
 }
 
 dl.tc-help-cheatsheet {


### PR DESCRIPTION
 - overflow auto removes the scroll bars in windows. 
 - width 25% is independent from browser zoom level and gives the cheat sheet more visible space.

original 100% browser zoom

![tw-help-panel](https://cloud.githubusercontent.com/assets/374655/6729523/7192dff2-ce33-11e4-831f-254117a4b26c.gif)

tc-panel 25% ... 100% browser zoom

![tw-help-panel-25](https://cloud.githubusercontent.com/assets/374655/6729536/8acd1b18-ce33-11e4-9be2-66ee290a1e5e.gif)
