### PR TITLE
Update edit-text-iframe.js by adding missing semi-colons

### DIFF
--- a/core/modules/widgets/edit-text-iframe.js
+++ b/core/modules/widgets/edit-text-iframe.js
@@ -149,7 +149,7 @@ EditTextIframeWidget.prototype.handleEditTextOperationMessage = function(event) 
 	if(operation.replacement !== null) {
 		// Work around the problem that textInput can't be used directly to delete text without also replacing it with a non-zero length string
 		if(operation.replacement === "") {
-			operation.replacement = operation.text.substring(0,operation.cutStart) + operation.text.substring(operation.cutEnd)
+			operation.replacement = operation.text.substring(0,operation.cutStart) + operation.text.substring(operation.cutEnd);
 			operation.cutStart = 0;
 			operation.cutEnd = operation.text.length;
 		}
@@ -360,7 +360,7 @@ EditTextIframeWidget.prototype.fixHeight = function() {
 		}
 	} else {
 		var fixedHeight = parseInt(this.wiki.getTiddlerText(HEIGHT_VALUE_TITLE,"400px"),10);
-		fixedHeight = Math.max(fixedHeight,20)
+		fixedHeight = Math.max(fixedHeight,20);
 		this.iframeTextArea.style.height = fixedHeight + "px";
 		this.iframeNode.style.height = (fixedHeight + 14) + "px";
 	}


### PR DESCRIPTION
I was thinking that by adding the semicolons it would show I am still interested in solving 2 problems. First Undo and Redo are greatly desired because of mobile users and the preview still disappears. Second, in Internet Explorer 11 which is what I use, the text area doesn't update after pressing buttons unless change preview every time. Obviously there is something about the refresh but I am so inexperienced with the undoManager in an iframe and also having a preview that everything I try breaks it.

I apologize if I didn't do this pull request properly. It is only the second one I have done and I'm not sure it is right. I also was hesitant in including hoisting newText to the top of the function so that it isn't out of scope. I am so new at pull requests and I feel I'm just spinning my wheels not really accomplishing fixing the two problems I set out to help fix. I'm sure these would have been caught by someone else before final release during refactoring. I just wanted to express my interest in helping.