### PR TITLE
Update utils.js

### DIFF
--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -451,7 +451,7 @@ exports.escapeRegExp = function(s) {
 
 // Checks whether a link target is external, i.e. not a tiddler title
 exports.isLinkExternal = function(to) {
-	var externalRegExp = /(?:file|http|https|mailto|ftp|irc|news|data|skype):[^\s<>{}\[\]`|'"\\^~]+(?:\/|\b)/i;
+	var externalRegExp = /^(?:file|http|https|mailto|ftp|irc|news|data|skype):[^\s<>{}\[\]`|'"\\^~]+(?:\/|\b)$/i;
 	return externalRegExp.test(to);
 };
 


### PR DESCRIPTION
I think this is the fix for issue #2255 (Titles containing URL get interpreted as external links). @jermolene wrote "the regexp for matching external links should be anchored to the start and end of the link string."