### PR TITLE
getElementById support for fakedom

### DIFF
--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -68,7 +68,7 @@ TW_Element.prototype.setAttribute = function(name,value) {
 		throw "Cannot setAttribute on a raw TW_Element";
 	}
 	this.attributes[name] = value;
-	if(name === "id") {
+	if(name === "id" && !elements[value]) {
 		elements[value] = this;
 	}
 };

--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -13,7 +13,8 @@ A barebones implementation of DOM interfaces needed by the rendering mechanism.
 "use strict";
 
 // Sequence number used to enable us to track objects for testing
-var sequenceNumber = null;
+var sequenceNumber = null,
+	elements = {};
 
 var bumpSequenceNumber = function(object) {
 	if(sequenceNumber !== null) {
@@ -67,6 +68,9 @@ TW_Element.prototype.setAttribute = function(name,value) {
 		throw "Cannot setAttribute on a raw TW_Element";
 	}
 	this.attributes[name] = value;
+	if(name === "id") {
+		elements[value] = this;
+	}
 };
 
 TW_Element.prototype.setAttributeNS = function(namespace,name,value) {
@@ -78,6 +82,9 @@ TW_Element.prototype.removeAttribute = function(name) {
 		throw "Cannot removeAttribute on a raw TW_Element";
 	}
 	if($tw.utils.hop(this.attributes,name)) {
+		if(name === "id") {
+			delete elements[this.attributes.id];
+		}
 		delete this.attributes[name];
 	}
 };
@@ -262,6 +269,9 @@ var document = {
 	},
 	createTextNode: function(text) {
 		return new TW_TextNode(text);
+	},
+	getElementById: function(id){
+		return elements[id];
 	},
 	compatMode: "CSS1Compat", // For KaTeX to know that we're not a browser in quirks mode
 	isTiddlyWikiFakeDom: true


### PR DESCRIPTION
**Note:** This is intended for comparison and @Jermolene has [already expressed no desire to merge](https://github.com/tobibeer/tw5-dom/issues/1) it.

Uses a basic hash-table applying "the winner takes it all" logic. Specifically, the first element to register an id is the one the id points to, so long as...

* it exists
* the id attribute is not removed from it