### PR TITLE
Added mobile-web-app-capable meta tag for Android Chrome

### DIFF
--- a/core/templates/static.template.html.tid
+++ b/core/templates/static.template.html.tid
@@ -15,6 +15,7 @@ type: text/vnd.tiddlywiki-html
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="mobile-web-app-capable" content="yes"/>
 <meta name="format-detection" content="telephone=no">
 <link id="faviconLink" rel="shortcut icon" href="favicon.ico">
 <title>{{$:/core/wiki/title}}</title>

--- a/core/templates/static.tiddler.html.tid
+++ b/core/templates/static.tiddler.html.tid
@@ -13,6 +13,7 @@ title: $:/core/templates/static.tiddler.html
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="mobile-web-app-capable" content="yes"/>
 <meta name="format-detection" content="telephone=no">
 <link id="faviconLink" rel="shortcut icon" href="favicon.ico">
 <link rel="stylesheet" href="static.css">

--- a/core/templates/tiddlywiki5.html.tid
+++ b/core/templates/tiddlywiki5.html.tid
@@ -12,6 +12,7 @@ title: $:/core/templates/tiddlywiki5.html
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="mobile-web-app-capable" content="yes"/>
 <meta name="format-detection" content="telephone=no" />
 <meta name="copyright" content="{{$:/core/copyright.txt}}" />
 <link id="faviconLink" rel="shortcut icon" href="favicon.ico">

--- a/plugins/tiddlywiki/blog/templates/html-page/page.tid
+++ b/plugins/tiddlywiki/blog/templates/html-page/page.tid
@@ -13,6 +13,7 @@ title: $:/plugins/tiddlywiki/blog/templates/html-page/page
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="mobile-web-app-capable" content="yes"/>
 <meta name="format-detection" content="telephone=no">
 <link id="faviconLink" rel="shortcut icon" href="favicon.ico">
 <link rel="stylesheet" href="static.css">

--- a/plugins/tiddlywiki/blog/templates/html-page/post.tid
+++ b/plugins/tiddlywiki/blog/templates/html-page/post.tid
@@ -13,6 +13,7 @@ title: $:/plugins/tiddlywiki/blog/templates/html-page/post
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="mobile-web-app-capable" content="yes"/>
 <meta name="format-detection" content="telephone=no">
 <link id="faviconLink" rel="shortcut icon" href="../favicon.ico">
 <link rel="stylesheet" href="../static.css">


### PR DESCRIPTION
Currently, the Android browser recognizes the `apple-mobile-web-app-capable` meta tag for web apps, but per [this page](https://developer.chrome.com/multidevice/android/installtohomescreen), support will stop in a future release. A similar meta tag, `mobile-web-app-capable`, will be used instead.