### PR TITLE
Remove space character between Cancel and Save buttons

### DIFF
--- a/core/ui/EditToolbar/save.tid
+++ b/core/ui/EditToolbar/save.tid
@@ -3,8 +3,7 @@ tags: $:/tags/EditToolbar
 caption: {{$:/core/images/done-button}} {{$:/language/Buttons/Save/Caption}}
 description: {{$:/language/Buttons/Save/Hint}}
 
-<$fieldmangler>
-<$button tooltip={{$:/language/Buttons/Save/Hint}} aria-label={{$:/language/Buttons/Save/Caption}} class=<<tv-config-toolbar-class>>>
+<$fieldmangler><$button tooltip={{$:/language/Buttons/Save/Hint}} aria-label={{$:/language/Buttons/Save/Caption}} class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-add-tag" $param={{$:/temp/NewTagName}}/>
 <$action-deletetiddler $tiddler="$:/temp/NewTagName"/>
 <$action-sendmessage $message="tm-add-field" $name={{$:/temp/newfieldname}} $value={{$:/temp/newfieldvalue}}/>


### PR DESCRIPTION
Buttons in edit toolbar are unevenly spaced because of this space character.

![screenshot_2016-05-08_13-08-38](https://cloud.githubusercontent.com/assets/212368/15100950/7e1c58ca-1536-11e6-9e38-d1b05cd92cb6.png)
