### PR TITLE
Do not delete the user name on check login status

### DIFF
--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -171,8 +171,6 @@ Syncer.prototype.getStatus = function(callback) {
 			self.wiki.addTiddler({title: self.titleIsLoggedIn,text: isLoggedIn ? "yes" : "no"});
 			if(isLoggedIn) {
 				self.wiki.addTiddler({title: self.titleUserName,text: username || ""});
-			} else {
-				self.wiki.deleteTiddler(self.titleUserName);
 			}
 			// Invoke the callback
 			if(callback) {


### PR DESCRIPTION
The purpose of this change is to make the getStatus function less destructive.
The user name tiddler should not be removed just because we are not logged in. It should be updated when the user logs-in, but if the user has set the user name for any reason, just checking if the user is logged in or not should not delete this tiddler.