### PR TITLE
SelectWidget: Update selected value if children have been refreshed

### DIFF
--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -127,10 +127,11 @@ SelectWidget.prototype.refresh = function(changedTiddlers) {
 		return true;
 	// If the target tiddler value has changed, just update setting and refresh the children
 	} else {
-		if(changedTiddlers[this.selectTitle]) {
+		var childrenRefreshed = this.refreshChildren(changedTiddlers);
+		if(changedTiddlers[this.selectTitle] || childrenRefreshed) {
 			this.setSelectValue();
 		} 
-		return this.refreshChildren(changedTiddlers);		
+		return childrenRefreshed;
 	}
 };
 


### PR DESCRIPTION
If the children have been refreshed, it is necessary to check, whether the value of the select box has been changed.

### Example
The following code creates a tiddler with a drop down box. A click on `create` creates a new relevant tiddler and sets the field to the referencevalue.

Try these steps:
* Click create and confirm the newly created tiddler (a)
* The select box contains the title of the newly created tiddler
* Click create again and confirm this newly created tiddler (b) too
* The select box still shows the title of tiddler (b); the `selectfield` contains the value of tiddler (b)

```
!Select Tiddler
<$select field="selectfield">
  <$list filter="[tag[selecttest]]">
    <option value={{!!value}}>{{!!title}}</option>
  </$list>
</$select>
<$button>create
  <$action-setfield $field="selectfield" $value=<<now YYYY0MM0DD0hh0mm0ss>>/>
  <$action-sendmessage $message="tm-new-tiddler" title=<<now "0DD. MMM YY, 0hh:0mm:0ss">> tags="selecttest" value=<<now YYYY0MM0DD0hh0mm0ss>>/>
</$button>

!Selected Value
<$view field="selectfield"/>
```