### PR TITLE
Replacing count with Object.keys

### DIFF
--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -35,9 +35,7 @@ exports.trim = function(str) {
 Return the number of keys in an object
 */
 exports.count = function(object) {
-	var s = 0;
-	$tw.utils.each(object,function() {s++;});
-	return s;
+	return Object.keys(object || {}).length;
 };
 
 /*


### PR DESCRIPTION
See #2046.

For backwards compatibility, $tw.utils.count is not removed but the function body is replaced as well.