### PR TITLE
fixed tag-button colors in templates and macro

### DIFF
--- a/core/ui/Components/tag-link.tid
+++ b/core/ui/Components/tag-link.tid
@@ -1,9 +1,0 @@
-title: $:/core/ui/Components/tag-link
-
-<$link>
-<$set name="backgroundColor" value={{!!color}}>
-<span style=<<tag-styles>> class="tc-tag-label">
-<$view field="title" format="text"/>
-</span>
-</$set>
-</$link>

--- a/core/ui/EditTemplate/tags.tid
+++ b/core/ui/EditTemplate/tags.tid
@@ -2,22 +2,13 @@ title: $:/core/ui/EditTemplate/tags
 tags: $:/tags/EditTemplate
 
 \define lingo-base() $:/language/EditTemplate/
-\define tag-styles()
-background-color:$(backgroundColor)$;
-\end
-<div class="tc-edit-tags">
-<$fieldmangler>
-<$list filter="[all[current]tags[]sort[title]]" storyview="pop"><$set name="backgroundColor" value={{!!color}}><span style=<<tag-styles>> class="tc-tag-label">
-<$view field="title" format="text" />
-<$button message="tm-remove-tag" param={{!!title}} class="tc-btn-invisible tc-remove-tag-button">&times;</$button></span>
-</$set>
-</$list>
 
+\define addtag()
 <div class="tc-edit-add-tag">
 <span class="tc-add-tag-name">
-<$edit-text tiddler="$:/temp/NewTagName" tag="input" default="" placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}} focusPopup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-edit-texteditor tc-popup-handle"/>
+<$edit-text tiddler="$(newtag)$" tag="input" default="" placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}} focusPopup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-edit-texteditor tc-popup-handle"/>
 </span> <$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button> <span class="tc-add-tag-button">
-<$button message="tm-add-tag" param={{$:/temp/NewTagName}} set="$:/temp/NewTagName" setTo="" class="">
+<$button message="tm-add-tag" param={{$(newtag)$}} set="$(newtag)$" setTo="" class="">
 <<lingo Tags/Add/Button>>
 </$button>
 </span>
@@ -26,17 +17,35 @@ background-color:$(backgroundColor)$;
 <div class="tc-block-dropdown-wrapper">
 <$reveal state=<<qualify "$:/state/popup/tags-auto-complete">> type="nomatch" text="" default="">
 <div class="tc-block-dropdown">
-<$linkcatcher set="$:/temp/NewTagName" setTo="" message="tm-add-tag">
-<$list filter="[tags[]!is[system]search:title{$:/temp/NewTagName}sort[]]">
-{{||$:/core/ui/Components/tag-link}}
+<$linkcatcher set="$(newtag)$" setTo="" message="tm-add-tag">
+<$list filter="
+	[tags[]search:title{$(newtag)$}]
+	-[all[current]tags[]]
+	+[sort[]]">
+<<tag mode:link>>
 </$list>
 <hr>
-<$list filter="[tags[]is[system]search:title{$:/temp/NewTagName}sort[]]">
-{{||$:/core/ui/Components/tag-link}}
+<$list filter="
+	[!is[system]!has[draft.of]search:title{$(newtag)$}]
+	-[tags[]search:title{$(newtag)$}]
+	-[all[current]tags[]]
+	+[sort[]]">
+<<tag mode:link>>
 </$list>
 </$linkcatcher>
 </div>
 </$reveal>
 </div>
+\end
+
+<$set name="newtag" value=<<qualify "$:/temp/newtagName">>>
+<div class="tc-edit-tags">
+<$fieldmangler>
+<$list filter="[all[current]tags[]sort[title]]" storyview="pop">
+<<tag mode:"remove">>
+</$list>
+
+<<addtag>>
 </$fieldmangler>
 </div>
+</$set>

--- a/core/ui/TagTemplate.tid
+++ b/core/ui/TagTemplate.tid
@@ -1,30 +1,49 @@
 title: $:/core/ui/TagTemplate
 
