### PR TITLE
canSave should always return true in TiddlyFox saver

### DIFF
--- a/core/modules/savers/tiddlyfox.js
+++ b/core/modules/savers/tiddlyfox.js
@@ -73,7 +73,7 @@ TiddlyFoxSaver.prototype.info = {
 Static method that returns true if this saver is capable of working
 */
 exports.canSave = function(wiki) {
-	return (window.location.protocol === "file:");
+	return true;
 };
 
 /*


### PR DESCRIPTION
Whether saving is allowed should be determined by the parent side of the TiddlyFox, as this plugin can be used in many places.

This is something I have run up against several times when trying to use the TiddlyFox saver for saving in other apps. The mechansim TiddlyFox uses works great in most environments, but restricts itself to only being used in file urls. This prevents it from being used if it is loaded from a Blob URL, for instance, as I do in TiddlyChrome.

With the new way, exports.canSave always returns true and then TiddlyFox saver returns true only if the message box is there? As far as I can tell, that is all that's necessary.
