### PR TITLE
Make rsod less annoying

### DIFF
--- a/boot/boot.css.tid
+++ b/boot/boot.css.tid
@@ -9,7 +9,39 @@ Basic styles used before we boot up the parsing engine
 Error message and password prompt
 */
 
-.tc-password-wrapper, .tc-error-form {
+.tc-error-form {
+	font-family: sans-serif;
+	color: #fff;
+	z-index: 20000;
+	position: fixed;
+	background-color: rgb(255, 75, 75);
+	border: 8px solid rgb(255, 0, 0);
+	border-radius: 8px;
+	width: 50%;
+	margin-left: 25%;
+	margin-top: 4em;
+	padding: 0 2em 2em 2em;
+}
+
+.tc-error-form h1 {
+	text-align: center;
+}
+
+.tc-error-prompt {
+	text-align: center;
+	color: #000;
+	margin-bottom: 1em;
+}
+
+.tc-error-message {
+	overflow: auto;
+	max-height: 40em;
+	padding-right: 1em;
+	margin-bottom: 1em;
+	white-space: pre-line;
+}
+
+.tc-password-wrapper {
     font-family: sans-serif;
 	z-index: 20000;
 	position: fixed;
@@ -20,24 +52,6 @@ Error message and password prompt
     margin-left: -144px; /* - width/2 - paddingHorz/2 - border */
 	padding: 16px 16px 16px 16px;
 	border-radius: 8px;
-}
-
-.tc-error-form {
-	color: #fff;
-	text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
-	background-color: rgb(255, 75, 75);
-	border: 8px solid rgb(255, 0, 0);
-	width: 480px;
-    margin-left: -244px; /* - width/2 - paddingHorz/2 - border */
-}
-
-.tc-error-form div {
-	padding-bottom: 1em;
-}
-
-.tc-error-prompt {
-	color: #000;
-	text-shadow: none;
 }
 
 .tc-password-wrapper {

--- a/boot/boot.css.tid
+++ b/boot/boot.css.tid
@@ -48,8 +48,8 @@ Error message and password prompt
 	text-align: center;
 	width: 200px;
 	top: 4em;
-    left: 50%;
-    margin-left: -144px; /* - width/2 - paddingHorz/2 - border */
+	left: 50%;
+	margin-left: -144px; /* - width/2 - paddingHorz/2 - border */
 	padding: 16px 16px 16px 16px;
 	border-radius: 8px;
 }

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -135,7 +135,7 @@ $tw.utils.error = function(err) {
 		var dm = $tw.utils.domMaker,
 			heading = dm("h1",{text: errHeading}),
 			prompt = dm("div",{text: promptMsg, "class": "tc-error-prompt"}),
-			message = dm("div",{text: err}),
+			message = dm("div",{text: err, "class":"tc-error-message"}),
 			button = dm("button",{text: ( $tw.language == undefined ? "close" : $tw.language.getString("Buttons/Close/Caption") )}),
 			form = dm("form",{children: [heading,prompt,message,button], "class": "tc-error-form"});
 		document.body.insertBefore(form,document.body.firstChild);


### PR DESCRIPTION
There are some good argument in [this discussion](https://groups.google.com/forum/#!topic/tiddlywiki/4p66lV9_LrU), to make the js error form more user friendly. 

 - I did reorganize the CSS a bit. 
 - centering the form is easier now. 
 - form is max 80% high
 - error-message has overflow auto, so scroll bars will be used if needed. 
 - error-message text got its own class name. 
 - did remove the text shadow, since it creates very hard to read text 