### PR TITLE
Text-slicer: Add support for definition lists

### DIFF
--- a/editions/text-slicer/tiddlers/Sample Text.tid
+++ b/editions/text-slicer/tiddlers/Sample Text.tid
@@ -104,6 +104,13 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 Dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 </p>
 
+<dl>
+<dt>Term being defined</dt>
+<dd>Definition of that term</dd>
+<dt>Another term</dt>
+<dd>Another definition</dd>
+</dl>
+
 <h3>Story</h3>
 
 <ul class="intro">

--- a/plugins/tiddlywiki/text-slicer/docs.tid
+++ b/plugins/tiddlywiki/text-slicer/docs.tid
@@ -144,6 +144,32 @@ The tiddlers representing items within the list have the following fields:
 * ''text'': the text of the list item
 * ''tags'': any CSS classes found in the HTML are converted into tags
 
+!!! Definition lists
+
+Definition lists are represented by several tiddlers: one for the definition list itself, and one for each term and definition in the list.
+
+The tiddler representing the definition list itself has the following fields:
+
+* ''toc-type'': the text "def-list"
+* ''toc-list-filter'': the default filter used to generate the titles of the list-items
+* ''title'': an automatically generated unique title
+* ''list'': ordered list of titles of tiddlers representing the items (terms and/or definition) in the definition list
+* ''tags'': any CSS classes found in the HTML are converted into tags
+
+The tiddlers representing terms within the definition list have the following fields:
+
+* ''toc-type'': the text "term"
+* ''title'': an automatically generated unique title
+* ''text'': the text of the definition list term
+* ''tags'': any CSS classes found in the HTML are converted into tags
+
+The tiddlers representing definitions within the definition list have the following fields:
+
+* ''toc-type'': the text "definition"
+* ''title'': an automatically generated unique title
+* ''text'' : the text of the definition list definition
+* ''tags'': any CSS classes found in the HTML are converted into tags
+
 !!! Images
 
 Tiddlers representing images have the following fields:

--- a/plugins/tiddlywiki/text-slicer/docs.tid
+++ b/plugins/tiddlywiki/text-slicer/docs.tid
@@ -151,7 +151,7 @@ Definition lists are represented by several tiddlers: one for the definition lis
 The tiddler representing the definition list itself has the following fields:
 
 * ''toc-type'': the text "def-list"
-* ''toc-list-filter'': the default filter used to generate the titles of the list-items
+* ''toc-list-filter'': the default filter used to generate the titles of the definition list items
 * ''title'': an automatically generated unique title
 * ''list'': ordered list of titles of tiddlers representing the items (terms and/or definition) in the definition list
 * ''tags'': any CSS classes found in the HTML are converted into tags

