### PR TITLE
Fix for #2274

### DIFF
--- a/core/modules/filters/has.js
+++ b/core/modules/filters/has.js
@@ -25,7 +25,7 @@ exports.has = function(source,operator,options) {
 		});
 	} else {
 		source(function(tiddler,title) {
-			if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && tiddler.fields[operator.operand] != "") {
+			if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && (tiddler.fields[operator.operand] !== "" || ($tw.utils.isArray(tiddler.fields[operator.operand]) && tiddler.fields[operator.operand].length == 0))) {
 				results.push(title);
 			}
 		});

--- a/core/modules/filters/has.js
+++ b/core/modules/filters/has.js
@@ -25,7 +25,7 @@ exports.has = function(source,operator,options) {
 		});
 	} else {
 		source(function(tiddler,title) {
-			if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && tiddler.fields[operator.operand] !== "") {
+			if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && tiddler.fields[operator.operand] != "") {
 				results.push(title);
 			}
 		});


### PR DESCRIPTION
List fields (such as tags) when evaluated to produce tiddlers result in empty arrays.  Using the exact not equals, an empty array is not the same as an empty string.  By using equivelent not equals, we state that the field is either != "" or anything that can be coerced to "".  Which, based on https://dorey.github.io/JavaScript-Equality-Table/ is `false` `0` `[]` or `[[]]` neither `false` nor `0` can be set as a tiddler field as both will end up being quoted (`"false"`, `"0"`) so this should work.