### PR TITLE
Updated spelling of résumé, fixed settings for new resumes, other minor fixes

### DIFF
--- a/editions/resumebuilder/tiddlers/Preview.tid
+++ b/editions/resumebuilder/tiddlers/Preview.tid
@@ -1,16 +1,10 @@
+created: 20150720171244344
+modified: 20150720171304274
 tags: $:/tags/SideBar
 title: Preview
 
-\define thisMakePreview()
-<$list filter='[tag[Section Display]removeprefix[$:/display/]addprefix[$:/settings/$(ThisResume)$/]sort[order]!show[false]removeprefix[$:/settings/$(ThisResume)$/]addprefix[$:/display/]]'>
-<$transclude mode=block/>
-</$list>
-\end
-
 <div class='tc-tiddly-frame' style='background:white;max-width:700px;border:solid black 1px;color:black'>
 <div style='max-width:689px;margin-left:20px'>
-<$vars ThisResume={{$:/settings/Global!!selected_resume}}>
-<<thisMakePreview>>
-</$vars>
+<$transclude tiddler='Print Version' mode=block/>
 </div>
 </div>

--- a/editions/resumebuilder/tiddlers/Print Version.tid
+++ b/editions/resumebuilder/tiddlers/Print Version.tid
@@ -1,0 +1,16 @@
+created: 20150720171146515
+modified: 20150720171221769
+tags: 
+title: Print Version
+
+\define thisMakePreview()
+<$list filter='[tag[Section Display]removeprefix[$:/display/]addprefix[$:/settings/$(ThisResume)$/]sort[order]!show[false]removeprefix[$:/settings/$(ThisResume)$/]addprefix[$:/display/]]'>
+<$transclude mode=block/>
+</$list>
+\end
+
+<div style='max-width:689px;margin-left:20px'>
+<$vars ThisResume={{$:/settings/Global!!selected_resume}}>
+<<thisMakePreview>>
+</$vars>
+</div>

--- a/editions/resumebuilder/tiddlers/Résumé Options.tid
+++ b/editions/resumebuilder/tiddlers/Résumé Options.tid
@@ -1,6 +1,6 @@
 created: 20150719183128695
-modified: 20150719183135450
+modified: 20150720163126223
 tags: 
-title: Resume Options
+title: Résumé Options
 
 <<tabs "[[Layout Options]][tag[Section Display]removeprefix[$:/display]addprefix{$:/settings/Global!!selected_resume}addprefix[$:/settings/]!show[false]sort[order]get[template]get[options_tiddler]]" [[Layout Options]]>>

--- a/editions/resumebuilder/tiddlers/Résumé Wizard.tid
+++ b/editions/resumebuilder/tiddlers/Résumé Wizard.tid
@@ -1,7 +1,7 @@
 created: 20150719173441992
-modified: 20150719182326153
+modified: 20150720171426440
 tags: 
-title: Resume Wizard
+title: Résumé Wizard
 
 \define CurrentResume() {{$:/settings/Global!!selected_resume}}
 
@@ -36,26 +36,44 @@ title: Resume Wizard
 </$list>
 \end
 
-<!-- If the user hasn't started the wizard yet display the interface to add or select a resume and the button to start the wizard -->
+\define thisAddResumeButton()
+<$button>
+	Add Résumé
+	<$action-setfield $tiddler='$:/data/ResumeList' $index={{$:/temp/NewResumeName!!resume_name}} $value=true/>
+	<$action-setfield $tiddler='$:/temp/NewResumeName' resume_name=''/>
+	<$action-setfield $tiddler='$:/settings/$(ResumeName)$/Resume Title Display' order=1 show=true template='$:/template/ResumeTitleTemplate'/>
+	<$action-setfield $tiddler='$:/settings/$(ResumeName)$/Contact Information Display' order=2 show=true template='$:/template/ContactInformationTemplate'/>
+	<$action-setfield $tiddler='$:/settings/$(ResumeName)$/Objective Display' order=3 show=true template='$:/template/ObjectiveTemplate'/>
+	<$action-setfield $tiddler='$:/settings/$(ResumeName)$/Skills and Expertise Display' order=4 show=true template='$:/template/SkillsAndExpertiseTemplate'/>
+	<$action-setfield $tiddler='$:/settings/$(ResumeName)$/Previous Employment Display' order=5 show=true template='$:/template/PreviousEmploymentTemplate'/>
+	<$action-setfield $tiddler='$:/settings/$(ResumeName)$/Education Display' order=6 show=true template='$:/template/EducationTemplate'/>
+	<$action-setfield $tiddler='$:/settings/$(ResumeName)$/ResumeTitle' text=Resume/>
+</$button>
+\end
+
+<!-- If the user hasn't started the wizard yet display the interface to add or select a résumé and the button to start the wizard -->
 <$reveal type='match' state='$:/state/ResumeWizardState' text=''>
