### PR TITLE
Fix heading-6.tid

### DIFF
--- a/core/ui/TextEditorToolbar/heading-6.tid
+++ b/core/ui/TextEditorToolbar/heading-6.tid
@@ -3,6 +3,7 @@ tags: $:/tags/TextEditorToolbar
 icon: {{$:/core/images/format-heading-6}}
 caption: {{$:/language/Buttons/Heading6/Caption}}
 description: {{$:/language/Buttons/Heading6/Hint}}
+condition: [all[current]!is[image]]
 
 <$button class="tc-btn-invisible" tooltip={{$:/language/Buttons/Heading6/Hint}} aria-label={{$:/language/Buttons/Heading6/Caption}}>
 <$action-sendmessage

--- a/core/ui/TextEditorToolbar/heading-6.tid
+++ b/core/ui/TextEditorToolbar/heading-6.tid
@@ -1,6 +1,6 @@
 title: $:/core/ui/TextEditorToolbar/heading-6
 tags: $:/tags/TextEditorToolbar
-icon: {{$:/core/images/format-heading-5}}
+icon: {{$:/core/images/format-heading-6}}
 caption: {{$:/language/Buttons/Heading6/Caption}}
 description: {{$:/language/Buttons/Heading6/Hint}}
 
@@ -9,7 +9,7 @@ description: {{$:/language/Buttons/Heading6/Hint}}
 	$message="tm-edit-text-operation"
 	$param="prefix-lines"
 	character="!"
-	count="5"
+	count="6"
 />
 {{$:/core/images/format-heading-6}}
 </$button>


### PR DESCRIPTION
The second `H5` should be `H6` in the tab `$:/ControlPanel/ Appearance/ Toolbar/ Text Editor Toolbar`, and it should generate 6's instead of 5's `!` characters.

![wrong icon](https://cloud.githubusercontent.com/assets/1026128/13779617/d7784074-eaf6-11e5-9d03-a96cfd588b04.png)