### PR TITLE
 New filter "recent"

### DIFF
--- a/core/modules/filters/recent.js
+++ b/core/modules/filters/recent.js
@@ -1,0 +1,35 @@
+/*\
+title: $:/core/modules/filters/recent.js
+type: application/javascript
+module-type: filteroperator
+
+Filter operator that selects tiddlers with a specified date field within the last N days.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.recent = function(source,operator,options) {
+	var results = [],
+		fieldName = operator.suffix || "modified",
+		targetTimeStamp = (new Date()).setHours(0,0,0,0) - 1000*60*60*24*(parseInt(operator.operand,10)||0);
+	var isRecent = function(dateField) {
+			return targetTimeStamp <= (new Date(dateField)).setHours(0,0,0,0);
+		};
+	source(function(tiddler,title) {
+		if(tiddler && tiddler.fields[fieldName]) {
+			if(isRecent($tw.utils.parseDate(tiddler.fields[fieldName]))) {
+				results.push(title);
+			}
+		}
+	});
+	return results;
+};
+
+})();

--- a/editions/tw5.com/tiddlers/filters/examples/recent.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/recent.tid
@@ -1,0 +1,6 @@
+tags: [[recent Operator]] [[Operator Examples]]
+title: recent Operator (Examples)
+type: text/vnd.tiddlywiki
+
+<<.operator-example 1 "[recent[1]]" "tiddlers modified yesterday and today">>
+<<.operator-example 2 "[recent:created[14]]" "tiddlers created within the last 14 days">>

--- a/editions/tw5.com/tiddlers/filters/recent.tid
+++ b/editions/tw5.com/tiddlers/filters/recent.tid
@@ -1,0 +1,15 @@
+tags: [[Filter Operators]] [[Date Operators]]
+title: recent Operator
+type: text/vnd.tiddlywiki
+caption: recent
+op-purpose: filter the input by age
+op-input: a [[selection of titles|Title Selection]]
+op-suffix: the name of a [[date field|Date Fields]], defaulting to <<.field modified>>
+op-suffix-name: F
+op-parameter: a number of days, defaulting to 0
+op-parameter-name: D
+op-output: those input tiddlers in which field <<.place F>> is at most <<.place D>> days old, ignoring time
+
+Select tiddlers where a specified date field (default "modified") is within the last N days (default 0, meaning today).
+
+<<.operator-examples "recent">>


### PR DESCRIPTION
Select tiddlers where a specified date field (default "modified") is within the last N days (default 0, meaning today).

Discussion at #1854.