### PR TITLE
Fix two files to permit local saving of filenames containing spaces

### DIFF
--- a/core/modules/savers/download.js
+++ b/core/modules/savers/download.js
@@ -26,6 +26,7 @@ DownloadSaver.prototype.save = function(text,method,callback,options) {
 		var p = document.location.pathname.lastIndexOf("/");
 		if(p !== -1) {
 			filename = document.location.pathname.substr(p+1);
+			filename = filename.replace(/%20/g, " ");
 		}
 	}
 	if(!filename) {

--- a/core/modules/savers/msdownload.js
+++ b/core/modules/savers/msdownload.js
@@ -24,6 +24,7 @@ MsDownloadSaver.prototype.save = function(text,method,callback) {
 		p = document.location.pathname.lastIndexOf("/");
 	if(p !== -1) {
 		filename = document.location.pathname.substr(p+1);
+		filename = filename.replace(/%20/g, " ");
 	}
 	// Set up the link
 	var blob = new Blob([text], {type: "text/html"});


### PR DESCRIPTION
Updated download.js and msdownload.js to permit local saving of files with space characters in them. Previously spaces were always replaced with %20 which over time becomes %25252525252525252525252525252520 as the newly inserted % symbol begins getting repeated replaced upon later saves too. See issue #2819 

I've tested saving under Chrome, Safari, and IE with no issues. I realize the user can constantly edit the filename on every save and manually reinsert the space characters, but that is a real hassle.

-Douglas Counts