### PR TITLE
Added getTiddlerTranscludes()

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -429,7 +429,7 @@ Return an array of tiddler titles that are directly linked from the specified ti
 */
 exports.getTiddlerLinks = function(title) {
 	var self = this;
-	return self.collectFromEachTiddlerNode(title, "link", function(parseTreeNode) {
+	return self.collectFromEachTiddlerNode(title, "links", function(parseTreeNode) {
 		if(parseTreeNode.type === "link" && parseTreeNode.attributes.to && parseTreeNode.attributes.to.type === "string") {
 			return parseTreeNode.attributes.to.value;
 		}
@@ -441,7 +441,7 @@ Return an array of tiddler titles that are directly transcluded from the specifi
 */
 exports.getTiddlerTranscludes = function(title) {
 	var self = this;
-	return self.collectFromEachTiddlerNode(title, "transclude", function(parseTreeNode) {
+	return self.collectFromEachTiddlerNode(title, "transcludes", function(parseTreeNode) {
 		if(parseTreeNode.type === "transclude" && parseTreeNode.attributes.tiddler && parseTreeNode.attributes.tiddler.type === "string") {
 			return parseTreeNode.attributes.tiddler.value;
 		}

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -427,6 +427,38 @@ exports.getTiddlerLinks = function(title) {
 };
 
 /*
+Return an array of tiddler titles that are directly transcluded from the specified tiddler
+*/
+exports.getTiddlerTranscludes = function(title) {
+	var self = this;
+	// We'll cache the transcludes  so they only get computed if the tiddler changes
+	return this.getCacheForTiddler(title,"transcludes",function() {
+		// Parse the tiddler
+		var parser = self.parseTiddler(title);
+		// Count up the transcludes
+		var transcludes = [],
+			checkParseTree = function(parseTree) {
+				for(var t=0; t<parseTree.length; t++) {
+					var parseTreeNode = parseTree[t];
+					if(parseTreeNode.type === "transclude" && parseTreeNode.attributes.tiddler && parseTreeNode.attributes.tiddler.type === "string") {
+						var value = parseTreeNode.attributes.tiddler.value;
+						if(transcludes.indexOf(value) === -1) {
+							transcludes.push(value);
+						}
+					}
+					if(parseTreeNode.children) {
+						checkParseTree(parseTreeNode.children);
+					}
+				}
+			};
+		if(parser) {
+			checkParseTree(parser.tree);
+		}
+		return transcludes;
+	});
+};
+
+/*
 Return an array of tiddler titles that link to the specified tiddler
 */
 exports.getTiddlerBacklinks = function(targetTitle) {


### PR DESCRIPTION
Here is a method for getting the transcludes for a given tiddler title. It behaves practically identically to getTiddlerLinks(). I've tested it. It seems fine. I pulled the tree node parsing in getTiddlerLinks out into its own method so there isn't code duplication between the two

There's more that could be done with this. There could be a getTiddlerBacktranscludes. Or maybe a transcludes filter operator. If you guys think it would be a good idea, let me know.
