### PR TITLE
change plugin list h2 color to improve readability

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1947,6 +1947,7 @@ a.tc-tiddlylink.tc-plugin-info:hover .tc-plugin-info > .tc-plugin-info-chunk > s
 .tc-plugin-info-chunk h2 {
 	font-size: 0.8em;
 	margin: 2px 0 2px 0;
+	color: green;
 }
 
 .tc-plugin-info-chunk div {


### PR DESCRIPTION
nothing more to say: IMO it gives a much better overview and plugins are much easier to find. 

![plugin-new-color](https://cloud.githubusercontent.com/assets/374655/22791441/a77892aa-eee9-11e6-96ce-4ffab91fea68.gif)


