### PR TITLE
Remove `tag` and `invertTag` attributes and related code from the Checkbox widget

### DIFF
--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -3,167 +3,118 @@ title: $:/core/modules/widgets/checkbox.js
 type: application/javascript
 module-type: widget
 
-Checkbox widget
+The Checkbox widget toggles the value of a field between two string values
 
 \*/
-(function(){
+(function () {
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
-"use strict";
+	/*jslint node: true, browser: true */
+	/*global $tw: false */
+	"use strict";
 
-var Widget = require("$:/core/modules/widgets/widget.js").widget;
+	var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
-var CheckboxWidget = function(parseTreeNode,options) {
-	this.initialise(parseTreeNode,options);
-};
+	var CheckboxWidget = function (parseTreeNode, options) {
+		this.initialise(parseTreeNode, options);
+	};
 
-/*
-Inherit from the base widget class
-*/
-CheckboxWidget.prototype = new Widget();
+	/*
+	Inherit from the base widget class
+	*/
+	CheckboxWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
-CheckboxWidget.prototype.render = function(parent,nextSibling) {
-	// Save the parent dom node
-	this.parentDomNode = parent;
-	// Compute our attributes
-	this.computeAttributes();
-	// Execute our logic
-	this.execute();
-	// Create our elements
-	this.labelDomNode = this.document.createElement("label");
-	this.labelDomNode.setAttribute("class",this.checkboxClass);
-	this.inputDomNode = this.document.createElement("input");
-	this.inputDomNode.setAttribute("type","checkbox");
-	if(this.getValue()) {
-		this.inputDomNode.setAttribute("checked","true");
-	}
-	this.labelDomNode.appendChild(this.inputDomNode);
-	this.spanDomNode = this.document.createElement("span");
-	this.labelDomNode.appendChild(this.spanDomNode);
-	// Add a click event handler
-	$tw.utils.addEventListeners(this.inputDomNode,[
-		{name: "change", handlerObject: this, handlerMethod: "handleChangeEvent"}
-	]);
-	// Insert the label into the DOM and render any children
-	parent.insertBefore(this.labelDomNode,nextSibling);
-	this.renderChildren(this.spanDomNode,null);
-	this.domNodes.push(this.labelDomNode);
-};
+	/*
+	Render this widget into the DOM
+	*/
+	CheckboxWidget.prototype.render = function (parent, nextSibling) {
+		this.parentDomNode = parent;
+		this.computeAttributes();
+		this.execute();
+		this.labelDomNode = this.document.createElement("label");
+		this.labelDomNode.setAttribute("class", this.checkboxClass);
+		this.inputDomNode = this.document.createElement("input");
+		this.inputDomNode.setAttribute("type", "checkbox");
+		if (this.getValue()) {
+			this.inputDomNode.setAttribute("checked", "true");
+		}
+		this.labelDomNode.appendChild(this.inputDomNode);
+		this.spanDomNode = this.document.createElement("span");
+		this.labelDomNode.appendChild(this.spanDomNode);
+		$tw.utils.addEventListeners(this.inputDomNode, [{
+			name: "change",
+			handlerObject: this,
+			handlerMethod: "handleChangeEvent"
+		}]);
+		parent.insertBefore(this.labelDomNode, nextSibling);
+		this.renderChildren(this.spanDomNode, null);
+		this.domNodes.push(this.labelDomNode);
+	};
 
-CheckboxWidget.prototype.getValue = function() {
-	var tiddler = this.wiki.getTiddler(this.checkboxTitle);
-	if(tiddler) {
-		if(this.checkboxTag) {
-			if(this.checkboxInvertTag) {
-				return !tiddler.hasTag(this.checkboxTag);
-			} else {
-				return tiddler.hasTag(this.checkboxTag);
+	CheckboxWidget.prototype.getValue = function () {
+		var tiddler = this.wiki.getTiddler(this.checkboxTitle),
+			value;
+		if (tiddler && this.checkboxField) {
+			value = tiddler.fields[this.checkboxField] || this.checkboxDefault || "";
+		} else {
+			value = this.checkboxDefault;
+		}
+		return (value === this.checkboxChecked) ? true :
+			(value === this.checkboxUnchecked) ? false :
+			false;
+	};
+
+	CheckboxWidget.prototype.handleChangeEvent = function (event) {
+		var checked = this.inputDomNode.checked,
+			tiddler = this.wiki.getTiddler(this.checkboxTitle),
+			fallbackFields = {text: ""},
+			newFields = {title: this.checkboxTitle},
+			hasChanged = false;
+		// Set the field if specified
+		if (this.checkboxField) {
+			var value = checked ? this.checkboxChecked : this.checkboxUnchecked;
+			if (!tiddler || tiddler.fields[this.checkboxField] !== value) {
+				newFields[this.checkboxField] = value;
+				hasChanged = true;
 			}
 		}
-		if(this.checkboxField) {
-			var value = tiddler.fields[this.checkboxField] || this.checkboxDefault || "";
-			if(value === this.checkboxChecked) {
-				return true;
-			}
-			if(value === this.checkboxUnchecked) {
-				return false;
-			}
+		if (hasChanged) {
+			this.wiki.addTiddler(new $tw.Tiddler(this.wiki.getCreationFields(), fallbackFields, tiddler, newFields, this.wiki.getModificationFields()));
 		}
-	} else {
-		if(this.checkboxTag) {
-			return false;
-		}
-		if(this.checkboxField) {
-			if(this.checkboxDefault === this.checkboxChecked) {
-				return true;
-			}
-			if(this.checkboxDefault === this.checkboxUnchecked) {
-				return false;
-			}
-		}
-	}
-	return false;
-};
+	};
 
-CheckboxWidget.prototype.handleChangeEvent = function(event) {
-	var checked = this.inputDomNode.checked,
-		tiddler = this.wiki.getTiddler(this.checkboxTitle),
-		fallbackFields = {text: ""},
-		newFields = {title: this.checkboxTitle},
-		hasChanged = false,
-		tagCheck = false,
-		hasTag = tiddler && tiddler.hasTag(this.checkboxTag);
-	if(this.checkboxTag && this.checkboxInvertTag === "yes") {
-		tagCheck = hasTag === checked;
-	} else {
-		tagCheck = hasTag !== checked;
-	}
-	// Set the tag if specified
-	if(this.checkboxTag && (!tiddler || tagCheck)) {
-		newFields.tags = tiddler ? (tiddler.fields.tags || []).slice(0) : [];
-		var pos = newFields.tags.indexOf(this.checkboxTag);
-		if(pos !== -1) {
-			newFields.tags.splice(pos,1);
-		}
-		if(this.checkboxInvertTag === "yes" && !checked) {
-			newFields.tags.push(this.checkboxTag);
-		} else if(this.checkboxInvertTag !== "yes" && checked) {
-			newFields.tags.push(this.checkboxTag);
-		}
-		hasChanged = true;
-	}
-	// Set the field if specified
-	if(this.checkboxField) {
-		var value = checked ? this.checkboxChecked : this.checkboxUnchecked;
-		if(!tiddler || tiddler.fields[this.checkboxField] !== value) {
-			newFields[this.checkboxField] = value;
-			hasChanged = true;
-		}
-	}
-	if(hasChanged) {
-		this.wiki.addTiddler(new $tw.Tiddler(this.wiki.getCreationFields(),fallbackFields,tiddler,newFields,this.wiki.getModificationFields()));
-	}
-};
+	/*
+	Compute the internal state of the widget
+	*/
+	CheckboxWidget.prototype.execute = function () {
+		// Get the parameters from the attributes
+		this.checkboxTitle = this.getAttribute("tiddler", this.getVariable("currentTiddler"));
+		this.checkboxField = this.getAttribute("field");
+		this.checkboxChecked = this.getAttribute("checked");
+		this.checkboxUnchecked = this.getAttribute("unchecked");
+		this.checkboxDefault = this.getAttribute("default");
+		this.checkboxClass = this.getAttribute("class", "");
+		// Make the child widgets
+		this.makeChildWidgets();
+	};
 
-/*
-Compute the internal state of the widget
-*/
-CheckboxWidget.prototype.execute = function() {
-	// Get the parameters from the attributes
-	this.checkboxTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
-	this.checkboxTag = this.getAttribute("tag");
-	this.checkboxField = this.getAttribute("field");
-	this.checkboxChecked = this.getAttribute("checked");
-	this.checkboxUnchecked = this.getAttribute("unchecked");
-	this.checkboxDefault = this.getAttribute("default");
-	this.checkboxClass = this.getAttribute("class","");
-	this.checkboxInvertTag = this.getAttribute("invertTag","");
-	// Make the child widgets
-	this.makeChildWidgets();
-};
-
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
-CheckboxWidget.prototype.refresh = function(changedTiddlers) {
-	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedAttributes.tag || changedAttributes.invertTag || changedAttributes.field || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes["class"]) {
-		this.refreshSelf();
-		return true;
-	} else {
-		var refreshed = false;
-		if(changedTiddlers[this.checkboxTitle]) {
-			this.inputDomNode.checked = this.getValue();
-			refreshed = true;
+	/*
+	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+	*/
+	CheckboxWidget.prototype.refresh = function (changedTiddlers) {
+		var changedAttributes = this.computeAttributes();
+		if (changedAttributes.tiddler || changedAttributes.field || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes["class"]) {
+			this.refreshSelf();
+			return true;
+		} else {
+			var refreshed = false;
+			if (changedTiddlers[this.checkboxTitle]) {
+				this.inputDomNode.checked = this.getValue();
+				refreshed = true;
+			}
+			return this.refreshChildren(changedTiddlers) || refreshed;
 		}
-		return this.refreshChildren(changedTiddlers) || refreshed;
-	}
-};
+	};
 
-exports.checkbox = CheckboxWidget;
+	exports.checkbox = CheckboxWidget;
 
 })();

--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -6,7 +6,7 @@ module-type: widget
 The Checkbox widget toggles the value of a field between two string values
 
 \*/
-(function () {
+(function() {
 
 /*jslint node: true, browser: true */
 /*global $tw: false */
@@ -14,7 +14,7 @@ The Checkbox widget toggles the value of a field between two string values
 
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
-var CheckboxWidget = function (parseTreeNode, options) {
+var CheckboxWidget = function(parseTreeNode, options) {
 	this.initialise(parseTreeNode, options);
 };
 
@@ -26,7 +26,7 @@ CheckboxWidget.prototype = new Widget();
 /*
 Render this widget into the DOM
 */
-CheckboxWidget.prototype.render = function (parent, nextSibling) {
+CheckboxWidget.prototype.render = function(parent, nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
@@ -34,7 +34,7 @@ CheckboxWidget.prototype.render = function (parent, nextSibling) {
 	this.labelDomNode.setAttribute("class", this.checkboxClass);
 	this.inputDomNode = this.document.createElement("input");
 	this.inputDomNode.setAttribute("type", "checkbox");
-	if (this.getValue()) {
+	if(this.getValue()) {
 		this.inputDomNode.setAttribute("checked", "true");
 	}
 	this.labelDomNode.appendChild(this.inputDomNode);
@@ -50,34 +50,38 @@ CheckboxWidget.prototype.render = function (parent, nextSibling) {
 	this.domNodes.push(this.labelDomNode);
 };
 
-CheckboxWidget.prototype.getValue = function () {
+CheckboxWidget.prototype.getValue = function() {
 	var tiddler = this.wiki.getTiddler(this.checkboxTitle),
 		value;
-	if (tiddler && this.checkboxField) {
+	if(tiddler && this.checkboxField) {
 		value = tiddler.fields[this.checkboxField] || this.checkboxDefault || "";
 	} else {
 		value = this.checkboxDefault;
 	}
-	return (value === this.checkboxChecked) ? true :
+	return(value === this.checkboxChecked) ? true :
 		(value === this.checkboxUnchecked) ? false :
 		false;
 };
 
-CheckboxWidget.prototype.handleChangeEvent = function (event) {
+CheckboxWidget.prototype.handleChangeEvent = function(event) {
 	var checked = this.inputDomNode.checked,
 		tiddler = this.wiki.getTiddler(this.checkboxTitle),
-		fallbackFields = {text: ""},
-		newFields = {title: this.checkboxTitle},
+		fallbackFields = {
+			text: ""
+		},
+		newFields = {
+			title: this.checkboxTitle
+		},
 		hasChanged = false;
 	// Set the field if specified
-	if (this.checkboxField) {
+	if(this.checkboxField) {
 		var value = checked ? this.checkboxChecked : this.checkboxUnchecked;
-		if (!tiddler || tiddler.fields[this.checkboxField] !== value) {
+		if(!tiddler || tiddler.fields[this.checkboxField] !== value) {
 			newFields[this.checkboxField] = value;
 			hasChanged = true;
 		}
 	}
-	if (hasChanged) {
+	if(hasChanged) {
 		this.wiki.addTiddler(new $tw.Tiddler(this.wiki.getCreationFields(), fallbackFields, tiddler, newFields, this.wiki.getModificationFields()));
 	}
 };
@@ -85,7 +89,7 @@ CheckboxWidget.prototype.handleChangeEvent = function (event) {
 /*
 Compute the internal state of the widget
 */
-CheckboxWidget.prototype.execute = function () {
+CheckboxWidget.prototype.execute = function() {
 	// Get the parameters from the attributes
 	this.checkboxTitle = this.getAttribute("tiddler", this.getVariable("currentTiddler"));
 	this.checkboxField = this.getAttribute("field");
@@ -100,14 +104,14 @@ CheckboxWidget.prototype.execute = function () {
 /*
 Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 */
-CheckboxWidget.prototype.refresh = function (changedTiddlers) {
+CheckboxWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if (changedAttributes.tiddler || changedAttributes.field || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes["class"]) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes["class"]) {
 		this.refreshSelf();
 		return true;
 	} else {
 		var refreshed = false;
-		if (changedTiddlers[this.checkboxTitle]) {
+		if(changedTiddlers[this.checkboxTitle]) {
 			this.inputDomNode.checked = this.getValue();
 			refreshed = true;
 		}

--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -8,113 +8,113 @@ The Checkbox widget toggles the value of a field between two string values
 \*/
 (function () {
 
-	/*jslint node: true, browser: true */
-	/*global $tw: false */
-	"use strict";
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
 
-	var Widget = require("$:/core/modules/widgets/widget.js").widget;
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
-	var CheckboxWidget = function (parseTreeNode, options) {
-		this.initialise(parseTreeNode, options);
-	};
+var CheckboxWidget = function (parseTreeNode, options) {
+	this.initialise(parseTreeNode, options);
+};
 
-	/*
-	Inherit from the base widget class
-	*/
-	CheckboxWidget.prototype = new Widget();
+/*
+Inherit from the base widget class
+*/
+CheckboxWidget.prototype = new Widget();
 
-	/*
-	Render this widget into the DOM
-	*/
-	CheckboxWidget.prototype.render = function (parent, nextSibling) {
-		this.parentDomNode = parent;
-		this.computeAttributes();
-		this.execute();
-		this.labelDomNode = this.document.createElement("label");
-		this.labelDomNode.setAttribute("class", this.checkboxClass);
-		this.inputDomNode = this.document.createElement("input");
-		this.inputDomNode.setAttribute("type", "checkbox");
-		if (this.getValue()) {
-			this.inputDomNode.setAttribute("checked", "true");
+/*
+Render this widget into the DOM
+*/
+CheckboxWidget.prototype.render = function (parent, nextSibling) {
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
+	this.labelDomNode = this.document.createElement("label");
+	this.labelDomNode.setAttribute("class", this.checkboxClass);
+	this.inputDomNode = this.document.createElement("input");
+	this.inputDomNode.setAttribute("type", "checkbox");
+	if (this.getValue()) {
+		this.inputDomNode.setAttribute("checked", "true");
+	}
+	this.labelDomNode.appendChild(this.inputDomNode);
+	this.spanDomNode = this.document.createElement("span");
+	this.labelDomNode.appendChild(this.spanDomNode);
+	$tw.utils.addEventListeners(this.inputDomNode, [{
+		name: "change",
+		handlerObject: this,
+		handlerMethod: "handleChangeEvent"
+	}]);
+	parent.insertBefore(this.labelDomNode, nextSibling);
+	this.renderChildren(this.spanDomNode, null);
+	this.domNodes.push(this.labelDomNode);
+};
+
+CheckboxWidget.prototype.getValue = function () {
+	var tiddler = this.wiki.getTiddler(this.checkboxTitle),
+		value;
+	if (tiddler && this.checkboxField) {
+		value = tiddler.fields[this.checkboxField] || this.checkboxDefault || "";
+	} else {
+		value = this.checkboxDefault;
+	}
+	return (value === this.checkboxChecked) ? true :
+		(value === this.checkboxUnchecked) ? false :
+		false;
+};
+
+CheckboxWidget.prototype.handleChangeEvent = function (event) {
+	var checked = this.inputDomNode.checked,
+		tiddler = this.wiki.getTiddler(this.checkboxTitle),
+		fallbackFields = {text: ""},
+		newFields = {title: this.checkboxTitle},
+		hasChanged = false;
+	// Set the field if specified
+	if (this.checkboxField) {
+		var value = checked ? this.checkboxChecked : this.checkboxUnchecked;
+		if (!tiddler || tiddler.fields[this.checkboxField] !== value) {
+			newFields[this.checkboxField] = value;
+			hasChanged = true;
 		}
-		this.labelDomNode.appendChild(this.inputDomNode);
-		this.spanDomNode = this.document.createElement("span");
-		this.labelDomNode.appendChild(this.spanDomNode);
-		$tw.utils.addEventListeners(this.inputDomNode, [{
-			name: "change",
-			handlerObject: this,
-			handlerMethod: "handleChangeEvent"
-		}]);
-		parent.insertBefore(this.labelDomNode, nextSibling);
-		this.renderChildren(this.spanDomNode, null);
-		this.domNodes.push(this.labelDomNode);
-	};
+	}
+	if (hasChanged) {
+		this.wiki.addTiddler(new $tw.Tiddler(this.wiki.getCreationFields(), fallbackFields, tiddler, newFields, this.wiki.getModificationFields()));
+	}
+};
 
-	CheckboxWidget.prototype.getValue = function () {
-		var tiddler = this.wiki.getTiddler(this.checkboxTitle),
-			value;
-		if (tiddler && this.checkboxField) {
-			value = tiddler.fields[this.checkboxField] || this.checkboxDefault || "";
-		} else {
-			value = this.checkboxDefault;
+/*
+Compute the internal state of the widget
+*/
+CheckboxWidget.prototype.execute = function () {
+	// Get the parameters from the attributes
+	this.checkboxTitle = this.getAttribute("tiddler", this.getVariable("currentTiddler"));
+	this.checkboxField = this.getAttribute("field");
+	this.checkboxChecked = this.getAttribute("checked");
+	this.checkboxUnchecked = this.getAttribute("unchecked");
+	this.checkboxDefault = this.getAttribute("default");
+	this.checkboxClass = this.getAttribute("class", "");
+	// Make the child widgets
+	this.makeChildWidgets();
+};
+
+/*
+Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+*/
+CheckboxWidget.prototype.refresh = function (changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if (changedAttributes.tiddler || changedAttributes.field || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes["class"]) {
+		this.refreshSelf();
+		return true;
+	} else {
+		var refreshed = false;
+		if (changedTiddlers[this.checkboxTitle]) {
+			this.inputDomNode.checked = this.getValue();
+			refreshed = true;
 		}
-		return (value === this.checkboxChecked) ? true :
-			(value === this.checkboxUnchecked) ? false :
-			false;
-	};
+		return this.refreshChildren(changedTiddlers) || refreshed;
+	}
+};
 
-	CheckboxWidget.prototype.handleChangeEvent = function (event) {
-		var checked = this.inputDomNode.checked,
-			tiddler = this.wiki.getTiddler(this.checkboxTitle),
-			fallbackFields = {text: ""},
-			newFields = {title: this.checkboxTitle},
-			hasChanged = false;
-		// Set the field if specified
-		if (this.checkboxField) {
-			var value = checked ? this.checkboxChecked : this.checkboxUnchecked;
-			if (!tiddler || tiddler.fields[this.checkboxField] !== value) {
-				newFields[this.checkboxField] = value;
-				hasChanged = true;
-			}
-		}
-		if (hasChanged) {
-			this.wiki.addTiddler(new $tw.Tiddler(this.wiki.getCreationFields(), fallbackFields, tiddler, newFields, this.wiki.getModificationFields()));
-		}
-	};
-
-	/*
-	Compute the internal state of the widget
-	*/
-	CheckboxWidget.prototype.execute = function () {
-		// Get the parameters from the attributes
-		this.checkboxTitle = this.getAttribute("tiddler", this.getVariable("currentTiddler"));
-		this.checkboxField = this.getAttribute("field");
-		this.checkboxChecked = this.getAttribute("checked");
-		this.checkboxUnchecked = this.getAttribute("unchecked");
-		this.checkboxDefault = this.getAttribute("default");
-		this.checkboxClass = this.getAttribute("class", "");
-		// Make the child widgets
-		this.makeChildWidgets();
-	};
-
-	/*
-	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-	*/
-	CheckboxWidget.prototype.refresh = function (changedTiddlers) {
-		var changedAttributes = this.computeAttributes();
-		if (changedAttributes.tiddler || changedAttributes.field || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes["class"]) {
-			this.refreshSelf();
-			return true;
-		} else {
-			var refreshed = false;
-			if (changedTiddlers[this.checkboxTitle]) {
-				this.inputDomNode.checked = this.getValue();
-				refreshed = true;
-			}
-			return this.refreshChildren(changedTiddlers) || refreshed;
-		}
-	};
-
-	exports.checkbox = CheckboxWidget;
+exports.checkbox = CheckboxWidget;
 
 })();


### PR DESCRIPTION
Should the Checklist widget be merged into the core, the tag handling mode of the legacy Checkbox widget will have become entirely duplicated, as the `tags` field is the default field for the Checklist widget.

Removing this duplicated code from the Checkbox widget:
* considerable streamlines the code in the Checkbox widget
* clearly renders the purposes of the three related widgets to the user
  * The Checkbox widget toggles the value of a field between two mutually exclusive string values.
  * The Checklist widget toggles individual items (including tags) from a list in a field
  * The Radio widget toggles the value of a field between two or more mutually exclusive string values
* simplifies the code in all three widgets, allowing each to be extended in different directions
  * e.g. Extension of the widgets to handle data dictionaries

The core uses only the `field` mode of the Checkbox widget, and tw5.com uses the `tag` mode in only two examples. It should be fairly easy, therefore, to deprecate the duplicated code from the Checkbox widget and remove any related documentation from tw5.com
  
