### PR TITLE
allows to retain tab contents

### DIFF
--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -1,7 +1,6 @@
 title: $:/core/macros/tabs
 tags: $:/tags/Macro
 
-\define retain-tab() $:/config/tabs/retain/$(currentTab)$
 \define tabs(tabsList,default,state:"$:/state/tab",class,template)
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
@@ -17,7 +16,7 @@ tags: $:/tags/Macro
 </div><div class="tc-tab-divider $class$"/><div class="tc-tab-content $class$">
 <$list filter="$tabsList$" variable="currentTab">
 
-<$set name="retain" filter="[<retain-tab>get[text]]">
+<$set name="retain" filter="[<currentTab>get[retain-tab]]">
 <$reveal type="match" state=<<qualify "$state$">> text=<<currentTab>> default="$default$" retain=<<retain>>>
 
 <$transclude tiddler="$template$" mode="block">

--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -1,6 +1,7 @@
 title: $:/core/macros/tabs
 tags: $:/tags/Macro
 
+\define retain-tab() $:/config/tabs/retain/$(currentTab)$
 \define tabs(tabsList,default,state:"$:/state/tab",class,template)
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
@@ -16,7 +17,8 @@ tags: $:/tags/Macro
 </div><div class="tc-tab-divider $class$"/><div class="tc-tab-content $class$">
 <$list filter="$tabsList$" variable="currentTab">
 
-<$reveal type="match" state=<<qualify "$state$">> text=<<currentTab>> default="$default$">
+<$set name="retain" filter="[<retain-tab>get[text]]">
+<$reveal type="match" state=<<qualify "$state$">> text=<<currentTab>> default="$default$" retain=<<retain>>>
 
 <$transclude tiddler="$template$" mode="block">
 
@@ -25,6 +27,7 @@ tags: $:/tags/Macro
 </$transclude>
 
 </$reveal>
+</$set>
 
 </$list>
 </div>

--- a/editions/tw5.com/tiddlers/macros/TabsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TabsMacro.tid
@@ -32,4 +32,4 @@ The <<.vlink currentTiddler>> variable is not affected by the <<.var tabs>> macr
 
 !! Preserving Tab Contents
 
-<<.from-version "5.1.14">> To preserve tab contents, e.g. iframes or embedded content, set the field ''retain-tab'' to `yes` at a tab tiddler. This will prevent reloading the content when switching tabs.
+<<.from-version "5.1.14">> To preserve active tab contents like embedded video or music, set the field ''retain-tab'' to `yes` at a tab tiddler. This will prevent reloading the content when switching tabs.

--- a/editions/tw5.com/tiddlers/macros/TabsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TabsMacro.tid
@@ -1,6 +1,6 @@
 caption: tabs
 created: 20131228162203521
-modified: 20150221211706000
+modified: 20161022095910026
 tags: Macros [[Core Macros]]
 title: tabs Macro
 type: text/vnd.tiddlywiki
@@ -29,3 +29,7 @@ Within the template, the title of the selected tab is available in the <<.var cu
 The <<.vlink currentTiddler>> variable is not affected by the <<.var tabs>> macro.
 
 <<.macro-examples "tabs">>
+
+!! Preserving Tab Contents
+
+<<.from-version "5.1.14">> To preserve tab contents, e.g. iframes or embedded content, set the field ''retain-tab'' to `yes` at a tab tiddler. This will prevent reloading the content when switching tabs.


### PR DESCRIPTION
**Discussion:** https://groups.google.com/forum/?fromgroups=#!topic/tiddlywiki/YvIHcRPc6aQ

Allows for iframed content in tabs to not be reloaded, by giving a tab tiddler a field `retain-tab` set to `yes`. Since this is possibly only relevant for custom user tabs, a user will not overwrite core tabs so as to change this setting.

Plugins that leverage iframes in tabs possibly also would know in advance if they'd like to retain those contents, rather than see them refreshed when the user makes the plugin tab active again. Perhaps relevant for @felixhayashi / [TiddlyMap](https://github.com/felixhayashi/TW5-TiddlyMap)?

~

First commit worked like so:

Set the text of `$:/config/tabs/retain/$:/_my/tabs/foo` to `yes` to have this tab retain its contents:

```
title: $:/_my/tabs/foo
tags: $:/tags/SideBar

<iframe src="https://tiddlywiki.com"/>
```

...and not refresh upon tab-switching.
