### PR TITLE
A third way to use TW5 on Android

### DIFF
--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Android.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Android.tid
@@ -1,10 +1,10 @@
 caption: Android
 created: 20140811171036268
-modified: 20140916124042604
+modified: 20160430121735629
 title: GettingStarted - Android
 type: text/vnd.tiddlywiki
 
-There are two options for using TiddlyWiki on Android:
+There are three options for using TiddlyWiki on Android:
 
 ! Using Firefox and TiddlyFox
 
@@ -13,3 +13,7 @@ There are two options for using TiddlyWiki on Android:
 ! Using the AndTidWiki App
 
 {{Saving on Android}}
+
+! Using Node.js in Termux
+
+{{Serving TW5 from Android}}

--- a/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki on Node.js.tid
+++ b/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki on Node.js.tid
@@ -1,10 +1,12 @@
 created: 20131219100608529
-modified: 20150325173825615
+modified: 20160430162310620
 tags: [[TiddlyWiki on Node.js]]
 title: Installing TiddlyWiki on Node.js
 type: text/vnd.tiddlywiki
 
-# Install [[Node.js]] from http://nodejs.org
+# Install [[Node.js]]
+#* either from your favourite package manager: typically  `apt-get install nodejs` on Debian/Ubuntu Linux or Termux for Android, or `brew install node` on a Mac
+#* or directly from http://nodejs.org
 # Open a command line terminal and type:
 #> `npm install -g tiddlywiki`
 #> If it fails with an error you may need to re-run the command as an administrator:

--- a/editions/tw5.com/tiddlers/nodejs/Serving_TW5_from_Android.tid
+++ b/editions/tw5.com/tiddlers/nodejs/Serving_TW5_from_Android.tid
@@ -1,0 +1,13 @@
+created: 20160430100634207
+modified: 20160430143725491
+tags: 
+title: Serving TW5 from Android
+type: text/vnd.tiddlywiki
+
+[[Termux|https://termux.com/]] is an open source Android application that combines a Linux system and a terminal.
+
+Once you open //Termux// on your Android system, it is very straightforward to [[install|Installing TiddlyWiki on Node.js]] and [[run|Using TiddlyWiki on Node.js]] the [[Node.js flavour of TiddlyWiki|TiddlyWiki on Node.js]] from its command line. 
+
+From then on, as long as //Termux// is not closed, you may access your wiki anytime from your favourite Web browser pointing on the expected address and port.
+
+> __note to contributors__: you may as well install //git//, //emacs// or //vi//, in order to edit and maintain individual tiddler files. This would probably require that you also attach a more powerful keyboard to your Android, like the [[Hacker's Keyboard|https://github.com/klausw/hackerskeyboard/]] application or a Bluetooth external device.


### PR DESCRIPTION
I just discovered the open source application [Termux](https://github.com/termux), which allows to run  Node.js (hence TW5) on Android very easily. I think it is worth mentioning as an alternate way to run TW5 on Android: here is my proposal for one addition and two modifications to the tw5.com documentation, edited and committed from this environment.