### PR TITLE
Login plugin to store user name in a cookie

### DIFF
--- a/plugins/tiddlywiki/login/files/login.tid
+++ b/plugins/tiddlywiki/login/files/login.tid
@@ -1,0 +1,25 @@
+created: 20160115112840267
+modified: 20160118125350050
+revision: 0
+tags: 
+title: Login
+type: text/vnd.tiddlywiki
+
+<$reveal type="match" state="$:/status/UserName" text="">
+I haven't found your user. Please insert your name or nick to get your tiddles tagged with your name.
+
+<$edit-text tiddler="$:/temp/holder" tag="input" default={{$:/status/UserName}} placeholder=""></$edit-text>
+<$button set="$:/status/UserName" setTo={{$:/temp/holder}}>
+<$action-setfield $tiddler="$:/status/UserName" text={{$:/temp/holder}}/>
+<$action-setfield $tiddler="$:/status/IsLoggedIn" text="yes"/>
+login
+</$button>
+</$reveal>
+
+<$reveal type="nomatch" state="$:/status/UserName" text="">
+Hi, {{$:/status/UserName}} <$button set="$:/status/UserName" setTo="">
+<$action-setfield $tiddler="$:/status/UserName" text=""/>
+<$action-setfield $tiddler="$:/status/IsLoggedIn" text="no"/>
+logoff
+</$button>
+</$reveal>

--- a/plugins/tiddlywiki/login/login.js
+++ b/plugins/tiddlywiki/login/login.js
@@ -1,0 +1,63 @@
+/*\
+title: $:/plugins/tiddlywiki/login/login.js
+type: application/javascript
+module-type: widget
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var CONFIG_COOKIE_TIDDLER = "$:/config/tiddlyweb/cookie",
+  DEFAULT_COOKIE_TIDDLER = "UserName"
+
+function Cookies() { 
+  var self = this; 
+  self.__parsed__ = false;
+  self.parse();
+}
+Cookies.prototype.parse = function() {
+  var self = this;
+  self.__parsed__ = true;
+  var cookies = document.cookie.split(/\s*;\s*/g);
+  var cookie;
+  for(var c = 0; c<cookies.length; c++) {
+    cookie = cookies[c].split("=");
+    self[cookie[0]] = cookie[1];
+  }    
+}
+Cookies.prototype.set = function(name, value, days) {
+  var self = this;
+  self[name] = value;
+  var str = name+"="+value;
+  if (days) {
+    var d = new Date();
+    d.setTime(d.getTime() + (days*24*60*60*1000));
+    str += ";expires="+d.toUTCString();
+  }
+  if (days==0) {
+    str += ";expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    self[name]=null;
+    delete self[name];
+  }
+  document.cookie = str;
+}
+
+if($tw.browser) {
+  $tw.wiki.addEventListener('change', function(data) {
+    for(var a in data) {
+      var matcher = /^\$:\/status\/UserName$/.exec(a);
+      if(matcher) {
+        var cookies = new Cookies();
+        var userName = $tw.wiki.getTiddlerText(a);
+        var cookie = $tw.wiki.getTiddlerText(CONFIG_COOKIE_TIDDLER,DEFAULT_COOKIE_TIDDLER);
+        cookies.set(cookie, userName, userName?100:0);
+        if(!userName) $tw.wiki.addTiddler(new $tw.Tiddler("$:/status/IsLoggedIn", { text: "no"}));
+      }
+    }
+  });
+}
+
+})();

--- a/plugins/tiddlywiki/login/plugin.info
+++ b/plugins/tiddlywiki/login/plugin.info
@@ -1,0 +1,8 @@
+{
+    "title": "$:/plugins/tiddlywiki/login",
+    "description": "Login plugin",
+    "author": "Koke Laast",
+    "version": "1.0.0",
+    "core-version": ">=5.1.5",
+    "list": "readme"
+}

--- a/plugins/tiddlywiki/login/readme.tid
+++ b/plugins/tiddlywiki/login/readme.tid
@@ -1,0 +1,5 @@
+title: $:/plugins/tiddlywiki/login/readme
+
+This plugin uses a cookie in the browser to store the username. When the cookie is present, the username is loaded from there, so automatically every time you add or change any tiddle your changes are signed with your username.
+
+[[Login]] is an example of how to show login information and how to log out.

--- a/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
+++ b/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
@@ -13,7 +13,9 @@ A sync adaptor module for synchronising with TiddlyWeb compatible servers
 "use strict";
 
 var CONFIG_HOST_TIDDLER = "$:/config/tiddlyweb/host",
-	DEFAULT_HOST_TIDDLER = "$protocol$//$host$/";
+	DEFAULT_HOST_TIDDLER = "$protocol$//$host$/",
+	CONFIG_COOKIE_TIDDLER = "$:/config/tiddlyweb/cookie",
+	DEFAULT_COOKIE_TIDDLER = "UserName";
 
 function TiddlyWebAdaptor(options) {
 	this.wiki = options.wiki;
@@ -69,6 +71,14 @@ TiddlyWebAdaptor.prototype.getStatus = function(callback) {
 				}
 				// Check if we're logged in
 				isLoggedIn = json.username !== "GUEST";
+        
+				var cookie = self.wiki.getTiddlerText(CONFIG_COOKIE_TIDDLER,DEFAULT_COOKIE_TIDDLER);
+				var cookieRegExp = new RegExp("(?:(?:^|.*;\\s*)"+cookie+"\\s*\\=\\s*([^;]*).*$)|^.*$");
+				var userName = document.cookie.replace(cookieRegExp, "$1");
+				if(userName) {
+					json.username = userName;
+					isLoggedIn = true;
+				}
 			}
 			// Invoke the callback if present
 			if(callback) {


### PR DESCRIPTION
Hi!

Here is a plugin to store user name in a cookie in the browser. It is almost independent but It needs a minimal change in tiddlyweb plugin to allow it to retrieve user name from the stored cookie and use it as the user name for the TiddlyWiki.

Best regards