### PR TITLE
Ask for confirmation when creating a new tiddler with the name that already exists

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -445,7 +445,7 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 		isConfirmed = confirm($tw.language.getString(
 			"ConfirmOverwriteTiddler",
 			{variables:
-				{title: draftTitle}
+				{title: title}
 			}
 		));
 	}


### PR DESCRIPTION
Hi, @Jermolene.

When designing my task management system, I use automatically generated numbers for some of my tiddler titles. Because I want to keep my titles short, I choose to generate numbers with less number of digits, which in consequence increases the chance of getting conflicts of tiddler titles.

I have found that, if you use `new-tiddler` button to create a new tiddler, and rename that tiddler with an existing title, TW will inform you that you are overwriting an old one when you are saving that tiddler.

On the contrary, if you use `tm-new-tiddler` message to create a new tiddler which shares the same title with an old one, TW will tend to merge _tag_ field and overwrite other fields **without** any warning. Therefore, people may accidentally overwrite an old tiddler without even aware of it.

In order to solve this inconsistent behavior, I add a simple prompt asking people if they really want to overwrite the old one, when creating a new tiddler.

What do you think?
