### PR TITLE
Auto-height fix for text area which is contained in a scroll container

### DIFF
--- a/core/modules/widgets/edit-text.js
+++ b/core/modules/widgets/edit-text.js
@@ -212,17 +212,30 @@ EditTextWidget.prototype.updateEditorDomNode = function(text) {
 };
 
 /*
+Get the first parent element that has scrollbars or use the body as fallback.
+*/
+EditTextWidget.prototype.getScrollContainer = function(el) {
+	while(el.parentNode) {	
+		el = el.parentNode;
+		if(el.scrollTop) {
+			return el;
+		}
+	}
+	return this.document.body;
+};
+
+/*
 Fix the height of textareas to fit their content
 */
 EditTextWidget.prototype.fixHeight = function() {
-	var self = this,
-		domNode = this.domNodes[0];
+	var domNode = this.domNodes[0];
 	if(this.editAutoHeight && domNode && !domNode.isTiddlyWikiFakeDom && this.editTag === "textarea") {
 		// Resize the textarea to fit its content, preserving scroll position
-		var scrollPosition = $tw.utils.getScrollPosition(),
-			scrollTop = scrollPosition.y;
-		// Measure the specified minimum height
-		domNode.style.height = self.editMinHeight;
+		// Get the scroll container and register the current scroll position
+		var container = this.getScrollContainer(domNode),
+			scrollTop = container.scrollTop;
+                // Measure the specified minimum height
+		domNode.style.height = this.editMinHeight;
 		var minHeight = domNode.offsetHeight;
 		// Set its height to auto so that it snaps to the correct height
 		domNode.style.height = "auto";
@@ -230,12 +243,11 @@ EditTextWidget.prototype.fixHeight = function() {
 		var newHeight = Math.max(domNode.scrollHeight + domNode.offsetHeight - domNode.clientHeight,minHeight);
 		// Only try to change the height if it has changed
 		if(newHeight !== domNode.offsetHeight) {
-			domNode.style.height =  newHeight + "px";
+			domNode.style.height = newHeight + "px";
 			// Make sure that the dimensions of the textarea are recalculated
 			$tw.utils.forceLayout(domNode);
-			// Check that the scroll position is still visible before trying to scroll back to it
-			scrollTop = Math.min(scrollTop,self.document.body.scrollHeight - window.innerHeight);
-			window.scrollTo(scrollPosition.x,scrollTop);
+			// Set the container to the position we registered at the beginning
+			container.scrollTop = scrollTop;
 		}
 	}
 };


### PR DESCRIPTION
Hi @Jermolene 

Finally found the time to implement this (see #1575). Your suggested way for fixing was the way to go.

### Description

Allows text areas to be auto-height while being wrapped in an
element that has scrollbars. The wrapper element with the
scroll bar does not need to be a direct parent of the text area.

# Demo

For a demo of the **new** behaviour see:
http://wkpr.de/hosting/tmp/tw5/scrolling/new.html

The **old** (bad) behaviour can be viewed here:
http://wkpr.de/hosting/tmp/tw5/scrolling/old.html

-Felix