### PR TITLE
Fix: bug in ActionSetField widget: currentTiddler!!text may be inadvertently cleared

### DIFF
--- a/core/modules/widgets/action-setfield.js
+++ b/core/modules/widgets/action-setfield.js
@@ -6,72 +6,74 @@ module-type: widget
 Action widget to set a single field or index on a tiddler.
 
 \*/
-(function(){
+(function () {
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
-"use strict";
+    /*jslint node: true, browser: true */
+    /*global $tw: false */
+    "use strict";
 
-var Widget = require("$:/core/modules/widgets/widget.js").widget;
+    var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
-var SetFieldWidget = function(parseTreeNode,options) {
-	this.initialise(parseTreeNode,options);
-};
+    var SetFieldWidget = function (parseTreeNode, options) {
+        this.initialise(parseTreeNode, options);
+    };
 
-/*
-Inherit from the base widget class
-*/
-SetFieldWidget.prototype = new Widget();
+    /*
+    Inherit from the base widget class
+    */
+    SetFieldWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
-SetFieldWidget.prototype.render = function(parent,nextSibling) {
-	this.computeAttributes();
-	this.execute();
-};
+    /*
+    Render this widget into the DOM
+    */
+    SetFieldWidget.prototype.render = function (parent, nextSibling) {
+        this.computeAttributes();
+        this.execute();
+    };
 
-/*
-Compute the internal state of the widget
-*/
-SetFieldWidget.prototype.execute = function() {
-	this.actionTiddler = this.getAttribute("$tiddler",this.getVariable("currentTiddler"));
-	this.actionField = this.getAttribute("$field");
-	this.actionIndex = this.getAttribute("$index");
-	this.actionValue = this.getAttribute("$value");
-	this.actionTimestamp = this.getAttribute("$timestamp","yes") === "yes";
-};
+    /*
+    Compute the internal state of the widget
+    */
+    SetFieldWidget.prototype.execute = function () {
+        this.actionTiddler = this.getAttribute("$tiddler", this.getVariable("currentTiddler"));
+        this.actionField = this.getAttribute("$field");
+        this.actionIndex = this.getAttribute("$index");
+        this.actionValue = this.getAttribute("$value");
+        this.actionTimestamp = this.getAttribute("$timestamp", "yes") === "yes";
+    };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
-SetFieldWidget.prototype.refresh = function(changedTiddlers) {
-	var changedAttributes = this.computeAttributes();
-	if(changedAttributes["$tiddler"] || changedAttributes["$field"] || changedAttributes["$index"] || changedAttributes["$value"]) {
-		this.refreshSelf();
-		return true;
-	}
-	return this.refreshChildren(changedTiddlers);
-};
+    /*
+    Refresh the widget by ensuring our attributes are up to date
+    */
+    SetFieldWidget.prototype.refresh = function (changedTiddlers) {
+        var changedAttributes = this.computeAttributes();
+        if (changedAttributes["$tiddler"] || changedAttributes["$field"] || changedAttributes["$index"] || changedAttributes["$value"]) {
+            this.refreshSelf();
+            return true;
+        }
+        return this.refreshChildren(changedTiddlers);
+    };
 
-/*
-Invoke the action associated with this widget
-*/
-SetFieldWidget.prototype.invokeAction = function(triggeringWidget,event) {
-	var self = this,
-		options = {};
-	options.suppressTimestamp = !this.actionTimestamp;
-	if((typeof this.actionField == "string") || (typeof this.actionIndex == "string")  || (typeof this.actionValue == "string")) {
-		this.wiki.setText(this.actionTiddler,this.actionField,this.actionIndex,this.actionValue,options);
-	}
-	$tw.utils.each(this.attributes,function(attribute,name) {
-		if(name.charAt(0) !== "$") {
-			self.wiki.setText(self.actionTiddler,name,undefined,attribute,options);
-		}
-	});
-	return true; // Action was invoked
-};
+    /*
+    Invoke the action associated with this widget
+    */
+    SetFieldWidget.prototype.invokeAction = function (triggeringWidget, event) {
+        var self = this,
+            options = {};
+        options.suppressTimestamp = !this.actionTimestamp;
+        if (this.actionField) {
+            this.wiki.setText(this.actionTiddler, this.actionField, this.actionIndex, this.actionValue, options);
+        }
+        $tw.utils.each(this.attributes, function (attribute, name) {
+            if (name.charAt(0) !== "$") {
+                (name.search("!!") !== -1 || name.search("##") !== -1) ?
+                self.wiki.setTextReference(name, attribute, self.actionTiddler) :
+                self.wiki.setText(self.actionTiddler, name, undefined, attribute, options);
+            }
+        });
+        return true; // Action was invoked
+    };
 
-exports["action-setfield"] = SetFieldWidget;
+    exports["action-setfield"] = SetFieldWidget;
 
 })();


### PR DESCRIPTION
If the `$field` and `$value` attributes are not set, the 'text' field of the current tiddler gets cleared (default field="text", default value="")

I've added an if() clause to check for the existence of the `field` attribute.

Whilst I was at it -- I added the facility to set any number of TextReferences with the widget. This means that values may be set for more than one data index, and different tiddlers may be targeted with the same widget.