-	<!-- User can select an existing resume -->
-	Select resume to work on:
+	<!-- User can select an existing résumé -->
+	Select résumé to work on:
 	<$select tiddler='$:/settings/Global' field='selected_resume'>
 		<$list filter='[[$:/data/ResumeList]indexes[]]'>
 			<option><$view field='title'/></option>
 		</$list>
 	</$select>
 	<br>
-	<!-- User can add a new resume -->
-	You can add a resume to the list:
-	<$edit-text tiddler='$:/temp/NewResumeName' field='resume_name' class='tc-edit-texteditor' placeholder='Name of new resume'/>
-	<$button>
-		Add Resume
-		<$action-setfield $tiddler='$:/data/ResumeList' $index={{$:/temp/NewResumeName!!resume_name}} $value=true/>
-		<$action-setfield $tiddler='$:/temp/NewResumeName' resume_name=''/>
-	</$button>
+	<!-- User can add a new résumé. Creating a new résumé automatically populates some of the settings, namely setting all default résumé sections to visible using the first template and in the default order. -->
+	You can add a résumé to the list:
+	<$edit-text tiddler='$:/temp/NewResumeName' field='resume_name' class='tc-edit-texteditor' placeholder='Name of new résumé'/>
+	<$vars ResumeName={{$:/temp/NewResumeName!!resume_name}}>
+		<<thisAddResumeButton>>
+	</$vars>
 	<br>
 	<br>
+
+	<!-- The layout options. This is so that the user can set up which sections they want to see before starting the résumé wizard. -->
+	The preview is displayed to the right. The options below let you set which sections are visible and the section order. Only sections that are visible will be included in the wizard. You will be able to change these options later also.
+
+	<$transclude tiddler='Layout Options' mode=block/>
 
 	<!-- The button that starts the wizard -->
 	<$button>
@@ -79,11 +97,11 @@ title: Resume Wizard
 			<<thisDisplayInputTiddler>>
 		</$vars>
 	</$list>
-	<!-- Display the resume options if that is the current section. -->
+	<!-- Display the résumé options if that is the current section. -->
 	<$reveal type='match' state='$:/state/ResumeWizardState' text='Resume Options'>
-		Here you can change the order of sections (or of items in each section) on your resume as well as set other options. Click on 'Print' to open the resume in a new window to save or print it.
+		Here you can change the order of sections (or of items in each section) on your résumé as well as set other options. Click on 'Print' to open the résumé in a new window to save or print it.<br>
 
-		<$transclude tiddler='Resume Options' mode=block/>
+		<$transclude tiddler='Résumé Options' mode=block/><br>
 	</$reveal>
 
 	<!-- If the user hasn't reached options section yet, make and display the back and next buttons. -->
@@ -113,8 +131,8 @@ title: Resume Wizard
 				<$action-setfield $tiddler='$:/state/ResumeWizardState' $field='text' $value=<<PreviousTiddler>>/>
 			</$button>
 		</$list>
-		<!-- Open resume in new window for saving/printing. -->
-		<$tiddler tiddler='Preview'>
+		<!-- Open résumé in new window for saving/printing. -->
+		<$tiddler tiddler='Print Version'>
 			<$button message="tm-open-window">
 				Print
 			</$button>

--- a/editions/resumebuilder/tiddlers/Top Bar Buttons.tid
+++ b/editions/resumebuilder/tiddlers/Top Bar Buttons.tid
@@ -1,14 +1,14 @@
 created: 20150719172021101
-modified: 20150719172244848
+modified: 20150720172257267
 tags: $:/tags/TopLeftBar
 title: Top Bar Buttons
 
