### PR TITLE
fix HelloThere video link icon for FF

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1776,9 +1776,11 @@ body.tc-dirty span.tc-dirty-indicator, body.tc-dirty span.tc-dirty-indicator svg
 	right: 0;
 	bottom: 0;
 	display: -webkit-flex;
-    display: flex;
-    -webkit-align-items: center;
-    -webkit-justify-content: center;
+	-webkit-align-items: center;
+	-webkit-justify-content: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .tc-thumbnail-caption {


### PR DESCRIPTION
FF needs unprefixed alignment settings. ... but there is still a problem with the drop shadow setting. ... but the icon is centered now. 