### PR TITLE
Transclusion and Substitution - fixed the link

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/Transclusion in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Transclusion in WikiText.tid
@@ -47,4 +47,4 @@ See also:
 * [[Transclusion with Templates]]
 * TemplateTiddlers
 * TranscludeWidget
-* [[Confusion between Transclusion and Substitution]]
+* [[Transclusion and Substitution]]


### PR DESCRIPTION
The tiddler got renamed a while ago, the link was pointing to non-existent old name.