### PR TITLE
Local relative urls in Markdown map to WikiLinks

### DIFF
--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -48,6 +48,18 @@ function transformNode(node) {
 				delete widget.attributes.src;
 			}
 		}
+		// Convert internal links to proper wikilinks
+		if (widget.tag === "a" && widget.attributes.href.value[0] === "#") {
+			widget.type = "link";
+			widget.attributes.to = widget.attributes.href;
+			if (widget.attributes.to.type === "string") {
+				//Remove '#' before conversion to wikilink
+				widget.attributes.to.value = widget.attributes.to.value.substr(1);
+			}
+			//Children is fine
+			delete widget.tag;
+			delete widget.attributes.href;
+		}
 		return widget;
 	} else {
 		return {type: "text", text: node};


### PR DESCRIPTION
Currently, local urls, e.g. `[TextToTiddler](#MyTiddlerTitle)`, in Markdown sources are not properly prepared for use in TiddlyWiki as links. Instead of being converted to *links* in the parse tree, they are converted to anchor, `a`, elements. I have diagnosed two issues with this:

1. Tiddlers linked to in this manner only by other tiddlers in Markdown will still be considered Orphans.
2. Link behaviour differs, in a minor inconvient manner. Normally, if you click on a link to a tiddler, the tiddler will open. Scroll away and click on the link again and the screen will scroll back to the tiddler like before. But with the links from markdown this is different. The first time the tiddler will open and be scrolled to (and the link the address bar will change), the second time nothing happens.

This change fixes the behaviour in the typical case. After rendering, the plugin extracts a parse tree. If the url is starts with `#`, as suggested by the usage document, the url is replaced to make a *link* instead of an anchor element. This fixes both issues mentioned above. I have tested the change on my only small TW, where it works without issue.