### PR TITLE
Added arrows to the sidebar to move tiddlers in the story river

### DIFF
--- a/core/ui/SideBar/Open.tid
+++ b/core/ui/SideBar/Open.tid
@@ -5,6 +5,22 @@ caption: {{$:/language/SideBar/Open/Caption}}
 \define lingo-base() $:/language/CloseAll/
 <$list filter="[list[$:/StoryList]]" history="$:/HistoryList" storyview="pop">
 
+<$button class="tc-btn-invisible">
+<$list variable="previous" filter="[list[$:/StoryList]] +[before<currentTiddler>] [title[]] +[first[]]">
+<$list filter="[title[]] [title<previous>] +[nth[2]]" variable="">
+<$action-listops $tiddler="$:/StoryList" $filter="[list[$:/StoryList]] [title<currentTiddler>]" $subfilter="+[putbefore<previous>]" />
+</$list>
+&uarr;
+</$list>
+</$button>
+<$button class="tc-btn-invisible">
+<$list variable="next" filter="[list[$:/StoryList]] +[after<currentTiddler>] [title[]] +[first[]]">
+<$list filter="[title[]] [title<next>] +[nth[2]]" variable="">
+<$action-listops $tiddler="$:/StoryList" $filter="[list[$:/StoryList]] [title<currentTiddler>]" $subfilter="+[putafter<next>]" />
+</$list>
+&darr;
+</$list>
+</$button>
 <$button message="tm-close-tiddler" tooltip={{$:/language/Buttons/Close/Hint}} aria-label={{$:/language/Buttons/Close/Caption}} class="tc-btn-invisible tc-btn-mini">&times;</$button> <$link to={{!!title}}><$view field="title"/></$link>
 
 </$list>


### PR DESCRIPTION
Using the listops filter operators, modify the order of list in the $:/StoryList tiddler.  This changes the order of tiddlers in the Story River.

@Jermolene I am not sure if there was anything else I needed to do to manage the order.  Changing the order shouldn't affect history, but let me know if there's any other Tiddlywiki internals I missed.