-\define tag-styles()
-background-color:$(backgroundColor)$;
-fill:$(foregroundColor)$;
-color:$(foregroundColor)$;
-\end
+\define tag-styles() color:$(foregroundColor)$;background-color:$(backgroundColor)$;
+\define svg-style() fill:$(foregroundColor)$;
 
-\define tag-body-inner(colour,fallbackTarget,colourA,colourB)
-<$set name="foregroundColor" value=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">>>
-<$set name="backgroundColor" value="""$colour$""">
-<$button popup=<<qualify "$:/state/popup/tag">> class="tc-btn-invisible tc-tag-label" style=<<tag-styles>>>
-<$transclude tiddler={{!!icon}}/> <$view field="title" format="text" />
+\define tag-body-inner()
+<$vars foregroundColor=<<contrastcolour
+	target:"""$(backgroundColor)$"""
+	fallbackTarget:"""$(fallbackTarget)$"""
+	colourA:"""$(colourA)$"""
+	colourB:"""$(colourB)$""">>>
+<$reveal type="nomatch" text="$(tag-no-popup)$" default="">
+<span class="tc-btn-invisible tc-tag-label" style=<<tag-styles>>>
+<$transclude tiddler={{!!icon}}/><$view field="title" format="text"/>
+<$reveal type="nomatch" text="$(tag-remove)$" default="">
+<$button message="tm-remove-tag" param={{!!title}}
+class="tc-btn-invisible tc-remove-tag-button">&times;</$button>
+</$reveal>
+</span>
+</$reveal>
+<$reveal type="match" text="$(tag-no-popup)$" default="">
+<$button popup=<<qualify "$:/state/popup/tag">>
+class="tc-btn-invisible tc-tag-label" style=<<tag-styles>>>
+<$transclude tiddler={{!!icon}}/><$view field="title" format="text"/>
 </$button>
-<$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes"><div class="tc-drop-down"><$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+<$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes">
+<div class="tc-drop-down">
+<$transclude tiddler="$:/core/ui/ListItemTemplate"/>
 <hr>
 <$list filter="[all[current]tagging[]]" template="$:/core/ui/ListItemTemplate"/>
 </div>
 </$reveal>
-</$set>
-</$set>
+</$reveal>
+</$vars>
 \end
 
