### PR TITLE
Filters involved saving mechanism of standalone

### DIFF
--- a/editions/tw5.com/tiddlers/mechanisms/SingleFileSaveFilters.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/SingleFileSaveFilters.tid
@@ -1,0 +1,10 @@
+created: 20150709150749755
+modified: 20150709150806031
+tags: Mechanisms
+title: Filters involved in saving of single file eddition
+type: text/vnd.tiddlywiki
+
+There are two filters controlling saving TiddlyWiki as a standalone file.
+
+* $:/config/SaverFilter determines which modified tiddlers trigger the dirty state
+* $:/core/save/all determines which tiddlers are saved in the file


### PR DESCRIPTION
This is directly extracted from the groups. I though that putting this info into documentation will be useful, because it is not stated in any other place.

ref: https://groups.google.com/d/msg/tiddlywiki/zB40PBIDkBE/DzV1ZHudM3sJ