### PR TITLE
Instrument search to provide default new tiddler titles

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -425,7 +425,7 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 		// Get the template tiddler
 		templateTiddler = this.wiki.getTiddler(event.param);
 		// Generate a new title
-		title = this.wiki.generateNewTitle(event.param || $tw.language.getString("DefaultNewTiddlerTitle"));
+		title = this.wiki.generateNewTitle(event.param || $tw.language.wiki.renderTiddler("text/plain","$:/snippets/DefaultNewDynamicTiddlerTitle"));
 	}
 	// Get the specified additional fields
 	if(typeof event.paramObject === "object") {
@@ -438,7 +438,7 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 		title = additionalFields.title;
 	}
 	// Generate a title if we don't have one
-	title = title || this.wiki.generateNewTitle($tw.language.getString("DefaultNewTiddlerTitle"));
+	title = title || this.wiki.generateNewTitle($tw.language.wiki.renderTiddler("text/plain","$:/snippets/DefaultNewDynamicTiddlerTitle"));
 	// Find any existing draft for this tiddler
 	draftTitle = this.wiki.findDraft(title);
 	// Pull in any existing tiddler

--- a/core/wiki/search-or-defaultnewtitle.tid
+++ b/core/wiki/search-or-defaultnewtitle.tid
@@ -1,0 +1,3 @@
+title: $:/snippets/DefaultNewDynamicTiddlerTitle
+
+<$list filter="[title[$:/temp/search]has[text]]" emptyMessage={{$:/language/DefaultNewTiddlerTitle}}><$transclude tiddler="$:/temp/search" mode="inline"/></$list>


### PR DESCRIPTION
Make use of the standard search area to provide a default new tiddler title. Clicking on the **+** control will use whatever is currently in the search box as the default title for the new tiddler. See a demo[ here](http://search.area-to-default.title.tiddlyspot.com/).
Typical use case:
![capture d ecran 2016-03-20 a 20 04 07](https://cloud.githubusercontent.com/assets/1314688/13906471/fb300b30-eed6-11e5-8473-d2ed8c905ce5.png)
After clicking on the **+** control:
![capture d ecran 2016-03-20 a 19 59 36](https://cloud.githubusercontent.com/assets/1314688/13906443/63f87b30-eed6-11e5-9a5c-1a5637a2580d.png)
Now is it worth the (slight) overload?