### PR TITLE
Documentation of Using Excise text

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/WikiText.tid
+++ b/editions/tw5.com/tiddlers/concepts/WikiText.tid
@@ -6,6 +6,8 @@ type: text/vnd.tiddlywiki
 
 ~WikiText is a concise, expressive way of typing a wide range of text formatting, hypertext and interactive features. It allows you to focus on writing without a complex user interface getting in the way. It is designed to be familiar for users of [[MarkDown|http://daringfireball.net/projects/markdown/]], but with more of a focus on linking and the interactive features.
 
+WikiText can also be inserted to the text field using the [[Editor toolbar]].
+
 See [[Formatting text in TiddlyWiki]] for an introduction to WikiText.
 
 The following elements of WikiText syntax are built into the core:

--- a/editions/tw5.com/tiddlers/concepts/WikiText.tid
+++ b/editions/tw5.com/tiddlers/concepts/WikiText.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 
 ~WikiText is a concise, expressive way of typing a wide range of text formatting, hypertext and interactive features. It allows you to focus on writing without a complex user interface getting in the way. It is designed to be familiar for users of [[MarkDown|http://daringfireball.net/projects/markdown/]], but with more of a focus on linking and the interactive features.
 
-WikiText can also be inserted to the text field using the [[Editor toolbar]].
+~WikiText can also be inserted to the text field using the [[Editor toolbar]].
 
 See [[Formatting text in TiddlyWiki]] for an introduction to WikiText.
 

--- a/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
+++ b/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
@@ -1,0 +1,21 @@
+created: 20160817093933820
+modified: 20160817110916813
+tags: Features [[Formatting text in TiddlyWiki]]
+title: Editor toolbar
+
+!! What is the editor toolbar
+
+The editor toolbar is a toolbar, to help you format text easily. It appear above the text input field in a tiddler when in edit mode. It have a similar appearance to desktop text editors like Microsoft Word or Libre Office Write. 
+
+
+!! What the Editor toolbar do
+When you press the button for a function. it will insert the WikiText in the text field. As an example, if you press the bold button it will insert `'' ''`. 
+
+If you ''highlight ''a piece of text the markup code will automatically go around the highlighted text.
+
+if you are in another mode, like MarkDown, the toolbar will change to that syntax and insert appropriate code. However It will not change already typed text or markup.
+
+Beside the standard WikiText formatting, the Editor toolbar have the following buttons:
+
+<<list-links "[tag[Editor toolbar]sort[title]]">>
+

--- a/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
+++ b/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
@@ -3,7 +3,7 @@ modified: 20160817110916813
 tags: Features [[Formatting text in TiddlyWiki]]
 title: Editor toolbar
 
-!! What is the editor toolbar
+!! How it Work
 
 The editor toolbar is a toolbar, to help you format text easily. It appear above the text input field in a tiddler when in edit mode. It have a similar appearance to desktop text editors like Microsoft Word or Libre Office Write. 
 

--- a/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
+++ b/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
@@ -11,7 +11,7 @@ The editor toolbar is a toolbar, to help you format text easily. It appear above
 !! What the Editor toolbar do
 When you press the button for a function, it will insert the WikiText in the text field. As an example, if you press the bold button it will insert `'' ''`. 
 
-If you ''highlight ''a piece of text the markup code will automatically go around the highlighted text.
+If you ''highlight'' a piece of text the markup code will automatically go around the highlighted text.
 
 if you are in another mode, like MarkDown, the toolbar will change to that syntax and insert appropriate code. However It will not change already typed text or markup.
 

--- a/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
+++ b/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
@@ -3,7 +3,7 @@ modified: 20160817110916813
 tags: Features [[Formatting text in TiddlyWiki]]
 title: Editor toolbar
 
-!! How it Work
+!! How it Works
 
 The editor toolbar is a toolbar, to help you format text easily. It appear above the text input field in a tiddler when in edit mode. It have a similar appearance to desktop text editors like Microsoft Word or Libre Office Write. 
 

--- a/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
+++ b/editions/tw5.com/tiddlers/howtos/Editor toolbar.tid
@@ -9,7 +9,7 @@ The editor toolbar is a toolbar, to help you format text easily. It appear above
 
 
 !! What the Editor toolbar do
-When you press the button for a function. it will insert the WikiText in the text field. As an example, if you press the bold button it will insert `'' ''`. 
+When you press the button for a function, it will insert the WikiText in the text field. As an example, if you press the bold button it will insert `'' ''`. 
 
 If you ''highlight ''a piece of text the markup code will automatically go around the highlighted text.
 

--- a/editions/tw5.com/tiddlers/howtos/Height of text editor.tid
+++ b/editions/tw5.com/tiddlers/howtos/Height of text editor.tid
@@ -1,0 +1,6 @@
+created: 20160817103854725
+modified: 20160817105415313
+tags: [[Editor toolbar]]
+title: Height of text editor
+
+The button {{ $:/core/ui/EditorToolbar/editor-height}} let you adjust the height of the text input field.

--- a/editions/tw5.com/tiddlers/howtos/Insert link.tid
+++ b/editions/tw5.com/tiddlers/howtos/Insert link.tid
@@ -1,0 +1,10 @@
+created: 20160817095829521
+modified: 20160817105713406
+tags: [[Editor toolbar]]
+title: Insert link
+
+This will give you a dialog to search for and pick existing tiddlers in the wiki. When you pick a tiddler it will be inserted as a WikiText link where the cursor is in the text field.
+
+Pressing {{$:/core/images/link}} will give you `[[Some link]]`
+
+It wil ''not'' insert: external web links or [[picture|Insert picture]] links.

--- a/editions/tw5.com/tiddlers/howtos/Insert picture.tid
+++ b/editions/tw5.com/tiddlers/howtos/Insert picture.tid
@@ -1,0 +1,9 @@
+created: 20160817100415079
+modified: 20160817110210268
+tags: [[Editor toolbar]]
+title: Insert picture
+
+This will give you a dialog to search for and pick existing image tiddlers in the wiki. When you pick a tiddler it will be inserted as a WikiText  image link where the cursor is in the text field.
+
+
+Pressing {{$:/core/images/picture}} will give you `[img[$:/favicon.ico]]`

--- a/editions/tw5.com/tiddlers/howtos/More actions.tid
+++ b/editions/tw5.com/tiddlers/howtos/More actions.tid
@@ -1,0 +1,6 @@
+created: 20160817104039668
+modified: 20160817110101356
+tags: [[Editor toolbar]]
+title: More actions
+
+Pressing {{$:/core/images/down-arrow}} Gives you  a dropdown menu with more editing options.

--- a/editions/tw5.com/tiddlers/howtos/Text preview.tid
+++ b/editions/tw5.com/tiddlers/howtos/Text preview.tid
@@ -1,0 +1,6 @@
+created: 20160817104110857
+modified: 20160817104802841
+tags: [[Editor toolbar]]
+title: Text preview
+
+Pressing the eye icon {{$:/core/ui/EditorToolbar/preview}} will open or close a preview window (and the eye) of the text you are editing.

--- a/editions/tw5.com/tiddlers/howtos/Using Excise.tid
+++ b/editions/tw5.com/tiddlers/howtos/Using Excise.tid
@@ -8,7 +8,7 @@ type: text/vnd.tiddlywiki
 ! Excise text
 From the EditorToolbar you can export selected text to a new tiddler and insert a [[link|Linking in WikiText]] [[Transclusion]] or [[macro|Macros]] in its place. Click ''Excise text'' ({{$:/core/images/excise}}), input name of the new tiddler, and choose excise method.
 
-! Excise a text
+!! How to excise text
 # Highlight the relevant piece of text 
 #Click ''Excise text'' ({{$:/core/images/excise}})
 # Give the new tiddler a title.

--- a/editions/tw5.com/tiddlers/howtos/Using Excise.tid
+++ b/editions/tw5.com/tiddlers/howtos/Using Excise.tid
@@ -1,0 +1,22 @@
+created: 20160810122928198
+modified: 20160810122934291
+tags: Learning
+title: Using Excise
+type: text/vnd.tiddlywiki
+
+
+! Excise text
+From the EditorToolbar you can export selected text to a new tiddler and insert a [[link|Linking in WikiText]] [[Transclusion]] or [[macro|Macros]] in its place. Click ''Excise text'' ({{$:/core/images/excise}}), input name of the new tiddler, and choose excise method.
+
+! Excise a text
+# Highlight the relevant piece of text 
+#Click ''Excise text'' ({{$:/core/images/excise}})
+# Give the new tiddler a title.
+# Chosse if the new tiddler will be tagged with the title of the current tiddler''*''.
+# Choose replacing method. [[link|Linking in WikiText]] [[Transclusion]] or [[macro|Macros]].
+
+# Click the ''{{$:/language/Buttons/Excise/Caption/Excise}}'' button
+
+
+
+''*NOTE:'' If you choose tic the option to `Tag new tiddler with the title of this tiddler`. The tag will be the'' draft title''. If you create a new tiddler (or clone an existing one), the draft title and the tag, will be `New Tiddler`. __You have to save the tiddler and re-edit it to get the new title as tag.__

--- a/editions/tw5.com/tiddlers/howtos/Using Excise.tid
+++ b/editions/tw5.com/tiddlers/howtos/Using Excise.tid
@@ -1,6 +1,6 @@
 created: 20160810122928198
 modified: 20160810122934291
-tags: Learning
+tags: [[Editor toolbar]]
 title: Using Excise
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/howtos/Using Stamp.tid
+++ b/editions/tw5.com/tiddlers/howtos/Using Stamp.tid
@@ -1,6 +1,6 @@
 created: 20160618090057124
 modified: 20160618090130833
-tags: Learning
+tags: [[Editor toolbar]]
 title: Using Stamp
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/workingwithtw/Formatting text in TiddlyWiki.tid
+++ b/editions/tw5.com/tiddlers/workingwithtw/Formatting text in TiddlyWiki.tid
@@ -6,6 +6,8 @@ type: text/vnd.tiddlywiki
 
 Within the text of a tiddler you can use special formatting called WikiText to control how the text is displayed.
 
+WikiText can be typed by using the [[Editor toolbar]] or by typing by hand. While the first is convenient the later can be faster when you know the WikiText markup code.
+
 ! Simple Formatting
 
 At its simplest, WikiText lets you use familiar word-processing features like bold, italic, lists and tables. For example:


### PR DESCRIPTION
Documentation on the Excise text function. 
I propose that the  Excise text drop down ( the tiddler: $:/language/Buttons/Excise/Caption/Tag) links to this doc. I don't have permission to (or don't know how to) edit that tiddler in github. 

I propose the following text for the drop-down tiddler:

Tag new tiddler with the title of this tiddler (If the title is changed you have to [[save and re-edit|Using Excise]] to use the new title as tag).

see the issue:
https://github.com/Jermolene/TiddlyWiki5/issues/2531
