### PR TITLE
Reduce hurdles for new users

### DIFF
--- a/core/language/en-GB/Buttons.multids
+++ b/core/language/en-GB/Buttons.multids
@@ -62,6 +62,8 @@ NewJournal/Caption: new journal
 NewJournal/Hint: Create a new journal tiddler
 NewJournalHere/Caption: new journal here
 NewJournalHere/Hint: Create a new journal tiddler tagged with this one
+NewSideBarTab/Caption: new sidebar tab
+NewSideBarTab/Hint: Create a new sidebar tab
 NewTiddler/Caption: new tiddler
 NewTiddler/Hint: Create a new tiddler
 OpenWindow/Caption: open in new window

--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -24,6 +24,7 @@ InternalJavaScriptError/Hint: Well, this is embarrassing. It is recommended that
 InvalidFieldName: Illegal characters in field name "<$text text=<<fieldName>>/>". Fields can only contain lowercase letters, digits and the characters underscore (`_`), hyphen (`-`) and period (`.`)
 LazyLoadingWarning: <p>Loading external text from ''<$text text={{!!_canonical_uri}}/>''</p><p>If this message doesn't disappear you may be using a browser that doesn't support external text in this configuration. See http://tiddlywiki.com/#ExternalText</p>
 MissingTiddler/Hint: Missing tiddler "<$text text=<<currentTiddler>>/>" - click {{$:/core/images/edit-button}} to create
+NewTabTitle: New Tab
 OfficialPluginLibrary: Official ~TiddlyWiki Plugin Library
 OfficialPluginLibrary/Hint: The official ~TiddlyWiki plugin library at tiddlywiki.com. Plugins, themes and language packs are maintained by the core team.
 PluginReloadWarning: Please save {{$:/core/ui/Buttons/save-wiki}} and reload {{$:/core/ui/Buttons/refresh}} to allow changes to plugins to take effect

--- a/core/ui/SideBar/NewTabButton.tid
+++ b/core/ui/SideBar/NewTabButton.tid
@@ -1,0 +1,10 @@
+title: $:/core/ui/SideBar/NewTabButton
+
+<$button tooltip={{$:/language/Buttons/NewSideBarTab/Hint}} aria-label={{$:/language/Buttons/NewSideBarTab/Caption}} class="tc-btn-invisible">
+<$action-sendmessage $message="tm-new-tiddler"
+	title={{$:/language/NewTabTitle}}
+	tags="$:/tags/SideBar"
+	text="""<div class="tc-table-of-contents"><<toc-selective-expandable $(currentTab)$>></div>"""
+	/>
+{{$:/core/images/new-button}}
+</$button>

--- a/core/ui/SideBarLists.tid
+++ b/core/ui/SideBarLists.tid
@@ -41,6 +41,6 @@ title: $:/core/ui/SideBarLists
 
 </$set>
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" />
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" tabsEpilog="[[$:/core/ui/SideBar/NewTabButton]]"/>
 
 </div>

--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -1,9 +1,9 @@
 title: $:/core/macros/tabs
 tags: $:/tags/Macro
 
-\define tabs(tabsList,default,state:"$:/state/tab",class,template)
+\define tabs(tabsList,default,state:"$:/state/tab",class,template,tabsEpilog)
 <div class="tc-tab-set $class$">
-<div class="tc-tab-buttons $class$">
+<span class="tc-tab-buttons $class$">
 <$list filter="$tabsList$" variable="currentTab"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
 <$tiddler tiddler=<<save-currentTiddler>>>
 <$set name="tv-wikilinks" value="no">
@@ -11,7 +11,8 @@ tags: $:/tags/Macro
 <$macrocall $name="currentTab" $type="text/plain" $output="text/plain"/>
 </$transclude>
 </$set></$tiddler></$button></$tiddler></$set></$list>
-</div>
+</span>
+<$list filter="$tabsEpilog$"><$transclude mode="inline"/></$list>
 <div class="tc-tab-divider $class$"/>
 <div class="tc-tab-content $class$">
 <$list filter="$tabsList$" variable="currentTab">

--- a/editions/server/tiddlywiki.info
+++ b/editions/server/tiddlywiki.info
@@ -8,5 +8,19 @@
 	"themes": [
 		"tiddlywiki/vanilla",
 		"tiddlywiki/snowwhite"
-	]
+	],
+	"build": {
+		"index": [
+			"--rendertiddler","$:/plugins/tiddlywiki/tiddlyweb/save/offline","index.html","text/plain"],
+		"externalimages": [
+			"--savetiddlers","[is[image]]","images",
+			"--setfield","[is[image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
+			"--setfield","[is[image]]","text","","text/plain",
+			"--rendertiddler","$:/plugins/tiddlywiki/tiddlyweb/save/offline","externalimages.html","text/plain"],
+		"static": [
+			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
+			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain",
+			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain"]
+	}
 }

--- a/editions/tw5.com/tiddlers/macros/TabsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TabsMacro.tid
@@ -23,6 +23,8 @@ By default the tabs are arranged horizontally above the content. To get vertical
 : Additional [[CSS|Cascading Style Sheets]] classes for the generated `div` elements. Multiple classes can be separated with spaces
 ;template
 : Optionally, the title of a tiddler to use as a [[template|TemplateTiddlers]] for transcluding the content of the selected tab
+;tabsEpilog
+: An optional [[filter|Filters]] selecting tiddlers to be transcluded right after the tab buttons.
 
 Within the template, the title of the selected tab is available in the <<.var currentTab>> variable.
 

--- a/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki on Node.js.tid
+++ b/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki on Node.js.tid
@@ -17,6 +17,10 @@ type: text/vnd.tiddlywiki
 ## `tiddlywiki mynewwiki --server` to start TiddlyWiki
 ## Visit http://127.0.0.1:8080/ in your browser
 ## Try editing and creating tiddlers
+# Optionally, make an offline copy:
+#* click the {{$:/core/images/save-button}} ''Save changes'' button in the sidebar, ''OR''
+#* `tiddlywiki --build index`
+
 
 The `-g` flag causes TiddlyWiki to be installed globally. Without it, TiddlyWiki will only be available in the directory where you installed it.
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -864,7 +864,8 @@ button.tc-untagged-label {
 }
 
 .tc-tiddler-controls button svg, .tc-tiddler-controls button img,
-.tc-search button svg, .tc-search a svg {
+.tc-search button svg, .tc-search a svg,
+.tc-tab-set button svg {
 	height: 0.75em;
 	fill: <<colour tiddler-controls-foreground>>;
 }


### PR DESCRIPTION
From my initial experience with TiddlyWiki as a notes-taking tool, usage is mostly self-explanatory, with the following notable exceptions:

* learning WikiText syntax -> #2315
* adding a sidebar tab for structuring notes -> a07aaec
* exporting a Node.js based wiki as offline version -> c958b93