### PR TITLE
refresh simple editor when empty text, e.g. hitting ENTER

### DIFF
--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -64,7 +64,7 @@ Set the text of the engine if it doesn't currently have focus
 */
 SimpleEngine.prototype.setText = function(text,type) {
 	if(!this.domNode.isTiddlyWikiFakeDom) {
-		if(this.domNode.ownerDocument.activeElement !== this.domNode) {
+		if(this.domNode.ownerDocument.activeElement !== this.domNode || text === "") {
 			this.domNode.value = text;
 		}
 		// Fix the height if needed


### PR DESCRIPTION
fixes #2592, the missing bit of deleting the field for adding a new tag in edit-mode

After all, the solution was simple, because no caret position is lost if the current value is empty anyway.

also fix for: https://groups.google.com/forum/?fromgroups=#!topic/tiddlywiki/L6Z7gSvBWjw