### PR TITLE
Add ability to auto generate Dropbox URL

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/Sharing a TiddlyWiki on Dropbox.tid
+++ b/editions/tw5.com/tiddlers/howtos/Sharing a TiddlyWiki on Dropbox.tid
@@ -1,5 +1,5 @@
 created: 20140122085818089
-modified: 20140919160722247
+modified: 20150608032039504
 tags: Learning
 title: Sharing a TiddlyWiki on Dropbox
 type: text/vnd.tiddlywiki
@@ -15,3 +15,11 @@ You can work on a TiddlyWiki file in Dropbox and publish a URL that anyone can u
 #> `https://dl.dropboxusercontent.com/s/<gobbledegook>/mywiki.html`
 
 The result is a "secret" URL that you can send to other people to enable them to see the wiki.
+
+----
+
+Enter a generated URL here and you can copy and paste the secret URL:
+
+<$edit-text tiddler="$:/temp/dropboxurl" default="https://www.dropbox.com/s/<gobbledegook>/mywiki.html" tag="input" type="text" size="60"/>
+
+<$macrocall $name="dropbox-url" url={{$:/temp/dropboxurl}}/>

--- a/editions/tw5.com/tiddlers/system/dropbox-url-macro.tid
+++ b/editions/tw5.com/tiddlers/system/dropbox-url-macro.tid
@@ -1,0 +1,39 @@
+created: 20150607235625799
+modified: 20150608032345215
+module-type: macro
+tags: $:/tags/Macro
+title: $:/edition/tw5.com/dropbox-url.js
+type: application/javascript
+
+/*\
+title: $:/edition/tw5.com/dropbox-url.js
+type: application/javascript
+tags: $:/tags/Macro
+module-type: macro
+
+Implements the Dropbox URL converter macro.
+
+```
+<$macrocall $name="dropbox-url" url={{$:/temp/dropbox}}/>
+```
+
+\*/
+
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.name = "dropbox-url";
+
+exports.params = [
+	{name: "url", default: "https://www.dropbox.com/s/<gobbledegook>/mywiki.html"}
+];
+
+exports.run = function(url) {
+	url = url.replace("www.dropbox.com",  "dl.dropboxusercontent.com");
+	return "`" + url + "` <small>([[open|" + url + "]])</small>";
+};
+
+})();


### PR DESCRIPTION
I felt the conversion from the Dropbox share URL to the "secret" URL was complicated enough to have the tiddler do it for the user. And so I wrote a macro to do that. The user enters in the shared URL given by Dropbox and the macro outputs the secret URL that they can copy / paste with.

See if it is worth having on the TW5.com site.