### PR TITLE
fix broken array in editions\empty\tiddlywiki.info

### DIFF
--- a/editions/de-AT/tiddlywiki.info
+++ b/editions/de-AT/tiddlywiki.info
@@ -18,16 +18,20 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"empty": [
 			"--rendertiddler","$:/editions/de-AT-DE/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/de-AT-DE/download-empty","empty.hta","text/plain"],
+			"--rendertiddler","$:/editions/de-AT-DE/download-empty","empty.hta","text/plain"
+		],
 		"favicon": [
-			"--savetiddler","$:/favicon.ico","favicon.ico"],
+			"--savetiddler","$:/favicon.ico","favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	}
 }

--- a/editions/de-DE/tiddlywiki.info
+++ b/editions/de-DE/tiddlywiki.info
@@ -21,16 +21,20 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"empty": [
 			"--rendertiddler","$:/editions/de-AT-DE/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/de-AT-DE/download-empty","empty.hta","text/plain"],
+			"--rendertiddler","$:/editions/de-AT-DE/download-empty","empty.hta","text/plain"
+		],
 		"favicon": [
-			"--savetiddler","$:/favicon.ico","favicon.ico"],
+			"--savetiddler","$:/favicon.ico","favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	}
 }

--- a/editions/dev/tiddlywiki.info
+++ b/editions/dev/tiddlywiki.info
@@ -45,15 +45,19 @@
 			"--savetiddlers","[tag[external-image]]","images",
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-image]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"build-readme": [
-			"--rendertiddler","ReadMe for build.jermolene.github.io","readme.md","text/html"],
+			"--rendertiddler","ReadMe for build.jermolene.github.io","readme.md","text/html"
+		],
 		"favicon": [
-			"--savetiddler","$:/favicon.ico","favicon.ico"],
+			"--savetiddler","$:/favicon.ico","favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	}
 }

--- a/editions/empty/tiddlywiki.info
+++ b/editions/empty/tiddlywiki.info
@@ -17,7 +17,7 @@
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain"],
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
 	}
 }

--- a/editions/empty/tiddlywiki.info
+++ b/editions/empty/tiddlywiki.info
@@ -8,16 +8,19 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"externalimages": [
 			"--savetiddlers","[is[image]]","images",
 			"--setfield","[is[image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[is[image]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","externalimages.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","externalimages.html","text/plain"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	}
 }

--- a/editions/es-ES/tiddlywiki.info
+++ b/editions/es-ES/tiddlywiki.info
@@ -24,18 +24,22 @@
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-text]]","_canonical_uri","$:/core/templates/canonical-uri-external-text","text/plain",
 			"--setfield","[tag[external-image]] [tag[external-text]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"empty": [
 			"--rendertiddler","$:/editions/es-ES/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/es-ES/download-empty","empty.hta","text/plain"],
+			"--rendertiddler","$:/editions/es-ES/download-empty","empty.hta","text/plain"
+		],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico",
-			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"],
+			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	},
 	"config": {
 		"retain-original-tiddler-path": true

--- a/editions/fr-FR/tiddlywiki.info
+++ b/editions/fr-FR/tiddlywiki.info
@@ -24,18 +24,22 @@
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-text]]","_canonical_uri","$:/core/templates/canonical-uri-external-text","text/plain",
 			"--setfield","[tag[external-image]] [tag[external-text]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"empty": [
 			"--rendertiddler","$:/editions/fr-FR/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/fr-FR/download-empty","empty.hta","text/plain"],
+			"--rendertiddler","$:/editions/fr-FR/download-empty","empty.hta","text/plain"
+		],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico",
-			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"],
+			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	},
 	"config": {
 		"retain-original-tiddler-path": true

--- a/editions/full/tiddlywiki.info
+++ b/editions/full/tiddlywiki.info
@@ -56,6 +56,7 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"]
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		]
 	}
 }

--- a/editions/highlightdemo/tiddlywiki.info
+++ b/editions/highlightdemo/tiddlywiki.info
@@ -11,11 +11,13 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","highlightdemo.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","highlightdemo.html","text/plain"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	}
 }

--- a/editions/introduction/tiddlywiki.info
+++ b/editions/introduction/tiddlywiki.info
@@ -45,14 +45,17 @@
 			"--savetiddlers","[tag[external-image]]","images",
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-image]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico",
-			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"],
+			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	}
 }

--- a/editions/ja-JP/tiddlywiki.info
+++ b/editions/ja-JP/tiddlywiki.info
@@ -24,18 +24,22 @@
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-text]]","_canonical_uri","$:/core/templates/canonical-uri-external-text","text/plain",
 			"--setfield","[tag[external-image]] [tag[external-text]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"empty": [
 			"--rendertiddler","$:/editions/ja-JP/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/ja-JP/download-empty","empty.hta","text/plain"],
+			"--rendertiddler","$:/editions/ja-JP/download-empty","empty.hta","text/plain"
+		],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico",
-			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"],
+			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	},
 	"config": {
 		"retain-original-tiddler-path": true

--- a/editions/katexdemo/tiddlywiki.info
+++ b/editions/katexdemo/tiddlywiki.info
@@ -11,11 +11,13 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","katexdemo.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","katexdemo.html","text/plain"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	}
 }

