### PR TITLE
[Incomplete PR for discussion] Added a destructor function

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -404,7 +404,7 @@ Rebuild a previously rendered widget
 */
 Widget.prototype.refreshSelf = function() {
 	var nextSibling = this.findNextSiblingDomNode();
-	this.removeChildDomNodes();
+	this.destroy();
 	this.render(this.parentDomNode,nextSibling);
 };
 
@@ -467,21 +467,36 @@ Widget.prototype.findFirstDomNode = function() {
 };
 
 /*
+Destructor
+*/
+Widget.prototype.destroy = function() {
+    // First ask the child widgets to destruct before this widget destroys itself and removes its dom nodes.
+    $tw.utils.each(this.children,function(childWidget) {
+        childWidget.destroy();
+    });
+    // Optional cleanup that may be overridden by the user
+    this.cleanup();
+    // Then remove dom nodes
+    this.removeChildDomNodes();
+};
+
+/*
+The user can override this to do any cleanup e.g. remove window listeners or other stuff.
+*/
+Widget.prototype.cleanup = function() {
+
+};
+
+/*
 Remove any DOM nodes created by this widget or its children
 */
-Widget.prototype.removeChildDomNodes = function() {
-	// If this widget has directly created DOM nodes, delete them and exit. This assumes that any child widgets are contained within the created DOM nodes, which would normally be the case
-	if(this.domNodes.length > 0) {
-		$tw.utils.each(this.domNodes,function(domNode) {
-			domNode.parentNode.removeChild(domNode);
-		});
-		this.domNodes = [];
-	} else {
-		// Otherwise, ask the child widgets to delete their DOM nodes
-		$tw.utils.each(this.children,function(childWidget) {
-			childWidget.removeChildDomNodes();
-		});
-	}
+Widget.prototype.removeChildDomNodes = function() { //formerly removeChildDomNodes
+    if(this.domNodes.length > 0) {
+        $tw.utils.each(this.domNodes,function(domNode) {
+            domNode.parentNode.removeChild(domNode);
+        });
+        this.domNodes = [];
+    }
 };
 
 /*


### PR DESCRIPTION
PR for https://github.com/Jermolene/TiddlyWiki5/issues/1784

Since @Jermolene said he is fine with adding a destructor, here is a solution which tries to incorporate all previous thoughts in the discussion.
- @buggyj said the destructor should always remove dom nodes. I agree and I suggest not to leave it to the user, therefore separating the removeChildDomNodes from a cleanup function so a user that overrides `cleanup` doesn't have to bother about removing dom nodes.
- I therefore propose a modified version of @vsivsi's https://github.com/Jermolene/TiddlyWiki5/issues/1784#issuecomment-111254331, which uses the naming suggested by @buggyj ("destroy")
- and calls (as suggested by @sukima) a dedicated separate cleanup function that the user may override or not.
