### PR TITLE
Add Open All feature to TagTemplate [REDUX]

### DIFF
--- a/core/language/en-GB/Buttons.multids
+++ b/core/language/en-GB/Buttons.multids
@@ -90,6 +90,7 @@ ShowSideBar/Caption: show sidebar
 ShowSideBar/Hint: Show sidebar
 TagManager/Caption: tag manager
 TagManager/Hint: Open tag manager
+TagManager/OpenAll: Open All
 Theme/Caption: theme
 Theme/Hint: Choose the display theme
 Bold/Caption: bold

--- a/core/ui/TagTemplate.tid
+++ b/core/ui/TagTemplate.tid
@@ -7,18 +7,22 @@ color:$(foregroundColor)$;
 \end
 
 \define tag-body-inner(colour,fallbackTarget,colourA,colourB)
-<$set name="foregroundColor" value=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">>>
-<$set name="backgroundColor" value="""$colour$""">
+<$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
 <$button popup=<<qualify "$:/state/popup/tag">> class="tc-btn-invisible tc-tag-label" style=<<tag-styles>>>
 <$transclude tiddler={{!!icon}}/> <$view field="title" format="text" />
 </$button>
 <$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes"><div class="tc-drop-down"><$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+<$button class="tc-btn-invisible">
+<$list filter="[tag{!!title}]">
+<$action-navigate $to=<<currentTiddler>> />
+</$list>
+Open All
+</$button>
 <hr>
 <$list filter="[all[current]tagging[]]" template="$:/core/ui/ListItemTemplate"/>
 </div>
 </$reveal>
-</$set>
-</$set>
+</$vars>
 \end
 
 \define tag-body(colour,palette)

--- a/core/ui/TagTemplate.tid
+++ b/core/ui/TagTemplate.tid
@@ -1,5 +1,6 @@
 title: $:/core/ui/TagTemplate
 
+\define lingo-base() $:/language/Buttons/
 \define tag-styles()
 background-color:$(backgroundColor)$;
 fill:$(foregroundColor)$;
@@ -16,7 +17,7 @@ color:$(foregroundColor)$;
 <$list filter="[tag{!!title}]">
 <$action-navigate $to=<<currentTiddler>> />
 </$list>
-Open All
+<<lingo TagManager/OpenAll>>
 </$button>
 <hr>
 <$list filter="[all[current]tagging[]]" template="$:/core/ui/ListItemTemplate"/>


### PR DESCRIPTION
This is in response to #2469

From Andrew J Harrison andrew.j.harrison84@gmail.com:

> My request is to add the Open All feature without drag and drop until the link widget can be extended so in the future it can be dragged as a group of tiddlers but for now at least get the feature of opening all with a particular tag available since it is so desired by many. This may be a duplicate of 2513 or even 192. Please forgive me since I may not know enough to be qualified to try to submit pull requests.

Rebased and edited by Devin Weaver suki@tritarget.org
