### PR TITLE
 implements #2086, SystemTemplates

### DIFF
--- a/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js
@@ -50,7 +50,7 @@ exports.parse = function() {
 		node.attributes.tooltip = {type: "string", value: tooltip};
 	}
 	if(template) {
-		node.attributes.template = {type: "string", value: template};
+		node.attributes.template = {type: "string", value: $tw.wiki.getTemplate(template)};
 	}
 	if(style) {
 		node.attributes.style = {type: "string", value: style};

--- a/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js
@@ -49,7 +49,7 @@ exports.parse = function() {
 		node.attributes.tooltip = {type: "string", value: tooltip};
 	}
 	if(template) {
-		node.attributes.template = {type: "string", value: template};
+		node.attributes.template = {type: "string", value: $tw.wiki.getTemplate(template)};
 	}
 	if(style) {
 		node.attributes.style = {type: "string", value: style};

--- a/core/modules/parsers/wikiparser/rules/transcludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeblock.js
@@ -57,11 +57,7 @@ exports.parse = function() {
 		};
 	}
 	if(template) {
-		var tpl = $tw.wiki.getTiddler("$:/config/templates/" + template);
-		if(tpl) {
-			template = tpl.getFieldString("title");
-		}
-		transcludeNode.attributes.tiddler = {type: "string", value: template};
+		transcludeNode.attributes.tiddler = {type: "string", value: $tw.wiki.getTemplate(template)};
 		if(textRef) {
 			return [tiddlerNode];
 		} else {

--- a/core/modules/parsers/wikiparser/rules/transcludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeblock.js
@@ -57,6 +57,10 @@ exports.parse = function() {
 		};
 	}
 	if(template) {
+		var tpl = $tw.wiki.getTiddler("$:/config/templates/" + template);
+		if(tpl) {
+			template = tpl.getFieldString("title");
+		}
 		transcludeNode.attributes.tiddler = {type: "string", value: template};
 		if(textRef) {
 			return [tiddlerNode];

--- a/core/modules/parsers/wikiparser/rules/transcludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeinline.js
@@ -53,6 +53,10 @@ exports.parse = function() {
 		};
 	}
 	if(template) {
+		var tpl = $tw.wiki.getTiddler("$:/config/templates/" + template);
+		if(tpl) {
+			template = tpl.getFieldString("title");
+		}
 		transcludeNode.attributes.tiddler = {type: "string", value: template};
 		if(textRef) {
 			return [tiddlerNode];

--- a/core/modules/parsers/wikiparser/rules/transcludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeinline.js
@@ -53,11 +53,7 @@ exports.parse = function() {
 		};
 	}
 	if(template) {
-		var tpl = $tw.wiki.getTiddler("$:/config/templates/" + template);
-		if(tpl) {
-			template = tpl.getFieldString("title");
-		}
-		transcludeNode.attributes.tiddler = {type: "string", value: template};
+		transcludeNode.attributes.tiddler = {type: "string", value: $tw.wiki.getTemplate(template)};
 		if(textRef) {
 			return [tiddlerNode];
 		} else {

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1217,4 +1217,15 @@ exports.invokeUpgraders = function(titles,tiddlers) {
 	return messages;
 };
 
+/*
+If existing, retrieves a template tiddler from $:/config/templates/<templatename>, otherwise returns given title
+*/
+exports.getTemplate = function(title){
+	var template = "$:/config/templates/" + title;
+	if($tw.wiki.getTiddler(template)) {
+		title = template;
+	}
+	return title;
+};
+
 })();


### PR DESCRIPTION
**SystemTemplates** (#2086) allow to define templates under this system namespace:

`$:/config/templates/`

For example:

`$:/config/templates/mytemplate`

Which can be used like we're used to and overrule any tiddlers by that name:

`{{||mytemplate}}`

## Components

* added `$tw.wiki.getTemplate(title)` to
    * **$:/core/modules/wiki.js**
* implemented at
    * **$:/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js**
    * **$:/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js**
    * **$:/core/modules/parsers/wikiparser/rules/transcludeblock.js**
    * **$:/core/modules/parsers/wikiparser/rules/transcludeinline.js**

## Demo

http://2086.tiddlyspot.com