### PR TITLE
Making use of the caption field as tag label to avoid long tag names

### DIFF
--- a/core/ui/TagTemplate.tid
+++ b/core/ui/TagTemplate.tid
@@ -10,7 +10,10 @@ color:$(foregroundColor)$;
 <$set name="foregroundColor" value=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">>>
 <$set name="backgroundColor" value="""$colour$""">
 <$button popup=<<qualify "$:/state/popup/tag">> class="tc-btn-invisible tc-tag-label" style=<<tag-styles>>>
-<$transclude tiddler={{!!icon}}/> <$view field="title" format="text" />
+<$transclude tiddler={{!!icon}}/>
+<$view field="caption" format="text">
+  <$view field="title" format="text" />
+</$view>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes"><div class="tc-drop-down"><$transclude tiddler="$:/core/ui/ListItemTemplate"/>
 <hr>


### PR DESCRIPTION
...er want to show the tiddler with a short title. For example when it is listed as tab or when it is displayed tag. In case of tabs, TiddlyWiki acknowledges the caption field. But in case of tags - the whole title is used. In most of the cases I see myself forced to use a very small title because I also want to use it as tag, which is bitter because I would prefer a longer tiddler title but this would spoil the tag look.

Therefore I propose the following change which takes advantage of the fact that "the content of the <$view> widget is displayed if the field or property is missing or empty":

For a tiddler that is *not* in draft mode:

1. Try to display the caption field as tag label
2. If the field does not exist or is empty, use the title

**This proposal does not break the reference-system**, as the correct title has to be entered to reference the tiddler.

I would also suggest to display the short title in the drop down. But want to discuss this first.