### PR TITLE
Fix inadvertent clearing of text field (default) when `field` attribu…

### DIFF
--- a/core/modules/widgets/action-setfield.js
+++ b/core/modules/widgets/action-setfield.js
@@ -59,14 +59,16 @@ Invoke the action associated with this widget
 */
 SetFieldWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var self = this,
-		options = {};
+	    options = {};
 	options.suppressTimestamp = !this.actionTimestamp;
-	if((typeof this.actionField == "string") || (typeof this.actionIndex == "string")  || (typeof this.actionValue == "string")) {
-		this.wiki.setText(this.actionTiddler,this.actionField,this.actionIndex,this.actionValue,options);
+	if (this.actionField) {
+		this.wiki.setText(this.actionTiddler, this.actionField, this.actionIndex, this.actionValue, options);
 	}
-	$tw.utils.each(this.attributes,function(attribute,name) {
-		if(name.charAt(0) !== "$") {
-			self.wiki.setText(self.actionTiddler,name,undefined,attribute,options);
+	$tw.utils.each(this.attributes, function (attribute, name) {
+		if (name.charAt(0) !== "$") {
+			(name.search("!!") !== -1 || name.search("##") !== -1) ?
+			self.wiki.setTextReference(name, attribute, self.actionTiddler):
+			self.wiki.setText(self.actionTiddler, name, undefined, attribute, options);
 		}
 	});
 	return true; // Action was invoked


### PR DESCRIPTION
…te of the ActionSetField widget isn't set.

When using the widget with only short form SetText attributes (field="value) -- the default field (text) of the default tiddler is set to the default value ("") -- thus clearing the text field of the current tiddler. I have inserted a conditional to test for the presence of the `field` attribute.

Whilst I was about this, I have inserted code to enable the setting of any number of TextReferences -- this fixes the issue of only being able to set one index per widget and also allows different tiddlers to be targeted by the same widget.