### PR TITLE
clears tiddler body for when one adds right-floating element to subtitle

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -938,6 +938,10 @@ canvas.tc-edit-bitmapeditor  {
 	display: block;
 }
 
+.tc-tiddler-body {
+	clear: both;
+}
+
 .tc-tiddler-frame .tc-tiddler-body {
 	font-size: {{$:/themes/tiddlywiki/vanilla/metrics/bodyfontsize}};
 	line-height: {{$:/themes/tiddlywiki/vanilla/metrics/bodylineheight}};


### PR DESCRIPTION
otherwise has no effect

without this, block-level content like a codeblock would only stretch as far as the element, rather than full tiddler width