### PR TITLE
Update tiddlers from the fr-FR edition to match their shadow counterparts

### DIFF
--- a/editions/fr-FR/tiddlers/$__core_ui_DefaultSearchResultList.tid
+++ b/editions/fr-FR/tiddlers/$__core_ui_DefaultSearchResultList.tid
@@ -6,18 +6,13 @@ title: $:/core/ui/DefaultSearchResultList
 type: text/vnd.tiddlywiki
 
 \define searchResultList()
-<$set name="resultCount" value="""<$count filter="[!is[system]search{$(searchTiddler)$}]"/>""">
-
-{{$:/language/Search/Matches}}
-
-</$set>
-
-//<small>Correspondances parmi les titres :</small>//
+//<small>{{$:/language/Search/Matches/Title}}</small>//
 
 <$list filter="[!is[system]search:title{$(searchTiddler)$}sort[caption]limit[250]] [!is[system]search:fr-title{$(searchTiddler)$}sort[title]limit[250]][!is[system]search:en-title{$(searchTiddler)$}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
 
-//<small>Toutes les correspondances :</small>//
+//<small>{{$:/language/Search/Matches/All}}</small>//
 
 <$list filter="[!is[system]search{$(searchTiddler)$}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+
 \end
 <<searchResultList>>

--- a/editions/fr-FR/tiddlers/$__core_ui_ViewTemplate_title.tid
+++ b/editions/fr-FR/tiddlers/$__core_ui_ViewTemplate_title.tid
@@ -15,6 +15,8 @@ $:/config/ViewToolbarButtons/Visibility/$(listItem)$
 <span class="tc-tiddler-controls">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]]" variable="listItem"><$reveal type="nomatch" state=<<config-title>> text="hide"><$transclude tiddler=<<listItem>>/></$reveal></$list>
 </span>
+<$set name="tv-wikilinks" value={{$:/config/Tiddlers/TitleLinks}}>
+<$link>
 <$set name="foregroundColor" value={{!!color}}>
 <span style=<<title-styles>>>
 <$transclude tiddler={{!!icon}}/>
@@ -32,6 +34,8 @@ $:/config/ViewToolbarButtons/Visibility/$(listItem)$
 </$view>
 </h2>
 </$list>
+</$link>
+</$set>
 </div>
 
 <$reveal type="nomatch" text="" default="" state=<<tiddlerInfoState>> class="tc-tiddler-info tc-popup" animate="yes" retain="yes">


### PR DESCRIPTION
Thanks @Jermolene for the alert. AFAICT, only those two shadow tiddlers had been updated since the last commit of the fr-FR edition overwrote them.