### PR TITLE
Add Google, Inc as a signer of the entity CLA.

### DIFF
--- a/licenses/cla-entity.md
+++ b/licenses/cla-entity.md
@@ -114,3 +114,4 @@ Contributors
 ------------
 
 Jeremy Ruston, @Jermolene for Federatial Limited, 2011/11/22
+Google Inc, 2015/12/21


### PR DESCRIPTION
I emailed a PDF with an actual signature, a moment ago, to jeremy@jermolene.com.  My understanding is that this signature would be valid not just for me but for other Googlers who contribute to TiddlyWiki in future, if there are any.  So I've omitted my personal name from the signature line - I think this is probably the way it's supposed to be?  If you look at the PDF you'll see that it's actually one of our lawyers who agreed to it, not me as an individual.  I'll be using my @google.com email address for this and any future patches, so record-keeping at TiddlyWiki's end shouldn't need a record of GitHub usernames.