### PR TITLE
Use of getTextRefence in ButtonWidget.isSelected

### DIFF
--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -107,11 +107,10 @@ ButtonWidget.prototype.allowActionPropagation = function() {
 
 ButtonWidget.prototype.getBoundingClientRect = function() {
 	return this.domNodes[0].getBoundingClientRect();
-}
+};
 
 ButtonWidget.prototype.isSelected = function() {
-	var tiddler = this.wiki.getTiddler(this.set);
-	return tiddler ? tiddler.fields.text === this.setTo : this.defaultSetValue === this.setTo;
+        return this.wiki.getTextReference(this.set,"",this.getVariable("currentTiddler")) === this.setTo;
 };
 
 ButtonWidget.prototype.isPoppedUp = function() {


### PR DESCRIPTION
According to the documentation, the Attribute `set` can be a TextReference. In combination with the Attribute `selectedClass` this does not work.

In my opinion the function `getTextReference` does the work. A private implementation for the ButtonWidget ist not necessary.

### Example
#### StyleSheet-Tiddler
    .test.button { border: 1px solid #ee0; background:#fff; color:#ccc; }
    .test.button.active { border-style: none !important; background:#888; color:#fff; }

#### Button
    <$button set="!!value" setTo="on" class="test button" selectedClass="active">on</$button>
    <$button set="!!value" setTo="off" class="test button" selectedClass="active">off</$button>