### PR TITLE
remove unmotivated formatting

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/Title List.tid
+++ b/editions/tw5.com/tiddlers/concepts/Title List.tid
@@ -5,10 +5,10 @@ title: Title List
 
 A <<.def "title list">> is a line of text that presents one or more tiddler titles, strung together with a space between each one and the next.
 
-If a title <<.em contains>> a space, it needs double square brackets around it:
+If a title contains a space, it needs double square brackets around it:
 
 `GettingStarted [[Discover TiddlyWiki]] Upgrading`
 
-Title lists are used in various places, including PermaLinks and the ListField.
+Title lists are used in various places, most frequently and usefully in PermaLinks and the ListField. Since the concept of ~TiddlyWiki is the assembly of small pieces of information into larger texts, identifying the "small pieces" is an essential skill.
 
 They are in fact the simplest case of a [[filter|Filters]], and are thus a way of expressing a [[selection of titles|Title Selection]].


### PR DESCRIPTION
It's not clear why "contains" needs to be formatted as it is. There is no discussion of the word in the tiddler.
Why pick Permalinks and ListField? Assume these are the most frequent or useful  & say so.
"thus" is unhelpful.