### PR TITLE
TabsMacro.tid - remove character that causes problem

### DIFF
--- a/editions/tw5.com/tiddlers/macros/TabsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TabsMacro.tid
@@ -32,6 +32,6 @@ The <<.vlink currentTiddler>> variable is not affected by the <<.var tabs>> macr
 <$tiddler tiddler=<<currentTab>>>
 <$transclude mode="block" />
 </$tiddler>
-``` 
+```
 
 <<.macro-examples "tabs">>


### PR DESCRIPTION
The example link at bottom was not visible in correct way