### PR TITLE
#2312 Prevent move filter from wrapping

### DIFF
--- a/core/modules/filters/x-listops.js
+++ b/core/modules/filters/x-listops.js
@@ -84,8 +84,9 @@ Extended filter operators to manipulate the current list.
         var results = prepare_results(source),
             index = results.indexOf(operator.operand),
             count = parseInt(operator.suffix) || 1,
-            marker = results.splice(index, 1);
-        return results.slice(0, index + count).concat(marker).concat(results.slice(index + count));
+            marker = results.splice(index, 1),
+            offset =  (index + count) > 0 ? index + count : 0;
+        return results.slice(0, offset).concat(marker).concat(results.slice(offset));
     };
 
     /*


### PR DESCRIPTION
Per Issue #2312 

> given a list `A B C D` if I run `A B C D +[move:-1 [A]]` I get `B C A D`.  However, if I were to do `A B C D +[move:1[D]]` it doesn't wrap around, and I get `A B C D`.  

This fixes that such that `A B C D +[move:-1 [A]]` gives `A B C D`