### PR TITLE
allows to specify state qualifier for tag popups

### DIFF
--- a/core/ui/TagTemplate.tid
+++ b/core/ui/TagTemplate.tid
@@ -8,10 +8,10 @@ color:$(foregroundColor)$;
 
 \define tag-body-inner(colour,fallbackTarget,colourA,colourB)
 <$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
-<$button popup=<<qualify "$:/state/popup/tag">> class="tc-btn-invisible tc-tag-label" style=<<tag-styles>>>
+<$button popup=<<qualify "$:/state/popup/tag$(qualifyState)$">> class="tc-btn-invisible tc-tag-label" style=<<tag-styles>>>
 <$transclude tiddler={{!!icon}}/> <$view field="title" format="text" />
 </$button>
-<$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes" class="tc-drop-down"><$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+<$reveal state=<<qualify "$:/state/popup/tag$(qualifyState)$">> type="popup" position="below" animate="yes" class="tc-drop-down"><$transclude tiddler="$:/core/ui/ListItemTemplate"/>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/TagDropdown]!has[draft.of]]" variable="listItem"> 
 <$transclude tiddler=<<listItem>>/> 
 </$list> 


### PR DESCRIPTION
w/o this all popup buttons for the same tag are popping up

## Demo

http://2628.tiddlyspot.com

# The Issue

In general, I don't think this should be needed.

For a given popup state:

1. only one popup should ever be displayed
2. at the anchor button that was clicked

Just wanting a single popup to open up should not require distinct
states.

## Example

```
<ul>
<$list filter="[tag[Filters]]">
<li>
<$link to={{!!title}}><$view field="title"/></$link><br>
<$vars qualifyState=<<currentTiddler>>>
<$list filter="[all[current]tags[]![Filters]sort[]]"
template="$:/core/ui/TagTemplate"/>
</$vars>
</li>
</$list>
</ul>
```