### PR TITLE
Add build targets to server edition

### DIFF
--- a/editions/server/tiddlywiki.info
+++ b/editions/server/tiddlywiki.info
@@ -8,5 +8,19 @@
 	"themes": [
 		"tiddlywiki/vanilla",
 		"tiddlywiki/snowwhite"
-	]
+	],
+	"build": {
+		"index": [
+			"--rendertiddler","$:/plugins/tiddlywiki/tiddlyweb/save/offline","index.html","text/plain"],
+		"externalimages": [
+			"--savetiddlers","[is[image]]","images",
+			"--setfield","[is[image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
+			"--setfield","[is[image]]","text","","text/plain",
+			"--rendertiddler","$:/plugins/tiddlywiki/tiddlyweb/save/offline","externalimages.html","text/plain"],
+		"static": [
+			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
+			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain",
+			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain"]
+	}
 }

--- a/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki on Node.js.tid
+++ b/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki on Node.js.tid
@@ -17,6 +17,10 @@ type: text/vnd.tiddlywiki
 ## `tiddlywiki mynewwiki --server` to start TiddlyWiki
 ## Visit http://127.0.0.1:8080/ in your browser
 ## Try editing and creating tiddlers
+# Optionally, make an offline copy:
+#* click the {{$:/core/images/save-button}} ''Save changes'' button in the sidebar, ''OR''
+#* `tiddlywiki --build index`
+
 
 The `-g` flag causes TiddlyWiki to be installed globally. Without it, TiddlyWiki will only be available in the directory where you installed it.
 


### PR DESCRIPTION
Define for the server edition the same build targets as for the empty
edition, but using the correct template so that the "offline" version
(target "index") works correctly when accessed via HTTP. With this,
`tiddlywiki --build index` is equivalent to the save button.

While the process of setting up TiddlyWiki on Node.js is well documented
and easy enough, the options for  publishing such a wiki to an offline
version (scriptably, e.g. for push-to-deploy setups) are decidedly
non-obvious. With the added build steps, the user only needs to know
three simple commands:

tiddlywiki --init server
tiddlywiki --server
tiddlywiki --build index

and optionally

tiddlywiki --build static

---

Split out from #2332. There were no objections raised, other than that this was mixed with unrelated commits.