### PR TITLE
Update has.js for improvement to #2274

### DIFF
--- a/core/modules/filters/has.js
+++ b/core/modules/filters/has.js
@@ -25,7 +25,7 @@ exports.has = function(source,operator,options) {
 		});
 	} else {
 		source(function(tiddler,title) {
-			if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && (tiddler.fields[operator.operand] !== "" || ($tw.utils.isArray(tiddler.fields[operator.operand]) && tiddler.fields[operator.operand].length == 0))) {
+			if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && !(tiddler.fields[operator.operand] === "" || tiddler.fields[operator.operand].length === 0)) {
 				results.push(title);
 			}
 		});


### PR DESCRIPTION
Changed the logic for has to check `NOT (equal to "" OR field.length === 0)` This catches list fields such as tags which have arrays instead of strings.  