### PR TITLE
Add missing macro bracket

### DIFF
--- a/editions/tw5.com/tiddlers/filters/is.tid
+++ b/editions/tw5.com/tiddlers/filters/is.tid
@@ -23,7 +23,7 @@ The parameter <<.place C>> is one of the following fundamental categories:
 |^`tag` |is in use as a tag |
 |^`tiddler` |exists as a non-shadow tiddler |
 
-If <<.place C>> is anything else an error message is returned. <<.from-version "5.1.14"> if <<.place C>> is blank, the output is passed through unchanged (in earlier versions an error message was returned).
+If <<.place C>> is anything else an error message is returned. <<.from-version "5.1.14">> if <<.place C>> is blank, the output is passed through unchanged (in earlier versions an error message was returned).
 
 `!is[tiddler]` is a synonym for `is[missing]`, and vice versa.
 


### PR DESCRIPTION
Missing closing bracket caused confusing text.