### PR TITLE
Add the missing operator to `sameday`

### DIFF
--- a/core/wiki/macros/timeline.tid
+++ b/core/wiki/macros/timeline.tid
@@ -16,7 +16,7 @@ type: text/vnd.tiddlywiki
 <$list filter="[!is[system]$subfilter$has[$dateField$]!sort[$dateField$]limit[$limit$]eachday[$dateField$]]">
 <div class="tc-menu-list-item">
 <$view field="$dateField$" format="date" template="$format$"/>
-<$list filter="[sameday{!!$dateField$}!is[system]$subfilter$!sort[$dateField$]]">
+<$list filter="[sameday:$dateField${!!$dateField$}!is[system]$subfilter$!sort[$dateField$]]">
 <div class="tc-menu-list-subitem">
 <$link to={{!!title}}>
 <<timeline-title>>


### PR DESCRIPTION
Otherwise, the `sameday` macro will default to `modified`.  In case the user set `dateField:"created"` when calling `timeline`, the result will be inconsitent.