### PR TITLE
Add displayMode attribute to katex widget.

### DIFF
--- a/licenses/cla-individual.md
+++ b/licenses/cla-individual.md
@@ -256,3 +256,5 @@ Tony Grosinger @tgrosinger 2015/10/03
 Antaeus Feldspar @afeldspar 2015/10/20
 
 Soeren Enevoldsen, @senevoldsen90, 2015/10/09
+
+Santiago Pelufo, @spelufo, 2015/12/18

--- a/plugins/tiddlywiki/katex/latex-parser.js
+++ b/plugins/tiddlywiki/katex/latex-parser.js
@@ -29,23 +29,26 @@ exports.types = {inline: true};
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /\$\$(?!\$)/mg;
+	this.matchRegExp = /\$\$?(?!\$)/mg;
 };
 
 exports.parse = function() {
 	// Move past the match
 	this.parser.pos = this.matchRegExp.lastIndex;
-	var reEnd = /\$\$/mg;
+	var reEnd = /\$\$?/mg;
 	// Look for the end marker
 	reEnd.lastIndex = this.parser.pos;
 	var match = reEnd.exec(this.parser.source),
-		text;
+		text,
+		displayMode;
 	// Process the text
 	if(match) {
 		text = this.parser.source.substring(this.parser.pos,match.index);
+		displayMode = match.indexOf('$$') != -1;
 		this.parser.pos = match.index + match[0].length;
 	} else {
 		text = this.parser.source.substr(this.parser.pos);
+		displayMode = false;
 		this.parser.pos = this.parser.sourceLength;
 	}
 	return [{
@@ -54,7 +57,12 @@ exports.parse = function() {
 			text: {
 				type: "text",
 				value: text
-			}}
+			},
+			displayMode: {
+				type: "text",
+				value: displayMode ? "true" : "false"
+			}
+		}
 	}];
 };
 

--- a/plugins/tiddlywiki/katex/wrapper.js
+++ b/plugins/tiddlywiki/katex/wrapper.js
@@ -34,9 +34,10 @@ KaTeXWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	// Get the source text
 	var text = this.getAttribute("text",this.parseTreeNode.text || "");
+	var displayMode = this.getAttribute("displayMode",this.parseTreeNode.displayMode || "false") === "true";
 	// Render it into a span
 	var span = this.document.createElement("span"),
-		options = {throwOnError: false};
+		options = {throwOnError: false, displayMode: displayMode};
 	try {
 		if(!this.document.isTiddlyWikiFakeDom) {
 			katex.render(text,span,options);


### PR DESCRIPTION
Hi, as far as I can tell the katex plugin always renders math in inline mode. This pull request makes it possible to use `<$katex text="\bold x + 3" displayMode="true" />` to render equations in display mode.

In my opiniton it would be best if `$$ ... $$` could default to display mode, and `$ ... $` to inline mode, like with most latex code, but perhaps `$ ... $` is already used for something else.

Edit: Sorry, I pushed the latex-parser commit to my fork and it automatically added it to this PR. I'm closing this and opening a new one with the first commit alone.