### PR TITLE
fix palette switcher popup overflow

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1606,6 +1606,7 @@ a.tc-tiddlylink.tc-plugin-info:hover svg {
 
 .tc-chooser-item {
 	border: 8px;
+	padding: 2px 4px;
 }
 
 .tc-chooser-item a.tc-tiddlylink {
@@ -1613,7 +1614,6 @@ a.tc-tiddlylink.tc-plugin-info:hover svg {
 	text-decoration: none;
 	color: <<colour tiddler-link-foreground>>;
 	background-color: <<colour tiddler-link-background>>;
-	margin: 4px;
 }
 
 .tc-chooser-item a.tc-tiddlylink:hover {


### PR DESCRIPTION
fixes this problem: 

![index](https://cloud.githubusercontent.com/assets/374655/7610285/e76e88a2-f97b-11e4-83d1-a14048a10641.png)

`.tc-chooser-item` is only used for Colour Switcher, so there should be no side effects. 

I did remove the margin from the link and added a padding for the wrapper. 
So it works for ControlPanel and the popup. 

after:

![fixed-color](https://cloud.githubusercontent.com/assets/374655/7610344/669f8054-f97c-11e4-885c-3e4faf57a248.gif)
