### PR TITLE
allows to format a datestring with / as a random number

### DIFF
--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -190,6 +190,13 @@ exports.formatDateString = function(date,template) {
 	var result = "",
 		t = template,
 		matches = [
+			[/^RANDOM\((\d*)\)/, function(match) {
+				var r = Math.random().toString(36).substr(2);
+				if(match[1]) {
+					r = r.substr(0,Math.min(16,match[1]));
+				}
+				return r;
+			}],
 			[/^0hh12/, function() {
 				return $tw.utils.pad($tw.utils.getHours12(date));
 			}],
@@ -276,7 +283,7 @@ exports.formatDateString = function(date,template) {
 		$tw.utils.each(matches, function(m) {
 			var match = m[0].exec(t);
 			if(match) {
-				matchString = m[1].call();
+				matchString = m[1].call(this,match);
 				t = t.substr(match[0].length);
 				return false;
 			}


### PR DESCRIPTION
e.g. for use as `<<now YYYY-RANDOM(8)>>` or in code to generate an id from date+random via **formatDateString**.

The optional parameter in the brackets defines the length of the random string, maxing at 16 and also defaulting to that number. Character pool: alphanum + integers.

Relevant for what #2112 tries to achieve.