### PR TITLE
Fix word wrapping in code blocks

### DIFF
--- a/themes/tiddlywiki/vanilla/ThemeTweaks.tid
+++ b/themes/tiddlywiki/vanilla/ThemeTweaks.tid
@@ -44,6 +44,7 @@ You can tweak certain aspects of the ''Vanilla'' theme.
 
 |[[Sidebar layout|$:/themes/tiddlywiki/vanilla/options/sidebarlayout]] |<$select tiddler="$:/themes/tiddlywiki/vanilla/options/sidebarlayout"><option value="fixed-fluid">Fixed story, fluid sidebar</option><option value="fluid-fixed">Fluid story, fixed sidebar</option></$select> |
 |[[Sticky titles|$:/themes/tiddlywiki/vanilla/options/stickytitles]]<br>//Causes tiddler titles to "stick" to the top of the browser window. Caution: Does not work at all with Chrome, and causes some layout issues in Firefox// |<$select tiddler="$:/themes/tiddlywiki/vanilla/options/stickytitles"><option value="no">No</option><option value="yes">Yes</option></$select> |
+|[[Wrap long lines in code blocks|$:/themes/tiddlywiki/vanilla/options/codewrapping]] |<$select tiddler="$:/themes/tiddlywiki/vanilla/options/codewrapping"><option value="pre">No</option><option value="pre-wrap">Yes</option></$select> |
 
 ! Settings
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -89,7 +89,6 @@ pre {
 	word-break: normal;
 	word-wrap: break-word;
 	white-space: pre;
-	white-space: pre-wrap;
 	background-color: <<colour pre-background>>;
 	border: 1px solid <<colour pre-border>>;
 	padding: 0 3px 2px;
@@ -101,7 +100,7 @@ code {
 	color: <<colour code-foreground>>;
 	background-color: <<colour code-background>>;
 	border: 1px solid <<colour code-border>>;
-    white-space: pre-wrap;
+	white-space: pre;
 	padding: 0 3px 2px;
 	border-radius: 3px;
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/codefontfamily}};

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -88,7 +88,7 @@ pre {
 	margin-bottom: 1em;
 	word-break: normal;
 	word-wrap: break-word;
-	white-space: pre;
+	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
 	background-color: <<colour pre-background>>;
 	border: 1px solid <<colour pre-border>>;
 	padding: 0 3px 2px;
@@ -100,7 +100,7 @@ code {
 	color: <<colour code-foreground>>;
 	background-color: <<colour code-background>>;
 	border: 1px solid <<colour code-border>>;
-	white-space: pre;
+	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
 	padding: 0 3px 2px;
 	border-radius: 3px;
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/codefontfamily}};

--- a/themes/tiddlywiki/vanilla/options.multids
+++ b/themes/tiddlywiki/vanilla/options.multids
@@ -2,3 +2,4 @@ title: $:/themes/tiddlywiki/vanilla/options/
 
 stickytitles: no
 sidebarlayout: fixed-fluid
+codewrapping: pre-wrap


### PR DESCRIPTION
When you create a code block with the three back ticks any thing that was wider then the pre block would be word wrapped. That causes code snippets to look odd.

A work around until this gets merged is to add this tiddler:

    title: $:/styles/pre-block-fix
    tags: [[$:/tags/Style]]

    pre>code {
      white-space: pre;
      overflow-y: scroll;
    }