### PR TITLE
tm-open-external-window plus documentation.

### DIFF
--- a/core/modules/startup/story.js
+++ b/core/modules/startup/story.js
@@ -28,6 +28,9 @@ var DEFAULT_TIDDLERS_TITLE = "$:/DefaultTiddlers";
 var CONFIG_UPDATE_ADDRESS_BAR = "$:/config/Navigation/UpdateAddressBar"; // Can be "no", "permalink", "permaview"
 var CONFIG_UPDATE_HISTORY = "$:/config/Navigation/UpdateHistory"; // Can be "yes" or "no"
 
+// Links to help, if there is no param
+var HELP_OPEN_EXTERNAL_WINDOW = "http://tiddlywiki.com/#WidgetMessage%3A%20tm-open-external-window";
+
 exports.startup = function() {
 	// Open startup tiddlers
 	openStartupTiddlers();
@@ -56,7 +59,7 @@ exports.startup = function() {
 		// Listen for tm-open-external-window message
 		$tw.rootWidget.addEventListener("tm-open-external-window",function(event) {
 			var paramObject = event.paramObject || {},
-				strUrl = event.param || "http://tiddlywiki.com/#WidgetMessage%3A%20tm-open-external-window",
+				strUrl = event.param || HELP_OPEN_EXTERNAL_WINDOW,
 				strWindowName = paramObject.windowName,
 				strWindowFeatures = paramObject.windowFeatures;
 			window.open(strUrl, strWindowName, strWindowFeatures);

--- a/core/modules/startup/story.js
+++ b/core/modules/startup/story.js
@@ -53,6 +53,14 @@ exports.startup = function() {
 		$tw.rootWidget.addEventListener("tm-browser-refresh",function(event) {
 			window.location.reload(true);
 		});
+		// Listen for tm-open-external-window message
+		$tw.rootWidget.addEventListener("tm-open-external-window",function(event) {
+			var paramObject = event.paramObject || {},
+				strUrl = event.param || "http://tiddlywiki.com/#WidgetMessage%3A%20tm-open-external-window",
+				strWindowName = paramObject.windowName,
+				strWindowFeatures = paramObject.windowFeatures;
+			window.open(strUrl, strWindowName, strWindowFeatures);
+		});
 		// Listen for the tm-print message
 		$tw.rootWidget.addEventListener("tm-print",function(event) {
 			(event.event.view || window).print();
@@ -66,7 +74,7 @@ exports.startup = function() {
 			storyList = $tw.hooks.invokeHook("th-opening-default-tiddlers-list",storyList);
 			$tw.wiki.addTiddler({title: DEFAULT_STORY_TITLE, text: "", list: storyList},$tw.wiki.getModificationFields());
 			if(storyList[0]) {
-				$tw.wiki.addToHistory(storyList[0]);				
+				$tw.wiki.addToHistory(storyList[0]);
 			}
 		});
 		// Listen for the tm-permalink message

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-external-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-external-window.tid
@@ -21,8 +21,10 @@ The `tm-open-external-window` message opens an external link eg: "http://tiddlyw
 
 The `tm-open-external-window` message is usually generated with the ButtonWidget or ActionSendMessageWidget and is handled by the core itself.
 
-```
-<$button>
+''Examples''
+
+<$macrocall $name='wikitext-example-without-html'
+src='<$button>
 <$action-sendmessage $message="tm-open-external-window" $param="http://tiddlywiki.com" windowName="_tiddlywiki" windowFeatures="height=500, width=900"/>
 Open ~TiddlyWiki - Action
 </$button>
@@ -34,5 +36,4 @@ Open Mozilla Help - Action
 
 <$button message="tm-open-external-window" param="http://tiddlywiki.com" >
 Open ~TiddlyWiki - Button
-</$button>
-```
+</$button>'/>

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-external-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-external-window.tid
@@ -1,0 +1,38 @@
+caption: tm-open-external-window
+created: 201701211823
+modified: 201701211825
+tags: Messages
+title: WidgetMessage: tm-open-external-window
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.14">>
+
+The `tm-open-external-window` message opens an external link eg: "http://tiddlywiki.com" in a new //browser// window. If no parameters are specified, it opens the help tiddler. Any additional parameters passed via the <<.param "paramObject">> are being provided as variables to the new window.
+
+|!Name |!Description |
+|param |URL of the tiddler to be opened in a new browser window, defaults to the [[TiddlyWiki help|http://tiddlywiki.com/#WidgetMessage%3A%20tm-open-external-window if empty]] |
+|paramObject |Optional: Hashmap of variables that will be provided to the window. see below |
+
+''parmObject''
+
+|!Name |!Description|!Important|
+|windowName|If a parameter is provided it can be used to open different links in the same window eg: `_tiddlywiki`. Default is empty, so every link opens a new window.|The behaviour is influenced by user settings in the browser and the browsers default behavior! |
+|windowFeatures|This parameter needs to be provided as a single string. eg: `"height=400, width=600"`. For detailed description about possible parameters see: [[Mozilla Help|https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features]] ||
+
+The `tm-open-external-window` message is usually generated with the ButtonWidget or ActionSendMessageWidget and is handled by the core itself.
+
+```
+<$button>
+<$action-sendmessage $message="tm-open-external-window" $param="http://tiddlywiki.com" windowName="_tiddlywiki" windowFeatures="height=500, width=900"/>
+Open ~TiddlyWiki - Action
+</$button>
+
+<$button>
+<$action-sendmessage $message="tm-open-external-window" $param="https://developer.mozilla.org/en-US/docs/Web/API/Window/open" windowName="_tiddlywiki" windowFeatures="height=400, width=600"/>
+Open Mozilla Help - Action
+</$button>
+
+<$button message="tm-open-external-window" param="http://tiddlywiki.com" >
+Open ~TiddlyWiki - Button
+</$button>
+```


### PR DESCRIPTION
This new message provides the possibility to open external pages in a new window. Similar to `tm-open-window`

Documentation is included. 

I did add the function to the `story.js` file, since the functionality is closer to `window.refresh` but it would be possible to include it at: title: $:/core/modules/startup/windows.js

@Jermolene @tobibeer what do you think?

The implementation was triggerd by a discussion in the google group: [TiddlyWiki app idea](https://groups.google.com/forum/#!topic/tiddlywiki/xEZSQvaNpqg)
my "link-journal" [proof of concept](https://groups.google.com/d/msg/tiddlywiki/xEZSQvaNpqg/5ejT7KXTEwAJ) and this implementation work very well together. 