-<$button style='border:solid 1px;height:1.25em;vertical-align:top;line-height:0.025em;' to="Resume Wizard">Resume Wizard</$button>
+<$button style='border:solid 1px;height:1.25em;vertical-align:top;line-height:0.025em;' to="Résumé Wizard">Résumé Wizard</$button>
 <$button style='border:solid 1px;height:1.25em;vertical-align:top;line-height:0.025em;' to="Edit Existing Items">Edit Existing Items</$button>
-<$button style='border:solid 1px;height:1.25em;vertical-align:top;line-height:0.025em;' to="Resume Options">Resume Options</$button>
+<$button style='border:solid 1px;height:1.25em;vertical-align:top;line-height:0.025em;' to="Résumé Options">Résumé Options</$button>
 <$button style='border:solid 1px;height:1.25em;vertical-align:top;line-height:0.025em;' to="Preview">Preview</$button>
 <$button style='border:solid 1px;height:1.25em;vertical-align:top;line-height:0.025em;' to="Help">Help</$button>
-<$tiddler tiddler=Preview>
+<$tiddler tiddler='Print Version'>
 <$button style='border:solid 1px;height:1.25em;vertical-align:top;line-height:0.025em;' message="tm-open-window">Print</$button>
 </$tiddler>
 <$button style='border:solid 1px;height:1.25em;vertical-align:top;line-height:0.025em;' message='tm-save-wiki'>Save</$button>

--- a/editions/resumebuilder/tiddlers/data/$__data_ResumeTitle_Résumé.tid
+++ b/editions/resumebuilder/tiddlers/data/$__data_ResumeTitle_Résumé.tid
@@ -1,0 +1,5 @@
+created: 20150720164801633
+modified: 20150720164806249
+resume_title: Résumé
+title: $:/data/ResumeTitle/Résumé
+

--- a/editions/resumebuilder/tiddlers/display/$__display_Resume Title Display.tid
+++ b/editions/resumebuilder/tiddlers/display/$__display_Resume Title Display.tid
@@ -1,4 +1,6 @@
-section: Resume Title
+created: 20150720164501834
+modified: 20150720164522750
+section: Résumé Title
 tags: [[Section Display]]
 template: $:/template/ResumeTitleTemplate
 title: $:/display/Resume Title Display

--- a/editions/resumebuilder/tiddlers/documentation/Help.tid
+++ b/editions/resumebuilder/tiddlers/documentation/Help.tid
@@ -1,35 +1,24 @@
 created: 20150719184941848
-modified: 20150719185024380
+modified: 20150720163457716
 tags: 
 title: Help
 
-Clicking on [[Resume Wizard]] at the top is a good place to start.
+Clicking on [[Résumé Wizard]] at the top is a good place to start.
 
 To save your work, either click on the {{$:/core/ui/Buttons/save-wiki}} button to the right or the Save button at the top of the screen. The button to the right will turn red when there are unsaved changes.
 
 How it works:
 
-There are buttons along the top that bring you to the different things you can do with the resume builder. To the right you should see a preview of the completed resume.
+There are buttons along the top that bring you to the different things you can do with the résumé builder. To the right you should see a preview of the completed résumé.
 
-*Resume Wizard - A wizard that guides you through a sequence of steps to create a resume.
+*Résumé Wizard - A wizard that guides you through a sequence of steps to create a résumé.
 *Edit Existing Items - An interface to edit already entered information
 *Layout Options - Options for changing the order of the sections, which sections are visible, and the templates used for each section.
-*Resume Options - Available options for the resume output. The `Layout Options` tab has options for which sections are included in the resume as well as their order and the templates used, the other tabs are for configuring each section individually.
+*Résumé Options - Available options for the résumé output. The `Layout Options` tab has options for which sections are included in the résumé as well as their order and the templates used, the other tabs are for configuring each section individually.
 *Preview - Shows a preview of the result, this is also shown on the right side of the screen by default.
 *Help - Displays this information.
-*Print - Open the resume by itself in a new window for printing.
+*Print - Open the résumé by itself in a new window for printing.
 *Save - saves your changes
