### PR TITLE
fix typo in FilterRun.tid diagram

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/FilterRun.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/FilterRun.tid
@@ -11,7 +11,7 @@ type: text/vnd.tiddlywiki
   |
   '"' [:{/'anything but "'/}] '"'
   |
-  "'" [:{/"anything but '"/}] '"'
+  "'" [:{/"anything but '"/}] "'"
 )
 """/>
 


### PR DESCRIPTION
corrected typo in the railroad diagram, which showed a double-quote where a single-quote should have been.