### PR TITLE
Add "new tab" button to sidebar

### DIFF
--- a/core/language/en-GB/Buttons.multids
+++ b/core/language/en-GB/Buttons.multids
@@ -62,6 +62,8 @@ NewJournal/Caption: new journal
 NewJournal/Hint: Create a new journal tiddler
 NewJournalHere/Caption: new journal here
 NewJournalHere/Hint: Create a new journal tiddler tagged with this one
+NewSideBarTab/Caption: new sidebar tab
+NewSideBarTab/Hint: Create a new sidebar tab
 NewTiddler/Caption: new tiddler
 NewTiddler/Hint: Create a new tiddler
 OpenWindow/Caption: open in new window

--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -96,6 +96,9 @@ Settings/NavigationHistory/Caption: Navigation History
 Settings/NavigationHistory/Hint: Update browser history when navigating to a tiddler:
 Settings/NavigationHistory/No/Description: Do not update history
 Settings/NavigationHistory/Yes/Description: Update history
+Settings/NewSideBarTab/Caption: New Sidebar Tab Button
+Settings/NewSideBarTab/Hint: Choose whether to display "+" button next to the sidebar tabs
+Settings/NewSideBarTab/Description: Show the "new sidebar tab" button
 Settings/PerformanceInstrumentation/Caption: Performance Instrumentation
 Settings/PerformanceInstrumentation/Hint: Displays performance statistics in the browser developer console. Requires reload to take effect
 Settings/PerformanceInstrumentation/Description: Enable performance instrumentation

--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -24,6 +24,7 @@ InternalJavaScriptError/Hint: Well, this is embarrassing. It is recommended that
 InvalidFieldName: Illegal characters in field name "<$text text=<<fieldName>>/>". Fields can only contain lowercase letters, digits and the characters underscore (`_`), hyphen (`-`) and period (`.`)
 LazyLoadingWarning: <p>Loading external text from ''<$text text={{!!_canonical_uri}}/>''</p><p>If this message doesn't disappear you may be using a browser that doesn't support external text in this configuration. See http://tiddlywiki.com/#ExternalText</p>
 MissingTiddler/Hint: Missing tiddler "<$text text=<<currentTiddler>>/>" - click {{$:/core/images/edit-button}} to create
+NewTabTitle: New Tab
 OfficialPluginLibrary: Official ~TiddlyWiki Plugin Library
 OfficialPluginLibrary/Hint: The official ~TiddlyWiki plugin library at tiddlywiki.com. Plugins, themes and language packs are maintained by the core team.
 PluginReloadWarning: Please save {{$:/core/ui/Buttons/save-wiki}} and reload {{$:/core/ui/Buttons/refresh}} to allow changes to plugins to take effect

--- a/core/ui/ControlPanel/Settings/NewSideBarTab.tid
+++ b/core/ui/ControlPanel/Settings/NewSideBarTab.tid
@@ -1,0 +1,12 @@
+title: $:/core/ui/ControlPanel/Settings/NewSideBarTab
+tags: $:/tags/ControlPanel/Settings
+caption: {{$:/language/ControlPanel/Settings/NewSideBarTab/Caption}}
+
+\define lingo-base() $:/language/ControlPanel/Settings/NewSideBarTab/
+<<lingo Hint>>
+
+<$checkbox tiddler="$:/config/SideBar/NewTabButton" field="visibility" checked="show" unchecked="hide" default="show">
+	<$link to="$:/config/SideBar/NewTabButton">
+		<<lingo Description>>
+	</$link>
+</$checkbox>

--- a/core/ui/SideBar/NewTabButton.tid
+++ b/core/ui/SideBar/NewTabButton.tid
@@ -1,0 +1,17 @@
+title: $:/core/ui/SideBar/NewTabButton
+tags: $:/tags/SideBarEpilog
+
+\define config-title()
+$:/config/SideBar/NewTabButton!!visibility
+\end
+
+<$reveal state=<<config-title>> type="nomatch" text="hide">
+<$button tooltip={{$:/language/Buttons/NewSideBarTab/Hint}} aria-label={{$:/language/Buttons/NewSideBarTab/Caption}} class="tc-btn-invisible">
+<$action-sendmessage $message="tm-new-tiddler"
+	title={{$:/language/NewTabTitle}}
+	tags="$:/tags/SideBar"
+	text="""<div class="tc-table-of-contents"><<toc-selective-expandable $(currentTab)$>></div>"""
+	/>
+{{$:/core/images/new-button}}
+</$button>
+</$reveal>

