### PR TITLE
Add an entry to the filter drop down for exporting the current story

### DIFF
--- a/core/language/en-GB/Filters.multids
+++ b/core/language/en-GB/Filters.multids
@@ -11,4 +11,5 @@ SystemTiddlers: System tiddlers
 ShadowTiddlers: Shadow tiddlers
 OverriddenShadowTiddlers: Overridden shadow tiddlers
 SystemTags: System tags
+StoryList: Story minus Advanced search
 TypedTiddlers: Non wiki-text tiddlers

--- a/core/ui/Filters/StoryList.tid
+++ b/core/ui/Filters/StoryList.tid
@@ -1,0 +1,5 @@
+title: $:/core/Filters/StoryList
+tags: $:/tags/Filter
+filter: [list[$:/StoryList]] -$:/AdvancedSearch
+description: {{$:/language/Filters/StoryList}}
+


### PR DESCRIPTION
Add an entry to the filter drop down for exporting the current story (minus the Advanced Search tiddler).