### PR TITLE
Modify extended listops filters

### DIFF
--- a/core/modules/filters/x-listops.js
+++ b/core/modules/filters/x-listops.js
@@ -159,6 +159,24 @@ Extended filter operators to manipulate the current list.
     };
 
     /*
+    Returns only those items from the current list that are listed in the operand array
+    */
+    exports.keep = function(source, operator) {
+        var array = $tw.utils.parseStringArray(operator.operand, "true"),
+            results = prepare_results(source),
+            len = array.length,
+            remain = [],
+            p;
+        for (p = 0; p < len; ++p) {
+            var index = results.indexOf(array[p]);
+            if (index >= 0) {
+                remain = remain.concat(results.splice(index, 1));
+            }
+        }
+        return (operator.prefix) ? results : remain;
+    };
+
+    /*
     Returns all items from the current list sorted in the order of the items in the operand array
     */
     exports.sortby = function (source, operator) {
@@ -186,4 +204,33 @@ Extended filter operators to manipulate the current list.
         }, []);
         return set;
     };
+
+    /*
+    Returns the next item from the operand list after any matching item from the current list -- else the first item from the operand list
+    */
+    exports.cycle = function(source, operator) {
+        var array = $tw.utils.parseStringArray(operator.operand, "true"),
+            results = prepare_results(source),
+            len = array.length,
+            found = 0,
+            p;
+        for (p = 0; p < len; p++) {
+            if (!found) {
+                var index = results.indexOf(array[p]);
+                if (index >= 0) {
+                    if (operator.prefix) {
+                        (p > 0) ? (results[index] = array[p - 1]) : (results[index] = array[
+                            len - 1]);
+                        found = 1;
+                    } else {
+                        (p < (len - 1)) ? (results[index] = array[p + 1]) : (results[index] =
+                            array[0]);
+                        found = 1;
+                    }
+                }
+            }
+        }
+        return (found) ? results : results.concat(array[0]);
+    };
+	
 })();

--- a/editions/tw5.com/tiddlers/filters/cycle.tid
+++ b/editions/tw5.com/tiddlers/filters/cycle.tid
@@ -1,0 +1,14 @@
+caption: cycle
+created: 20160115004529776
+modified: 20160814073013238
+op-input: a list of items
+op-neg-output: replace first matching item in the current list, with the item occurring before the first matching item in the reference list
+op-output: replace first matching item in the current list, with the item occurring after the first matching item in the reference list
+op-parameter: a reference list of items to cycle through
+op-parameter-name: reference list
+op-purpose: cycle through a list of items from a reference list
+tags: [[Filter Operators]] [[Order Operators]] [[Listops Operators]]
+title: cycle Operator
+type: text/vnd.tiddlywiki
+
+<<.operator-examples "cycle">>

--- a/editions/tw5.com/tiddlers/filters/examples/Lists.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/Lists.tid
@@ -1,0 +1,11 @@
+created: 20160114193046373
+modified: 20160115014200334
+tags:
+title: Lists
+type: application/x-tiddler-dictionary
+
+days: Mon Tue Wed Thu Fri Sat Sun
+months: Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
+dates: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+status: #todo #pending #active #done
+context: @inbox @home @work @shopping @errands