-
-<!--
-Things to add:
-
-*The section/item order options should get a better way to change the order
-*There should be options for other templates for each section
-*options for fonts and sizes and so on. Using a settings system like I have for the contacts database would be a good idea.
-*More section options
-*A reasonable way for users to create custom sections without requiring knowledge of wikitext. This could turn into something rather complex by itself if I let it. I will try to avoid that.
-*Other user options?
--->
 
 Other documentation:
 

--- a/editions/resumebuilder/tiddlers/documentation/Making a new section.tid
+++ b/editions/resumebuilder/tiddlers/documentation/Making a new section.tid
@@ -1,8 +1,8 @@
 created: 20150719191225198
-modified: 20150719234223143
+modified: 20150720163929573
 title: Making a new section
 
-There is a [[New Section Creation Tool]] to help with creating new resume sections.
+There is a [[New Section Creation Tool]] to help with creating new résumé sections.
 
 Each section needs the following tiddlers:
 
@@ -15,13 +15,13 @@ You can have multiple template tiddlers that use the same input and options tidd
 
 !!Display tiddler
 
-This is the container used to display the section in the resume itself, there isn't any customization here.
+This is the container used to display the section in the résumé itself, there isn't any customization here.
 
 ''Required tags'': `Section Display`<br>
 ''Required name format'': `$:/display/(section name) Display`<br>
 ''Additional fields'':
 
-*'section' - the section name, something like 'Resume Title' or 'Objective'.
+*'section' - the section name, something like 'Résumé Title' or 'Objective'.
 ''Examples'': [[$:/display/Resume Title Display]] and [[$:/display/Objective Display]].<br>
 
 ''Other things'':
@@ -38,7 +38,7 @@ This tiddler should have only what is listed above.
 
 !!Template tiddler(s)
 
-These tiddlers determine how the section is displayed on the resume. This sets the look of the final result.
+These tiddlers determine how the section is displayed on the résumé. This sets the look of the final result.
 
 ''Required tags'': `DisplayTemplate`<br>
 ''Required name format'': `$:/template/(template name)`<br>
@@ -61,7 +61,7 @@ A tiddler that contains the input from for adding entries to the section, and if
 ''Required name format'': `$:/input/(template name)`<br>
 ''Additional fields'': 
 
-*`caption` - The contents of this field will be displayed as the section name in the [[Resume Wizard]].
+*`caption` - The contents of this field will be displayed as the section name in the [[Résumé Wizard]].
 ''Examples'': [[$:/input/Resume Title]], [[$:/input/Education]]
 
 The data taken from the input tiddler should be stored in the fields of a tiddler named in the form `$:/data/(SectionName)/(ItemName)`.
@@ -76,7 +76,7 @@ A tiddler used to set options for a section.
 ''Required name format'': `$:/options/(template name)`<br>
 ''Additional fields'':
 
-*`caption` - a caption field, it should have something like `(section name) Options`. This is what appears on the tabs in the [[Resume Options]] tiddler.
+*`caption` - a caption field, it should have something like `(section name) Options`. This is what appears on the tabs in the [[Résumé Options]] tiddler.
 ''Examples'': [[$:/options/Education Options]], [[$:/options/Previous Employment Options]].
 
 You would use this tiddler to change the fonts used and list types and similar things here.
@@ -84,11 +84,11 @@ All settings and state information about each section should be stored in a tidd
 For each item within a section all state and configuration information should be kept in a tiddler with a name in the form `$:/settings/(ResumeName)/(SectionName)/(ItemName)`.
 The options tiddler must only change fields in these tiddlers.
 
-These tiddlers hold the information about which items/sections are visible in each resume. See the list of system tiddlers for many examples. You don't need to make those tiddlers, you just need to make your input and settings tiddlers create or modify the correct tiddler name and they will be created. See the examples.
+These tiddlers hold the information about which items/sections are visible in each résumé. See the list of system tiddlers for many examples. You don't need to make those tiddlers, you just need to make your input and settings tiddlers create or modify the correct tiddler name and they will be created. See the examples.
 
 ''Important note:''
 
-If you are going to make your own section, in order to allow the items to be in different orders in different resumes you will need to use this wonderful filter
+If you are going to make your own section, in order to allow the items to be in different orders in different résumés you will need to use this wonderful filter
 (Thanks to Eric for pointing out that my original version could be shortened):
 
 `[prefix[$:/data/(SectionName)/]removeprefix[$:/data/]addprefix[$:/settings/$(ThisResumeName)$/]!show[false]sort[order]removeprefix[$:/settings/$(ThisResumeName)$/]addprefix[$:/data/]]`