-\define tag-body(colour,palette)
+\define tag-body(palette)
+<$vars
+	backgroundColor={{!!color}}
+	fallbackTarget={{$palette$##tag-background}}
+	colourA={{$palette$##foreground}}
+	colourB={{$palette$##background}}>
+<<tag-body-inner>>
+</$vars>
+\end
+
 <span class="tc-tag-list-item">
-<$macrocall $name="tag-body-inner" colour="""$colour$""" fallbackTarget={{$palette$##tag-background}} colourA={{$palette$##foreground}} colourB={{$palette$##background}}/>
+<$macrocall $name="tag-body" palette={{$:/palette}}>
 </span>
-\end
-
-<$macrocall $name="tag-body" colour={{!!color}} palette={{$:/palette}}/>

--- a/core/ui/ViewTemplate/title.tid
+++ b/core/ui/ViewTemplate/title.tid
@@ -1,6 +1,9 @@
 title: $:/core/ui/ViewTemplate/title
 tags: $:/tags/ViewTemplate
 
+\define icon()
+<span class="tc-tiddler-title-icon" style=<<title-styles>>><$transclude tiddler={{!!icon}}/></span>
+\end
 \define title-styles()
 fill:$(foregroundColor)$;
 \end
@@ -12,25 +15,22 @@ $:/config/ViewToolbarButtons/Visibility/$(listItem)$
 <span class="tc-tiddler-controls">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]]" variable="listItem"><$reveal type="nomatch" state=<<config-title>> text="hide"><$transclude tiddler=<<listItem>>/></$reveal></$list>
 </span>
-<$set name="tv-wikilinks" value={{$:/config/Tiddlers/TitleLinks}}>
+<$vars
+	tv-wikilinks={{$:/config/Tiddlers/TitleLinks}}
+	foregroundColor={{!!color}}>
 <$link>
-<$set name="foregroundColor" value={{!!color}}>
-<span class="tc-tiddler-title-icon" style=<<title-styles>>>
-<$transclude tiddler={{!!icon}}/>
-</span>
-</$set>
 <$list filter="[all[current]removeprefix[$:/]]">
 <h2 class="tc-title" title={{$:/language/SystemTiddler/Tooltip}}>
-<span class="tc-system-title-prefix">$:/</span><$text text=<<currentTiddler>>/>
+<<icon>><span class="tc-system-title-prefix">$:/</span><$text text=<<currentTiddler>>/>
 </h2>
 </$list>
 <$list filter="[all[current]!prefix[$:/]]">
 <h2 class="tc-title">
-<$view field="title"/>
+<<icon>><$view field="title"/>
 </h2>
 </$list>
 </$link>
-</$set>
+</$vars>
 </div>
 
 <$reveal type="nomatch" text="" default="" state=<<tiddlerInfoState>> class="tc-tiddler-info tc-popup-handle" animate="yes" retain="yes">

--- a/core/wiki/macros/tag.tid
+++ b/core/wiki/macros/tag.tid
@@ -1,6 +1,20 @@
 title: $:/core/macros/tag
 tags: $:/tags/Macro
 
-\define tag(tag)
-{{$tag$||$:/core/ui/TagTemplate}}
+\define tag(tag,mode:"button")
+<$reveal type="match" default="$mode$" text="button">
+{{||$:/core/ui/TagTemplate}}
+</$reveal>
+<$reveal type="match" default="$mode$" text="link">
+<$vars tag-no-popup="true">
+<$link>
+{{||$:/core/ui/TagTemplate}}
+</$link>
+</$vars>
+</$reveal>
+<$reveal type="match" default="$mode$" text="remove">
+<$vars tag-no-popup="true" tag-remove="true">
+{{||$:/core/ui/TagTemplate}}
+</$vars>
+</$reveal>
 \end

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -321,8 +321,13 @@ a.tc-tiddlylink-external:hover {
 ** Buttons
 */
 
-button svg, button img {
+button svg, button img,
+.tc-tag-label .tc-image-button{
 	vertical-align: middle;
+}
+
+.tc-tag-label .tc-image-button{
+margin-right: 3px;
 }
 
 .tc-btn-invisible {
@@ -820,6 +825,7 @@ button.tc-untagged-label {
 
 .tc-tiddler-title-icon {
 	vertical-align: middle;
+	margin-right:5px;
 }
 
 .tc-system-title-prefix {


### PR DESCRIPTION
replaces #1379

fixes edit-mode tags and enhances tag macro

* **modified**
* *$:/core/ui/EditTemplate/tags*
    * now uses proper contrast color
    * harmonized with ViewTemplate via...
* *$:/core/macros/tag*
    * enhanced with different modes to render a tag as:
        * either a **button**
        * or a **link**
        * or an X to **remove** it
* *$:/core/ui/TagTemplate*
    * enhanced to cater for tag-button-modes
    * removed `fill:$(foregroundColor)$;` as it was __''not''__ addressing the svg!
        * introduced a &lt;&lt;svg-style>> variable
            * all core button svg need to define this as a placeholder, on top of stylesheet declarations
* *$:/tags/ViewTemplate*
    * it was showing a superfluous, underlined blank if a tiddler had an icon and title-links enabled
        * also placed icon inside heading, not before
        * in this PR because since it's a simple fix and would otherwise be more difficult to merge with both changing vanilla/base
* *$:/themes/tiddlywiki/vanilla/base*
    * to cater for proper icon positioning and title fix
* **removed**
* *$:/core/ui/Components/tag-link.tid*
    * no longer needed

## Differences to #1379

* no changes to &lt;&lt;contrastcolour>>
* moved helper macros back from tag macro to TagTemplate so as to not clutter the global variable space
* svg fix preparation
* title fix

## Demo

http://2119.tiddlyspot.com