--- a/editions/ko-KR/tiddlywiki.info
+++ b/editions/ko-KR/tiddlywiki.info
@@ -24,18 +24,22 @@
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-text]]","_canonical_uri","$:/core/templates/canonical-uri-external-text","text/plain",
 			"--setfield","[tag[external-image]] [tag[external-text]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"empty": [
 			"--rendertiddler","$:/editions/ko-KR/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/ko-KR/download-empty","empty.hta","text/plain"],
+			"--rendertiddler","$:/editions/ko-KR/download-empty","empty.hta","text/plain"
+		],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico",
-			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"],
+			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	},
 	"config": {
 		"retain-original-tiddler-path": true

--- a/editions/markdowndemo/tiddlywiki.info
+++ b/editions/markdowndemo/tiddlywiki.info
@@ -11,6 +11,7 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","markdowndemo.html","text/plain"]
+			"--rendertiddler","$:/core/save/all","markdowndemo.html","text/plain"
+		]
 	}
 }

--- a/editions/pluginlibrary/tiddlywiki.info
+++ b/editions/pluginlibrary/tiddlywiki.info
@@ -12,6 +12,7 @@
 			"--makelibrary","$:/UpgradeLibrary",
    			"--savelibrarytiddlers","$:/UpgradeLibrary","[prefix[$:/]] -[[$:/plugins/tiddlywiki/upgrade]] -[[$:/plugins/tiddlywiki/translators]] -[[$:/plugins/tiddlywiki/pluginlibrary]] -[[$:/plugins/tiddlywiki/jasmine]]","recipes/library/tiddlers/","$:/UpgradeLibrary/List",
    			"--savetiddler","$:/UpgradeLibrary/List","recipes/library/tiddlers.json",
-			"--rendertiddler","$:/plugins/tiddlywiki/pluginlibrary/library.template.html","index.html","text/plain"]
+			"--rendertiddler","$:/plugins/tiddlywiki/pluginlibrary/library.template.html","index.html","text/plain"
+		]
 	}
 }

--- a/editions/resumebuilder/tiddlywiki.info
+++ b/editions/resumebuilder/tiddlywiki.info
@@ -16,8 +16,10 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"favicon": [
-			"--savetiddler","$:/favicon.ico","favicon.ico"]
+			"--savetiddler","$:/favicon.ico","favicon.ico"
+		]
 	}
 }

--- a/editions/server/tiddlywiki.info
+++ b/editions/server/tiddlywiki.info
@@ -11,16 +11,19 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/plugins/tiddlywiki/tiddlyweb/save/offline","index.html","text/plain"],
+			"--rendertiddler","$:/plugins/tiddlywiki/tiddlyweb/save/offline","index.html","text/plain"
+		],
 		"externalimages": [
 			"--savetiddlers","[is[image]]","images",
 			"--setfield","[is[image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[is[image]]","text","","text/plain",
-			"--rendertiddler","$:/plugins/tiddlywiki/tiddlyweb/save/offline","externalimages.html","text/plain"],
+			"--rendertiddler","$:/plugins/tiddlywiki/tiddlyweb/save/offline","externalimages.html","text/plain"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	}
 }

--- a/editions/tahoelafs/tiddlywiki.info
+++ b/editions/tahoelafs/tiddlywiki.info
@@ -9,6 +9,7 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","tahoelafs.html","text/plain"]
+			"--rendertiddler","$:/core/save/all","tahoelafs.html","text/plain"
+		]
 	}
 }

--- a/editions/test/tiddlywiki.info
+++ b/editions/test/tiddlywiki.info
@@ -9,6 +9,7 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","test.html","text/plain"]
+			"--rendertiddler","$:/core/save/all","test.html","text/plain"
+		]
 	}
 }

--- a/editions/translators/tiddlywiki.info
+++ b/editions/translators/tiddlywiki.info
@@ -35,7 +35,8 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"output-files": [
 			"--rendertiddler","$:/plugins/tiddlywiki/translators/templates/Buttons.multids","language/Buttons.multids","text/plain",
 			"--rendertiddler","$:/plugins/tiddlywiki/translators/templates/ControlPanel.multids","language/ControlPanel.multids","text/plain",
@@ -61,6 +62,7 @@
 			"--rendertiddlers","[prefix[$:/language/Docs/Types/]removeprefix[$:/language/Docs/Types/]]","$:/plugins/tiddlywiki/translators/templates/type-tid","language/Types","text/plain",".tid",
 			"--rendertiddlers","[prefix[$:/language/Help/]removeprefix[$:/language/Help/]]","$:/plugins/tiddlywiki/translators/templates/help-tid","language/Help","text/plain",".tid",
 			"--rendertiddlers","[prefix[$:/language/Modals/]removeprefix[$:/language/Modals/]]","$:/plugins/tiddlywiki/translators/templates/modal-tid","language/Modals","text/plain",".tid",
-			"--rendertiddlers","[prefix[$:/language/Snippets/]removeprefix[$:/language/Snippets/]]","$:/plugins/tiddlywiki/translators/templates/snippet-tid","language/Snippets","text/plain",".tid"]
+			"--rendertiddlers","[prefix[$:/language/Snippets/]removeprefix[$:/language/Snippets/]]","$:/plugins/tiddlywiki/translators/templates/snippet-tid","language/Snippets","text/plain",".tid"
+		]
 	}
 }

