### PR TITLE
Added mechanism to rename tags

### DIFF
--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -45,6 +45,28 @@ exports.startup = function() {
 			}
 		});
 	}
+	// Listen to tag renaming events
+	$tw.rootWidget.addEventListener("tm-rename-tag",function(event) {
+		var params = event.paramObject;
+		if(!params || !params["old"] || !params["new"]) {
+			return;
+		}
+		var filter = "[tag[" + params["old"] + "]!has[draft.of]]";
+		var tiddlers = this.wiki.filterTiddlers(filter);
+		// First change the tag in all tiddlers that have this tag
+		for(var i = 0; i < tiddlers.length; i++) {
+			var curTid = this.wiki.getTiddler(tiddlers[i]);
+			// Clone tags property to be able to modify it
+			var tags = curTid.fields.tags.slice(0);
+			tags[tags.indexOf(params["old"])] = params["new"];
+			$tw.wiki.addTiddler(new $tw.Tiddler(curTid, { tags: tags }));
+		}
+		// Now change the tag-tiddler itself (if it exists)
+		var tagTid = this.wiki.getTiddler(params["old"]);
+		if(tagTid) {
+			$tw.wiki.addTiddler(new $tw.Tiddler(tagTid, { title: params["new"] }));
+		}
+	});
 	// If we're being viewed on a data: URI then give instructions for how to save
 	if(document.location.protocol === "data:") {
 		$tw.rootWidget.dispatchEvent({

--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -39,6 +39,18 @@ $title$$(currentTiddler)$
 </$button>
 </$reveal>
 \end
+\define toggleRenameButton(state)
+<$reveal state="$state$" type="match" text="closed" default="closed">
+<$button set="$state$" setTo="open" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
+{{$:/core/images/edit-button}}
+</$button>
+</$reveal>
+<$reveal state="$state$" type="match" text="open" default="closed">
+<$button set="$state$" setTo="closed" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
+{{$:/core/images/edit-button}}
+</$button>
+</$reveal>
+\end
 <table class="tc-tag-manager-table">
 <tbody>
 <tr>
@@ -47,6 +59,7 @@ $title$$(currentTiddler)$
 <th><<lingo Count/Heading>></th>
 <th><<lingo Icon/Heading>></th>
 <th><<lingo Info/Heading>></th>
+<th>Rename</th>
 </tr>
 <$list filter="[tags[]!is[system]sort[title]]">
 <tr>
@@ -59,10 +72,13 @@ $title$$(currentTiddler)$
 <td>
 <$macrocall $name="toggleButton" state=<<qualifyTitle "$:/state/tag-manager/">> /> 
 </td>
+<td>
+<$macrocall $name="toggleRenameButton" state=<<qualifyTitle "$:/state/tag-manager/rename">> /> 
+</td>
 </tr>
 <tr>
 <td></td>
-<td colspan="4">
+<td colspan="5">
 <$reveal state=<<qualifyTitle "$:/state/tag-manager/">> type="match" text="open" default="">
 <table>
 <tbody>
@@ -70,6 +86,19 @@ $title$$(currentTiddler)$
 <tr><td><<lingo Icon/Heading>></td><td><$edit-text field="icon" tag="input" size="45"/></td></tr>
 </tbody>
 </table>
+</$reveal>
+</td>
+</tr>
+<tr>
+<td></td>
+<td colspan="5">
+<$reveal state=<<qualifyTitle "$:/state/tag-manager/rename">> type="match" text="open" default="">
+<b>Rename Tag</b>
+<$edit-text focus="true" tiddler="$:/temp/renameTag" type="text" tag="input" default="" />
+<$button>Apply
+<$action-sendmessage $message="tm-rename-tag" old={{!!title}} new={{$:/temp/renameTag}} />
+<$action-setfield $tiddler="$:/temp/renameTag" text="" />
+</$button>
 </$reveal>
 </td>
 </tr>
@@ -82,6 +111,7 @@ $title$$(currentTiddler)$
 <td>
 <small class="tc-menu-list-count"><$count filter="[untagged[]!is[system]] -[tags[]]"/></small>
 </td>
+<td></td>
 <td></td>
 <td></td>
 </tr>


### PR DESCRIPTION
## Introduction

TiddlyWiki's strength is to allow a user to manipulate or reorganize content/data/meta-data in the wiki as fast as the person's mind changes thoughts. This way the wiki is always an explicit model of the current mind state.

The tag mechanism is an important part here but it doesn't allow renaming tags, which is a major drawback: If a user created a tag and in the course of building the wiki discovers that the tag is not appropriately named, he/she has to edit maybe 30 tiddlers to rename a single tag.

Naturally, many users asked about a feauture to rename tags.

* https://groups.google.com/forum/#!searchin/tiddlywiki/rename$20tag|sort:date/tiddlywiki/P_el-4lg_P0/5WgyPcTW8I8J
* https://groups.google.com/forum/#!searchin/tiddlywiki/rename$20tag|sort:date/tiddlywiki/uuNeYfa5d0U/txJAIoU8aA4J
* https://groups.google.com/forum/#!searchin/tiddlywiki/rename$20tag/tiddlywiki/5vjg5EXSXrw/Dp8wSz4H6gwJ
*...

## Demo

In response to #1614 I now did the PR you are looking at.

See a demo at http://wkpr.de/hosting/tmp/tw5/tagrenaming/

The word Literature is not spelled correctly. You can use the tag manager to fix that.

I think the GUI can be optimized but this is just a demo.

## About

How it works

1. Tags will be renamed in all tiddlers containing the tag
1. Finally the tag tiddler (if exists) will be renamed

# Similar work

Jed's wikitext based method is extremy smart(!) but it is not javascript based which prevents it from being invoked from js-code.

http://inmysocks.tiddlyspot.com/#Draft%20of%20%27Search%20and%20Replace%20Tags%27

# Note

The PR doesn't contain lingo-stuff yet. This will be added at the end after discussion.