### PR TITLE
Add Tw Pre-release & Td Releases To Tw.com

### DIFF
--- a/editions/tw5.com/tiddlers/$__StoryList.tid
+++ b/editions/tw5.com/tiddlers/$__StoryList.tid
@@ -1,0 +1,5 @@
+created: 20150426183820864
+list: HelloThere GettingStarted Community
+title: $:/StoryList
+type: text/vnd.tiddlywiki
+

--- a/editions/tw5.com/tiddlers/Pre-Release.tid
+++ b/editions/tw5.com/tiddlers/Pre-Release.tid
@@ -1,0 +1,10 @@
+caption: Pre-release
+created: 20150419155241817
+modified: 20150419163304537
+tags: Releases
+title: Pre-Release
+type: text/vnd.tiddlywiki
+
+A pre-release version is available at http://tiddlywiki.com/prerelease/
+
+It is provided for testing purposes. Please don't try to use it for anything important – you should use the latest official release from http://tiddlywiki.com.

--- a/editions/tw5.com/tiddlers/TiddlyDesktop_Release_0.0.1.tid
+++ b/editions/tw5.com/tiddlers/TiddlyDesktop_Release_0.0.1.tid
@@ -1,0 +1,8 @@
+caption: 0.0.1
+created: 20150419144925501
+modified: 20150419152103526
+tags: TiddlyDesktopReleaseNotes
+title: TiddlyDesktop Release 0.0.1
+type: text/vnd.tiddlywiki
+
+First release - use with extreme caution

--- a/editions/tw5.com/tiddlers/TiddlyDesktop_Release_0.0.2.tid
+++ b/editions/tw5.com/tiddlers/TiddlyDesktop_Release_0.0.2.tid
@@ -1,0 +1,16 @@
+caption: 0.0.2
+created: 20150419150123810
+modified: 20150419154256169
+tags: TiddlyDesktopReleaseNotes
+title: TiddlyDesktop Release 0.0.2
+type: text/vnd.tiddlywiki
+
+[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyDesktop/compare/v0.0.1...v0.0.2]]
+
+This second version of TiddlyDesktop has the following fixes and improvements:
+
+*The saving mechanism is now TiddlyFox compatible, so TiddlyWiki5 wikis don't need a special plugin to work with TiddlyDesktop
+*TiddlyDesktop is now compatible with TiddlyWiki Classic
+*Chromium Developer Tools now accessible via a pulldown menu
+*Each TiddlyWiki document is now sandboxed, so it isn't possible for malicious or buggy JavaScript to affect other documents
+*Linux 32-bit and 64-bit builds

--- a/editions/tw5.com/tiddlers/TiddlyDesktop_Release_0.0.3.tid
+++ b/editions/tw5.com/tiddlers/TiddlyDesktop_Release_0.0.3.tid
@@ -1,0 +1,18 @@
+caption: 0.0.3
+created: 20150419150143521
+modified: 20150419154240713
+tags: TiddlyDesktopReleaseNotes
+title: TiddlyDesktop Release 0.0.3
+type: text/vnd.tiddlywiki
+
+[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyDesktop/compare/v0.0.2...v0.0.3]]
+
+This third version of TiddlyDesktop has the following fixes and improvements:
+
+*Access Chromium developer tools with F12
+*No menu bars
+*Fixed problem with paths containing spaces
+*Enabled webkit experimental features
+*Adjusted the main window toolbar to be position: sticky
+*Fixed problem with relative inter-wiki links not working
+*Add "file not found" error indication