--- a/editions/tw5.com-docs/tiddlywiki.info
+++ b/editions/tw5.com-docs/tiddlywiki.info
@@ -9,6 +9,7 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"]
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		]
 	}
 }

--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -25,29 +25,36 @@
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-text]]","_canonical_uri","$:/core/templates/canonical-uri-external-text","text/plain",
 			"--setfield","[tag[external-image]] [tag[external-text]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"empty": [
 			"--rendertiddler","$:/editions/tw5.com/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/tw5.com/download-empty","empty.hta","text/plain"],
+			"--rendertiddler","$:/editions/tw5.com/download-empty","empty.hta","text/plain"
+		],
 		"encrypted": [
 			"--password", "password",
 			"--rendertiddler", "$:/core/save/all", "encrypted.html", "text/plain",
-			"--clearpassword"],
+			"--clearpassword"
+		],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico",
-			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"],
+			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"
+		],
 		"readmes": [
 			"--rendertiddler","ReadMe","readme.md","text/html",
 			"--rendertiddler","ReadMeBinFolder","bin/readme.md","text/html",
 			"--rendertiddler","ContributingTemplate","contributing.md","text/html",
-			"--rendertiddler","$:/core/copyright.txt","license.md","text/plain"],
+			"--rendertiddler","$:/core/copyright.txt","license.md","text/plain"
+		],
 		"tw2": [
-			"--rendertiddler","TiddlyWiki2ReadMe","tw2/readme.md","text/html"],
+			"--rendertiddler","TiddlyWiki2ReadMe","tw2/readme.md","text/html"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	},
 	"config": {
 		"retain-original-tiddler-path": true

--- a/editions/tw5tank/tiddlywiki.info
+++ b/editions/tw5tank/tiddlywiki.info
@@ -9,6 +9,7 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","tw5tank.html","text/plain"]
+			"--rendertiddler","$:/core/save/all","tw5tank.html","text/plain"
+		]
 	}
 }

--- a/editions/tw5tiddlyweb/tiddlywiki.info
+++ b/editions/tw5tiddlyweb/tiddlywiki.info
@@ -9,6 +9,7 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","tw5tiddlyweb.html","text/plain"]
+			"--rendertiddler","$:/core/save/all","tw5tiddlyweb.html","text/plain"
+		]
 	}
 }

--- a/editions/upgrade/tiddlywiki.info
+++ b/editions/upgrade/tiddlywiki.info
@@ -10,6 +10,7 @@
 	"build": {
 		"upgrade": [
 			"--makelibrary",
-			"--rendertiddler","$:/core/save/all","upgrade.html","text/plain"]
+			"--rendertiddler","$:/core/save/all","upgrade.html","text/plain"
+		]
 	}
 }

--- a/editions/zh-Hans/tiddlywiki.info
+++ b/editions/zh-Hans/tiddlywiki.info
@@ -24,18 +24,22 @@
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-text]]","_canonical_uri","$:/core/templates/canonical-uri-external-text","text/plain",
 			"--setfield","[tag[external-image]] [tag[external-text]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"empty": [
 			"--rendertiddler","$:/editions/zh-Hans/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/zh-Hans/download-empty","empty.hta","text/plain"],
+			"--rendertiddler","$:/editions/zh-Hans/download-empty","empty.hta","text/plain"
+		],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico",
-			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"],
+			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	},
 	"config": {
 		"retain-original-tiddler-path": true

--- a/editions/zh-Hant/tiddlywiki.info
+++ b/editions/zh-Hant/tiddlywiki.info
@@ -24,18 +24,22 @@
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-text]]","_canonical_uri","$:/core/templates/canonical-uri-external-text","text/plain",
 			"--setfield","[tag[external-image]] [tag[external-text]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--rendertiddler","$:/core/save/all","index.html","text/plain"
+		],
 		"empty": [
 			"--rendertiddler","$:/editions/zh-Hant/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/zh-Hant/download-empty","empty.hta","text/plain"],
+			"--rendertiddler","$:/editions/zh-Hant/download-empty","empty.hta","text/plain"
+		],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico",
-			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"],
+			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"
+		],
 		"static": [
 			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
 			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
 			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"
+		]
 	},
 	"config": {
 		"retain-original-tiddler-path": true


### PR DESCRIPTION
otherwise build & server command fail

Update: a per @pmario's feedback, I eventually modified the bracket style in all **tiddlywiki.info** on top of merely fixing the broken one for the [empty edition](https://github.com/tobibeer/TiddlyWiki5/commit/675412dea7602ac44b83746aabe03ecbb45c0be7)