### PR TITLE
Create a widget that triggers actions when you drag a link to it.

### DIFF
--- a/core/modules/widgets/dropaction.js
+++ b/core/modules/widgets/dropaction.js
@@ -1,0 +1,218 @@
+/*\
+title: $:/core/modules/widgets/dropaction.js
+type: application/javascript
+module-type: widget
+Dropzone widget
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var DropActionWidget = function(parseTreeNode,options) {
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+DropActionWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+DropActionWidget.prototype.render = function(parent,nextSibling) {
+	var self = this;
+	// Remember parent
+	this.parentDomNode = parent;
+	// Compute attributes and execute state
+	this.computeAttributes();
+	this.execute();
+	// Create element
+	var domNode = this.document.createElement("div");
+	domNode.className = "tc-dropzone";
+	// Add event handlers
+	$tw.utils.addEventListeners(domNode,[
+		{name: "dragenter", handlerObject: this, handlerMethod: "handleDragEnterEvent"},
+		{name: "dragover", handlerObject: this, handlerMethod: "handleDragOverEvent"},
+		{name: "dragleave", handlerObject: this, handlerMethod: "handleDragLeaveEvent"},
+		{name: "drop", handlerObject: this, handlerMethod: "handleDropEvent"},
+	]);
+	domNode.addEventListener("click",function (event) {
+	},false);
+	// Insert element
+	parent.insertBefore(domNode,nextSibling);
+	this.renderChildren(domNode,null);
+	this.domNodes.push(domNode);
+};
+
+DropActionWidget.prototype.enterDrag = function() {
+	// Check for this window being the source of the drag
+	if(!$tw.dragInProgress) {
+		return false;
+	}
+	// We count enter/leave events
+	this.dragEnterCount = (this.dragEnterCount || 0) + 1;
+	// If we're entering for the first time we need to apply highlighting
+	if(this.dragEnterCount === 1) {
+		$tw.utils.addClass(this.domNodes[0],"tc-dragover");
+	}
+};
+
+DropActionWidget.prototype.leaveDrag = function() {
+	// Reduce the enter count
+	this.dragEnterCount = (this.dragEnterCount || 0) - 1;
+	// Remove highlighting if we're leaving externally
+	if(this.dragEnterCount <= 0) {
+		$tw.utils.removeClass(this.domNodes[0],"tc-dragover");
+	}
+};
+
+DropActionWidget.prototype.handleDragEnterEvent  = function(event) {
+	this.enterDrag();
+	// Tell the browser that we're ready to handle the drop
+	event.preventDefault();
+	// Tell the browser not to ripple the drag up to any parent drop handlers
+	event.stopPropagation();
+};
+
+DropActionWidget.prototype.handleDragOverEvent  = function(event) {
+	// Check for being over a TEXTAREA or INPUT
+	if(["TEXTAREA","INPUT"].indexOf(event.target.tagName) !== -1) {
+		return false;
+	}
+	// Check for this window being the source of the drag
+	if(!$tw.dragInProgress) {
+		return false;
+	}
+	// Tell the browser that we're still interested in the drop
+	event.preventDefault();
+	event.dataTransfer.dropEffect = "copy"; // Explicitly show this is a copy
+};
+
+DropActionWidget.prototype.handleDragLeaveEvent  = function(event) {
+	this.leaveDrag();
+};
+
+DropActionWidget.prototype.handleDropEvent  = function(event) {
+	this.leaveDrag();
+	// Check for being over a TEXTAREA or INPUT
+	if(["TEXTAREA","INPUT"].indexOf(event.target.tagName) !== -1) {
+		return false;
+	}
+	// Check for this window being the source of the drag
+	if(!$tw.dragInProgress) {
+		return false;
+	}
+	
+	// Reset the enter count
+	this.dragEnterCount = 0;
+	
+	// Remove highlighting
+	$tw.utils.removeClass(this.domNodes[0],"tc-dragover");
+
+	// Try to import the various data types we understand
+	var tiddler = this.importData(event.dataTransfer);
+	
+	this.setVariable("currentTiddler",tiddler.title);
+
+    this.invokeActions(this,event);
+	
+	
+	// Tell the browser that we handled the drop
+	event.preventDefault();
+	// Stop the drop ripple up to any parent handlers
+	event.stopPropagation();
+};
+
+DropActionWidget.prototype.importData = function(dataTransfer) {
+	// Try each provided data type in turn
+	for(var t=0; t<this.importDataTypes.length; t++) {
+		if(!$tw.browser.isIE || this.importDataTypes[t].IECompatible) {
+			// Get the data
+			var dataType = this.importDataTypes[t];
+				var data = dataTransfer.getData(dataType.type);
+			// Import the tiddlers in the data
+			if(data !== "" && data !== null) {
+				if($tw.log.IMPORT) {
+					console.log("Importing data type '" + dataType.type + "', data: '" + data + "'")
+				}
+				var tiddlerFields = dataType.convertToFields(data);
+				if(!tiddlerFields.title) {
+					tiddlerFields.title = this.wiki.generateNewTitle("Untitled");
+				}
+				return tiddlerFields;
+			}
+		}
+	}
+};
+
+DropActionWidget.prototype.importDataTypes = [
+	{type: "text/vnd.tiddler", IECompatible: false, convertToFields: function(data) {
+		return JSON.parse(data);
+	}},
+	{type: "URL", IECompatible: true, convertToFields: function(data) {
+		// Check for tiddler data URI
+		var match = decodeURIComponent(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
+		if(match) {
+			return JSON.parse(match[1]);
+		} else {
+			return { // As URL string
+				text: data
+			};
+		}
+	}},
+	{type: "text/x-moz-url", IECompatible: false, convertToFields: function(data) {
+		// Check for tiddler data URI
+		var match = decodeURIComponent(data).match(/^data\:text\/vnd\.tiddler,(.*)/i);
+		if(match) {
+			return JSON.parse(match[1]);
+		} else {
+			return { // As URL string
+				text: data
+			};
+		}
+	}},
+	{type: "text/html", IECompatible: false, convertToFields: function(data) {
+		return {
+			text: data
+		};
+	}},
+	{type: "text/plain", IECompatible: false, convertToFields: function(data) {
+		return {
+			text: data
+		};
+	}},
+	{type: "Text", IECompatible: true, convertToFields: function(data) {
+		return {
+			text: data
+		};
+	}},
+	{type: "text/uri-list", IECompatible: false, convertToFields: function(data) {
+		return {
+			text: data
+		};
+	}}
+];
+
+/*
+Compute the internal state of the widget
+*/
+DropActionWidget.prototype.execute = function() {
+	// Make child widgets
+	this.makeChildWidgets();
+};
+
+/*
+Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+*/
+DropActionWidget.prototype.refresh = function(changedTiddlers) {
+	return this.refreshChildren(changedTiddlers);
+};
+
+exports.dropaction = DropActionWidget;
+
+})();