--- a/editions/resumebuilder/tiddlers/input/$__input_Contact Information.tid
+++ b/editions/resumebuilder/tiddlers/input/$__input_Contact Information.tid
@@ -1,8 +1,10 @@
 caption: Contact Information
+created: 20150720164912365
+modified: 20150720164948543
 tags: Section
 title: $:/input/Contact Information
 
-This is contact information to be included in your resume.
+This is contact information to be included in your résumé.<br><br>
 
 Name: <$edit-text tiddler='$:/data/Personal Information' field='name' placeholder='Your Name' class='tc-edit-texteditor'/>
 

--- a/editions/resumebuilder/tiddlers/input/$__input_ObjectiveInput1.tid
+++ b/editions/resumebuilder/tiddlers/input/$__input_ObjectiveInput1.tid
@@ -1,4 +1,6 @@
 caption: Objective
+created: 20150720165104821
+modified: 20150720165123543
 tags: Section
 title: $:/input/ObjectiveInput1
 
@@ -11,10 +13,12 @@ title: $:/input/ObjectiveInput1
 \end
 
 Your objective should very briefly describe the sort of job you are looking for and be phrased in a way that flatters the company you are applying to. Something like 'To gain professional experience with a leader in the field of underwater basket weaving.' 
-
+<br>
+<br>
 You can enter multiple possible objectives and then select the one you want to use on the current resume.
 You can add a new objective or select one that you have already entered (if you have previously entered any).
-
+<br>
+<br>
 Name:
 <$edit-text tiddler='$:/temp/Objective' field=name class='tc-edit-texteditor' placeholder='Short Name'/>
 

--- a/editions/resumebuilder/tiddlers/input/$__input_Resume Title.tid
+++ b/editions/resumebuilder/tiddlers/input/$__input_Resume Title.tid
@@ -1,3 +1,5 @@
+created: 20150720170603658
+modified: 20150720170624801
 tags: Section
 title: $:/input/Resume Title
 
@@ -11,10 +13,10 @@ Select title to use:<br>
 </$list>
 \end
 
-This is the title that will appear at the top of your resume. Just putting 'Resume' isn't an uncommon choice. You can add a new title or pick an existing title from the list. If you select 'Use your name' than your name (entered with your contact information) will be used as the title.
+This is the title that will appear at the top of your résumé. Just putting 'Résumé' isn't an uncommon choice. You can add a new title or pick an existing title from the list. If you select 'Use your name' than your name (entered with your contact information) will be used as the title.
 
 Add New Title:
-<$edit-text tiddler='$:/temp/ResumeTitle' field='resume_title' placeholder='Resume Title' class='tc-edit-texteditor'/>
+<$edit-text tiddler='$:/temp/ResumeTitle' field='resume_title' placeholder='Résumé Title' class='tc-edit-texteditor'/>
 
 <$vars ThisResume={{$:/settings/Global!!selected_resume}} ThisTitle={{$:/temp/ResumeTitle!!resume_title}}>
 <<thisResumeTitleInput>>

--- a/editions/resumebuilder/tiddlers/input/$__input_Resume Title2.tid
+++ b/editions/resumebuilder/tiddlers/input/$__input_Resume Title2.tid
@@ -1,4 +1,6 @@
 caption: Resume Title
+created: 20150720170858240
+modified: 20150720170900145
 tags: Section
 title: $:/input/Resume Title2
 
@@ -13,7 +15,7 @@ Select title to use:<br>
 \end
 
 Add New Title:
-<$edit-text tiddler='$:/temp/ResumeTitle' field='resume_title' placeholder='Resume Title' class='tc-edit-texteditor'/>
+<$edit-text tiddler='$:/temp/ResumeTitle' field='resume_title' placeholder='Résumé Title' class='tc-edit-texteditor'/>
 
 <$vars ThisResume={{$:/settings/Global!!selected_resume}} ThisTitle={{$:/temp/ResumeTitle!!resume_title}}>
 <<thisResumeTitleInput>>

