### PR TITLE
Improvement to prfix option of generateNewTite

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -179,7 +179,7 @@ exports.generateNewTitle = function(baseTitle,options) {
 		title = baseTitle;
 	while(this.tiddlerExists(title) || this.isShadowTiddler(title) || this.findDraft(title)) {
 		title = baseTitle + 
-			(options.prefix || " ") + 
+			(options.prefix === undefined ? " " || options.prefix) + 
 			(++c);
 	}
 	return title;

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -179,7 +179,7 @@ exports.generateNewTitle = function(baseTitle,options) {
 		title = baseTitle;
 	while(this.tiddlerExists(title) || this.isShadowTiddler(title) || this.findDraft(title)) {
 		title = baseTitle + 
-			(options.prefix === undefined ? " " || options.prefix) + 
+			(options.prefix === undefined ? " " : options.prefix) + 
 			(++c);
 	}
 	return title;


### PR DESCRIPTION
The prefix should only be substituted by space in case of undefined value. There are a lot of valid prefixes that are interpreted as false by JavaScript such as: "",0,00 and so on.

Without this is impossible to generate new titles without space like col1
