### PR TITLE
minlength search only for full text search / all matches

### DIFF
--- a/core/language/en-GB/Search.multids
+++ b/core/language/en-GB/Search.multids
@@ -8,7 +8,7 @@ Matches: //<small><<resultCount>> matches</small>//
 Matches/All: All matches:
 Matches/Title: Title matches:
 Search: Search
-Search/TooShort: Search text too short
+Search/TooShort: For full text search, enter {{$:/config/Search/MinLength}} characters or more.
 Shadows/Caption: Shadows
 Shadows/Hint: Search for shadow tiddlers
 Shadows/Matches: //<small><<resultCount>> matches</small>//

--- a/core/ui/AdvancedSearch.tid
+++ b/core/ui/AdvancedSearch.tid
@@ -2,6 +2,21 @@ title: $:/AdvancedSearch
 icon: $:/core/images/advanced-search-button
 color: #bbb
 
+\define searchTiddler() $:/temp/advancedsearch
+\define results(type)
+<$vars resultCount="""<$count filter="[$(searchScope)$search$(field)${$(searchTiddler)$}]"/>""">
+
+<div class="tc-search-results">
+
+<<lingo $type$/Matches>>
+
+{{$:/core/ui/SearchResults}}
+
+</div>
+</$vars>
+\end
 <div class="tc-advanced-search">
+<$set name="field" filter="[{$:/temp/advancedsearch}minlength{$:/config/Search/MinLength}removeprefix{$:/temp/advancedsearch}]" emptyValue="title">
 <<tabs "[all[shadows+tiddlers]tag[$:/tags/AdvancedSearch]!has[draft.of]]" "$:/core/ui/AdvancedSearch/System">>
+</$set>
 </div>

--- a/core/ui/AdvancedSearch/Shadows.tid
+++ b/core/ui/AdvancedSearch/Shadows.tid
@@ -21,24 +21,10 @@ caption: {{$:/language/Search/Shadows/Caption}}
 
 <$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
 
-<$list filter="[{$:/temp/advancedsearch}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
+<$vars searchScope="all[shadows]">
 
-<$set name="resultCount" value="""<$count filter="[all[shadows]search{$:/temp/advancedsearch}] -[[$:/temp/advancedsearch]]"/>""">
+<<results Shadows>>
 
-<div class="tc-search-results">
-
-<<lingo Shadows/Matches>>
-
-<$list filter="[all[shadows]search{$:/temp/advancedsearch}sort[title]limit[250]] -[[$:/temp/advancedsearch]]" template="$:/core/ui/ListItemTemplate"/>
-
-</div>
-
-</$set>
-
-</$list>
-
-</$reveal>
-
-<$reveal state="$:/temp/advancedsearch" type="match" text="">
+</$vars>
 
 </$reveal>

--- a/core/ui/AdvancedSearch/Standard.tid
+++ b/core/ui/AdvancedSearch/Standard.tid
@@ -20,15 +20,10 @@ caption: {{$:/language/Search/Standard/Caption}}
 </$linkcatcher>
 
 <$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
