### PR TITLE
navigator: update tag and list references on rename

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -353,7 +353,7 @@ NavigatorWidget.prototype.handleSaveTiddlerEvent = function(event) {
 				this.wiki.deleteTiddler(title);
 				// Remove the original tiddler if we're renaming it
 				if(isRename) {
-					this.wiki.retargetReferences(draftOf, draftTitle);
+					// Allow plugins to update references
 					$tw.hooks.invokeHook("th-renaming-tiddler", {
 						fromTitle: draftOf,
 						toTitle: draftTitle

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -353,6 +353,11 @@ NavigatorWidget.prototype.handleSaveTiddlerEvent = function(event) {
 				this.wiki.deleteTiddler(title);
 				// Remove the original tiddler if we're renaming it
 				if(isRename) {
+					this.wiki.retargetReferences(draftOf, draftTitle);
+					$tw.hooks.invokeHook("th-renaming-tiddler", {
+						fromTitle: draftOf,
+						toTitle: draftTitle
+					});
 					this.wiki.deleteTiddler(draftOf);
 				}
 				if(!event.paramObject || event.paramObject.suppressNavigation !== "yes") {
@@ -611,7 +616,6 @@ NavigatorWidget.prototype.handleUnfoldAllTiddlersEvent = function(event) {
 		self.wiki.setText(prefix + title,"text",null,"show");
 	});
 };
-
 NavigatorWidget.prototype.handleRenameTiddlerEvent = function(event) {
 	var self = this,
 		paramObject = event.paramObject || {},

--- a/core/modules/wiki-bulkops.js
+++ b/core/modules/wiki-bulkops.js
@@ -13,10 +13,38 @@ Bulk tiddler operations such as rename.
 "use strict";
 
 /*
+Retarget tags and lists from fromTitle toTitle.
+*/
+exports.retargetReferences = function(fromTitle,toTitle) {
+	var self = this;
+	// Rename any tags or lists that reference it
+	this.each(function(tiddler,title) {
+		var tags = (tiddler.fields.tags || []).slice(0),
+				list = (tiddler.fields.list || []).slice(0),
+				isModified = false;
+		// Rename tags
+		$tw.utils.each(tags,function (title,index) {
+			if(title === fromTitle) {
+				tags[index] = toTitle;
+				isModified = true;
+			}
+		});
+		// Rename lists
+		$tw.utils.each(list,function (title,index) {
+			if(title === fromTitle) {
+				list[index] = toTitle;
+				isModified = true;
+			}
+		});
+		if(isModified) {
+			self.addTiddler(new $tw.Tiddler(tiddler,{tags: tags, list: list},self.getModificationFields()));
+		}
+	});
+}
+/*
 Rename a tiddler, and relink any tags or lists that reference it.
 */
 exports.renameTiddler = function(fromTitle,toTitle) {
-	var self = this;
 	fromTitle = (fromTitle || "").trim();
 	toTitle = (toTitle || "").trim();
 	if(fromTitle && toTitle && fromTitle !== toTitle) {
@@ -24,29 +52,7 @@ exports.renameTiddler = function(fromTitle,toTitle) {
 		var tiddler = this.getTiddler(fromTitle);
 		this.addTiddler(new $tw.Tiddler(tiddler,{title: toTitle},this.getModificationFields()));
 		this.deleteTiddler(fromTitle);
-		// Rename any tags or lists that reference it
-		this.each(function(tiddler,title) {
-			var tags = (tiddler.fields.tags || []).slice(0),
-				list = (tiddler.fields.list || []).slice(0),
-				isModified = false;
-			// Rename tags
-			$tw.utils.each(tags,function (title,index) {
-				if(title === fromTitle) {
-					tags[index] = toTitle;
-					isModified = true;
-				}
-			});
-			// Rename lists
-			$tw.utils.each(list,function (title,index) {
-				if(title === fromTitle) {
-					list[index] = toTitle;
-					isModified = true;
-				}
-			});
-			if(isModified) {
-				self.addTiddler(new $tw.Tiddler(tiddler,{tags: tags, list: list},self.getModificationFields()));
-			}
-		});
+		this.retargetReferences(fromTitle, toTitle)
 	}
 }
 

--- a/core/modules/wiki-bulkops.js
+++ b/core/modules/wiki-bulkops.js
@@ -9,7 +9,7 @@ Bulk tiddler operations such as rename.
 (function(){
 
 /*jslint node: true, browser: true */
-/*global $tw: false */
+/*global $tw: true */
 "use strict";
 
 /*
@@ -41,6 +41,13 @@ exports.retargetReferences = function(fromTitle,toTitle) {
 		}
 	});
 }
+
+$tw.hooks.addHook("th-renaming-tiddler",function(params) {
+	$tw.wiki.retargetReferences(params.fromTitle, params.toTitle);
+	// Otherwise the next function in the chain gets params = null
+	return params;
+});
+
 /*
 Rename a tiddler, and relink any tags or lists that reference it.
 */


### PR DESCRIPTION
This change addresses #196 by updating tags and lists when a tiddler is renamed throught the UI.

It extracts the tag and list update logic from Wiki.renameTiddler, and calls it from navigator's save handler.

I just wanted to get something up for people to comment on. Some options:

- prompt with summary before actually updating references
- post-hoc message listing updates

I'd be fine with it staying silent though. Less UI is generally better unless there's a clear need.

It also introduces a new hook `th-renaming-tiddler`, which can be used by other plugins that want to update their data when a tiddler is renamed. Specifically, gsd5 needs this to update various fields that it uses. I didn't think much about how the API should look.
