### PR TITLE
Add this.document to ES2016 documentation

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/Using ES2016 for Writing Plugins.tid
+++ b/editions/tw5.com/tiddlers/howtos/Using ES2016 for Writing Plugins.tid
@@ -1,4 +1,4 @@
-modified: 20160112175004000
+modified: 20160305222940000
 created: 20160111034749658
 tags: documenting Concepts
 title: Using ES2016 for Writing Plugins
@@ -154,7 +154,10 @@ class ClockWidget extends Widget {
     this.logger.log('Rendering clock DOM nodes');
     this.computeAttributes()
     this.parentDomNode = parent;
-    this.domNode = $tw.utils.domMaker('div', {class: 'tc-clock-widget'});
+    this.domNode = $tw.utils.domMaker('div', {
+      document: this.document,
+      class: 'tc-clock-widget'
+    });
     parent.insertBefore(this.domNode, nextSibling);
     this.tick();
   }


### PR DESCRIPTION
In the sample example for using ES2016 it used the `$tw.utils.domMaker()`. I just found out that if this code is executed by Node.js instead of in the browser that it doesn't work because `window.document` doesn't exist. The expectation is that widgets pass in the fake `this.document`.

I updated the example to reflect this.