### PR TITLE
fix youtube icon cut of in FF win. 

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1845,13 +1845,13 @@ body.tc-dirty span.tc-dirty-indicator, body.tc-dirty span.tc-dirty-indicator svg
 .tc-thumbnail-icon img {
 	width: 3em;
 	height: 3em;
-	<<filter "drop-shadow(2px 2px 2px rgba(0,0,0,0.3))">>
+	<<filter "drop-shadow(2px 2px 4px rgba(0,0,0,0.3))">>
 }
 
 .tc-thumbnail-wrapper:hover .tc-thumbnail-icon svg,
 .tc-thumbnail-wrapper:hover .tc-thumbnail-icon img {
 	fill: #fff;
-	<<filter "drop-shadow(3px 3px 2px rgba(0,0,0,0.6))">>
+	<<filter "drop-shadow(3px 3px 4px rgba(0,0,0,0.6))">>
 }
 
 .tc-thumbnail-icon {


### PR DESCRIPTION
Fixes the cut of yt icon fin FF Win. ... I can't fix the colour problem atm. 

I'll create a new ticket for this one:
https://github.com/Jermolene/TiddlyWiki5/commit/28050fb4885f36b0abf19d4d5a49c175fb5c3f4e#commitcomment-11170096