### PR TITLE
Fix thumbnail macro when no caption parameter is provided

### DIFF
--- a/core/wiki/macros/thumbnails.tid
+++ b/core/wiki/macros/thumbnails.tid
@@ -9,7 +9,8 @@ tags: $:/tags/Macro
 $icon$
 </div><div class="tc-thumbnail-caption">
 $caption$
-</div></div></$link>
+</div>
+</div></$link>
 \end
 
 \define thumbnail-right(link,icon,color,background-color,image,caption,width:"280",height:"157")


### PR DESCRIPTION
Fix an inappropriate  `<$/link>` that is visible when no caption parameter is provided to the thumbnail macro (see https://groups.google.com/forum/#!topic/tiddlywiki/qDcQZ0OGVIs).

I don't know why this line break correct the issue... as I don't understand why this ending `<$/link>` was visible under this specific condition.
All that I know is that sometimes a line break can change things, even in "inline" mode where you wouldn't expect it, so I tried it out and it's worked...