### PR TITLE
RevealWidget state can be a text reference

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
@@ -18,7 +18,7 @@ The reveal widget hides or shows its content depending upon the value of a [[sta
 The content of the `<$reveal>` widget is displayed according to the rules given above.
 
 |!Attribute |!Description |
-|state |The title of the tiddler containing the state |
+|state |A TextReference containing the state |
 |tag |Overrides the default HTML element tag (`<div>` in block mode or `<span>` in inline mode) |
 |type |The type of matching performed: ''match'', ''nomatch'' or ''popup'' |
 |text |The text to match when the type is ''match'' and ''nomatch'' |


### PR DESCRIPTION
[Reveal widget](http://tiddlywiki.com/static/RevealWidget) accepts a [text reference](http://tiddlywiki.com/static/TextReference) for the `state` attribute.