--- a/editions/tw5.com/tiddlers/filters/examples/cycle.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/cycle.tid
@@ -1,0 +1,46 @@
+created: 20160115172254916
+modified: 20160814073025289
+tags: [[Operator Examples]] [[cycle Operator]] _Fri
+title: cycle Operator (Examples)
+type: text/vnd.tiddlywiki
+
+;Cycle a tag from a list of items specified in the operator operand
+: In this case, the 'tags' field of the current tiddler is specified as the target by using the '$tags=' attribute, and the reference list is directly specified in the operand.
+:__Note__: A list specified in this way may not contain any item with spaces
+
+<$macrocall $name='wikitext-example-without-html'
+src="""<$button><$action-listops $tags="+[cycle[_Mon _Tue _Wed _Thu _Fri _Sat _Sun]]"/>Cycle Tag</$button>
+
+<$button><$action-listops $tags="+[!cycle[_Mon _Tue _Wed _Thu _Fri _Sat _Sun]]"/>Reverse Cycle Tag</$button>"""/>
+
+;Cycle items in an index from reference lists contained in a Data Dictionary
+: In this case the target is specified via the '$tiddler=' and '$index=' attributes, and the reference lists are specified using TextReferences within curly brackets (useful for lists containing items with spaces, and for generic lists.)
+
+<$macrocall $name='wikitext-example-without-html'
+src="""<$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $index="cycled-tags" $subfilter="+[cycle{Lists##status}]"/>Status {{$:/core/images/chevron-right}}</$button>
+
+<$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $index="cycled-tags" $subfilter="+[cycle{Lists##context}]"/>Context {{$:/core/images/chevron-right}}</$button>
+
+{{Target}}"""/>
+
+;Cycle items in an index from reference list contained in a variable
+: In this case the target is specified via the '$tiddler=' and '$index=' attributes, and the reference list is specified via a variable (useful for lists containing items with spaces.)
+
+<$macrocall $name='wikitext-example-without-html'
+src="""<$vars authors="[[Joe Bloggs]] [[Mark Spark]] [[Cedric Leo]] [[Oli Phant]]"><$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $index="cycled-tags" $subfilter="+[cycle<authors>]"/>Author {{$:/core/images/chevron-right}}</$button></$vars>
+
+{{Target}}"""/>
+
+;Cycle items in a field from reference lists contained in a Data Dictionary
+: In this case a field is targetted using the '$tiddler=' and '$field=' attributes, and the reference list is specified with a TextReference within curly brackets. The label is configured to clear the target index of all items in the reference list (useful for lists containing items with spaces, and for generic lists.)
+
+<$macrocall $name='wikitext-example-without-html'
+src="""<$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $field="cycled-tags" $subfilter="+[!cycle{Lists##dates}]"/>{{$:/core/images/chevron-left}}</$button>
+<$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $field="cycled-tags" $subfilter="+[remove{Lists##dates}]"/>Dates</$button>
+<$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $field="cycled-tags" $subfilter="+[cycle{Lists##dates}]"/>{{$:/core/images/chevron-right}}</$button>
+
+<$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $field="cycled-tags" $subfilter="+[!cycle{Lists##months}]"/>{{$:/core/images/chevron-left}}</$button>
+<$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $field="cycled-tags" $subfilter="+[remove{Lists##months}]"/>Months</$button>
+<$button class="tc-btn-invisible"><$action-listops $tiddler="Target" $field="cycled-tags" $subfilter="+[cycle{Lists##months}]"/>{{$:/core/images/chevron-right}}</$button>
+
+|Target!!cycled-tags |<$view tiddler="Target" field="cycled-tags"/>|"""/>

--- a/editions/tw5.com/tiddlers/filters/examples/keep.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/keep.tid
@@ -1,0 +1,32 @@
+context: home work shopping errands
+created: 20160117112509803
+modified: 20160814073039238
+status: maybe todo active done
+tags: [[Operator Examples]] [[keep Operator]] slide
+title: keep Operator (Examples)
+
+<<.using-days-of-week>>
+
+;Keep only those items from a list that occur in the reference list
+<<.operator-example 1 "[list[Days of the Week]] +[keep[Mon Tuesday Wed Thursday Fri]]">>
+
+;Keep only those items from a list that don't occur in the reference list
+<<.operator-example 2 "[list[Days of the Week]] +[!keep[Monday Friday Saturday]]">>
+
+;Cycle a tag from a reference list, with button label indicating current item
+<$macrocall $name='wikitext-example-without-html'
+src="""<ul><$list filter="[tag[Features]]">
+<li>
+<$link><<currentTiddler>>  </$link><$button class="tc-btn-invisible" tooltip="cycle context">
+<$action-listops $tags="+[cycle{keep Operator (Examples)!!context}]"/>
+@<$list filter="[is[current]tags[]] +[keep{keep Operator (Examples)!!context}]" variable="item">
+<<item>>
+</$list>
+</$button>
+<$button class="tc-btn-invisible" tooltip="cycle status">
+<$action-listops $tags="+[cycle{keep Operator (Examples)!!status}]"/>
+#<$list filter="[is[current]tags[]] +[keep{keep Operator (Examples)!!status}]" variable="item">
+<<item>>
+</$list>
+</$button></li>
+</$list></ul>"""/>

--- a/editions/tw5.com/tiddlers/filters/keep.tid
+++ b/editions/tw5.com/tiddlers/filters/keep.tid
@@ -1,0 +1,14 @@
+caption: keep
+created: 20160117114959196
+modified: 20160814083955345
+op-input: a list of items
+op-neg-output: keep only items from the current list that don't match items occurring in the reference list
+op-output: keep only items from the current list that match items occurring in the reference list
+op-parameter: a reference list of items
+op-parameter-name: reference list
+op-purpose: keep only those items in the list matching an item from the reference list (view the current item from a reference list)
+tags: [[Filter Operators]] [[Order Operators]] [[Listops Operators]]
+title: keep Operator
+type: text/vnd.tiddlywiki
+
+<<.operator-examples "keep">>


### PR DESCRIPTION
1. Added keep[] and cycle[] filters to the ExtendedListops filters in the core
2. Added documentation and examples for the keep[] and cycle[] filters to tw5.com documentation

Example usage of these new filters may be seen at the ActionListops wiki: http://listops.tiddlyspot.com/