### PR TITLE
New cycle() filter operator and associated documentation

### DIFF
--- a/core/modules/filters/x-listops.js
+++ b/core/modules/filters/x-listops.js
@@ -186,4 +186,33 @@ Extended filter operators to manipulate the current list.
         }, []);
         return set;
     };
+    
+    /*
+	Returns the next item from the operand list after any matching item from the current list -- else the first item from the operand list
+	*/
+	exports.cycle = function(source, operator) {
+		var array = $tw.utils.parseStringArray(operator.operand, "true"),
+			results = prepare_results(source),
+			len = array.length,
+			found = 0,
+			p;
+		for(p = 0; p < len; p++) {
+			if(!found) {
+				var index = results.indexOf(array[p]);
+				if(index >= 0) {
+					if(operator.prefix) {
+						(p > 0) ? (results[index] = array[p - 1])
+						: (results[index] = array[len - 1]);
+						found = 1;
+					} else {
+						(p < (len - 1)) ? (results[index] = array[p + 1])
+						: (results[index] =	array[0]);
+						found = 1;
+					}
+				}
+			}
+		}
+		return(found) ? results : results.concat(array[0]);
+	};
+	
 })();

--- a/editions/tw5.com/tiddlers/filters/cycle.tid
+++ b/editions/tw5.com/tiddlers/filters/cycle.tid
@@ -1,0 +1,14 @@
+caption: cycle
+created: 20160115004529776
+modified: 20160115004543421
+op-input: a list of items
+op-neg-output: item from operand before any that match any item in the current list
+op-output: item from operand after any that match any item in the current list
+op-parameter: an array of items to cycle through
+op-parameter-name: array
+op-purpose: cycle through an array of items
+tags: [[Filter Operators]] [[Order Operators]] [[Listops Operators]]
+title: cycle Operator
+type: text/vnd.tiddlywiki
+
+<<.operator-examples "cycle">>

--- a/editions/tw5.com/tiddlers/filters/examples/cycle.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/cycle.tid
@@ -1,0 +1,27 @@
+created: 20160115011315279
+cycled-tags: 1 Mar
+modified: 20160115014113926
+tags: [[Operator Examples]] [[cycle Operator]] _Tue
+title: cycle Operator (Examples)
+type: text/vnd.tiddlywiki
+
+;Cycle a Tag
+<$macrocall $name='wikitext-example-without-html'
+src="""<$button><$action-listops $tags="+[cycle[_Mon _Tue _Wed _Thu _Fri _Sat _Sun]]"/>Cycle Tag</$button>
+<$button><$action-listops $tags="+[!cycle[_Mon _Tue _Wed _Thu _Fri _Sat _Sun]]"/>Reverse Cycle Tag</$button>"""/>
+
+;Cycle Items from a Data Dictionary
+<$macrocall $name='wikitext-example-without-html'
+src="""<$button class="tc-btn-invisible"><$action-listops $field="cycled-tags" $subfilter="+[!cycle{Lists##dates}]"/>{{$:/core/images/chevron-left}}</$button> Dates 
+<$button class="tc-btn-invisible"><$action-listops $field="cycled-tags" $subfilter="+[cycle{Lists##dates}]"/>{{$:/core/images/chevron-right}}</$button>
+
+<$button class="tc-btn-invisible"><$action-listops $field="cycled-tags" $subfilter="+[!cycle{Lists##months}]"/>{{$:/core/images/chevron-left}}</$button> Months 
+<$button class="tc-btn-invisible"><$action-listops $field="cycled-tags" $subfilter="+[cycle{Lists##months}]"/>{{$:/core/images/chevron-right}}</$button>
+
+Status <$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $index="cycled-tags" $subfilter="+[cycle{Lists##status}]"/>{{$:/core/images/chevron-right}}</$button>
+
+Context <$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $index="cycled-tags" $subfilter="+[cycle{Lists##context}]"/>{{$:/core/images/chevron-right}}</$button>
+
+cycled-tags: {{!!cycled-tags}}
+
+{{Target}}"""/>

--- a/editions/tw5.com/tiddlers/filters/examples/lists.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/lists.tid
@@ -1,0 +1,11 @@
+created: 20160114193046373
+modified: 20160115014200334
+tags: 
+title: Lists
+type: application/x-tiddler-dictionary
+
+days: Mon Tue Wed Thu Fri Sat Sun
+months: Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
+dates: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+status: #todo #pending #active #done
+context: @inbox @home @work @shopping @errands


### PR DESCRIPTION
The `cycle[]` filter operator is designed for use with the ActionListops widget, and cycles the value of the first matching item in the current list, from a list of options specified by the operator operand.

Whilst this is already possible using two ActionListops widgets (one, when cycling tags), the required filter expression is difficult to construct. The new `cycle[]` operator renders the construction of the filter expression trivial.

There is a demo for the `cycle[]`filter operation posted [here] (http://listops.tiddlyspot.com/), where the action of the operator may be explored. 

Suggestions are welcome.