### PR TITLE
Add displayMode attribute to katex widget

### DIFF
--- a/licenses/cla-individual.md
+++ b/licenses/cla-individual.md
@@ -256,3 +256,5 @@ Tony Grosinger @tgrosinger 2015/10/03
 Antaeus Feldspar @afeldspar 2015/10/20
 
 Soeren Enevoldsen, @senevoldsen90, 2015/10/09
+
+Santiago Pelufo, @spelufo, 2015/12/18

--- a/plugins/tiddlywiki/katex/wrapper.js
+++ b/plugins/tiddlywiki/katex/wrapper.js
@@ -34,9 +34,10 @@ KaTeXWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	// Get the source text
 	var text = this.getAttribute("text",this.parseTreeNode.text || "");
+	var displayMode = this.getAttribute("displayMode",this.parseTreeNode.displayMode || "false") === "true";
 	// Render it into a span
 	var span = this.document.createElement("span"),
-		options = {throwOnError: false};
+		options = {throwOnError: false, displayMode: displayMode};
 	try {
 		if(!this.document.isTiddlyWikiFakeDom) {
 			katex.render(text,span,options);


### PR DESCRIPTION
Hi, as far as I can tell the katex plugin always renders math in inline mode. This pull request makes it possible to use `<$katex text="\bold x + 3" displayMode="true" />` to render equations in display mode.