### PR TITLE
Updated docs of ActionSetfield widget to include setting of TextReferences

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/ActionSetFieldWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionSetFieldWidget.tid
@@ -19,7 +19,8 @@ The ''action-setfield'' widget is invisible. Any content within it is ignored.
 |$index |Optional index of a property in a [[data tiddler|DataTiddlers]] to be assigned the $value attribute|
 |$value |The value to be assigned to the field or index identified by the $field or $index attribute. If neither is specified then the value is assigned to the text field. If no value is specified, $field or $index will be deleted.|
 |$timestamp |Specifies whether the timestamp(s) of the target tiddler will be updated (''modified'' and ''modifier'', plus ''created'' and ''creator'' for newly created tiddlers). Can be "yes" (the default) or "no" |
-|//{any attributes not starting with $}// |Each attribute name specifies a field to be modified with the attribute value providing the value to assign to the field  |
+|Attributes of the form TextReference="value" |Each TextReference identifies a field or index to be assigned the corresponding attribute value |
+|//{any other attributes not starting with $}// |Each attribute name specifies a field to be assigned the value specified by the attribute value  |
 
 ! Examples
 
@@ -53,7 +54,7 @@ Here is an example of a button that assigns tags and fields to the tiddler Hello
 
 <$macrocall $name='wikitext-example-without-html'
 src='<$button>
-<$action-setfield $tiddler="HelloThere" tags="MoreTag [[Further More Tags]]" color="green"/>
+<$action-setfield HelloThere!!tags="MoreTag [[Further More Tags]]" HelloThere!!color="green"/>
 <$action-sendmessage $message="tm-edit-tiddler" $param="HelloThere"/>
 Edit ~HelloThere
 </$button>'/>


### PR DESCRIPTION
Can now accept any number of attributes of the form TextReference="value" -- these may be fields "(Tiddler!!field="value") or indices (Tiddler##index="value.)