### PR TITLE
Add localisable strings for plugin library

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -45,6 +45,7 @@ Parsing/Inline/Caption: Inline Parse Rules
 Parsing/Pragma/Caption: Pragma Parse Rules
 Plugins/Add/Hint: Install plugins from the official library
 Plugins/Add/Caption: Get more plugins
+Plugins/AlreadyInstalled: This plugin is already installed at version <$text text=<<installedVersion>>/>
 Plugins/Caption: Plugins
 Plugins/Disable/Caption: disable
 Plugins/Disable/Hint: Disable this plugin when reloading page
@@ -57,6 +58,7 @@ Plugins/Installed/Hint: Currently installed plugins:
 Plugins/Languages/Caption: Languages
 Plugins/Languages/Hint: Language pack plugins
 Plugins/NoInformation: No information provided
+Plugins/NotInstalled: This plugin is not currently installed
 Plugins/OpenPluginLibrary: open plugin library
 Plugins/Plugins/Caption: Plugins
 Plugins/Plugins/Hint: Plugins

--- a/core/ui/ControlPanel/Modals/AddPlugins.tid
+++ b/core/ui/ControlPanel/Modals/AddPlugins.tid
@@ -1,8 +1,6 @@
 title: $:/core/ui/ControlPanel/Modals/AddPlugins
 subtitle: {{$:/core/images/download-button}} {{$:/language/ControlPanel/Plugins/Add/Caption}}
 
-\define lingo-base() $:/language/ControlPanel/Plugins/
-
 \define install-plugin-button()
 <$button>
 <$action-sendmessage $message="tm-load-plugin-from-library" url={{!!url}} title={{$(assetInfo)$!!original-title}}/>
@@ -48,9 +46,9 @@ $:/state/add-plugin-info/$(connectionTiddler)$/$(assetInfo)$
 <$reveal type="match" text="yes" state=<<popup-state>>>
 <div class="tc-plugin-info-dropdown">
 <div class="tc-plugin-info-dropdown-message">
-<$list filter="[<assetInfo>get[original-title]get[version]]" variable="installedVersion" emptyMessage="""This plugin is not currently installed""">
+<$list filter="[<assetInfo>get[original-title]get[version]]" variable="installedVersion" emptyMessage="""{{$:/language/ControlPanel/Plugins/NotInstalled}}""">
 <em>
-This plugin is already installed at version <$text text=<<installedVersion>>/>
+{{$:/language/ControlPanel/Plugins/AlreadyInstalled}}
 </em>
 </$list>
 </div>

--- a/languages/ko-KR/ControlPanel.multids
+++ b/languages/ko-KR/ControlPanel.multids
@@ -45,6 +45,7 @@ Parsing/Inline/Caption: 인라인 파서 규칙
 Parsing/Pragma/Caption: 플라그마 파서 규칙
 Plugins/Add/Caption: 더 많은 플러그인 얻기
 Plugins/Add/Hint: 공식 라이브러리에서 플러그인을 설치합니다
+Plugins/AlreadyInstalled: 이 플러그인은 이미 <$text text=<<installedVersion>>/> 버전으로 설치되어 있습니다
 Plugins/Caption: 플러그인
 Plugins/Disable/Caption: 비활성화
 Plugins/Disable/Hint: 페이지를 다시 불러올 때 이 플러그인을 비활성화합니다
@@ -57,6 +58,7 @@ Plugins/Installed/Hint: 현재 설치된 플러그인:
 Plugins/Languages/Caption: 언어
 Plugins/Languages/Hint: 언어 팩 플러그인
 Plugins/NoInformation: 제공된 정보 없음
+Plugins/NotInstalled: 이 플러그인은 현재 설치되어 있지 않습니다
 Plugins/OpenPluginLibrary: 플러그인 라이브러리 열기
 Plugins/Plugins/Caption: 플러그인
 Plugins/Plugins/Hint: 플러그인


### PR DESCRIPTION
'define lingo-base()' is don't need in dialog 'get more plugins'.