### PR TITLE
Button to hide the contents of plugin libraries

### DIFF
--- a/core/ui/ControlPanel/Modals/AddPlugins.tid
+++ b/core/ui/ControlPanel/Modals/AddPlugins.tid
@@ -87,7 +87,14 @@ Search: <$edit-text tiddler="""$:/temp/RemoteAssetSearch/$(currentTiddler)$""" d
 \define display-server-connection()
 <$list filter="[all[tiddlers+shadows]tag[$:/tags/ServerConnection]suffix{!!url}]" variable="connectionTiddler" emptyMessage=<<load-plugin-library-button>>>
 
+<$reveal type='match' state=<<qualify $(currentTiddler)$>> text='show'>
+<$button set=<<qualify $(currentTiddler)$>> setTo=hide>Hide Plugins</$button>
 <<tabs "[[$:/core/ui/ControlPanel/Plugins/Add/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Add/Themes]] [[$:/core/ui/ControlPanel/Plugins/Add/Languages]]" "$:/core/ui/ControlPanel/Plugins/Add/Plugins">>
+</$reveal>
+
+<$reveal type='nomatch' state=<<qualify $(currentTiddler)$>> text='show'>
+<$button set=<<qualify $(currentTiddler)$>> setTo=show>Show Plugins</$button>
+</$reveal>
 
 </$list>
 \end


### PR DESCRIPTION
This just adds a button and reveal around the list of tiddlers contained in a plugin library so that they can be hidden if desired.

When you have multiple libraries open the wiki can get confused about which one you are looking at when you change between the plugin, theme and languages tabs. There is strange scrolling behaviour and it seems to give focus to the search box from one of the libraries chosen at random.

Also when you have multiple libraries open the list can get quite long and being able to hide them makes it look a bit cleaner.