--- a/core/ui/SideBarLists.tid
+++ b/core/ui/SideBarLists.tid
@@ -41,6 +41,6 @@ title: $:/core/ui/SideBarLists
 
 </$set>
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" />
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" tabsEpilog="[all[shadows+tiddlers]tag[$:/tags/SideBarEpilog]!has[draft.of]]"/>
 
 </div>

--- a/core/wiki/config/SideBar/NewTabButton.tid
+++ b/core/wiki/config/SideBar/NewTabButton.tid
@@ -1,0 +1,2 @@
+title: $:/config/SideBar/NewTabButton
+visibility: show

--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -1,9 +1,9 @@
 title: $:/core/macros/tabs
 tags: $:/tags/Macro
 
-\define tabs(tabsList,default,state:"$:/state/tab",class,template)
+\define tabs(tabsList,default,state:"$:/state/tab",class,template,tabsEpilog)
 <div class="tc-tab-set $class$">
-<div class="tc-tab-buttons $class$">
+<span class="tc-tab-buttons $class$">
 <$list filter="$tabsList$" variable="currentTab"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
 <$tiddler tiddler=<<save-currentTiddler>>>
 <$set name="tv-wikilinks" value="no">
@@ -11,7 +11,8 @@ tags: $:/tags/Macro
 <$macrocall $name="currentTab" $type="text/plain" $output="text/plain"/>
 </$transclude>
 </$set></$tiddler></$button></$tiddler></$set></$list>
-</div>
+</span>
+<$list filter="$tabsEpilog$"><$transclude mode="inline"/></$list>
 <div class="tc-tab-divider $class$"/>
 <div class="tc-tab-content $class$">
 <$list filter="$tabsList$" variable="currentTab">

--- a/editions/tw5.com/tiddlers/macros/TabsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TabsMacro.tid
@@ -23,6 +23,8 @@ By default the tabs are arranged horizontally above the content. To get vertical
 : Additional [[CSS|Cascading Style Sheets]] classes for the generated `div` elements. Multiple classes can be separated with spaces
 ;template
 : Optionally, the title of a tiddler to use as a [[template|TemplateTiddlers]] for transcluding the content of the selected tab
+;tabsEpilog
+: An optional [[filter|Filters]] selecting tiddlers to be transcluded right after the tab buttons.
 
 Within the template, the title of the selected tab is available in the <<.var currentTab>> variable.
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -864,7 +864,8 @@ button.tc-untagged-label {
 }
 
 .tc-tiddler-controls button svg, .tc-tiddler-controls button img,
-.tc-search button svg, .tc-search a svg {
+.tc-search button svg, .tc-search a svg,
+.tc-tab-set button svg {
 	height: 0.75em;
 	fill: <<colour tiddler-controls-foreground>>;
 }


### PR DESCRIPTION
Adding a tab to the sidebar is a common operation when using TiddlyWiki for organizing notes. Currenty, new users have to find the relevant howto in the documentation, enter the correct tag and copy-paste the macro call. Adding a button after the regular sidebar tabs makes all of this easily discoverable, and streamlines the process also for experienced users.

The button can be switched off in the Settings tab of the $:/ControlPanel.

This has been split out from #2332. Objections that were raised:

1. This should be a plugin.
    - As far as I can see, this would require at least the addition in `$:/core/ui/SideBarLists` and the accompanying extension of the tabs macro to be included in core; otherwise, the plugin would have to hide core tiddlers. I've refactored the proposal a bit, introducing a new tag `$:/tags/SideBarEpilog` which could be used as extension point for a plugin.

2. This should be configurable via ControlPanel.
    - I've added a setting which allows users to switch the button on or off.

3. It adds visual noise to the user interface for everyone but is only useful to a subset of users.
    - A non-representative, non-exhaustive sampling of some public TiddlyWikis indicates that indeed most don't define custom sidebar tabs, or only a single "Content" one. But maybe more people would use this feature if it were more accessible?
    - It's a very small button, comparable to the "advanced search" button next to the search box.
    - The user interface is very similar to the corresponding "new tab" feature in many browsers, and to the generic "new tiddler" button, so it should be familiar.
