### PR TITLE
Wrong macro name in example description

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/Variables in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Variables in WikiText.tid
@@ -22,7 +22,7 @@ eg="""<$set name=animal value=zebra>
 
 !! Example: defining a macro
 
-The `\define` pragma below [[defines a macro|Macros in WikiText]] called <<.var tags>>. The macro returns the value of the tiddler's <<.field tags>> field, and can be accessed from anywhere else in the same tiddler (or in any tiddler that [[imports|ImportVariablesWidget]] it).
+The `\define` pragma below [[defines a macro|Macros in WikiText]] called <<.var tags-of-current-tiddler>>. The macro returns the value of the tiddler's <<.field tags>> field, and can be accessed from anywhere else in the same tiddler (or in any tiddler that [[imports|ImportVariablesWidget]] it).
 
 <$importvariables filter="$:/editions/tw5.com/macro-examples/tags-of-current-tiddler">
 <$codeblock code={{$:/editions/tw5.com/macro-examples/tags-of-current-tiddler}}/>


### PR DESCRIPTION
The \define pragma below defines a macro called tags.
should be:
The \define pragma below defines a macro called tags-of-current-tiddler.