-<$list filter="[{$:/temp/advancedsearch}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
-<$set name="searchTiddler" value="$:/temp/advancedsearch">
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]butfirst[]limit[1]]" emptyMessage="""
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]">
-<$transclude/>
-</$list>
-""">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]" default={{$:/config/SearchResults/Default}}/>
-</$list>
-</$set>
-</$list>
+
+<$vars searchScope="!is[system]">
+
+<<results Standard>>
+
+</$vars>
 </$reveal>

--- a/core/ui/AdvancedSearch/System.tid
+++ b/core/ui/AdvancedSearch/System.tid
@@ -21,24 +21,9 @@ caption: {{$:/language/Search/System/Caption}}
 
 <$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
 
-<$list filter="[{$:/temp/advancedsearch}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
+<$vars searchScope="is[system]">
 
-<$set name="resultCount" value="""<$count filter="[is[system]search{$:/temp/advancedsearch}] -[[$:/temp/advancedsearch]]"/>""">
-
-<div class="tc-search-results">
-
-<<lingo System/Matches>>
-
-<$list filter="[is[system]search{$:/temp/advancedsearch}sort[title]limit[250]] -[[$:/temp/advancedsearch]]" template="$:/core/ui/ListItemTemplate"/>
-
-</div>
-
-</$set>
-
-</$list>
-
-</$reveal>
-
-<$reveal state="$:/temp/advancedsearch" type="match" text="">
+<<results System>>
+</$vars>
 
 </$reveal>

--- a/core/ui/DefaultSearchResultList.tid
+++ b/core/ui/DefaultSearchResultList.tid
@@ -5,11 +5,15 @@ caption: {{$:/language/Search/DefaultResults/Caption}}
 \define searchResultList()
 //<small>{{$:/language/Search/Matches/Title}}</small>//
 
-<$list filter="[!is[system]search:title{$(searchTiddler)$}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+<$list filter="[$(searchScope)$search:title{$(searchTiddler)$}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
 
 //<small>{{$:/language/Search/Matches/All}}</small>//
 
-<$list filter="[!is[system]search{$(searchTiddler)$}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+<$list filter="[{$(searchTiddler)$}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
 
+<$list filter="[$(searchScope)$search{$(searchTiddler)$}sort[title]limit[250]]"
+template="$:/core/ui/ListItemTemplate"/>
+
+</$list>
 \end
 <<searchResultList>>

--- a/core/ui/SideBarLists.tid
+++ b/core/ui/SideBarLists.tid
@@ -1,5 +1,10 @@
 title: $:/core/ui/SideBarLists
 
+\define label()
+<$vars resultCount="""<$count filter="[!is[system]search:$(search-field)${$:/temp/search}]"/>""">
+{{$:/language/Search/Matches}}
+</$vars>
+\end
 <div class="tc-sidebar-lists">
 
 <$set name="searchTiddler" value="$:/temp/search">
@@ -18,11 +23,9 @@ title: $:/core/ui/SideBarLists
 </$button>
 <$button popup=<<qualify "$:/state/popup/search-dropdown">> class="tc-btn-invisible">
 {{$:/core/images/down-arrow}}
-<$list filter="[{$:/temp/search}minlength{$:/config/Search/MinLength}limit[1]]" variable="listItem">
-<$set name="resultCount" value="""<$count filter="[!is[system]search{$(searchTiddler)$}]"/>""">
-{{$:/language/Search/Matches}}
+<$set name="search-field" filter="[{$:/temp/search}minlength{$:/config/Search/MinLength}removeprefix{$:/temp/search}]" emptyValue="title">
+<<label>>
 </$set>
-</$list>
 </$button>
 </$reveal>
 <$reveal state="$:/temp/search" type="match" text="">
@@ -36,17 +39,15 @@ title: $:/core/ui/SideBarLists
 
 <$reveal tag="div" class="tc-block-dropdown tc-search-drop-down tc-popup-handle" state=<<qualify "$:/state/popup/search-dropdown">> type="nomatch" text="" default="">
 
-<$list filter="[{$:/temp/search}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
+<$vars searchScope="!is[system]">
 
 {{$:/core/ui/SearchResults}}
 
-</$list>
+</$vars>
 
 </$reveal>
 
 </$reveal>
-
-</$set>
 
 <$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" />
 

--- a/editions/tw5.com/tiddlers/$__StoryList.tid
+++ b/editions/tw5.com/tiddlers/$__StoryList.tid
@@ -1,0 +1,6 @@
+created: 20161021003057865
+list: $:/AdvancedSearch [[New Tiddler]] HelloThere GettingStarted Community
+modified: 20161021003057865
+title: $:/StoryList
+type: text/vnd.tiddlywiki
+

--- a/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting SearchMinLength.tid
+++ b/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting SearchMinLength.tid
@@ -1,10 +1,10 @@
 created: 20161011074235805
 modified: 20161011074235805
 tags: [[Hidden Settings]]
-title: Hidden Setting: Search Minimum Length
+title: Hidden Setting: Minimum Length For Full Text Search
 type: text/vnd.tiddlywiki
 
-<<.from-version "5.1.14">> Controls the minimum length of a search string before results are displayed.
+<<.from-version "5.1.14">> Controls the minimum length of a search string before full text results are displayed.
 
 Defaults to "3".
 


### PR DESCRIPTION
also reuses searchresults template in sidebar and advanced search
(standard, system, and shadows)