--- a/editions/resumebuilder/tiddlers/system/$__DefaultTiddlers.tid
+++ b/editions/resumebuilder/tiddlers/system/$__DefaultTiddlers.tid
@@ -1,9 +1,9 @@
 created: 20150620003518997
-modified: 20150717051407353
+modified: 20150720162957690
 title: $:/DefaultTiddlers
 
 [[Help]]
-[[Resume Wizard]]
+[[Résumé Wizard]]
 [[Edit Existing Items]]
 [[Layout Options]]
-[[Resume Options]]
+[[Résumé Options]]

--- a/editions/resumebuilder/tiddlers/system/$__SiteSubtitle.tid
+++ b/editions/resumebuilder/tiddlers/system/$__SiteSubtitle.tid
@@ -1,5 +1,5 @@
 created: 20150619215753488
-modified: 20150619215804124
+modified: 20150720163304383
 title: $:/SiteSubtitle
 
-a resume building tool using ~TiddlyWiki
+a résumé building tool using ~TiddlyWiki

--- a/editions/resumebuilder/tiddlers/system/$__SiteTitle.tid
+++ b/editions/resumebuilder/tiddlers/system/$__SiteTitle.tid
@@ -1,5 +1,5 @@
 created: 20150619215748447
-modified: 20150619215751266
+modified: 20150720163301922
 title: $:/SiteTitle
 
-Resume Builder
+Résumé Builder

--- a/editions/resumebuilder/tiddlers/temp tiddlers/$__temp_NewSection_InputTiddler.tid
+++ b/editions/resumebuilder/tiddlers/temp tiddlers/$__temp_NewSection_InputTiddler.tid
@@ -1,0 +1,4 @@
+created: 20150720164306989
+modified: 20150720164306989
+title: $:/temp/NewSection/InputTiddler
+

--- a/editions/resumebuilder/tiddlers/temp tiddlers/$__temp_NewSection_OptionsTiddler.tid
+++ b/editions/resumebuilder/tiddlers/temp tiddlers/$__temp_NewSection_OptionsTiddler.tid
@@ -1,0 +1,4 @@
+created: 20150720164308156
+modified: 20150720164308156
+title: $:/temp/NewSection/OptionsTiddler
+

--- a/editions/resumebuilder/tiddlers/temp tiddlers/$__temp_NewSection_TemplateTiddler.tid
+++ b/editions/resumebuilder/tiddlers/temp tiddlers/$__temp_NewSection_TemplateTiddler.tid
@@ -1,0 +1,4 @@
+created: 20150720164309668
+modified: 20150720164309668
+title: $:/temp/NewSection/TemplateTiddler
+

--- a/editions/resumebuilder/tiddlers/temp tiddlers/$__temp_Objective.tid
+++ b/editions/resumebuilder/tiddlers/temp tiddlers/$__temp_Objective.tid
@@ -1,0 +1,4 @@
+created: 20150720165013749
+modified: 20150720165013749
+title: $:/temp/Objective
+

--- a/editions/resumebuilder/tiddlers/templates/$__template_ResumeTitleTemplate.tid
+++ b/editions/resumebuilder/tiddlers/templates/$__template_ResumeTitleTemplate.tid
@@ -1,6 +1,8 @@
+created: 20150720170700740
 input_tiddler: $:/input/Resume Title
+modified: 20150720170702537
 options_tiddler: $:/options/Title Options
-section_name: Resume Title
+section_name: Résumé Title
 tags: DisplayTemplate
 template_name: Title Template 1
 title: $:/template/ResumeTitleTemplate

--- a/editions/resumebuilder/tiddlers/templates/$__template_ResumeTitleTemplate2.tid
+++ b/editions/resumebuilder/tiddlers/templates/$__template_ResumeTitleTemplate2.tid
@@ -1,6 +1,8 @@
+created: 20150720170711876
 input_tiddler: $:/input/Resume Title2
+modified: 20150720170713665
 options_tiddler: $:/options/Title Options
-section_name: Resume Title
+section_name: Résumé Title
 tags: DisplayTemplate
 template_name: Title Template 2
 title: $:/template/ResumeTitleTemplate2

--- a/editions/resumebuilder/tiddlers/tools/New Section Creation Tool.tid
+++ b/editions/resumebuilder/tiddlers/tools/New Section Creation Tool.tid
@@ -1,5 +1,5 @@
 created: 20150719200725211
