### PR TITLE
Change the order of static content generation.

### DIFF
--- a/editions/empty/tiddlywiki.info
+++ b/editions/empty/tiddlywiki.info
@@ -17,7 +17,7 @@
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain"]
+			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain"],
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
 	}
 }

--- a/editions/server/tiddlywiki.info
+++ b/editions/server/tiddlywiki.info
@@ -20,7 +20,7 @@
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain"]
+			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain"],
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
 	}
 }


### PR DESCRIPTION
Prevents the `--rendertiddlers` to remove `static.css` rendered earlier,
similar to https://github.com/Jermolene/TiddlyWiki5/pull/1207
and https://github.com/Jermolene/TiddlyWiki5/issues/703.