### PR TITLE
Align the right edge of the preview

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1168,7 +1168,7 @@ html body.tc-body.tc-single-tiddler-window {
 	float: right;
 	width: 49%;
 	border: 1px solid <<colour tiddler-editor-border>>;
-	margin: 4px 3px 3px 3px;
+	margin: 4px 0 3px 3px;
 	padding: 3px 3px 3px 3px;
 }
 


### PR DESCRIPTION
Currently it's 3px off to the left compared to the above element.
See screenshot with a vertical line added to illustrate the misalignment.
![2016-09-21_18-20-40](https://cloud.githubusercontent.com/assets/212368/18734429/34ae3f60-8029-11e6-9cb3-ede67020b147.png)