### PR TITLE
Added a close library butten to add plugins modal

### DIFF
--- a/core/ui/ControlPanel/Modals/AddPlugins.tid
+++ b/core/ui/ControlPanel/Modals/AddPlugins.tid
@@ -92,6 +92,19 @@ Search: <$edit-text tiddler="""$:/temp/RemoteAssetSearch/$(currentTiddler)$""" d
 </$list>
 \end
 
+\define close-library-button()
+<$reveal type='nomatch' state='$:/temp/ServerConnection/$(PluginLibraryURL)$' text=''>
+<$navigator story='$:/StoryList' history='$:/HistoryList'>
+<$button class='tc-btn-big-green' style='font-size:small'>
+{{$:/core/images/close-button}}Close Library
+<$list filter='[prefix[$:/temp/ServerConnection/$(PluginLibraryURL)$]][prefix[$:/temp/RemoteAssetInfo/$(PluginLibraryURL)$]]'>
+<$action-sendmessage $message='tm-delete-tiddler' $param=<<currentTiddler>>/>
+</$list>
+</$button>
+</$navigator>
+</$reveal>
+\end
+
 \define plugin-library-listing()
 <$list filter="[all[tiddlers+shadows]tag[$:/tags/PluginLibrary]]">
 <div class="tc-plugin-library">
@@ -99,6 +112,10 @@ Search: <$edit-text tiddler="""$:/temp/RemoteAssetSearch/$(currentTiddler)$""" d
 !! <$link><$transclude field="caption"><$view field="title"/></$transclude></$link>
 
 //<$view field="url"/>//
+
+<$set name=PluginLibraryURL value={{!!url}}>
+<<close-library-button>>
+</$set>
 
 <$transclude/>
 


### PR DESCRIPTION
The button deletes the local tiddlers that contain information about the library. This allows you to:

*hide the library contents
*reload the library to see any updates to the plugins it contains. If this isn't done than local information about the available plugins is never updated (this problem may need a separate fix that doesn't require reloading the library).

I have three problems that should be addressed:

*I am not sure that the location and color of the close library button is appropriate
*When you click on the close library button a message asking you if you want to delete the $:/temp/ServerConnection/(url) tiddler appears, if you click 'cancel' than the library is shown as open and empty, the only way to fix this condition is to delete the server connection tiddler manually. I think there is a simple fix to this but I can't think of anything.
*Sometimes if you try to open a library that you have just closed it won't open properly. The tiddlers that contain the plugin information are created, but the server connection tiddler isn't created until you reload the wiki. This behavior is inconsistent and sometimes opening the library again works with no problems. I do not know why. I would be fine with requiring a refresh before a library could be reopened so that the startup module acts, but I am not sure what to do about this inconsistent behaivor. I have not been able to find any cause.