### PR TITLE
always set emptyValue, not just for filter

### DIFF
--- a/core/modules/widgets/setvariable.js
+++ b/core/modules/widgets/setvariable.js
@@ -61,6 +61,8 @@ SetWidget.prototype.getValue = function() {
 		if(results.length === 0 && this.setEmptyValue !== undefined) {
 			value = this.setEmptyValue;
 		}
+	} else if(!value && this.setEmptyValue) {
+		value = this.setEmptyValue;
 	}
 	return value;
 };


### PR DESCRIPTION
I often find myself in need to see if a parameter is defined and if not to set a dynamic (!) fallback, not one defined as the default. It only seems consistent to apply **emptyValue** if the user bothered specifying it.