### PR TITLE
Rename "Mail List" to be "Discussion Board"

### DIFF
--- a/editions/tw5.com/tiddlers/hellothere/HelloThere.tid
+++ b/editions/tw5.com/tiddlers/hellothere/HelloThere.tid
@@ -19,7 +19,7 @@ Unlike conventional online services, TiddlyWiki lets you choose where to keep yo
 
 <div style="font-size:0.7em;text-align:center;margin-top:3em;margin-bottom:3em;">
 <a href="http://groups.google.com/group/TiddlyWiki" class="tc-btn-big-green" style="background-color:#FF8C19;" target="_blank" rel="noopener noreferrer">
-{{$:/core/images/mail}} ~TiddlyWiki Mailing List
+{{$:/core/images/mail}} ~TiddlyWiki Discussion Board
 </a>
 <a href="http://www.youtube.com/c/JeremyRuston" class="tc-btn-big-green" style="background-color:#e52d27;" target="_blank" rel="noopener noreferrer">
 {{$:/core/images/video}} ~TiddlyWiki on ~YouTube


### PR DESCRIPTION
`Mail list` implies *giving-out-my-email-address*. Also, IMO "mail lists" can be anything from ads to release updates, which is not really what our case is about.

Better call it the *Discussion Board*, or the *Discussion Forum* - and **on the board** inform people that they can subscribe to it.