### PR TITLE
allows to specify a class for each individual tab

### DIFF
--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -13,8 +13,9 @@ tags: $:/tags/Macro
 </$set></$tiddler></$button></$tiddler></$set></$list>
 </div>
 <div class="tc-tab-divider $class$"/>
-<div class="tc-tab-content $class$">
 <$list filter="$tabsList$" variable="currentTab">
+<$set name="class" filter="[<currentTab>get[tab-class]addprefix[tc-tab-content $class$ ]]" select="0" emptyValue="tc-tab-content $class$">
+<div class=<<class>>>
 
 <$reveal type="match" state=<<qualify "$state$">> text=<<currentTab>> default="$default$">
 
@@ -25,8 +26,8 @@ tags: $:/tags/Macro
 </$transclude>
 
 </$reveal>
-
-</$list>
 </div>
+</$set>
+</$list>
 </div>
 \end

--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -4,13 +4,13 @@ tags: $:/tags/Macro
 \define tabs(tabsList,default,state:"$:/state/tab",class,template)
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
-<$list filter="$tabsList$" variable="currentTab"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
+<$list filter="$tabsList$" variable="currentTab"><$set name="save-currentTiddler" value=<<currentTiddler>>><$set name="tab-class" filter="[<currentTab>get[tab-class]]"><$tiddler tiddler=<<currentTab>>><$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" class=<<tab-class>> selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
 <$tiddler tiddler=<<save-currentTiddler>>>
 <$set name="tv-wikilinks" value="no">
 <$transclude tiddler=<<currentTab>> field="caption">
 <$macrocall $name="currentTab" $type="text/plain" $output="text/plain"/>
 </$transclude>
-</$set></$tiddler></$button></$tiddler></$set></$list>
+</$set></$tiddler></$button></$tiddler></$set></$set></$list>
 </div>
 <div class="tc-tab-divider $class$"/>
 <div class="tc-tab-content $class$">

--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -4,13 +4,13 @@ tags: $:/tags/Macro
 \define tabs(tabsList,default,state:"$:/state/tab",class,template)
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
-<$list filter="$tabsList$" variable="currentTab"><$set name="save-currentTiddler" value=<<currentTiddler>>><$set name="tab-class" filter="[<currentTab>get[tab-class]]"><$tiddler tiddler=<<currentTab>>><$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" class=<<tab-class>> selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
+<$list filter="$tabsList$" variable="currentTab"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" class={{!!tab-class}} selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
 <$tiddler tiddler=<<save-currentTiddler>>>
 <$set name="tv-wikilinks" value="no">
 <$transclude tiddler=<<currentTab>> field="caption">
 <$macrocall $name="currentTab" $type="text/plain" $output="text/plain"/>
 </$transclude>
-</$set></$tiddler></$button></$tiddler></$set></$set></$list>
+</$set></$tiddler></$button></$tiddler></$set></$list>
 </div>
 <div class="tc-tab-divider $class$"/>
 <div class="tc-tab-content $class$">

--- a/editions/tw5.com/tiddlers/demonstrations/SampleTabOne.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/SampleTabOne.tid
@@ -1,6 +1,9 @@
 created: 20150221211544000
-title: SampleTabOne
-tags: sampletab
+modified: 20170122171127661
 order: 1
+tab-class: tab-class-test
+tags: sampletab
+title: SampleTabOne
+type: text/vnd.tiddlywiki
 
 This is the first of our sample tabs.

--- a/editions/tw5.com/tiddlers/macros/TabsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TabsMacro.tid
@@ -13,7 +13,7 @@ Certain properties of the tab buttons can be controlled by setting certain field
 
 |!Field |!Description |!Fallback |
 |<<.field caption>>|the button label|the tiddler title|
-|<<.field tooltip>>|the button tooltup|n.a.|
+|<<.field tooltip>>|the button tooltip|n.a.|
 |<<.field "tab-class">>|<<.from-version "5.1.14">> a css class assigned to the button as well as the tab content|n.a.|
 
 !! Parameters

--- a/editions/tw5.com/tiddlers/macros/TabsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TabsMacro.tid
@@ -1,6 +1,6 @@
 caption: tabs
 created: 20131228162203521
-modified: 20170122122551972
+modified: 20170122171605674
 tags: Macros [[Core Macros]]
 title: tabs Macro
 type: text/vnd.tiddlywiki
@@ -14,7 +14,7 @@ Certain properties of the tab buttons can be controlled by setting certain field
 |!Field |!Description |!Fallback |
 |<<.field caption>>|the button label|the tiddler title|
 |<<.field tooltip>>|the button tooltup|n.a.|
-|<<.field tab-class>>|<<.from-version "5.1.14">> the button class|n.a.|
+|<<.field "tab-class">>|<<.from-version "5.1.14">> a css class assigned to the button as well as the tab content|n.a.|
 
 !! Parameters
 
@@ -39,6 +39,6 @@ The <<.vlink currentTiddler>> variable is not affected by the <<.var tabs>> macr
 <$tiddler tiddler=<<currentTab>>>
 <$transclude mode="block" />
 </$tiddler>
-``` 
+```
 
 <<.macro-examples "tabs">>

--- a/editions/tw5.com/tiddlers/macros/TabsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TabsMacro.tid
@@ -1,17 +1,24 @@
 caption: tabs
 created: 20131228162203521
-modified: 20150221211706000
+modified: 20170122122551972
 tags: Macros [[Core Macros]]
 title: tabs Macro
 type: text/vnd.tiddlywiki
 
 The <<.def tabs>> [[macro|Macros]] presents a [[selection of tiddlers|Title Selection]] as a set of tabs that the user can switch between.
 
-The tabs display the <<.field caption>> field of a tiddler if it has one, or the tiddler's title otherwise. If specified, the tabs display the <<.field tooltip>> field of a tiddler as the respective button tooltip.
+!! Tiddler Fields
 
-By default the tabs are arranged horizontally above the content. To get vertical tabs, set the <<.param class>> parameter to <<.value tc-vertical>>.
+Certain properties of the tab buttons can be controlled by setting certain fields for the tiddlers being rendered as tabs:
+
+|!Field |!Description |!Fallback |
+|<<.field caption>>|the button label|the tiddler title|
+|<<.field tooltip>>|the button tooltup|n.a.|
+|<<.field tab-class>>|<<.from-version "5.1.14">> the button class|n.a.|
 
 !! Parameters
+
+By default the tabs are arranged horizontally above the content. To get vertical tabs, set the <<.param class>> parameter to <<.value tc-vertical>>.
 
 ;tabsList
 : A [[filter|Filters]] selecting which tiddlers to include


### PR DESCRIPTION
assignes class via `tab-class` field to both the button as well as the tab content wrapper

demo for documentation: http://2724.tiddlyspot.com