### PR TITLE
updated #1480 "undefined value removes field or index"

### DIFF
--- a/core/modules/widgets/action-setfield.js
+++ b/core/modules/widgets/action-setfield.js
@@ -61,9 +61,7 @@ SetFieldWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var self = this,
 		options = {};
 	options.suppressTimestamp = !this.actionTimestamp;
-	if(typeof this.actionValue === "string") {
-		this.wiki.setText(this.actionTiddler,this.actionField,this.actionIndex,this.actionValue,options);		
-	}
+	this.wiki.setText(this.actionTiddler,this.actionField,this.actionIndex,this.actionValue,options);
 	$tw.utils.each(this.attributes,function(attribute,name) {
 		if(name.charAt(0) !== "$") {
 			self.wiki.setText(self.actionTiddler,name,undefined,attribute,options);

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -65,7 +65,11 @@ exports.setText = function(title,field,index,value,options) {
 	// Check if it is a reference to a tiddler field
 	if(index) {
 		var data = this.getTiddlerData(title,Object.create(null));
-		data[index] = value;
+		if(value !== undefined) {
+			data[index] = value;
+		} else {
+			delete data[index];
+		}
 		this.setTiddlerData(title,data,modificationFields);
 	} else {
 		var tiddler = this.getTiddler(title),

--- a/editions/tw5.com/tiddlers/widgets/ActionSetFieldWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionSetFieldWidget.tid
@@ -17,7 +17,7 @@ The ''action-setfield'' widget is invisible. Any content within it is ignored.
 |$tiddler |The title of the tiddler whose fields are to be modified (if not provided defaults to the [[current tiddler|Current Tiddler]] |
 |$field |Optional name of a field to be assigned the $value attribute |
 |$index |Optional index of a property in a [[data tiddler|DataTiddlers]] to be assigned the $value attribute|
-|$value |The value to be assigned to the field or index identified by the $field or $index attribute. If neither is specified then the value is assigned to the text field |
+|$value |The value to be assigned to the field or index identified by the $field or $index attribute. If neither is specified then the value is assigned to the text field. If no value is specified, $field or $index are being deleted.|
 |$timestamp |Specifies whether the timestamp(s) of the target tiddler will be updated (''modified'' and ''modifier'', plus ''created'' and ''creator'' for newly created tiddlers). Can be "yes" (the default) or "no" |
 |//{any attributes not starting with $}// |Each attribute name specifies a field to be modified with the attribute value providing the value to assign to the field  |
 

--- a/editions/tw5.com/tiddlers/widgets/ActionSetFieldWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionSetFieldWidget.tid
@@ -17,7 +17,7 @@ The ''action-setfield'' widget is invisible. Any content within it is ignored.
 |$tiddler |The title of the tiddler whose fields are to be modified (if not provided defaults to the [[current tiddler|Current Tiddler]] |
 |$field |Optional name of a field to be assigned the $value attribute |
 |$index |Optional index of a property in a [[data tiddler|DataTiddlers]] to be assigned the $value attribute|
-|$value |The value to be assigned to the field or index identified by the $field or $index attribute. If neither is specified then the value is assigned to the text field. If no value is specified, $field or $index are being deleted.|
+|$value |The value to be assigned to the field or index identified by the $field or $index attribute. If neither is specified then the value is assigned to the text field. If no value is specified, $field or $index will be deleted.|
 |$timestamp |Specifies whether the timestamp(s) of the target tiddler will be updated (''modified'' and ''modifier'', plus ''created'' and ''creator'' for newly created tiddlers). Can be "yes" (the default) or "no" |
 |//{any attributes not starting with $}// |Each attribute name specifies a field to be modified with the attribute value providing the value to assign to the field  |
 


### PR DESCRIPTION
when `$value` is unspecified, `$action-setfield` removes field or index...

**modified**

* `setText()`
    * $:/core/modules/wiki.js
* `invokeAction()`
    * $:/core/modules/widgets/action-setfield

**demo**

http://tobibeer.github.io/tw/batch/#ActionSetField-RemoveIndex