### PR TITLE
make editor font-family configurable, so user can easily change it

### DIFF
--- a/core/language/en-GB/ThemeTweaks.multids
+++ b/core/language/en-GB/ThemeTweaks.multids
@@ -12,6 +12,7 @@ Options/CodeWrapping: Wrap long lines in code blocks
 Settings: Settings
 Settings/FontFamily: Font family
 Settings/CodeFontFamily: Code font family
+Settings/EditorFontFamily: Editor font family
 Settings/BackgroundImage: Page background image
 Settings/BackgroundImageAttachment: Page background image attachment
 Settings/BackgroundImageAttachment/Scroll: Scroll with tiddlers

--- a/languages/de-DE/ThemeTweaks.multids
+++ b/languages/de-DE/ThemeTweaks.multids
@@ -12,6 +12,7 @@ Options/CodeWrapping: Lange Zeilen in "Code-Blöcken" umbrechen
 Settings: Einstellungen
 Settings/FontFamily: Schriftfamilie
 Settings/CodeFontFamily: "Code" Schriftfamilie
+Settings/EditorFontFamily: Editor Schriftfamilie
 Settings/BackgroundImage: Hintergrundbild für die Seite
 Settings/BackgroundImageAttachment: Hintergrundbild Anhang
 Settings/BackgroundImageAttachment/Scroll: Mit Inhalt "scrollen"

--- a/themes/tiddlywiki/snowwhite/base.tid
+++ b/themes/tiddlywiki/snowwhite/base.tid
@@ -46,6 +46,10 @@ tags: [[$:/tags/Stylesheet]]
 	outline: none;
 }
 
+textarea.tc-edit-texteditor {
+	font-family: {{$:/themes/tiddlywiki/vanilla/settings/editorfontfamily}};
+}
+
 canvas.tc-edit-bitmapeditor  {
 	<<box-shadow "2px 2px 5px rgba(0, 0, 0, 0.5)">>
 }

--- a/themes/tiddlywiki/vanilla/ThemeTweaks.tid
+++ b/themes/tiddlywiki/vanilla/ThemeTweaks.tid
@@ -53,6 +53,7 @@ caption: {{$:/language/ThemeTweaks/ThemeTweaks}}
 
 |<$link to="$:/themes/tiddlywiki/vanilla/settings/fontfamily"><<lingo Settings/FontFamily>></$link> |<$edit-text tiddler="$:/themes/tiddlywiki/vanilla/settings/fontfamily" default="" tag="input"/> | |
 |<$link to="$:/themes/tiddlywiki/vanilla/settings/codefontfamily"><<lingo Settings/CodeFontFamily>></$link> |<$edit-text tiddler="$:/themes/tiddlywiki/vanilla/settings/codefontfamily" default="" tag="input"/> | |
+|<$link to="$:/themes/tiddlywiki/vanilla/settings/editorfontfamily"><<lingo Settings/EditorFontFamily>></$link> |<$edit-text tiddler="$:/themes/tiddlywiki/vanilla/settings/editorfontfamily" default="" tag="input"/> | |
 |<$link to="$:/themes/tiddlywiki/vanilla/settings/backgroundimage"><<lingo Settings/BackgroundImage>></$link> |<$edit-text tiddler="$:/themes/tiddlywiki/vanilla/settings/backgroundimage" default="" tag="input"/> |<<backgroundimage-dropdown>> |
 |<$link to="$:/themes/tiddlywiki/vanilla/settings/backgroundimageattachment"><<lingo Settings/BackgroundImageAttachment>></$link> |<<backgroundimageattachment-dropdown>> | |
 |<$link to="$:/themes/tiddlywiki/vanilla/settings/backgroundimagesize"><<lingo Settings/BackgroundImageSize>></$link> |<<backgroundimagesize-dropdown>> | |

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -993,6 +993,7 @@ button.tc-untagged-label {
 	background-color: <<colour tiddler-editor-background>>;
 	line-height: 1.3em;
 	-webkit-appearance: none;
+	font-family: {{$:/themes/tiddlywiki/vanilla/settings/editorfontfamily}};
 }
 
 .tc-tiddler-frame .tc-binary-warning {


### PR DESCRIPTION
fixes: #1608 .. as promised

* make editor textarea configurable, so user can easily change it to eg: monospace font. 
* Tested with all other themes

looks like this: 
![monospace](https://cloud.githubusercontent.com/assets/374655/26175741/fccde456-3b53-11e7-8ebf-2e8dcba8ab8d.png)