--- a/editions/tw5.com/tiddlers/TiddlyDesktop_Release_0.0.4.tid
+++ b/editions/tw5.com/tiddlers/TiddlyDesktop_Release_0.0.4.tid
@@ -1,0 +1,39 @@
+caption: 0.0.4
+created: 20150419150210402
+modified: 20150419154800738
+tags: TiddlyDesktopReleaseNotes
+title: TiddlyDesktop Release 0.0.4
+type: text/vnd.tiddlywiki
+
+[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyDesktop/compare/v0.0.3...v0.0.4]]
+
+This release includes a major reworking of the internals of TiddlyDesktop. It's really a bit early for general release, but we need feedback to improve it. Please use it with great caution, and consider reverting to v0.0.3 if you run into any problems.
+
+Please report any problems or suggestions via GitHub issues, or post to the TiddlyWiki discussion group:
+
+http://groups.google.com/group/TiddlyWiki
+
+!New Features
+*Warning message when closing windows with unsaved changes (TWC and TW 5.1.8 and above only)
+*Help window
+*Toolbar for TiddlyWiki windows
+*Reveal original file in Finder/Explorer
+*Automatic backups
+Note that there is currently no way to hide the toolbar for TiddlyWiki windows. This will be remedied soon!
+
+!New Architecture
+TiddlyDesktop itself is now an instance of the Node.js edition of TiddlyWiki. TiddlyWiki HTML files are run within embedded, sandboxed iframes with the "backstage" TiddlyWiki providing services such as saving to the file system.
+
+The advantage of this approach is that the user interface and functionality of the desktop application can now be customised and extended with exactly the same techniques that are used in regular TiddlyWiki.
+
+!Coming Soon
+The functionality of this release barely matches that of the previous v0.0.3 version, but it lays the groundwork for a number of other features such as:
+
+*Configurable toolbars
+*Hyperbookmarklets
+*Page zoom
+*Creating new wikis from standard editions and custom templates
+*Dragging _canonical_uri links from the file system
+*Multiple languages
+*One-click copying of text to the clipboard from within TiddlyWiki
+*Global keyboard shortcut for clipping content etc.

--- a/editions/tw5.com/tiddlers/TiddlyDesktop_Releases.tid
+++ b/editions/tw5.com/tiddlers/TiddlyDesktop_Releases.tid
@@ -1,0 +1,12 @@
+caption: Tiddlydesktop
+created: 20150419144649101
+modified: 20150419153948247
+tags: Releases
+title: TiddlyDesktop Releases
+type: text/vnd.tiddlywiki
+
+Here are the details of recent releases of TiddlyDesktop
+
+<$list filter="[tag[TiddlyDesktopReleaseNotes]!sort[created]limit[1]]">
+  <$macrocall $name="tabs" tabsList="[tag[TiddlyDesktopReleaseNotes]!sort[created]]"default={{!!title}} class="tc-vertical" template="ReleaseTemplate" />
+</$list>

--- a/editions/tw5.com/tiddlers/TiddlyWiki_Releases.tid
+++ b/editions/tw5.com/tiddlers/TiddlyWiki_Releases.tid
@@ -1,0 +1,14 @@
+caption: Tiddlywiki
+created: 20131109105400007
+modified: 20150419163355790
+tags: Releases
+title: TiddlyWiki Releases
+type: text/vnd.tiddlywiki
+
+Here are the details of recent releases of TiddlyWiki5. See [[TiddlyWiki5 Versioning]] for details of how releases are named.
+
+(BetaReleases and AlphaReleases are listed separately).
+
+<$list filter="[tag[ReleaseNotes]!sort[created]limit[1]]">
+  <$macrocall $name="tabs" tabsList="[[Pre-Release]][tag[ReleaseNotes]!sort[created]]"default={{!!title}} class="tc-vertical" template="ReleaseTemplate" />
+</$list>

--- a/editions/tw5.com/tiddlers/releasenotes/Releases.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Releases.tid
@@ -1,13 +1,7 @@
-created: 20131109105400007
-modified: 20150417163307227
+created: 20150419144523070
+modified: 20150420114530386
 tags: About
 title: Releases
 type: text/vnd.tiddlywiki
 
-Here are the details of recent releases of TiddlyWiki5. See [[TiddlyWiki5 Versioning]] for details of how releases are named.
-
-(BetaReleases and AlphaReleases are listed separately).
-
-<$list filter="[tag[ReleaseNotes]!sort[created]limit[1]]">
-  <$macrocall $name="tabs" tabsList="[tag[ReleaseNotes]!sort[created]]"default={{!!title}} class="tc-vertical" template="ReleaseTemplate" />
-</$list>
+<<tabs "[[TiddlyWiki Releases]] [[TiddlyDesktop Releases]]" "[[TiddlyWiki Releases]]" "$:/state/tab">>


### PR DESCRIPTION
Hi @Jermolene,
Following the issue https://github.com/Jermolene/TiddlyDesktop/issues/54 here are my propositions of modifications to add Tiddlydesktop releases and the tiddlywiki pre-release to tw.com.

Hope this will help,
Thank you