### PR TITLE
is[empty] filter operator

### DIFF
--- a/core/modules/filters/is/empty.js
+++ b/core/modules/filters/is/empty.js
@@ -1,0 +1,36 @@
+/*\
+title: $:/core/modules/filters/is/empty.js
+type: application/javascript
+module-type: isfilteroperator
+
+Filter function for [is[empty]]
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.empty = function(source,prefix,options) {
+	var results = [];
+	if(prefix === "!") {
+		source(function(tiddler,title) {
+			if(title) {
+				results.push(title);
+			}
+		});
+	} else {
+		source(function(tiddler,title) {
+			if(!title) {
+				results.push(title);
+			}
+		});
+	}
+	return results;
+};
+
+})();

--- a/editions/tw5.com/tiddlers/filters/examples/is.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/is.tid
@@ -1,5 +1,5 @@
 created: 20150119133413000
-modified: 20150119134652000
+modified: 20160106134658836
 tags: [[is Operator]] [[Operator Examples]]
 title: is Operator (Examples)
 type: text/vnd.tiddlywiki
@@ -11,3 +11,4 @@ type: text/vnd.tiddlywiki
 <<.operator-example 5 "[all[shadows]is[system]tag[$:/tags/Stylesheet]]" "shadow system stylesheets">>
 <<.operator-example 6 "[is[shadow]]" "overridden shadow tiddlers">>
 <<.operator-example 7 "[is[missing]]" "empty because its input contains only tiddlers that exist">>
+<<.operator-example 8 "[[]is[empty]]" "returns an empty item, but runs once nonetheless">>

--- a/editions/tw5.com/tiddlers/filters/is.tid
+++ b/editions/tw5.com/tiddlers/filters/is.tid
@@ -1,15 +1,15 @@
+caption: is
 created: 20140410103123179
-modified: 20150220161001000
+modified: 20160106134655725
+op-input: a [[selection of titles|Title Selection]]
+op-neg-output: those input tiddlers that do <<.em not>> belong to category <<.place C>>
+op-output: those input tiddlers that belong to category <<.place C>>
+op-parameter: a category
+op-parameter-name: C
+op-purpose: filter the input by fundamental category
 tags: [[Filter Operators]] [[Common Operators]] [[Negatable Operators]]
 title: is Operator
 type: text/vnd.tiddlywiki
-caption: is
-op-purpose: filter the input by fundamental category
-op-input: a [[selection of titles|Title Selection]]
-op-parameter: a category
-op-parameter-name: C
-op-output: those input tiddlers that belong to category <<.place C>>
-op-neg-output: those input tiddlers that do <<.em not>> belong to category <<.place C>>
 
 The parameter <<.place C>> is one of the following fundamental categories:
 
@@ -22,6 +22,7 @@ The parameter <<.place C>> is one of the following fundamental categories:
 |^`system` |is a [[system tiddler|SystemTiddlers]], i.e. its title starts with `$:/` |
 |^`tag` |is in use as a tag |
 |^`tiddler` |exists as a non-shadow tiddler |
+|^`empty` |the input title is an empty string |
 
 If <<.place C>> is anything else, the output is an error message.
 


### PR DESCRIPTION
Something I have been needing / missing for a long time ...wanting to use the list widget to see if a text reference, variable or macro parameter is specified:

* `[[$param$]is[empty]]` vs.
* `[[$param$]!is[empty]]`

* `[{foo!!bar}is[empty]]` vs.
* `[{foo!!bar}!is[empty]]`

* `[<foo>is[empty]]` vs.
* `[<foo>!is[empty]]`

...rather than a reveal creating unneded, even unwanted elements with a complicated syntax.