### PR TITLE
Change palette chooser layout

### DIFF
--- a/core/wiki/paletteswitcher.tid
+++ b/core/wiki/paletteswitcher.tid
@@ -4,9 +4,10 @@ title: $:/snippets/paletteswitcher
 <div class="tc-prompt">
 <<lingo Prompt>> <$view tiddler={{$:/palette}} field="name"/>
 </div>
-
 <$linkcatcher to="$:/palette">
-<div class="tc-chooser"><$list filter="[all[shadows+tiddlers]tag[$:/tags/Palette]sort[description]]"><div class="tc-chooser-item"><$link to={{!!title}}><div><$reveal state="$:/palette" type="match" text={{!!title}}>&bull;</$reveal><$reveal state="$:/palette" type="nomatch" text={{!!title}}>&nbsp;</$reveal> ''<$view field="name" format="text"/>'' - <$view field="description" format="text"/></div><$transclude tiddler="$:/snippets/currpalettepreview"/></$link></div>
+<table class="tc-chooser">
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/Palette]sort[description]]">
+<tr><td><$reveal state="$:/palette" type="match" text={{!!title}}>&bull;&bull;&bull;</$reveal></td><td class="tc-chooser-item"><$link to={{!!title}}><div><$reveal state="$:/palette" type="nomatch" text={{!!title}}></$reveal>''&nbsp;<$view field="name" format="text"/>'' - <$view field="description" format="text"/></div><$transclude tiddler="$:/snippets/currpalettepreview"/></$link></td></tr> 
 </$list>
-</div>
+</table>
 </$linkcatcher>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1120,16 +1120,7 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-drop-down .tc-prompt {
-	padding: 0 14px;	
-}
-
-.tc-drop-down .tc-chooser {
-	border: none;
-}
-
-.tc-drop-down .tc-chooser .tc-swatches-horiz {
-	font-size: 0.4em;
-	padding-left: 1.2em;
+	padding: 0 14px;
 }
 
 .tc-drop-down .tc-file-input-wrapper {
@@ -1601,11 +1592,9 @@ a.tc-tiddlylink.tc-plugin-info:hover svg {
 */
 
 .tc-chooser {
-	border: 1px solid <<colour table-border>>;
 }
 
 .tc-chooser-item {
-	border: 8px;
 	padding: 2px 4px;
 }
 
@@ -1627,6 +1616,7 @@ a.tc-tiddlylink.tc-plugin-info:hover svg {
 */
 
 .tc-swatches-horiz {
+	padding: 4px;
 }
 
 .tc-swatches-horiz .tc-swatch {
@@ -1636,7 +1626,7 @@ a.tc-tiddlylink.tc-plugin-info:hover svg {
 .tc-swatch {
 	width: 2em;
 	height: 2em;
-	margin: 0.4em;
+	margin-right: 1em;
 	border: 1px solid #888;
 }
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1606,6 +1606,7 @@ a.tc-tiddlylink.tc-plugin-info:hover svg {
 
 .tc-chooser-item {
 	border: 8px;
+	padding: 2px 4px;
 }
 
 .tc-chooser-item a.tc-tiddlylink {
@@ -1613,7 +1614,6 @@ a.tc-tiddlylink.tc-plugin-info:hover svg {
 	text-decoration: none;
 	color: <<colour tiddler-link-foreground>>;
 	background-color: <<colour tiddler-link-background>>;
-	margin: 4px;
 }
 
 .tc-chooser-item a.tc-tiddlylink:hover {


### PR DESCRIPTION
before
![palette-switcher-before](https://cloud.githubusercontent.com/assets/374655/7612869/b2269be6-f98d-11e4-8ffc-e6de6817dbfd.gif)
after
![palette-switcher-afer](https://cloud.githubusercontent.com/assets/374655/7612872/b8a58c84-f98d-11e4-83da-ee5351b0d207.gif)

---

Dropdown CSS fixes have been removed, since they are not needed anymore. 

.tc-drop-down .tc-chooser {
.tc-drop-down .tc-chooser .tc-swatches-horiz {

---

Instead of `&bull;&bull;&bull;`  as a marker I wanted to use `$:/core/ui/Buttons/save` but this is not possible, since some colour palettes use svg fill white. So we get white tick on white background. 
