### PR TITLE
Move tag counts to TagManager

### DIFF
--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -25,6 +25,7 @@ PluginReloadWarning: Please save {{$:/core/ui/Buttons/save-wiki}} and reload {{$
 RecentChanges/DateFormat: DDth MMM YYYY
 SystemTiddler/Tooltip: This is a system tiddler
 TagManager/Colour/Heading: Colour
+TagManager/Count/Heading: Count
 TagManager/Icon/Heading: Icon
 TagManager/Info/Heading: Info
 TagManager/Tag/Heading: Tag

--- a/core/ui/MoreSideBar/Tags.tid
+++ b/core/ui/MoreSideBar/Tags.tid
@@ -18,10 +18,10 @@ caption: {{$:/language/SideBar/Tags/Caption}}
 
 <$list filter={{$:/core/Filters/AllTags!!filter}}>
 
-<$transclude tiddler="$:/core/ui/TagTemplate"/> <small class="tc-menu-list-count"><$count filter="[all[current]tagging[]]"/></small>
+<$transclude tiddler="$:/core/ui/TagTemplate"/>
 
 </$list>
 
 <hr class="tc-untagged-separator">
 
-{{$:/core/ui/UntaggedTemplate}} <small class="tc-menu-list-count"><$count filter="[untagged[]!is[system]] -[tags[]]"/></small>
+{{$:/core/ui/UntaggedTemplate}}

--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -44,6 +44,7 @@ $title$$(currentTiddler)$
 <tr>
 <th><<lingo Colour/Heading>></th>
 <th class="tc-tag-manager-tag"><<lingo Tag/Heading>></th>
+<th><<lingo Count/Heading>></th>
 <th><<lingo Icon/Heading>></th>
 <th><<lingo Info/Heading>></th>
 </tr>
@@ -51,6 +52,7 @@ $title$$(currentTiddler)$
 <tr>
 <td><$edit-text field="color" tag="input" type="color"/></td>
 <td><$transclude tiddler="$:/core/ui/TagTemplate"/></td>
+<td><$count filter="[all[current]tagging[]]"/></td>
 <td>
 <$macrocall $name="iconEditor" title={{!!title}}/>
 </td>

--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -62,7 +62,7 @@ $title$$(currentTiddler)$
 </tr>
 <tr>
 <td></td>
-<td>
+<td colspan="4">
 <$reveal state=<<qualifyTitle "$:/state/tag-manager/">> type="match" text="open" default="">
 <table>
 <tbody>
@@ -72,8 +72,6 @@ $title$$(currentTiddler)$
 </table>
 </$reveal>
 </td>
-<td></td>
-<td></td>
 </tr>
 </$list>
 <tr>

--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -76,5 +76,16 @@ $title$$(currentTiddler)$
 <td></td>
 </tr>
 </$list>
+<tr>
+<td></td>
+<td>
+{{$:/core/ui/UntaggedTemplate}}
+</td>
+<td>
+<small class="tc-menu-list-count"><$count filter="[untagged[]!is[system]] -[tags[]]"/></small>
+</td>
+<td></td>
+<td></td>
+</tr>
 </tbody>
 </table>


### PR DESCRIPTION
This fixes issue #1715 by moving the counts to the TagManager instead of the tags sidebar. Should help a little speed improvement since counts are expensive.

![screen shot 2015-07-01 at 00 05 00](https://cloud.githubusercontent.com/assets/70075/8447334/e3e4feee-1f84-11e5-9507-ee1b541f28a0.png)