--- a/core/modules/widgets/dropaction.js
+++ b/core/modules/widgets/dropaction.js
@@ -32,7 +32,7 @@ DropActionWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 	// Create element
-	var domNode = this.document.createElement("div");
+	var domNode = this.document.createElement("span");
 	domNode.className = "tc-dropzone";
 	// Add event handlers
 	$tw.utils.addEventListeners(domNode,[
@@ -117,9 +117,12 @@ DropActionWidget.prototype.handleDropEvent  = function(event) {
 	// Try to import the various data types we understand
 	var tiddler = this.importData(event.dataTransfer);
 	
+	var currentTiddler = this.getVariable("currentTiddler");
 	this.setVariable("currentTiddler",tiddler.title);
 
     this.invokeActions(this,event);
+    
+    this.setVariable("currentTiddler",currentTiddler);
 	
 	
 	// Tell the browser that we handled the drop

--- a/core/modules/widgets/fieldmangler.js
+++ b/core/modules/widgets/fieldmangler.js
@@ -43,8 +43,6 @@ FieldManglerWidget.prototype.render = function(parent,nextSibling) {
 Compute the internal state of the widget
 */
 FieldManglerWidget.prototype.execute = function() {
-	// Get our parameters
-	this.mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
 	// Construct the child widgets
 	this.makeChildWidgets();
 };
@@ -63,7 +61,8 @@ FieldManglerWidget.prototype.refresh = function(changedTiddlers) {
 };
 
 FieldManglerWidget.prototype.handleRemoveFieldEvent = function(event) {
-	var tiddler = this.wiki.getTiddler(this.mangleTitle),
+    var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
+        tiddler = this.wiki.getTiddler(mangleTitle),
 		deletion = {};
 	deletion[event.param] = undefined;
 	this.wiki.addTiddler(new $tw.Tiddler(tiddler,deletion));
@@ -71,7 +70,8 @@ FieldManglerWidget.prototype.handleRemoveFieldEvent = function(event) {
 };
 
 FieldManglerWidget.prototype.handleAddFieldEvent = function(event) {
-	var tiddler = this.wiki.getTiddler(this.mangleTitle),
+    var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
+        tiddler = this.wiki.getTiddler(mangleTitle),
 		addition = this.wiki.getModificationFields(),
 		hadInvalidFieldName = false,
 		addField = function(name,value) {
@@ -109,7 +109,8 @@ FieldManglerWidget.prototype.handleAddFieldEvent = function(event) {
 };
 
 FieldManglerWidget.prototype.handleRemoveTagEvent = function(event) {
-	var tiddler = this.wiki.getTiddler(this.mangleTitle);
+    var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
+        tiddler = this.wiki.getTiddler(mangleTitle);
 	if(tiddler && tiddler.fields.tags) {
 		var p = tiddler.fields.tags.indexOf(event.param);
 		if(p !== -1) {
@@ -126,7 +127,8 @@ FieldManglerWidget.prototype.handleRemoveTagEvent = function(event) {
 };
 
 FieldManglerWidget.prototype.handleAddTagEvent = function(event) {
-	var tiddler = this.wiki.getTiddler(this.mangleTitle);
+    var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
+        tiddler = this.wiki.getTiddler(mangleTitle);
 	if(tiddler && typeof event.param === "string") {
 		var tag = event.param.trim();
 		if(tag !== "") {

--- a/core/modules/widgets/fieldmangler.js
+++ b/core/modules/widgets/fieldmangler.js
@@ -61,8 +61,8 @@ FieldManglerWidget.prototype.refresh = function(changedTiddlers) {
 };
 
 FieldManglerWidget.prototype.handleRemoveFieldEvent = function(event) {
-    var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
-        tiddler = this.wiki.getTiddler(mangleTitle),
+	var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
+		tiddler = this.wiki.getTiddler(mangleTitle),
 		deletion = {};
 	deletion[event.param] = undefined;
 	this.wiki.addTiddler(new $tw.Tiddler(tiddler,deletion));
@@ -70,8 +70,8 @@ FieldManglerWidget.prototype.handleRemoveFieldEvent = function(event) {
 };
 
 FieldManglerWidget.prototype.handleAddFieldEvent = function(event) {
-    var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
-        tiddler = this.wiki.getTiddler(mangleTitle),
+	var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
+		tiddler = this.wiki.getTiddler(mangleTitle),
 		addition = this.wiki.getModificationFields(),
 		hadInvalidFieldName = false,
 		addField = function(name,value) {
@@ -109,8 +109,8 @@ FieldManglerWidget.prototype.handleAddFieldEvent = function(event) {
 };
 
 FieldManglerWidget.prototype.handleRemoveTagEvent = function(event) {
-    var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
-        tiddler = this.wiki.getTiddler(mangleTitle);
+	var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
+		tiddler = this.wiki.getTiddler(mangleTitle);
 	if(tiddler && tiddler.fields.tags) {
 		var p = tiddler.fields.tags.indexOf(event.param);
 		if(p !== -1) {
@@ -127,8 +127,8 @@ FieldManglerWidget.prototype.handleRemoveTagEvent = function(event) {
 };
 
 FieldManglerWidget.prototype.handleAddTagEvent = function(event) {
-    var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
-        tiddler = this.wiki.getTiddler(mangleTitle);
+	var mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler")),
+		tiddler = this.wiki.getTiddler(mangleTitle);
 	if(tiddler && typeof event.param === "string") {
 		var tag = event.param.trim();
 		if(tag !== "") {


### PR DESCRIPTION
The widget triggers actions with the dragged link as the currentTiddler.  

The goal of this widget is to allow you to trigger action widgets by dragging a link into a target area.  For example, you could use the following code to add a tag by dragging a link onto the phrase "Add Tag".  Doing so would add the tag "Testing" to the tiddler you dragged onto the text.

```HTML
<$dropaction>
<$fieldmangler>
<$action-sendmessage $message ="tm-add-tag" $param="Testing" />
</$fieldmangler>
Add Tag
</$dropaction>
````

My primary reason for making this a PR rather than (or in addition to) making it a plugin is that it requires changes to the `<$fieldmangler>` widget.  However, it is currently available at [Matt's Plugin Library.tid](https://github.com/Jermolene/TiddlyWiki5/files/326118/Matt.s.Plugin.Library.tid.txt)
