### PR TITLE
upgrading the navigator widget

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -88,6 +88,13 @@ Settings/ToolbarButtons/Icons/Description: Include icon
 Settings/ToolbarButtons/Text/Description: Include text
 Settings/DefaultSidebarTab/Caption: Default Sidebar Tab
 Settings/DefaultSidebarTab/Hint: Specify which sidebar tab is displayed by default
+Settings/LinkToBehaviour/Caption: Internal link opening behaviour
+Settings/LinkToBehaviour/InsideRiver/Hint: Click occurred //within// the story river
+Settings/LinkToBehaviour/OutsideRiver/Hint: Click occurred //outside// the story river
+Settings/LinkToBehaviour/OpenAbove: Open above the current tiddler
+Settings/LinkToBehaviour/OpenBelow: Open below the current tiddler
+Settings/LinkToBehaviour/OpenAtTop: Open at the top of the river
+Settings/LinkToBehaviour/OpenAtBottom: Open at the bottom of the river
 StoryView/Caption: Story View
 StoryView/Prompt: Current view:
 Theme/Caption: Theme

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -85,11 +85,6 @@ NavigatorWidget.prototype.saveStoryList = function(storyList) {
 	));
 };
 
-NavigatorWidget.prototype.findTitleInStory = function(storyList,title,defaultIndex) {
-	var p = storyList.indexOf(title);
-	return p === -1 ? defaultIndex : p;
-};
-
 NavigatorWidget.prototype.removeTitleFromStory = function(storyList,title) {
 	var p = storyList.indexOf(title);
 	while(p !== -1) {
@@ -112,22 +107,55 @@ NavigatorWidget.prototype.replaceFirstTitleInStory = function(storyList,oldTitle
 		storyList.splice(0,0,newTitle);
 	}
 };
-
+	
 NavigatorWidget.prototype.addToStory = function(title,fromTitle) {
 	var storyList = this.getStoryList();
-	if(storyList) {
-		// See if the tiddler is already there
-		var slot = this.findTitleInStory(storyList,title,-1);
-		// If not we need to add it
-		if(slot === -1) {
-			// First we try to find the position of the story element we navigated from
-			slot = this.findTitleInStory(storyList,fromTitle,-1) + 1;
-			// Add the tiddler
-			storyList.splice(slot,0,title);
-			// Save the story
-			this.saveStoryList(storyList);
+	// Quit if we cannot get hold of the story list
+	if(!storyList) {
+		return;
+	}
+	// See if the tiddler is already there
+	var slot = storyList.indexOf(title);
+	// Quit if it already exists in the story river
+	if(slot >= 0) {
+		return;
+	}
+	// First we try to find the position of the story element we navigated from
+	var fromIndex = storyList.indexOf(fromTitle);
+	if(fromIndex >= 0) {
+		// How to open internal links that were clicked from *within* the story river?
+		var openLinkFromInsideRiver = $tw.wiki.getTiddlerText("$:/config/Navigation/openLinkFromInsideRiver", "below");
+		// The tiddler is added from inside the river
+		// Determine where to insert the tiddler; Fallback is "below"
+		switch(openLinkFromInsideRiver) {
+			case "top":
+				slot = 0;
+				break;
+			case "bottom":
+				slot = storyList.length;
+				break;
+			case "above":
+				slot = fromIndex;
+				break;
+			default:
+				slot = fromIndex + 1;
+		}
+	} else {
+		// The tiddler is opened from outside the river.
+		var openLinkFromOutsideRiver = $tw.wiki.getTiddlerText("$:/config/Navigation/openLinkFromOutsideRiver", "top");
+		// Determine where to insert the tiddler; Default is "top"
+		if(openLinkFromOutsideRiver === "bottom") {
+			// Insert at bottom
+			slot = 	storyList.length;
+		} else {
+			// Insert at top
+			slot = 0;
 		}
 	}
+	// Add the tiddler
+	storyList.splice(slot,0,title);
+	// Save the story
+	this.saveStoryList(storyList);
 };
 
 /*

--- a/core/ui/ControlPanel/Settings/LinkToBehaviour.tid
+++ b/core/ui/ControlPanel/Settings/LinkToBehaviour.tid
@@ -1,0 +1,21 @@
+title: $:/core/ui/ControlPanel/Settings/LinkToBehaviour
+tags: $:/tags/ControlPanel/Settings
+caption: {{$:/language/ControlPanel/Settings/LinkToBehaviour/Caption}}
+
+\define lingo-base() $:/language/ControlPanel/Settings/LinkToBehaviour/
+
+<$link to="$:/config/Navigation/openLinkFromInsideRiver"><<lingo "InsideRiver/Hint">></$link>
+
+<$select tiddler="$:/config/Navigation/openLinkFromInsideRiver">
+  <option value="above"><<lingo "OpenAbove">></option>
+  <option value="below"><<lingo "OpenBelow">></option>
+  <option value="top"><<lingo "OpenAtTop">></option>
+  <option value="bottom"><<lingo "OpenAtBottom">></option>
+</$select>
+
+<$link to="$:/config/Navigation/openLinkFromOutsideRiver"><<lingo "OutsideRiver/Hint">></$link>
+
+<$select tiddler="$:/config/Navigation/openLinkFromOutsideRiver">
+  <option value="top"><<lingo "OpenAtTop">></option>
+  <option value="bottom"><<lingo "OpenAtBottom">></option>
+</$select>

--- a/core/wiki/config/OpenLinkFromInsideRiver.tid
+++ b/core/wiki/config/OpenLinkFromInsideRiver.tid
@@ -1,0 +1,2 @@
+title: $:/config/Navigation/openLinkFromInsideRiver
+text: below

--- a/core/wiki/config/OpenLinkFromOutsideRiver.tid
+++ b/core/wiki/config/OpenLinkFromOutsideRiver.tid
@@ -1,0 +1,2 @@
+title: $:/config/Navigation/openLinkFromOutsideRiver
+text: top


### PR DESCRIPTION
### Context

* https://github.com/Jermolene/TiddlyWiki5/issues/1651
* https://github.com/Jermolene/TiddlyWiki5/issues/1650

### Summary:

1. Enhanced `addToStory()` which is called by `handleNavigateEvent`.
1. Created settings part in the tw-config: "Internal link opening behaviour"
1. Applied lingo to selectbox options as pointed out in https://github.com/Jermolene/TiddlyWiki5/pull/1662#issuecomment-93982102

### Demo
(probably not up-to-date with code changes)

http://wkpr.de/hosting/tmp/navigation-demo/
