### PR TITLE
Update TagTemplate.tid

### DIFF
--- a/core/ui/TagTemplate.tid
+++ b/core/ui/TagTemplate.tid
@@ -13,6 +13,12 @@ color:$(foregroundColor)$;
 <$transclude tiddler={{!!icon}}/> <$view field="title" format="text" />
 </$button>
 <$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes"><div class="tc-drop-down"><$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+<$button class="tc-btn-invisible">
+<$list filter="[tag{!!title}]">
+<$action-navigate $to=<<currentTiddler>> />
+</$list>
+Open All
+</$button>
 <hr>
 <$list filter="[all[current]tagging[]]" template="$:/core/ui/ListItemTemplate"/>
 </div>


### PR DESCRIPTION
My request is to add the Open All feature without drag and drop until the link widget can be extended so in the future it can be dragged as a group of tiddlers but for now at least get the feature of opening all with a particular tag available since it is so desired by many. This may be a duplicate of 2513 or even 192. Please forgive me since I may not know enough to be qualified to try to submit pull requests.