### PR TITLE
Handle binary files better when saving on Node.JS

### DIFF
--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -699,4 +699,20 @@ exports.sign = Math.sign || function(x) {
 	return x > 0 ? 1 : -1;
 };
 
+/*
+IE does not have an endsWith function
+*/
+exports.strEndsWith = function(str,ending,position) {
+	if(str.endsWith) {
+		return str.endsWith(ending,position);
+	} else {
+		if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > str.length) {
+			position = str.length;
+		}
+		position -= str.length;
+		var lastIndex = str.indexOf(ending, position);
+		return lastIndex !== -1 && lastIndex === position;
+	}
+};
+
 })();

--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -123,6 +123,10 @@ FileSystemAdaptor.prototype.generateTiddlerFilename = function(title,extension,e
 	if(baseFilename.length > 200) {
 		baseFilename = baseFilename.substr(0,200);
 	}
+	// Prevent redundent file extensions
+	if($tw.utils.strEndsWith(baseFilename,extension)) {
+		extension = "";
+	}
 	// Start with the base filename plus the extension
 	var filename = baseFilename + extension,
 		count = 1;

--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -32,9 +32,6 @@ $tw.config.typeInfo = {
 	"text/vnd.tiddlywiki": {
 		fileType: "application/x-tiddler",
 		extension: ".tid"
-	},
-	"image/jpeg" : {
-		hasMetaFile: true
 	}
 };
 
@@ -48,11 +45,10 @@ FileSystemAdaptor.prototype.getTiddlerFileInfo = function(tiddler,callback) {
 		title = tiddler.fields.title,
 		fileInfo = $tw.boot.files[title];
 	// Get information about how to save tiddlers of this type
-	var type = tiddler.fields.type || "text/vnd.tiddlywiki",
-		typeInfo = $tw.config.typeInfo[type];
-	if(!typeInfo) {
-		typeInfo = $tw.config.typeInfo["text/vnd.tiddlywiki"];
-	}
+	var type = tiddler.fields.type || "text/vnd.tiddlywiki";
+	var typeInfo = $tw.config.typeInfo[type] ||
+		$tw.config.contentTypeInfo[type] ||
+		$tw.config.typeInfo["text/vnd.tiddlywiki"];
 	var extension = typeInfo.extension || "";
 	if(!fileInfo) {
 		// If not, we'll need to generate it


### PR DESCRIPTION
This PR handles binary (base64) data on the filesystem better. Previously the only filetype that was saved in its correct binary format were `image/jpeg`. This PR will perform the same action with all base64 encoded content.

Please read the commit message for more details.