### PR TITLE
parameter "format" for set widget

### DIFF
--- a/core/modules/widgets/setvariable.js
+++ b/core/modules/widgets/setvariable.js
@@ -41,6 +41,7 @@ SetWidget.prototype.execute = function() {
 	this.setName = this.getAttribute("name","currentTiddler");
 	this.setFilter = this.getAttribute("filter");
 	this.setValue = this.getAttribute("value");
+	this.setFormat = this.getAttribute("format","list");
 	this.setEmptyValue = this.getAttribute("emptyValue");
 	// Set context variable
 	this.setVariable(this.setName,this.getValue(),this.parseTreeNode.params);
@@ -56,7 +57,11 @@ SetWidget.prototype.getValue = function() {
 	if(this.setFilter) {
 		var results = this.wiki.filterTiddlers(this.setFilter,this);
 		if(!this.setValue) {
-			value = $tw.utils.stringifyList(results);
+			if(this.setFormat === "list") {
+				value = $tw.utils.stringifyList(results);
+			} else {
+				value = results.join(" ");
+			}
 		}
 		if(results.length === 0 && this.setEmptyValue !== undefined) {
 			value = this.setEmptyValue;

--- a/editions/tw5.com/tiddlers/widgets/SetWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SetWidget.tid
@@ -16,6 +16,7 @@ The content of the `<$set>` widget is the scope for the value assigned to the va
 |name |The name of the variable to assign (defaults to "currentTiddler") |
 |value |The value to assign to the variable if the filter is missing or not empty |
 |filter |An optional filter to be evaluated and assigned to the variable (see below) |
+|format|The output format when using ''filter'' (defaults to "list" , see below) |
 |emptyValue |The value to assign to the variable if the filter is present and evaluates to an empty list (see below) |
 
 !! Simple Variable Assignment
@@ -55,3 +56,23 @@ This form of the set variable widget evaluates the filter and assigns the result
 <$text text=<<myVariable>>/>
 </$set>
 ```
+
+Without a defined an output ''format'', the output is a list of tiddler titles as encoded in the tags field...
+
+```
+<$set name="myVariable" filter="[[my tiddler]]">
+<$text text=<<myVariable>>/>
+</$set>
+```
+
+> ''outputs:'' <$text text="[[my tiddler]]"/>
+
+If you set the format to "text", all list items returned by the filter are joined to a string instead...
+
+```
+<$set name="myVariable" filter="[[my tiddler]]" format="text">
+<$text text=<<myVariable>>/>
+</$set>
+```
+
+> ''outputs:'' my tiddler

--- a/editions/tw5.com/tiddlers/widgets/SetWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SetWidget.tid
@@ -57,7 +57,7 @@ This form of the set variable widget evaluates the filter and assigns the result
 </$set>
 ```
 
-Without a defined an output ''format'', the output is a list of tiddler titles as encoded in the tags field...
+Without a defined ''format'', the output is a list of tiddler titles as encoded in the tags field...
 
 ```
 <$set name="myVariable" filter="[[my tiddler]]">


### PR DESCRIPTION
This is necessary when you just want to compare a single title against another stored value without having to be concerned about double square brackets, the handling of which is pretty much impossible using reveal or a filter with the list widget.

Without a defined ''format'', the output is a list of tiddler titles as encoded in the tags field...

```
<$set name="myVariable" filter="[[my tiddler]]">
<$text text=<<myVariable>>/>
</$set>
```

> **outputs:** [[my tiddler]]

If you set the format to "text", all list items returned by the filter are joined to a string instead...

```
<$set name="myVariable" filter="[[my tiddler]]" format="text">
<$text text=<<myVariable>>/>
</$set>
```

> **outputs:** my tiddler