### PR TITLE
Clarifying Tiddlywiki node.js launch instructions.

### DIFF
--- a/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki Prerelease on Node.js.tid
+++ b/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki Prerelease on Node.js.tid
@@ -1,5 +1,5 @@
 created: 20150926162849519
-modified: 20150926163219630
+modified: 20161215160531991
 tags: [[Installing TiddlyWiki on Node.js]]
 title: Installing TiddlyWiki Prerelease on Node.js
 type: text/vnd.tiddlywiki
@@ -7,6 +7,7 @@ type: text/vnd.tiddlywiki
 # Clone a local copy of the TiddlyWiki5 GitHub repository from https://github.com/Jermolene/TiddlyWiki5
 # Open a command line terminal and change the current working directory to the root of the TiddlyWiki5 repo
 # Type `npm link` (Windows) or `sudo npm link` (Mac/Linux) to tell [[npm]] to use this copy of the repo as the globally installed one
+# Inside the root, you can launch ~TiddlyWiki like this:  <br/>``tiddlywiki editions/tw5.com-server --server 8080 $:/core/save/all text/plain text/html``
 
 After this procedure you can work with TiddlyWiki5 via [[npm]] as though it had been installed in the usual way with `npm install -g tiddlywiki`.
 


### PR DESCRIPTION
The way you launch from a git repository is not obvious (or at least not the first time). Added one step to clarify what to do next.