### PR TITLE
Make tiddler file paths configurable

### DIFF
--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -160,4 +160,25 @@ exports.isDirectoryEmpty = function(dirPath) {
 	return empty;
 };
 
+/*
+Recursively delete a tree of empty directories
+*/
+exports.deleteEmptyDirs = function(dirpath,callback) {
+	var self = this;
+	fs.readdir(dirpath,function(err,files) {
+		if(err) {
+			return callback(err);
+		}
+		if(files.length > 0) {
+			return callback(null);
+		}
+		fs.rmdir(dirpath,function(err) {
+			if(err) {
+				return callback(err);
+			}
+			self.deleteEmptyDirs(path.dirname(dirpath),callback);
+		});
+	});
+};
+
 })();

--- a/editions/tw5.com/tiddlers/concepts/TiddlyWikiFolders.tid
+++ b/editions/tw5.com/tiddlers/concepts/TiddlyWikiFolders.tid
@@ -74,7 +74,7 @@ For example:
 
 !! Content of `tiddlers` folder
 
-All the TiddlerFiles in the `tiddlers` folder are read into the wiki at startup. Sub-folders are scanned recursively for TiddlerFiles.
+All the TiddlerFiles in the `tiddlers` folder are read into the wiki at startup. Sub-folders are scanned recursively for TiddlerFiles. Newly created tiddlers are stored in TiddlerFiles directly beneath the `tiddlers` folder, unless [[configured otherwise|Customizing Tiddler File Naming]].
 
 Sub-folders within the `tiddlers` folder can also be given a `tiddlywiki.files` JSON file that overrides the default processing for that folder. The file format is illustrated with this example:
 

--- a/editions/tw5.com/tiddlers/nodejs/Customizing_Tiddler_File_Naming.tid
+++ b/editions/tw5.com/tiddlers/nodejs/Customizing_Tiddler_File_Naming.tid
@@ -1,0 +1,23 @@
+created: 20160424181300000
+modified: 20160424181300000
+tags: [[TiddlyWiki on Node.js]]
+title: Customizing Tiddler File Naming
+type: text/vnd.tiddlywiki
+
+By default, a [[TiddlyWiki on Node.js]] instance using a [[wiki folder|TiddlyWikiFolders]] will create new tiddler files by using the sanitized and disambiguated title as filename.
+
+This can be customized by creating a tiddler [[$:/config/FileSystemPaths]] containing one or more [[filter expressions|Filter Syntax]], each on a line of its own. Newly created tiddlers are matched to each filter in turn, and the first output of the first filter to produce any output is taken as a logical path to be used for the tiddler file. Logical paths don't include the `.tid` extension, and they always use `/` as directory separator (when generating the physical path, this is replaced by the correct separator for the platform ~TiddlyWiki is running on). If none of the filters matches, the logical path is simply the title with all occurences of `/` replaced by `_` (for backwards compatibility).
+
+In both cases, the characters `<>:"\|?*^ ` are replaced by `_` in order to guarantee that the resulting path is legal on all supported platforms.
+
+!! Example
+
+```
+[is[system]removeprefix[$:/]addprefix[_system/]]
+[tag[task][addprefix[mytasks/]]
+[!has[draft.of]]
+```
+
+This will store newly created system tiddlers in `tiddlers/_system` (after stripping the `$:/` prefix), tiddlers tagged [[task]] in a subdirectory `tiddlers/mytasks`, and also create subdirectory structures for all other non-draft tiddlers.
+
+Thus, $:/config/FileSystemPaths itself will end up in `tiddlers/_system/config/FileSystemPaths.tid` or `tiddlers\_system\config\FileSystemPaths.tid`, depending on the platform.


### PR DESCRIPTION
When saving new tiddlers on node.js, allow the user to override the path of the
generated .tid file. This is done by creating a tiddler
$:/config/FileSystemPaths which contains one or more filter expressions, one
per line. These filters are applied in turn to the tiddler to be saved, and
the first output produced is taken as a logical path relative to the wiki's
tiddlers directory. Any occurences of "/" in the logical path are replaced with
the platform's path separator, the extension ".tid" is appended, illegal
characters are replaced by "_" and the path is disambiguated (if necessary) in
order to arrive at the final tiddler file path. If none of the filters matches,
or the configuration tiddler does not exist, fall back to the previous file
naming scheme (i.e. replacing "/" by "_").

This implies we will now, for tiddlers matching the user-specified filters,
create directory trees below the tiddlers directory. In order to avoid
cluttering it with empty directory trees when renaming or removing tiddlers, any
directories that become empty by deleting a tiddler file are removed
(recursively).

Benefits of this configuration option include the ability to organize git
repositories of TiddlyWikis running on node.js, ability to replace characters
that cause trouble with particular operating systems or workflows (e.g. '$' on
unix) and the ability to replicate tiddler "paths" in the filesystem (by
including a filter like "[!has[draft.of]]") without forcing such a (potentially
problematic) change on all users.

---

This is a more ambitious version of #2360, so these PRs are mutually exclusive. Tested with node.js 0.10.25 on Linux. Should receive further testing on different configurations to make sure it doesn't break anything.

Example:

```
[is[system]removeprefix[$:/]addprefix[_system/]]
[tag[task][addprefix[mytasks/tiddlers/]]
[!has[draft.of]]
```

The first line causes system tiddlers to be written to `tiddlers/_system/`, minus the `$:/` prefix (as suggested by @sukima and initially implemented in #2360). The second line causes tiddlers tagged `task` to be written to a separate subdirectory, as suggested by @Jermolene. The third line causes
 logical "paths" of all other non-draft tiddlers to be replicated in the filesystem.