### PR TITLE
ENEX import - Apply modified (updated) dates

### DIFF
--- a/plugins/tiddlywiki/evernote/modules/enex-deserializer.js
+++ b/plugins/tiddlywiki/evernote/modules/enex-deserializer.js
@@ -38,11 +38,19 @@ exports["application/enex+xml"] = function(text,fields) {
 			title: getTextContent(noteNode,"title"),
 			type: "text/html",
 			tags: [],
-			text: getTextContent(noteNode,"content")
+			text: getTextContent(noteNode,"content"),
+			modified: getTextContent(noteNode,"created").replace("T","").replace("Z",""),
+			created:  getTextContent(noteNode,"created").replace("T","").replace("Z","")
+
 		};
 		$tw.utils.each(noteNode.querySelectorAll("tag"),function(tagNode) {
 			result.tags.push(tagNode.textContent);
 		});
+		// If there's an update date, set modifiy date accordingly 
+		$tw.utils.each(noteNode.querySelectorAll("updated"),function(modifiedNode) {
+			result["modified"] = modifiedNode.textContent.replace("T","").replace("Z","") + "000" ; 
+		});
+
 		$tw.utils.each(noteNode.querySelectorAll("note-attributes"),function(attrNode) {
 			result[attrNode.tagName] = attrNode.textContent;
 		});


### PR DESCRIPTION
Without modified dates, new imports do not appear in recent file list. The equivalent of modified dates in ENEX is the 'updated' tag, with a date format similar to that of TW with the exception that the date format consists of a date stamp, a letter T, and a time stamp followed by Z for UTC presumably. There is no millisecond indicator. Not all ENEX notes have an update tag. The solution here is to apply creation date by default and then apply the update date if it is available.  Dates are converted by stripping out Z and T and appending '000'.