### PR TITLE
improved docs

### DIFF
--- a/editions/tw5.com/tiddlers/community/resources/TiddlyMap by Felix Kuppers.tid
+++ b/editions/tw5.com/tiddlers/community/resources/TiddlyMap by Felix Kuppers.tid
@@ -3,14 +3,14 @@ modified: 20141122093837330
 tags: Resources
 title: TiddlyMap Plugin by Felix Küppers
 type: text/vnd.tiddlywiki
-url: http://bit.ly/tiddlymap
+url: http://tiddlymap.org
 
-An interactive network visualisation plugin based on [[Vis.js|http://visjs.org]]. A demo can be found here: {{!!url}}.
+An interactive network visualisation plugin based on [[Vis.js|http://visjs.org]]. A demo that also contains installation instructions can be found here: {{!!url}}. The plugin's GitHub repository can be found [[here|https://github.com/felixhayashi/TW5-TiddlyMap]].
 
 <<<
 ~TiddlyMap is a TiddlyWiki plugin that allows you to link your wiki-topics (tiddlers) in order to create clickable graphs. By creating relations between your topics you can easily do the following:
 
-* Create mindmaps and quickly manifest your ideas in tiddlers (wiki entries).
+* Create concept maps and quickly manifest your ideas in tiddlers.
 * Create task-dependency graphs to organize and describe your tasks.
 * Visualize your topic structures to get an immediate grasp of topics and relations.
 

--- a/editions/tw5.com/tiddlers/definitions/GitHub.tid
+++ b/editions/tw5.com/tiddlers/definitions/GitHub.tid
@@ -4,7 +4,7 @@ tags: Definitions
 title: GitHub
 type: text/vnd.tiddlywiki
 
-GitHub is a commercial organisation that operates a service for hosting code that includes powerful collaborative features.
+GitHub is a hosting service for distributed projects that use git as their version-control system. It allows free hosting and management of open-source projects and facilitates collaborative developement on the source code. Using GitHub for non-open-source endeavors requires additional fees.
 
 The code and documentation of TiddlyWiki is hosted on GitHub at:
 


### PR DESCRIPTION
Hi @Jermolene 

I updated the tiddlymap resource description :)

Moreover I noticed that in the GitHub description the first aspect mentioned is that GitHub is commercial and immediately afterwards TiddlyWiki is related to GitHub. This makes it appear as if it were commercial or has commercial affiliation to GitHub. So I changed the description so no negative impressions arise.

-Felix