### PR TITLE
Changed Transclusion from html to TidlerWiki syntax in order to force…

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/Transclusion.tid
+++ b/editions/tw5.com/tiddlers/concepts/Transclusion.tid
@@ -3,7 +3,7 @@ modified: 20141130195444237
 tags: Concepts
 title: Transclusion
 
-<a href="http://en.wikipedia.org/wiki/Transclusion">Transclusion</a> is the process of referencing one tiddler "A" from another tiddler "B" such that the content of "A" appears to be a part of "B".
+[[Transclusion|http://en.wikipedia.org/wiki/Transclusion]] is the process of referencing one tiddler "A" from another tiddler "B" such that the content of "A" appears to be a part of "B".
 
 Copying and pasting content creates multiple copies of the same content in several different places. With transclusion, there can be a single copy and a special instruction in "B" which indicates the point at which content should be inserted from tiddler "A".
 


### PR DESCRIPTION
… new tab when following

With the html syntax when you go back after following the link knowledges of open tiddlers is lost.
Not sure if there should also be feature request for TiddlerWiki to store knowledge of open tiddlers in browser history.