### PR TITLE
Outdated source of Corner ribbon plugin

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/How to put the last modification date in a banner.tid
+++ b/editions/tw5.com/tiddlers/howtos/How to put the last modification date in a banner.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 
 Here's how to display the last modification date of a wiki in a banner in the corner of the window:
 
-# [[Install the plugin|Installing a plugin from the plugin library]] <<.def "Corner ribbon">> in your ~TiddlyWiki.
+# [[Install the plugin|Installing a plugin from the plugin library]] <<.def "Corner ribbon">> in your ~TiddlyWiki
 # Save and reload your wiki
 # Create a new tiddler called [[$:/_MyRibbon]] tagged [[$:/tags/PageControls]] and containing:<div>
 

--- a/editions/tw5.com/tiddlers/howtos/How to put the last modification date in a banner.tid
+++ b/editions/tw5.com/tiddlers/howtos/How to put the last modification date in a banner.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 
 Here's how to display the last modification date of a wiki in a banner in the corner of the window:
 
-# [[Install the plugin|Installing a plugin from the plugin library]] <<.def "Corner ribbon">> in your TiddlyWiki.
+# [[Install the plugin|Installing a plugin from the plugin library]] <<.def "Corner ribbon">> in your ~TiddlyWiki.
 # Save and reload your wiki
 # Create a new tiddler called [[$:/_MyRibbon]] tagged [[$:/tags/PageControls]] and containing:<div>
 

--- a/editions/tw5.com/tiddlers/howtos/How to put the last modification date in a banner.tid
+++ b/editions/tw5.com/tiddlers/howtos/How to put the last modification date in a banner.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 
 Here's how to display the last modification date of a wiki in a banner in the corner of the window:
 
-# Copy the plugin [[$:/plugins/tiddlywiki/github-fork-ribbon]] to your TiddlyWiki
+# [[Install the plugin|Installing a plugin from the plugin library]] <<.def "Corner ribbon">> in your TiddlyWiki.
 # Save and reload your wiki
 # Create a new tiddler called [[$:/_MyRibbon]] tagged [[$:/tags/PageControls]] and containing:<div>
 


### PR DESCRIPTION
No sources provided for  [[$:/plugins/tiddlywiki/github-fork-ribbon]].
Edition aims to its current source in the plugin library and updates the plugin name