### PR TITLE
Invoke th-saving-tiddler hook with renaming param

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2020,11 +2020,14 @@ $tw.hooks.addHook = function(hookName,definition) {
 
 /*
 Invoke the hook by key
+Additional arguments may be passed
 */
 $tw.hooks.invokeHook = function(hookName, value) {
 	if($tw.utils.hop($tw.hooks.names,hookName)) {
 		for (var i = 0; i < $tw.hooks.names[hookName].length; i++) {
-			value = $tw.hooks.names[hookName][i](value);
+			var args = Array.prototype.slice.apply(arguments,[2]);
+			args.unshift(value);
+			value = $tw.hooks.names[hookName][i].apply(null, args);
 		}
 	}
 	return value;

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -347,7 +347,8 @@ NavigatorWidget.prototype.handleSaveTiddlerEvent = function(event) {
 					"draft.title": undefined,
 					"draft.of": undefined
 				},this.wiki.getModificationFields());
-				newTiddler = $tw.hooks.invokeHook("th-saving-tiddler",newTiddler);
+				// th-saving-tiddler sets tiddler.renaming to the old title if renaming
+				newTiddler = $tw.hooks.invokeHook("th-saving-tiddler", newTiddler, isRename? draftOf : undefined);
 				this.wiki.addTiddler(newTiddler);
 				// Remove the draft tiddler
 				this.wiki.deleteTiddler(title);

--- a/core/modules/wiki-bulkops.js
+++ b/core/modules/wiki-bulkops.js
@@ -13,10 +13,39 @@ Bulk tiddler operations such as rename.
 "use strict";
 
 /*
+Retarget tags and lists from fromTitle toTitle.
+*/
+exports.retargetReferences = function(fromTitle,toTitle) {
+	var self = this;
+	// Rename any tags or lists that reference it
+	this.each(function(tiddler,title) {
+		var tags = (tiddler.fields.tags || []).slice(0),
+				list = (tiddler.fields.list || []).slice(0),
+				isModified = false;
+		// Rename tags
+		$tw.utils.each(tags,function (title,index) {
+			if(title === fromTitle) {
+				tags[index] = toTitle;
+				isModified = true;
+			}
+		});
+		// Rename lists
+		$tw.utils.each(list,function (title,index) {
+			if(title === fromTitle) {
+				list[index] = toTitle;
+				isModified = true;
+			}
+		});
+		if(isModified) {
+			self.addTiddler(new $tw.Tiddler(tiddler,{tags: tags, list: list},self.getModificationFields()));
+		}
+	});
+}
+
+/*
 Rename a tiddler, and relink any tags or lists that reference it.
 */
 exports.renameTiddler = function(fromTitle,toTitle) {
-	var self = this;
 	fromTitle = (fromTitle || "").trim();
 	toTitle = (toTitle || "").trim();
 	if(fromTitle && toTitle && fromTitle !== toTitle) {
@@ -24,29 +53,7 @@ exports.renameTiddler = function(fromTitle,toTitle) {
 		var tiddler = this.getTiddler(fromTitle);
 		this.addTiddler(new $tw.Tiddler(tiddler,{title: toTitle},this.getModificationFields()));
 		this.deleteTiddler(fromTitle);
-		// Rename any tags or lists that reference it
-		this.each(function(tiddler,title) {
-			var tags = (tiddler.fields.tags || []).slice(0),
-				list = (tiddler.fields.list || []).slice(0),
-				isModified = false;
-			// Rename tags
-			$tw.utils.each(tags,function (title,index) {
-				if(title === fromTitle) {
-					tags[index] = toTitle;
-					isModified = true;
-				}
-			});
-			// Rename lists
-			$tw.utils.each(list,function (title,index) {
-				if(title === fromTitle) {
-					list[index] = toTitle;
-					isModified = true;
-				}
-			});
-			if(isModified) {
-				self.addTiddler(new $tw.Tiddler(tiddler,{tags: tags, list: list},self.getModificationFields()));
-			}
-		});
+		this.retargetReferences(fromTitle,toTitle)
 	}
 }
 

--- a/editions/dev/tiddlers/new/th-saving-tiddler.tid
+++ b/editions/dev/tiddlers/new/th-saving-tiddler.tid
@@ -20,3 +20,5 @@ The original tiddler object can be returned unmodified by the hook. If the hook 
 ```
 
 Hooks must not change the ''title'' field but can freely modify any other field of the tiddler.
+
+If the tiddler is being renamed, the field ''tiddler.renaming'' will be set to the old title.


### PR DESCRIPTION
This extends `th-saving-tiddler` to expose the old title as `tiddler.renaming` if the save is a rename. Read it as "we are renaming this existing title, with tiddler.title set to the new title".

It's not on `tiddler.fields` to avoid conflicts with existing fields, and is unset before saving.

This is so hook implementers can do things on rename like
- retarget references in other tiddlers
- display a modal UI for interactively updating references
- access the old tiddler, and the one that is about to be overwritten if it exists (maybe to make a backup or something? idk).

It also extracts a wiki method `retargetReferences(from, to)` from `renameTiddler` which updates references in tags and lists without actually renaming the tiddler, as a convenience method for implementers of the hook as well as power users. It doesn't change the existing behavior of the **text-slicer** edition. Once there is a more general UX for retargeting references I think this special code path could be removed.

It doesn't add a default implementation of the hook.

Here is an example implementation which uses the new field and wiki method to automatically retarget tags and lists on rename:

``` javascript
  $tw.hooks.addHook("th-saving-tiddler",function(tiddler) {
    if (tiddler.renaming) {
      $tw.wiki.retargetReferences(tiddler.renaming, tiddler.fields.title);
    }
    return tiddler;
  });

```

I'm excited to see this go in, since I plan to use the hook to implement reference updating in gsd5, which makes heavy use of reference fields and tags to model application data.