--- a/plugins/tiddlywiki/text-slicer/modules/slicers/def-list.js
+++ b/plugins/tiddlywiki/text-slicer/modules/slicers/def-list.js
@@ -1,0 +1,40 @@
+/*\
+title: $:/plugins/tiddlywiki/text-slicer/modules/slicers/def-list.js
+type: application/javascript
+module-type: slicer
+
+Handle slicing definition list nodes
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.processDefListNode = function(domNode,tagName) {
+	if(domNode.nodeType === 1 && tagName === "dl") {
+		var title = this.makeUniqueTitle("def-list-" + tagName),
+			parentTitle = this.parentStack[this.parentStack.length - 1].title,
+			tags = [];
+		if(domNode.className.trim() !== "") {
+			tags = tags.concat(domNode.className.split(" "));
+		}
+		this.addToList(parentTitle,title);
+		this.parentStack.push({type: tagName, title: this.addTiddler({
+			"toc-type": "def-list",
+			"toc-list-filter": "[list<currentTiddler>!has[draft.of]]",
+			text: "",
+			title: title,
+			list: [],
+			tags: tags
+		})});
+		this.currentTiddler = title;
+		this.processNodeList(domNode.childNodes);
+		this.parentStack.pop();
+		return true;
+	}
+	return false;
+};
+
+})();

--- a/plugins/tiddlywiki/text-slicer/modules/slicers/definition.js
+++ b/plugins/tiddlywiki/text-slicer/modules/slicers/definition.js
@@ -3,7 +3,7 @@ title: $:/plugins/tiddlywiki/text-slicer/modules/slicers/definition.js
 type: application/javascript
 module-type: slicer
 
-Handle slicing definition list definition nodes
+Handle slicing definition nodes in definition lists
 
 \*/
 (function(){
@@ -12,7 +12,7 @@ Handle slicing definition list definition nodes
 /*global $tw: false */
 "use strict";
 
-exports.processDefinitionItemNode = function(domNode,tagName) {
+exports.processDefinitionNode = function(domNode,tagName) {
 	var text = $tw.utils.htmlEncode(domNode.textContent);
 	if(domNode.nodeType === 1 && tagName === "dd") {
 		// if(!this.isBlank(text)) {

--- a/plugins/tiddlywiki/text-slicer/modules/slicers/definition.js
+++ b/plugins/tiddlywiki/text-slicer/modules/slicers/definition.js
@@ -1,0 +1,44 @@
+/*\
+title: $:/plugins/tiddlywiki/text-slicer/modules/slicers/definition.js
+type: application/javascript
+module-type: slicer
+
+Handle slicing definition list definition nodes
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.processDefinitionItemNode = function(domNode,tagName) {
+	var text = $tw.utils.htmlEncode(domNode.textContent);
+	if(domNode.nodeType === 1 && tagName === "dd") {
+		// if(!this.isBlank(text)) {
+			var title = this.makeUniqueTitle("definition",text),
+				parentTitle = this.parentStack[this.parentStack.length - 1].title,
+				tags = [];
+			if(domNode.className.trim() !== "") {
+				tags = tags.concat(domNode.className.split(" "));
+			}
+			this.addToList(parentTitle,title);
+			this.addTiddler({
+				"toc-type": "definition",
+				title: title,
+				text: "",
+				list: [],
+				tags: tags
+			});
+			this.currentTiddler = title;
+			this.containerStack.push(title);
+			// this.containerStack.push("Just testing" + new Date());
+			this.processNodeList(domNode.childNodes);
+			this.containerStack.pop();
+			return true;
+		// }
+	}
+	return false;
+};
+
+})();

--- a/plugins/tiddlywiki/text-slicer/modules/slicers/term.js
+++ b/plugins/tiddlywiki/text-slicer/modules/slicers/term.js
@@ -1,0 +1,44 @@
+/*\
+title: $:/plugins/tiddlywiki/text-slicer/modules/slicers/term.js
+type: application/javascript
+module-type: slicer
+
+Handle slicing definition list term nodes
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.processTermItemNode = function(domNode,tagName) {
+	var text = $tw.utils.htmlEncode(domNode.textContent);
+	if(domNode.nodeType === 1 && tagName === "dt") {
+		// if(!this.isBlank(text)) {
+			var title = this.makeUniqueTitle("term",text),
+				parentTitle = this.parentStack[this.parentStack.length - 1].title,
+				tags = [];
+			if(domNode.className.trim() !== "") {
+				tags = tags.concat(domNode.className.split(" "));
+			}
+			this.addToList(parentTitle,title);
+			this.addTiddler({
+				"toc-type": "term",
+				title: title,
+				text: "",
+				list: [],
+				tags: tags
+			});
+			this.currentTiddler = title;
+			this.containerStack.push(title);
+			// this.containerStack.push("Just testing" + new Date());
+			this.processNodeList(domNode.childNodes);
+			this.containerStack.pop();
+			return true;
+		// }
+	}
+	return false;
+};
+
+})();

--- a/plugins/tiddlywiki/text-slicer/modules/slicers/term.js
+++ b/plugins/tiddlywiki/text-slicer/modules/slicers/term.js
@@ -3,7 +3,7 @@ title: $:/plugins/tiddlywiki/text-slicer/modules/slicers/term.js
 type: application/javascript
 module-type: slicer
 
-Handle slicing definition list term nodes
+Handle slicing term nodes in definition lists
 
 \*/
 (function(){
@@ -12,7 +12,7 @@ Handle slicing definition list term nodes
 /*global $tw: false */
 "use strict";
 
-exports.processTermItemNode = function(domNode,tagName) {
+exports.processTermNode = function(domNode,tagName) {
 	var text = $tw.utils.htmlEncode(domNode.textContent);
 	if(domNode.nodeType === 1 && tagName === "dt") {
 		// if(!this.isBlank(text)) {

--- a/plugins/tiddlywiki/text-slicer/templates/interactive/def-list.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/interactive/def-list.tid
@@ -1,0 +1,11 @@
+title: $:/plugins/tiddlywiki/text-slicer/templates/interactive/def-list
+
+\define body()
+<dl>
+<$list filter="""[all[current]] $(tv-exclude-filter)$ +[limit[1]]""" variable="item">
+<$list filter={{!!toc-list-filter}} template="$:/plugins/tiddlywiki/text-slicer/templates/interactive/tiddler"/>
+</$list>
+</dl>
+\end
+
+<<body>>

--- a/plugins/tiddlywiki/text-slicer/templates/interactive/definition.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/interactive/definition.tid
@@ -1,0 +1,11 @@
+title: $:/plugins/tiddlywiki/text-slicer/templates/interactive/definition
+
+\define body()
+<$link tag="dd" class="tc-document-tiddler-link">
+
+<$transclude/>
+
+</$link>
+\end
+
+<<body>>

--- a/plugins/tiddlywiki/text-slicer/templates/interactive/term.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/interactive/term.tid
@@ -1,0 +1,11 @@
+title: $:/plugins/tiddlywiki/text-slicer/templates/interactive/term
+
+\define body()
+<$link tag="dt" class="tc-document-tiddler-link">
+
+<$transclude/>
+
+</$link>
+\end
+
+<<body>>

--- a/plugins/tiddlywiki/text-slicer/templates/interactive/tiddler.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/interactive/tiddler.tid
@@ -27,3 +27,15 @@ title: $:/plugins/tiddlywiki/text-slicer/templates/interactive/tiddler
 <$reveal type="match" state="!!toc-type" text="image">
 <$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/interactive/image" mode="block"/>
 </$reveal>
+
+<$reveal type="match" state="!!toc-type" text="def-list">
+<$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/interactive/def-list" mode="block"/>
+</$reveal>
+
+<$reveal type="match" state="!!toc-type" text="term">
+<$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/interactive/term" mode="block"/>
+</$reveal>
+
+<$reveal type="match" state="!!toc-type" text="definition">
+<$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/interactive/definition" mode="block"/>
+</$reveal>

--- a/plugins/tiddlywiki/text-slicer/templates/plain/def-list.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/plain/def-list.tid
@@ -1,0 +1,11 @@
+title: $:/plugins/tiddlywiki/text-slicer/templates/plain/def-list
+
+\define body()
+<dl>
+<$list filter="""[all[current]] $(tv-exclude-filter)$ +[limit[1]]""" variable="item">
+<$list filter={{!!toc-list-filter}} template="$:/plugins/tiddlywiki/text-slicer/templates/plain/tiddler"/>
+</$list>
+</dl>
+\end
+
+<<body>>

--- a/plugins/tiddlywiki/text-slicer/templates/plain/definition.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/plain/definition.tid
@@ -1,0 +1,11 @@
+title: $:/plugins/tiddlywiki/text-slicer/templates/plain/definition
+
+\define body()
+<dd>
+
+<$transclude/>
+
+</dd>
+\end
+
+<<body>>

--- a/plugins/tiddlywiki/text-slicer/templates/plain/term.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/plain/term.tid
@@ -1,0 +1,11 @@
+title: $:/plugins/tiddlywiki/text-slicer/templates/plain/term
+
+\define body()
+<dt>
+
+<$transclude/>
+
+</dt>
+\end
+
+<<body>>

--- a/plugins/tiddlywiki/text-slicer/templates/plain/tiddler.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/plain/tiddler.tid
@@ -26,4 +26,16 @@ title: $:/plugins/tiddlywiki/text-slicer/templates/plain/tiddler
 <$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/plain/image" mode="block"/>
 </$list>
 
+<$list filter="[<toc-type>prefix[def-list]]" variable="item">
+<$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/plain/def-list" mode="block"/>
+</$list>
+
+<$list filter="[<toc-type>prefix[term]]" variable="item">
+<$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/plain/term" mode="block"/>
+</$list>
+
+<$list filter="[<toc-type>prefix[definition]]" variable="item">
+<$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/plain/definition" mode="block"/>
+</$list>
+
 </$vars>

--- a/plugins/tiddlywiki/text-slicer/templates/static/def-list.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/static/def-list.tid
@@ -1,0 +1,11 @@
+title: $:/plugins/tiddlywiki/text-slicer/templates/static/def-list
+
+<$list filter="""[all[current]] $(tv-exclude-filter)$ +[limit[1]]""" variable="item">
+
+`<dl class="`{{||$:/plugins/tiddlywiki/text-slicer/templates/static/helpers/classes}}`">`
+
+<$list filter={{!!toc-list-filter}} template="$:/plugins/tiddlywiki/text-slicer/templates/static/tiddler"/>
+
+`</dl>`
+
+</$list>

--- a/plugins/tiddlywiki/text-slicer/templates/static/definition.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/static/definition.tid
@@ -1,0 +1,9 @@
+title: $:/plugins/tiddlywiki/text-slicer/templates/static/definition
+
+`<dd class="`{{||$:/plugins/tiddlywiki/text-slicer/templates/static/helpers/classes}}`">`
+
+<$transclude/>
+
+`</dd>`
+
+<$list filter="[list<currentTiddler>!has[draft.of]]" template="$:/plugins/tiddlywiki/text-slicer/templates/static/tiddler"/>

--- a/plugins/tiddlywiki/text-slicer/templates/static/term.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/static/term.tid
@@ -1,0 +1,9 @@
+title: $:/plugins/tiddlywiki/text-slicer/templates/static/term
+
+`<dt class="`{{||$:/plugins/tiddlywiki/text-slicer/templates/static/helpers/classes}}`">`
+
+<$transclude/>
+
+`</dt>`
+
+<$list filter="[list<currentTiddler>!has[draft.of]]" template="$:/plugins/tiddlywiki/text-slicer/templates/static/tiddler"/>

--- a/plugins/tiddlywiki/text-slicer/templates/static/tiddler.tid
+++ b/plugins/tiddlywiki/text-slicer/templates/static/tiddler.tid
@@ -38,4 +38,22 @@ title: $:/plugins/tiddlywiki/text-slicer/templates/static/tiddler
 
 </$list>
 
+<$list filter="[<toc-type>prefix[def-list]]" variable="item">
+
+<$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/static/def-list" mode="block"/>
+
+</$list>
+
+<$list filter="[<toc-type>prefix[term]]" variable="item">
+
+<$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/static/term" mode="block"/>
+
+</$list>
+
+<$list filter="[<toc-type>prefix[definition]]" variable="item">
+
+<$transclude tiddler="$:/plugins/tiddlywiki/text-slicer/templates/static/definition" mode="block"/>
+
+</$list>
+
 </$vars>


### PR DESCRIPTION
I've tried to add support for definition list, as I will need them for my text-slicing use-cases.

As I'm not a js developer, it is based on list and item files (js, templates), and I hope I've not forgotten anything. I'm also not very good at naming in general, so I'll not be worried if you rename some thing later on, or ask me to do so!

It seemed to work on a first try I made to test the feasibility (by directly editing the plugin tiddler in a local copy of the text-slicer html file), but I've not tested this particular code (my local TW5 repo is on a NAS, and I've not figured out how to start the text-slicer edition from there). So I'm sorry you will have to test it yourself.

It's also my first try at using a branch, so I also hope I've done it right!
