### PR TITLE
sets checked class for radio widget wrapper / label

### DIFF
--- a/core/modules/widgets/radio.js
+++ b/core/modules/widgets/radio.js
@@ -37,7 +37,7 @@ RadioWidget.prototype.render = function(parent,nextSibling) {
 	// Create our elements
 	this.labelDomNode = this.document.createElement("label");
 	this.labelDomNode.setAttribute("class",
-   		this.radioClass + (isChecked ? " tc-radio-selected " + this.selectedClass : "")
+   		"tc-radio " + this.radioClass + (isChecked ? " tc-radio-selected " + this.selectedClass : "")
   	);
 	this.inputDomNode = this.document.createElement("input");
 	this.inputDomNode.setAttribute("type","radio");

--- a/core/modules/widgets/radio.js
+++ b/core/modules/widgets/radio.js
@@ -33,12 +33,15 @@ RadioWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	// Execute our logic
 	this.execute();
+	var isChecked = this.getValue() === this.radioValue;
 	// Create our elements
 	this.labelDomNode = this.document.createElement("label");
-	this.labelDomNode.setAttribute("class",this.radioClass);
+	this.labelDomNode.setAttribute("class",
+   		this.radioClass + (isChecked ? " tc-radio-selected " + this.selectedClass : "")
+  	);
 	this.inputDomNode = this.document.createElement("input");
 	this.inputDomNode.setAttribute("type","radio");
-	if(this.getValue() == this.radioValue) {
+	if(isChecked) {
 		this.inputDomNode.setAttribute("checked","true");
 	}
 	this.labelDomNode.appendChild(this.inputDomNode);
@@ -92,6 +95,7 @@ RadioWidget.prototype.execute = function() {
 	this.radioIndex = this.getAttribute("index");
 	this.radioValue = this.getAttribute("value");
 	this.radioClass = this.getAttribute("class","");
+	this.selectedClass = this.getAttribute("selectedClass","");
 	if(this.radioClass !== "") {
 		this.radioClass += " ";
 	}
@@ -105,7 +109,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 RadioWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.value || changedAttributes["class"]) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.value || changedAttributes["class"] || changedAttributes.selectedClass) {
 		this.refreshSelf();
 		return true;
 	} else {

--- a/core/modules/widgets/radio.js
+++ b/core/modules/widgets/radio.js
@@ -37,7 +37,7 @@ RadioWidget.prototype.render = function(parent,nextSibling) {
 	// Create our elements
 	this.labelDomNode = this.document.createElement("label");
 	this.labelDomNode.setAttribute("class",
-   		"tc-radio " + this.radioClass + (isChecked ? " tc-radio-selected " + this.selectedClass : "")
+   		"tc-radio " + this.radioClass + (isChecked ? " tc-radio-selected" : "")
   	);
 	this.inputDomNode = this.document.createElement("input");
 	this.inputDomNode.setAttribute("type","radio");
@@ -95,11 +95,6 @@ RadioWidget.prototype.execute = function() {
 	this.radioIndex = this.getAttribute("index");
 	this.radioValue = this.getAttribute("value");
 	this.radioClass = this.getAttribute("class","");
-	this.selectedClass = this.getAttribute("selectedClass","");
-	if(this.radioClass !== "") {
-		this.radioClass += " ";
-	}
-	this.radioClass += "tc-radio";
 	// Make the child widgets
 	this.makeChildWidgets();
 };
@@ -109,7 +104,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 RadioWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.value || changedAttributes["class"] || changedAttributes.selectedClass) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.value || changedAttributes["class"]) {
 		this.refreshSelf();
 		return true;
 	} else {

--- a/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
@@ -1,6 +1,6 @@
 caption: radio
 created: 20131212195353929
-modified: 20161217112444671
+modified: 20170112102444671
 tags: Widgets
 title: RadioWidget
 type: text/vnd.tiddlywiki
@@ -19,14 +19,14 @@ The content of the `<$radio>` widget is displayed within an HTML `<label>` eleme
 |index|<<.from-version "5.1.14">> The index of the //tiddler// being [[DataTiddler|DataTiddlers]] bound to the radio button<<.tip "takes precedence over //field//">>|
 |value |The value for the //field// or //index// of the //tiddler//|
 |class |CSS classes to be assigned to the label around the radio button |
+|selectedClass |<<.from-version "5.1.14">> a CSS class assigned to the wrapper when the radio button is selected<br>» `tc-radio-selected` is always applied when selected |
 
 !! Field Mode
 
 This example uses the radio widget to change the `modifier` field of this tiddler:
 
-<<wikitext-example-without-html """<$radio field="modifier" value="JoeBloggs"> Joe Bloggs</$radio>
+<<wikitext-example-without-html """<$radio field="modifier" value="JoeBloggs" selectedClass="tc-btn-big-green"> Joe Bloggs</$radio>
 <$radio field="modifier" value="JaneBloggs"> Jane Bloggs</$radio>""">>
-
 
 !! Index Mode
 
@@ -35,6 +35,6 @@ Using the radio widget in index mode requires the //index// attribute to specify
 This example sets the `Tree Frog` index in the tiddler AnimalColours:
 
 <$macrocall $name="wikitext-example-without-html" src="""<$tiddler tiddler="AnimalColours">
-<$radio index="Tree Frog" value="green"> green</$radio>
+<$radio index="Tree Frog" value="green" selectedClass="tc-btn-big-green"> green</$radio>
 <$radio index="Tree Frog" value="brown"> brown</$radio>
 </$tiddler>"""/>

--- a/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
@@ -1,6 +1,6 @@
 caption: radio
 created: 20131212195353929
-modified: 20170112102444671
+modified: 20170115095809695
 tags: Widgets
 title: RadioWidget
 type: text/vnd.tiddlywiki
@@ -18,14 +18,13 @@ The content of the `<$radio>` widget is displayed within an HTML `<label>` eleme
 |field |The field of the //tiddler// bound to the radio button|
 |index|<<.from-version "5.1.14">> The index of the //tiddler// being [[DataTiddler|DataTiddlers]] bound to the radio button<<.tip "takes precedence over //field//">>|
 |value |The value for the //field// or //index// of the //tiddler//|
-|class |The CSS classes assigned to the label around the radio button<$macrocall $name=".tip" _="""<<.from-version "5.1.14">> `tc-radio` is always applied by default"""/>|
-|selectedClass |<<.from-version "5.1.14">> a CSS class assigned to the wrapper when the radio button is selected<<.tip "`tc-radio-selected` is always applied when selected">>|
+|class |The CSS classes assigned to the label around the radio button<$macrocall $name=".tip" _="""<<.from-version "5.1.14">> `tc-radio` is always applied by default, as well as `tc-radio-selected` when selected"""/>|
 
 !! Field Mode
 
 This example uses the radio widget to change the `modifier` field of this tiddler:
 
-<<wikitext-example-without-html """<$radio field="modifier" value="JoeBloggs" selectedClass="tc-btn-big-green"> Joe Bloggs</$radio>
+<<wikitext-example-without-html """<$radio field="modifier" value="JoeBloggs"> Joe Bloggs</$radio>
 <$radio field="modifier" value="JaneBloggs"> Jane Bloggs</$radio>""">>
 
 !! Index Mode
@@ -35,6 +34,6 @@ Using the radio widget in index mode requires the //index// attribute to specify
 This example sets the `Tree Frog` index in the tiddler AnimalColours:
 
 <$macrocall $name="wikitext-example-without-html" src="""<$tiddler tiddler="AnimalColours">
-<$radio index="Tree Frog" value="green" selectedClass="tc-btn-big-green"> green</$radio>
+<$radio index="Tree Frog" value="green"> green</$radio>
 <$radio index="Tree Frog" value="brown"> brown</$radio>
 </$tiddler>"""/>

--- a/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
@@ -18,8 +18,8 @@ The content of the `<$radio>` widget is displayed within an HTML `<label>` eleme
 |field |The field of the //tiddler// bound to the radio button|
 |index|<<.from-version "5.1.14">> The index of the //tiddler// being [[DataTiddler|DataTiddlers]] bound to the radio button<<.tip "takes precedence over //field//">>|
 |value |The value for the //field// or //index// of the //tiddler//|
-|class |CSS classes to be assigned to the label around the radio button |
-|selectedClass |<<.from-version "5.1.14">> a CSS class assigned to the wrapper when the radio button is selected<br>» `tc-radio-selected` is always applied when selected |
+|class |The CSS classes assigned to the label around the radio button<$macrocall $name=".tip" _="""<<.from-version "5.1.14">> `tc-radio` is always applied by default"""/>|
+|selectedClass |<<.from-version "5.1.14">> a CSS class assigned to the wrapper when the radio button is selected<<.tip "`tc-radio-selected` is always applied when selected">>|
 
 !! Field Mode
 


### PR DESCRIPTION
With this minor change we're able to implement a simple rating macro which we otherwise can't because the input with its checked state is buried in the label.

In other words, the current design does not allow to address the **entire** radio widget in its **checked** state via css, hence this PR setting a `tc-checked` class at the label when the input inside is checked.

Another way would be to actually take the input out of the label... but I guess you did that to avoid needing another wrapper. Besides, changing this possibly would not be backwards compatible.
