### PR TITLE
CodeMirror plugin now refreshes the tiddler type

### DIFF
--- a/plugins/tiddlywiki/codemirror/edit-codemirror.js
+++ b/plugins/tiddlywiki/codemirror/edit-codemirror.js
@@ -173,18 +173,20 @@ EditCodeMirrorWidget.prototype.refresh = function(changedTiddlers) {
 		this.refreshSelf();
 		return true;
 	} else if(changedTiddlers[this.editTitle]) {
-		this.updateEditor(this.getEditInfo().value);
+		var editInfo = this.getEditInfo();
+		this.updateEditor(editInfo.value, editInfo.type);
 		return true;
 	}
 	return false;
 };
 
 /*
-Update the editor with new text. This method is separate from updateEditorDomNode()
+Update the editor with new text and type. This method is separate from updateEditorDomNode()
 so that subclasses can override updateEditor() and still use updateEditorDomNode()
 */
-EditCodeMirrorWidget.prototype.updateEditor = function(text) {
+EditCodeMirrorWidget.prototype.updateEditor = function(text, type) {
 	this.updateEditorDomNode(text);
+	this.codeMirrorInstance.setOption("mode", type);
 };
 
 /*


### PR DESCRIPTION
You can find a demo here: http://fixcmrefresh.tiddlyspot.com/

Basically when changing the type of a tiddler, while that tiddler is actively edited somewhere, it may now refresh the syntax highlighting, depending on the CodeMirror settings. 
*(This also applies to changing the type of a draft tiddler, the text field will be immediately recolored when syntax highlighting is turned on for that type)*

/Andreas