-modified: 20150719235401264
+modified: 20150720164139669
 tags: Tools
 title: New Section Creation Tool
 
@@ -39,9 +39,9 @@ $(UserTemplateTiddlerText)$
 <$action-setfield $tiddler="""$:/template/$(ThisSection)$/$(TemplateName)$""" text=<<thisTemplateTiddlerText>> input_tiddler="""$:/input/$(ThisSection)$/$(TemplateName)$""" options_tiddler="""$:/options/$(ThisSection)$/$(TemplateName)$""" section_name="""$(ThisSection)$""" template_name="""$(TemplateName)$""" tags=DisplayTemplate/>
 \end
 
-''Once you have created your new section you have to go to [[Resume Options]] and select a template and set the section as visible before it will appear in the resume.''
+''Once you have created your new section you have to go to [[Résumé Options]] and select a template and set the section as visible before it will appear in the résumé.''
 
-This is a tool to aid in the creation of custom resume sections. Fill out each section and then click on the 'Create Section' button below. Click on the ^^(?)^^ next to each tiddler name to get more information and a basic example. If you copy all of the examples given they will work together.
+This is a tool to aid in the creation of custom résumé sections. Fill out each section and then click on the 'Create Section' button below. Click on the ^^(?)^^ next to each tiddler name to get more information and a basic example. If you copy all of the examples given they will work together.
 
 Automatically defined helper macros and values (with the exception of `<<thisAddResumeSectionItem>>` these macros are defined for all of the tiddlers created using this tool.):
 
@@ -53,7 +53,7 @@ Automatically defined helper macros and values (with the exception of `<<thisAdd
 *`<<SectionName>>` - This is the name of the current section.
 *`<<SectionSettingsTiddler>>` - This is the name of the tiddler containing the settings for the current section. It holds the visibility and order settings, but they are automatically created by the [[Layout Options]] tiddler. You shouldn't need to use this unless you are doing something special.
 
-Section Name^^(<$button class='tc-btn-invisible' popup='$:/state/popup/SectionNameHelp'>?</$button><$reveal type='popup' state='$:/state/popup/SectionNameHelp'><div class='tc-drop-down'>This should be a short descriptive section name, like 'Resume Title' or 'Lands Conquered'</div></$reveal>)^^:
+Section Name^^(<$button class='tc-btn-invisible' popup='$:/state/popup/SectionNameHelp'>?</$button><$reveal type='popup' state='$:/state/popup/SectionNameHelp'><div class='tc-drop-down'>This should be a short descriptive section name, like 'Résumé Title' or 'Lands Conquered'</div></$reveal>)^^:
 <$edit-text tiddler='$:/temp/NewSection' field='section_name' class='tc-edit-texteditor' placeholder='Section Name'/>
 
 Input Tiddler^^(<$reveal type='nomatch' state='$:/state/popup/InputTiddlerHelp' text=show><$button class='tc-btn-invisible' set='$:/state/popup/InputTiddlerHelp' setTo='show'>?</$button></$reveal><$reveal type='match' state='$:/state/popup/InputTiddlerHelp' text=show><$button class='tc-btn-invisible' set='$:/state/popup/InputTiddlerHelp' setTo='hide'>?</$button></$reveal>)^^:
@@ -137,7 +137,7 @@ Template Tiddler^^(<$reveal type='nomatch' state='$:/state/popup/TemplateTiddler
 <div style="word-wrap: true;">
 <hr>
 
-A template tiddler is used to display the section in the final resume. Each template must have a unique name. It should be descriptive (like Basic Objective Template).
+A template tiddler is used to display the section in the final résumé. Each template must have a unique name. It should be descriptive (like Basic Objective Template).
 
 A very example template tiddler is:
 


### PR DESCRIPTION
The spelling for résumé should include the accents everywhere but in some tiddler titles.
Newly created resumes now automatically have the default settings for visibility and templates
The first page of the resume wizard now displays options for which sections are displayed along with the order and templates to use
The print option no longer puts a black box around the text area out the output
Some temp tiddlers are included to prevent the default 'Enter text for <tiddlername> tiddler' from showing up in some text entry boxes
There are some other minor layout improvements