### PR TITLE
Fix the title

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/FieldMangler Widget (Examples).tid
+++ b/editions/tw5.com/tiddlers/widgets/FieldMangler Widget (Examples).tid
@@ -1,7 +1,7 @@
 created: 20150706160301163
 modified: 20150706172915783
 tags: [[Widget Examples]] FieldManglerWidget
-title: FieldMangler Widget Example
+title: FieldMangler Widget (Examples)
 type: text/vnd.tiddlywiki
 
 <$macrocall $name=".example" n="1"


### PR DESCRIPTION
 to match the one required by the "FieldManglerWidget" tiddler's link to examples, broken for now. (pointing to a non existant tiddler because of the wrong name)