### PR TITLE
fixed bug in $action-setfield introduced by #1963

### DIFF
--- a/core/modules/widgets/action-setfield.js
+++ b/core/modules/widgets/action-setfield.js
@@ -61,7 +61,9 @@ SetFieldWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var self = this,
 		options = {};
 	options.suppressTimestamp = !this.actionTimestamp;
-	this.wiki.setText(this.actionTiddler,this.actionField,this.actionIndex,this.actionValue,options);
+	if((typeof this.actionField == "string") || (typeof this.actionIndex == "string")  || (typeof this.actionValue == "string")) {
+		this.wiki.setText(this.actionTiddler,this.actionField,this.actionIndex,this.actionValue,options);
+	}
 	$tw.utils.each(this.attributes,function(attribute,name) {
 		if(name.charAt(0) !== "$") {
 			self.wiki.setText(self.actionTiddler,name,undefined,attribute,options);


### PR DESCRIPTION
 At least one of '$field', '$value' or '$index' must be specified in order to act upon the information from the fields. Prevents default deletion of the 'text' field when none are specified.

See demo here: http://twguides.org/contrib/fixActionSetField.html
Previous change here: #1963

/Andreas