### PR TITLE
Add ability to now macro to return same UTC string used in date fields

### DIFF
--- a/core/modules/macros/now.js
+++ b/core/modules/macros/now.js
@@ -26,6 +26,9 @@ exports.params = [
 Run the macro
 */
 exports.run = function(format) {
+if(format == "UTC") {
+	return $tw.utils.stringifyDate(new Date());
+} else 
 	return $tw.utils.formatDateString(new Date(),format || "0hh:0mm, DDth MMM YYYY");
 };
 

--- a/core/modules/macros/now.js
+++ b/core/modules/macros/now.js
@@ -26,9 +26,6 @@ exports.params = [
 Run the macro
 */
 exports.run = function(format) {
-if(format == "UTC") {
-	return $tw.utils.stringifyDate(new Date());
-} else 
 	return $tw.utils.formatDateString(new Date(),format || "0hh:0mm, DDth MMM YYYY");
 };
 

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -267,6 +267,9 @@ exports.formatDateString = function(date,template) {
 			[/^0ss/, function() {
 				return $tw.utils.pad(date.getSeconds());
 			}],
+			[/^0XXX/, function() {
+				return $tw.utils.pad(date.getMilliseconds());
+			}],
 			[/^0DD/, function() {
 				return $tw.utils.pad(date.getDate());
 			}],
@@ -308,6 +311,9 @@ exports.formatDateString = function(date,template) {
 			[/^ss/, function() {
 				return date.getSeconds();
 			}],
+			[/^XXX/, function() {
+				return date.getMilliseconds();
+			}],
 			[/^[AP]M/, function() {
 				return $tw.utils.getAmPm(date).toUpperCase();
 			}],
@@ -324,6 +330,16 @@ exports.formatDateString = function(date,template) {
 				return $tw.utils.pad(date.getFullYear() - 2000);
 			}]
 		];
+	// If the user wants everything in UTC, shift the datestamp
+	// Optimize for format string that essentially means 
+	// 'return raw UTC (tiddlywiki style) date string.'
+	if(t.indexOf("[UTC]") == 0 ) {
+		if(t == "[UTC]YYYY0MM0DD0hh0mm0ssXXX") 
+			return $tw.utils.stringifyDate(new Date());
+		var offset = date.getTimezoneOffset() ; // in minutes
+		date = new Date(date.getTime()+offset*60*1000) ;
+		t = t.substr(5) ;
+	} 
 	while(t.length){
 		var matchString = "";
 		$tw.utils.each(matches, function(m) {

--- a/editions/tw5.com/tiddlers/features/DateFormat.tid
+++ b/editions/tw5.com/tiddlers/features/DateFormat.tid
@@ -1,5 +1,5 @@
 created: 20140418142957325
-modified: 20140912145809035
+modified: 20170630223008226
 tags: Features
 title: DateFormat
 type: text/vnd.tiddlywiki
@@ -30,10 +30,13 @@ The ViewWidget accepts a `template` attribute that allows the format of date val
 |`0mm` |Minutes with leading zero |
 |`ss` |Seconds |
 |`0ss` |Seconds with leading zero |
+|`XXX` |Milliseconds |
+|`0XXX` |Milliseconds with leading zero |
 |`am` or `pm` |Lower case AM/PM indicator |
 |`AM` or `PM` |Upper case AM/PM indicator |
 |`TZD` |Timezone offset |
 |`\x` |Used to escape a character that would otherwise have special meaning |
+|`[UTC]`|Time-shift the represented date to UTC. Must be at very start of format string|
 
 Note that other text is passed through unchanged, allowing commas, colons or other separators to be used.
 

--- a/editions/tw5.com/tiddlers/macros/NowMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/NowMacro.tid
@@ -1,6 +1,6 @@
 caption: now
 created: 20141008141616791
-modified: 20150221170300000
+modified: 20170630223406157
 tags: Macros [[Core Macros]]
 title: now Macro
 type: text/vnd.tiddlywiki
@@ -13,5 +13,8 @@ The value doesn't update automatically, like a ticking clock. It updates wheneve
 
 ;format
 : A string specifying the desired [[format|DateFormat]], defaulting to `0hh:0mm, DDth MMM YYYY`
+
+''Note'': The format string `[UTC]YYYY0MM0DD0hh0mm0ssXXX` will return a date string representing the UTC time-stamp as it is used in the ~TiddlyWiki `created` and `modified` time-stamp fields.
+
 
 <<.macro-examples "now">>


### PR DESCRIPTION
Invoking the now macro with the string 'UTC' alone by itself will cause the macro to return a UTC datestamp as is used by the created and modified fields. This will be useful for individuals attempting to create their own TW-compatible date stamps.  

I put the change inside of the now macro rather than inside of formatDateString because fDS has no way to completely reset the return result, which would be the typical use case.