### PR TITLE
Boot process using RxJS

### DIFF
--- a/boot/boot-node.js
+++ b/boot/boot-node.js
@@ -1,0 +1,459 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var rxjs = require("rxjs");
+var path = require("path");
+var fs = require("fs");
+var maxConcurrent = 20;
+function obs_stat(tag) {
+	return rxjs.Observable.bindCallback(fs.stat, function (err, stat) { return [err, stat, tag]; });
+}
+function obs_readdir(tag) {
+	return rxjs.Observable.bindCallback(fs.readdir, function (err, files) { return [err, files, tag]; });
+}
+function obs_readFile(tag) {
+	return rxjs.Observable.bindCallback(fs.readFile, function (err, data) { return [err, data, tag]; });
+}
+function bootNode($tw) {
+	/**
+	Load the tiddlers contained in a particular file (and optionally extract fields from the
+	accompanying .meta file) returned as { filepath, type, tiddlers[], hasMetaFile }. Returns
+	exactly one item.
+	*/
+	function loadTiddlersFromFile(filepath, fields) {
+		//return Observable.of(filepath).switchMap(() => {
+		var ext = path.extname(filepath), extensionInfo = $tw.utils.getFileExtensionInfo(ext), type = extensionInfo ? extensionInfo.type : null, typeInfo = type ? $tw.config.contentTypeInfo[type] : null;
+		return obs_readFile({ type: type, filepath: filepath })(filepath, typeInfo ? typeInfo.encoding : "utf8").switchMap(function (_a) {
+			var err = _a[0], data = _a[1], _b = _a[2], type = _b.type, filepath = _b.filepath;
+			var tag = {
+				type: type, filepath: filepath,
+				tiddlers: $tw.wiki.deserializeTiddlers(ext, data, fields)
+			};
+			//const tag1 = extend(tag, { tiddlers })
+			if (ext !== ".json" && tag.tiddlers.length === 1) {
+				return loadMetadataForFile(filepath).map(function (metadata) { return [metadata || {}, tag]; });
+			}
+			else {
+				return rxjs.Observable.of([false, tag]);
+			}
+		}).map(function (_a) {
+			var metadata = _a[0], tag = _a[1];
+			if (metadata)
+				tag.tiddlers = [$tw.utils.extend({}, tag.tiddlers[0], metadata)];
+			return { filepath: tag.filepath, type: tag.type, tiddlers: tag.tiddlers, hasMetaFile: !!metadata };
+		});
+	}
+	;
+	/**
+	Load the metadata fields in the .meta file corresponding to a particular file. Returns null
+	if none is found.
+	*/
+	function loadMetadataForFile(filepath) {
+		var metafilename = filepath + ".meta";
+		return obs_readFile()(metafilename, "utf8").map(function (_a) {
+			var err = _a[0], data = _a[1];
+			if (err) {
+				return null;
+			}
+			else {
+				return $tw.utils.parseFields(data || "");
+			}
+		});
+	}
+	;
+	/**
+	A default set of files for TiddlyWiki to ignore during load.
+	This matches what NPM ignores, and adds "*.meta" to ignore tiddler
+	metadata files.
+	*/
+	$tw.boot.excludeRegExp = /^\.DS_Store$|^.*\.meta$|^\..*\.swp$|^\._.*$|^\.git$|^\.hg$|^\.lock-wscript$|^\.svn$|^\.wafpickle-.*$|^CVS$|^npm-debug\.log$/;
+	/**
+	Load all the tiddlers recursively from a directory, including honouring `tiddlywiki.files` files for drawing in external files. Returns an array of {filepath:,type:,tiddlers: [{..fields...}],hasMetaFile:}. Note that no file information is returned for externally loaded tiddlers, just the `tiddlers` property.
+	*/
+	function loadTiddlersFromPath(filepath, excludeRegExp) {
+		excludeRegExp = excludeRegExp || $tw.boot.excludeRegExp;
+		var tiddlers = [];
+		return obs_stat()(filepath).switchMap(function (_a) {
+			var err = _a[0], stat = _a[1];
+			if (err) {
+				return rxjs.Observable.empty();
+			}
+			else {
+				if (stat.isDirectory()) {
+					return obs_readdir()(filepath).switchMap(function (_a) {
+						var err = _a[0], files = _a[1];
+						if (files.indexOf("tiddlywiki.files") !== -1) {
+							return loadTiddlersFromSpecification(filepath, excludeRegExp);
+						}
+						else {
+							// If not, read all the files in the directory
+							return rxjs.Observable.from(files.filter(function (file) {
+								return (!excludeRegExp.test(file) && file !== "plugin.info");
+							})).mergeMap(function (file) {
+								return loadTiddlersFromPath(filepath + path.sep + file, excludeRegExp);
+							}, maxConcurrent);
+						}
+					});
+				}
+				else if (stat.isFile()) {
+					return loadTiddlersFromFile(filepath);
+				}
+				else {
+					return rxjs.Observable.empty();
+				}
+			}
+		});
+	}
+	;
+	/**
+	Load all the tiddlers defined by a `tiddlywiki.files` specification file
+	filepath: pathname of the directory containing the specification file
+	*/
+	function loadTiddlersFromSpecification(filepath, excludeRegExp) {
+		var tiddlers = [];
+		// Read the specification
+		return obs_readFile()(filepath + path.sep + "tiddlywiki.files", "utf8").switchMap(function (res) {
+			var err = res[0];
+			var filesInfo = JSON.parse(res[1]);
+			return rxjs.Observable.from(filesInfo.tiddlers || []).concatMap(function (tidInfo) {
+				if (tidInfo.prefix && tidInfo.suffix) {
+					tidInfo.fields.text = { prefix: tidInfo.prefix, suffix: tidInfo.suffix };
+				}
+				else if (tidInfo.prefix) {
+					tidInfo.fields.text = { prefix: tidInfo.prefix };
+				}
+				else if (tidInfo.suffix) {
+					tidInfo.fields.text = { suffix: tidInfo.suffix };
+				}
+				return processFile(tidInfo.file, tidInfo.isTiddlerFile, tidInfo.fields);
+			}).concat(rxjs.Observable.from(filesInfo.directories || []).concatMap(function (dirInfo) {
+				if (typeof dirInfo === "string") {
+					var pathname = path.resolve(filepath, dirInfo);
+					return obs_stat()(pathname).switchMap(function (_a) {
+						var err = _a[0], stat = _a[1];
+						if (err || !stat.isDirectory())
+							return rxjs.Observable.empty();
+						else
+							return loadTiddlersFromPath(pathname, excludeRegExp);
+					});
+				}
+				else {
+					// Process directory specifier
+					var dirPath = path.resolve(filepath, dirInfo.path);
+					return obs_readdir()(dirPath).switchMap(function (_a) {
+						var err = _a[0], files = _a[1];
+						var fileRegExp = new RegExp(dirInfo.filesRegExp || "^.*$"), metaRegExp = /^.*\.meta$/;
+						return rxjs.Observable.from(files.filter(function (filename) {
+							return filename !== "tiddlywiki.files" && !metaRegExp.test(filename) && fileRegExp.test(filename);
+						})).concatMap(function (filename) {
+							return processFile(dirPath + path.sep + filename, dirInfo.isTiddlerFile, dirInfo.fields);
+						});
+					});
+				}
+			}));
+		});
+		// Helper to process a file
+		function processFile(filename, isTiddlerFile, fields) {
+			var extInfo = $tw.config.fileExtensionInfo[path.extname(filename)], type = (extInfo || {}).type || fields.type || "text/plain", typeInfo = $tw.config.contentTypeInfo[type] || {}, pathname = path.resolve(filepath, filename);
+			return obs_readFile()(pathname, typeInfo.encoding || "utf8").switchMap(function (_a) {
+				var err = _a[0], text = _a[1];
+				return loadMetadataForFile(pathname).map(function (metadata) { return [metadata || {}, text]; });
+			}).map(function (_a) {
+				var metadata = _a[0], text = _a[1];
+				var fileTiddlers;
+				if (isTiddlerFile) {
+					fileTiddlers = $tw.wiki.deserializeTiddlers(path.extname(pathname), text, metadata) || [];
+				}
+				else {
+					fileTiddlers = [$tw.utils.extend({ text: text }, metadata)];
+				}
+				var combinedFields = $tw.utils.extend({}, fields, metadata);
+				$tw.utils.each(fileTiddlers, function (tiddler) {
+					$tw.utils.each(combinedFields, function (fieldInfo, name) {
+						if (typeof fieldInfo === "string" || $tw.utils.isArray(fieldInfo)) {
+							tiddler[name] = fieldInfo;
+						}
+						else {
+							var value = tiddler[name];
+							switch (fieldInfo.source) {
+								case "filename":
+									value = path.basename(filename);
+									break;
+								case "filename-uri-decoded":
+									value = decodeURIComponent(path.basename(filename));
+									break;
+								case "basename":
+									value = path.basename(filename, path.extname(filename));
+									break;
+								case "basename-uri-decoded":
+									value = decodeURIComponent(path.basename(filename, path.extname(filename)));
+									break;
+								case "extname":
+									value = path.extname(filename);
+									break;
+								case "created":
+									value = new Date(fs.statSync(pathname).birthtime);
+									break;
+								case "modified":
+									value = new Date(fs.statSync(pathname).mtime);
+									break;
+							}
+							if (fieldInfo.prefix) {
+								value = fieldInfo.prefix + value;
+							}
+							if (fieldInfo.suffix) {
+								value = value + fieldInfo.suffix;
+							}
+							tiddler[name] = value;
+						}
+					});
+				});
+				return { tiddlers: fileTiddlers };
+			});
+		} //End processFile()
+	}
+	;
+	/**
+	Load the tiddlers from a plugin folder, and package them up into a proper JSON plugin tiddler
+	*/
+	function loadPluginFolder(filepath, excludeRegExp) {
+		excludeRegExp = excludeRegExp || $tw.boot.excludeRegExp;
+		return obs_stat()(filepath).switchMap(function (_a) {
+			var err = _a[0], stat = _a[1];
+			if (err || !stat.isDirectory())
+				return rxjs.Observable.throw(err || { message: "Directory required" });
+			return obs_readFile()(filepath + path.sep + "plugin.info", "utf8");
+		}).switchMap(function (_a) {
+			var err = _a[0], data = _a[1];
+			var pluginInfo = JSON.parse(data);
+			return loadTiddlersFromPath(filepath, excludeRegExp)
+				.reduce(function (n, e) { n.push(e); return n; }, [])
+				.map(function (tiddlers) { return [tiddlers, pluginInfo]; });
+		}).map(function (_a) {
+			var pluginFiles = _a[0], pluginInfo = _a[1];
+			pluginInfo.tiddlers = pluginInfo.tiddlers || Object.create(null);
+			for (var f = 0; f < pluginFiles.length; f++) {
+				var tiddlers = pluginFiles[f].tiddlers;
+				for (var t = 0; t < tiddlers.length; t++) {
+					var tiddler = tiddlers[t];
+					if (tiddler.title) {
+						pluginInfo.tiddlers[tiddler.title] = tiddler;
+					}
+				}
+			}
+			// Give the plugin the same version number as the core if it doesn't have one
+			if (!("version" in pluginInfo)) {
+				pluginInfo.version = $tw.packageInfo.version;
+			}
+			// Use "plugin" as the plugin-type if we don't have one
+			if (!("plugin-type" in pluginInfo)) {
+				pluginInfo["plugin-type"] = "plugin";
+			}
+			pluginInfo.dependents = pluginInfo.dependents || [];
+			pluginInfo.type = "application/json";
+			// Set plugin text
+			pluginInfo.text = JSON.stringify({ tiddlers: pluginInfo.tiddlers }, null, 4);
+			delete pluginInfo.tiddlers;
+			// Deserialise array fields (currently required for the dependents field)
+			for (var field in pluginInfo) {
+				if ($tw.utils.isArray(pluginInfo[field])) {
+					pluginInfo[field] = $tw.utils.stringifyList(pluginInfo[field]);
+				}
+			}
+			return pluginInfo;
+		}).catch(function (err) {
+			return rxjs.Observable.of(null);
+		});
+	}
+	;
+	/**
+	name: Name of the plugin to find
+	paths: array of file paths to search for it
+	Returns the path of the plugin folder
+	*/
+	function findLibraryItem(name, paths) {
+		return rxjs.Observable.from(paths).concatMap(function (itemPath) {
+			var pluginPath = path.resolve(itemPath, "./" + name);
+			return obs_stat(pluginPath)(pluginPath);
+		}).first(function (_a) {
+			var err = _a[0], stat = _a[1], pluginPath = _a[2];
+			return (!err && stat.isDirectory());
+		}, function (_a) {
+			var err = _a[0], stat = _a[1], pluginPath = _a[2];
+			return pluginPath;
+		}, null);
+	}
+	;
+	/**
+	name: Name of the plugin to load
+	paths: array of file paths to search for it
+	*/
+	function loadPlugin(name, paths) {
+		return findLibraryItem(name, paths).switchMap(function (pluginPath) {
+			if (pluginPath)
+				return loadPluginFolder(pluginPath);
+			else
+				return rxjs.Observable.empty();
+		}).map(function (pluginFields) {
+			if (pluginFields)
+				return $tw.wiki.addTiddler(pluginFields);
+		}).ignoreElements();
+	}
+	;
+	/**
+	libraryPath: Path of library folder for these plugins (relative to core path)
+	envVar: Environment variable name for these plugins
+	Returns an array of search paths
+	*/
+	function getLibraryItemSearchPaths(libraryPath, envVar) {
+		var pluginPaths = [path.resolve($tw.boot.corePath, libraryPath)], env = process.env[envVar];
+		if (env) {
+			env.split(path.delimiter).map(function (item) {
+				if (item) {
+					pluginPaths.push(item);
+				}
+			});
+		}
+		return pluginPaths;
+	}
+	;
+	/**
+	plugins: Array of names of plugins (eg, "tiddlywiki/filesystemadaptor")
+	libraryPath: Path of library folder for these plugins (relative to core path)
+	envVar: Environment variable name for these plugins
+	*/
+	function loadPlugins(plugins, libraryPath, envVar) {
+		if (plugins) {
+			var pluginPaths = getLibraryItemSearchPaths(libraryPath, envVar);
+			return rxjs.Observable.from(plugins).concatMap(function (plugin) {
+				return loadPlugin(plugin, pluginPaths);
+			});
+		}
+		else {
+			return rxjs.Observable.of();
+		}
+	}
+	;
+	/*
+	 * Loads the tiddlers from a wiki directory
+	 * @param wikiPath - path of wiki directory
+	 * @param options
+	 * @param options.parentPaths - array of parent paths that we mustn't recurse into
+	 * @param options.readOnly - true if the tiddler file paths should not be retained
+	 */
+	/**
+	 *
+	 *
+	 * @param {any} wikiPath path of wiki directory
+	 * @param {any} [options]
+	 * @returns
+	 */
+	function loadWikiTiddlers(wikiPath, options) {
+		options = options || {};
+		var parentPaths = options.parentPaths || [], wikiInfoPath = path.resolve(wikiPath, $tw.config.wikiInfo), wikiInfo, pluginFields;
+		// Bail if we don't have a wiki info file
+		return obs_readFile()(wikiInfoPath, "utf8").concatMap(function (_a) {
+			var err = _a[0], wikiInfoFile = _a[1];
+			if (err)
+				return rxjs.Observable.throw(err);
+			var wikiInfo = JSON.parse(wikiInfoFile);
+			// Load any parent wikis
+			if (wikiInfo.includeWikis) {
+				parentPaths = parentPaths.slice(0);
+				parentPaths.push(wikiPath);
+				return rxjs.Observable.from(wikiInfo.includeWikis).concatMap(function (info) {
+					if (typeof info === "string") {
+						info = { path: info };
+					}
+					var resolvedIncludedWikiPath = path.resolve(wikiPath, info.path);
+					if (parentPaths.indexOf(resolvedIncludedWikiPath) === -1) {
+						return loadWikiTiddlers(resolvedIncludedWikiPath, {
+							parentPaths: parentPaths,
+							readOnly: info["read-only"]
+						}).map(function (subWikiInfo) {
+							wikiInfo.build = $tw.utils.extend([], subWikiInfo.build, wikiInfo.build);
+						});
+					}
+					else {
+						$tw.utils.error("Cannot recursively include wiki " + resolvedIncludedWikiPath);
+					}
+				}).count().mapTo(wikiInfo); //drop any output and just forward the wikiInfo.
+			}
+			return rxjs.Observable.of(wikiInfo);
+		}).concatMap(function (wikiInfo) {
+			return rxjs.Observable.concat(loadPlugins(wikiInfo.plugins, $tw.config.pluginsPath, $tw.config.pluginsEnvVar), loadPlugins(wikiInfo.themes, $tw.config.themesPath, $tw.config.themesEnvVar), loadPlugins(wikiInfo.languages, $tw.config.languagesPath, $tw.config.languagesEnvVar)).count().mapTo(wikiInfo);
+		}).concatMap(function (wikiInfo) {
+			// Load the wiki files, registering them as writable
+			var resolvedWikiPath = path.resolve(wikiPath, $tw.config.wikiTiddlersSubDir);
+			return loadTiddlersFromPath(resolvedWikiPath).do(function (tiddlerFile) {
+				if (!options.readOnly && tiddlerFile.filepath) {
+					$tw.utils.each(tiddlerFile.tiddlers, function (tiddler) {
+						$tw.boot.files[tiddler.title] = {
+							filepath: tiddlerFile.filepath,
+							type: tiddlerFile.type,
+							hasMetaFile: tiddlerFile.hasMetaFile
+						};
+					});
+				}
+				$tw.wiki.addTiddlers(tiddlerFile.tiddlers);
+			}).count().mapTo([wikiInfo, resolvedWikiPath]);
+		}).concatMap(function (_a) {
+			var wikiInfo = _a[0], resolvedWikiPath = _a[1];
+			// Save the original tiddler file locations if requested
+			var config = wikiInfo.config || {};
+			if (config["retain-original-tiddler-path"]) {
+				var output = {};
+				for (var title in $tw.boot.files) {
+					output[title] = path.relative(resolvedWikiPath, $tw.boot.files[title].filepath);
+				}
+				$tw.wiki.addTiddler({ title: "$:/config/OriginalTiddlerPaths", type: "application/json", text: JSON.stringify(output) });
+			}
+			// Save the path to the tiddlers folder for the filesystemadaptor
+			$tw.boot.wikiTiddlersPath = path.resolve($tw.boot.wikiPath, config["default-tiddler-location"] || $tw.config.wikiTiddlersSubDir);
+			// Load any plugins, themes and languages listed in the wiki info file
+			return rxjs.Observable.from([
+				path.resolve(wikiPath, $tw.config.wikiPluginsSubDir),
+				path.resolve(wikiPath, $tw.config.wikiThemesSubDir),
+				path.resolve(wikiPath, $tw.config.wikiLanguagesSubDir)
+			]).concatMap(function (pluginPath) {
+				return obs_readdir(pluginPath)(pluginPath);
+			}).concatMap(function (_a) {
+				var err = _a[0], pluginFolders = _a[1], pluginPath = _a[2];
+				if (err)
+					return rxjs.Observable.empty();
+				else
+					return rxjs.Observable.from(pluginFolders.map(function (a) { return [a, pluginPath]; }));
+			}).concatMap(function (_a) {
+				var pluginFolder = _a[0], pluginPath = _a[1];
+				return loadPluginFolder(path.resolve(pluginPath, "./" + pluginFolder));
+			}).map(function (pluginFields) {
+				$tw.wiki.addTiddler(pluginFields);
+			}).count().mapTo(wikiInfo);
+		});
+	}
+	;
+	function loadTiddlersNode() {
+		// Load the boot tiddlers
+		return rxjs.Observable.concat(loadTiddlersFromPath($tw.boot.bootPath).do(function (tiddlerFile) {
+			$tw.wiki.addTiddlers(tiddlerFile.tiddlers);
+		}).ignoreElements(), loadPluginFolder($tw.boot.corePath).do(function (coreTiddlers) {
+			$tw.wiki.addTiddler(coreTiddlers);
+		}).ignoreElements(), ($tw.boot.wikiPath ? loadWikiTiddlers($tw.boot.wikiPath).do(function (wikiInfo) {
+			$tw.boot.wikiInfo = wikiInfo;
+		}) : rxjs.Observable.empty())).ignoreElements();
+	}
+	;
+	$tw.utils.extend($tw, {
+		loadTiddlersFromFile: loadTiddlersFromFile,
+		loadMetadataForFile: loadMetadataForFile,
+		loadTiddlersFromPath: loadTiddlersFromPath,
+		loadTiddlersFromSpecification: loadTiddlersFromSpecification,
+		loadPluginFolder: loadPluginFolder,
+		findLibraryItem: findLibraryItem,
+		loadPlugin: loadPlugin,
+		getLibraryItemSearchPaths: getLibraryItemSearchPaths,
+		loadPlugins: loadPlugins,
+		loadWikiTiddlers: loadWikiTiddlers,
+		loadTiddlersNode: loadTiddlersNode
+	});
+}
+exports.bootNode = bootNode;

--- a/boot/boot-node.ts
+++ b/boot/boot-node.ts
@@ -1,0 +1,692 @@
+import { Observable } from 'rxjs';
+import * as path from 'path';
+import * as fs from 'fs';
+
+declare module 'rxjs/operator/ignoreElements' {
+    export function ignoreElements<T>(this: Observable<T>): Observable<never>;
+}
+
+const maxConcurrent = 20;
+
+type Hashmap<T> = { [K: string]: T };
+export interface Boot {
+    logMessages: string[];
+    log(str: string): void;
+    tasks: {
+        trapErrors: boolean;
+    };
+}
+interface Utils {
+    hop<T>(object: T, property: keyof T): T[keyof T] | false;
+    isArray(value: any): value is Array<any>;
+    isDate(value: any): value is Date;
+    each<T>(object: T[], callback: (e: T, i: number, a: T[]) => void): any;
+    each<T extends {
+        [K: string]: any;
+    }>(object: T, callback: (e: T[keyof T], i: keyof T, a: T) => void): any;
+    domMaker(tag: string, options: {
+        document?: Document;
+        text?: string;
+        innerHTML?: string;
+        children?: Node[];
+        attributes?: {
+            [K: string]: string;
+        };
+        eventListeners?: any[];
+        class?: string;
+    }): any;
+    error(err: any): void;
+    extend<T, S1>(object: T, source1: S1): T & S1;
+    extend<T, S1, S2>(object: T, source1: S1, source2: S2): T & S1 & S2;
+    extend<T, S1, S2, S3, R extends T & S1 & S2 & S3>(object: T, source1: S1, source2: S2, source3: S3): R;
+    extend<T, S1, S2, S3, S4, R extends T & S1 & S2 & S3 & S4>(object: T, source1: S1, source2: S2, source3: S3, source4: S4): R;
+    extend<T, S1, S2, S3, S4, S5, R extends T & S1 & S2 & S3 & S4 & S5>(object: T, source1: S1, source2: S2, source3: S3, source4: S4, source5: S5): R;
+    extend<T, S1, S2, S3, S4, S5, S6, R extends T & S1 & S2 & S3 & S4 & S5>(object: T, source1: S1, source2: S2, source3: S3, source4: S4, source5: S5, ...sources: S6[]): R;
+    deepDefaults<T, S1, R extends T & S1>(object: T, source1: S1): R;
+    deepDefaults<T, S1, S2, R extends T & S1 & S2>(object: T, source1: S1, source2: S2): R;
+    deepDefaults<T, S1, S2, S3, R extends T & S1 & S2 & S3>(object: T, source1: S1, source2: S2, source3: S3): R;
+    deepDefaults<T, S1, S2, S3, S4, R extends T & S1 & S2 & S3 & S4>(object: T, source1: S1, source2: S2, source3: S3, source4: S4): R;
+    deepDefaults<T, S1, S2, S3, S4, S5, R extends T & S1 & S2 & S3 & S4 & S5>(object: T, source1: S1, source2: S2, source3: S3, source4: S4, source5: S5): R;
+    deepDefaults<T, S1, S2, S3, S4, S5, S6, R extends T & S1 & S2 & S3 & S4 & S5>(object: T, source1: S1, source2: S2, source3: S3, source4: S4, source5: S5, ...sources: S6[]): R;
+    htmlDecode(html: string): string;
+    getLocationHash(): string;
+    /**
+     * Pad a string to a given length with "0"s. Length defaults to 2, max is 27
+     */
+    pad(value: any, length?: number): string;
+    stringifyDate(value: Date): string;
+    parseDate(value: string): Date | null;
+    /**
+     * Stringify an array of tiddler titles into a list string
+     */
+    stringifyList(value: string[]): string;
+    parseStringArray(value: string): string[] | null;
+    parseFields<S = {}, T = {}>(text: string, result?: T): typeof result & S;
+    resolvePath(sourcePath: string, rootPath: string): string;
+    parseVersion(version: string): {
+        version: string;
+        major: number;
+        minor: number;
+        patch: number;
+        prerelease: string;
+        build: string;
+    } | null;
+    /**
+     * Check whether version A is greater than or equal to version B
+     */
+    checkVersions(versionStringA: string, versionStringB: string): boolean;
+    registerFileType(type: any, encoding: any, extension: any, options: {
+        flags: ("image")[];
+        deserializerType: string;
+    }): any;
+    getFileExtensionInfo(ext: string): FileExtensionInfo | null;
+    getTypeEncoding(ext: string): ContentTypeInfo;
+    evalGlobal(code: string, context: any, filename: string): any;
+    evalSandboxed(code: string, context: any, filename: string): any;
+    PasswordPrompt: new () => PasswordPrompt;
+    Crypto: new () => Crypto;
+}
+interface PasswordPrompt {
+    constructor(): any;
+    setWrapperDisplay(): any;
+    createPrompt(options: any): any;
+    removePrompt(promptInfo: any): any;
+}
+interface Crypto {
+    setPassword(newPassword: string): any;
+    updateCryptoStateTiddler(): any;
+    hasPassword(): any;
+    encrypt(text: string, password: string): any;
+    decrypt(text: string, password: string): any;
+}
+
+interface FileExtensionInfo {
+    type: string;
+}
+interface ContentTypeInfo {
+    encoding: string;
+    extension: string;
+    flags: string[];
+    deserializerType: string;
+}
+
+export interface Tiddler {
+    fields: TiddlerFields
+}
+
+export interface TiddlerFields {
+    readonly text: string
+    readonly type: string
+    readonly title: string
+}
+
+export interface FileInfo {
+    filepath?: string;
+    type?: string;
+    tiddlers: TiddlerFields[];
+    hasMetaFile?: boolean;
+
+}
+interface WikiInfo {
+    includeWikis: { path: string }[]
+    build: string[]
+    plugins: string[]
+    themes: string[]
+    languages: string[]
+    config?: {}
+}
+interface FieldInfo {
+    source?: string
+    prefix?: string;
+    suffix?: string;
+}
+
+interface TiddlerInfo {
+    fields: {
+        [field: string]: FieldInfo
+    }
+    prefix: string
+    suffix: string
+    file: string
+    isTiddlerFile: boolean
+
+}
+interface DirectoryInfo {
+    path: string
+    filesRegExp: string
+    isTiddlerFile: boolean
+    fields: any
+}
+interface packageInfo {
+    name: string
+    preferGlobal: string
+    version: string
+    author: string
+    description: string
+    contributors: string
+    bin: string
+    main: string
+    repository: string
+    keywords: string
+    dependencies: string
+    devDependencies: string
+    bundleDependencies: string
+    license: string
+    engines: string
+}
+
+interface $tw {
+    boot: {
+        excludeRegExp: RegExp,
+        files: {
+            [title: string]: {
+                filepath: string,
+                type: string,
+                hasMetaFile: boolean
+            }
+        }
+        wikiTiddlersPath: string,
+        wikiPath: string
+        corePath: string
+        bootPath: string
+        wikiInfo: WikiInfo
+    }
+    utils: Utils/*{
+        getFileExtensionInfo: (ext) => any,
+        parseFields: <T>(string, fields:T) => T
+    }*/,
+    config: {
+        contentTypeInfo: {
+            [type: string]: ContentTypeInfo
+        },
+        fileExtensionInfo: {
+            [ext: string]: FileExtensionInfo
+        },
+        wikiInfo: {},
+        pluginsPath: string
+        themesPath: string
+        languagesPath: string
+        pluginsEnvVar: string
+        themesEnvVar: string
+        languagesEnvVar: string
+        wikiTiddlersSubDir: string
+        wikiPluginsSubDir: string
+        wikiThemesSubDir: string
+        wikiLanguagesSubDir: string
+    },
+    wiki: {
+        deserializeTiddlers(ext, data, fields): TiddlerFields[]
+        addTiddler(data: TiddlerFields | Tiddler): void;
+        addTiddlers(data: (TiddlerFields | Tiddler)[]): void;
+    }
+    packageInfo: packageInfo
+}
+
+function obs_stat<T>(tag?: T): (path: string) => Observable<[NodeJS.ErrnoException, fs.Stats, T]> {
+    return Observable.bindCallback(fs.stat, (err, stat) => [err, stat, tag])
+}
+
+function obs_readdir<T>(tag?: T): (path: string) => Observable<[NodeJS.ErrnoException, string[], T]> {
+    return Observable.bindCallback(fs.readdir, (err, files) => [err, files, tag]);
+}
+
+function obs_readFile<T>(tag?: T): (path: string, encoding: string) => Observable<[NodeJS.ErrnoException, string, T]> {
+    return Observable.bindCallback(fs.readFile, (err, data) => [err, data, tag]);
+}
+export function bootNode($tw) {
+
+
+
+    /**
+    Load the tiddlers contained in a particular file (and optionally extract fields from the 
+    accompanying .meta file) returned as { filepath, type, tiddlers[], hasMetaFile }. Returns
+    exactly one item.
+    */
+    function loadTiddlersFromFile(filepath, fields?): Observable<FileInfo> {
+        //return Observable.of(filepath).switchMap(() => {
+        var ext = path.extname(filepath),
+            extensionInfo = $tw.utils.getFileExtensionInfo(ext),
+            type = extensionInfo ? extensionInfo.type : null,
+            typeInfo = type ? $tw.config.contentTypeInfo[type] : null;
+        return obs_readFile({ type, filepath })(
+            filepath as string, typeInfo ? typeInfo.encoding : "utf8"
+        ).switchMap(([err, data, { type, filepath }])/*: Observable<[any, { tiddlers: TiddlerFields[], type: string, filepath: string }]>*/ => {
+            const tag = {
+                type, filepath,
+                tiddlers: $tw.wiki.deserializeTiddlers(ext, data, fields)
+            }
+            //const tag1 = extend(tag, { tiddlers })
+
+            if (ext !== ".json" && tag.tiddlers.length === 1) {
+                return loadMetadataForFile(filepath).map(metadata => [metadata || {}, tag] as [{}, typeof tag]);
+            } else {
+                return Observable.of([false, tag] as [false, typeof tag]);
+            }
+        }).map(([metadata, tag]) => {
+            if (metadata) tag.tiddlers = [$tw.utils.extend({}, tag.tiddlers[0], metadata)] as TiddlerFields[];
+            return { filepath: tag.filepath, type: tag.type, tiddlers: tag.tiddlers, hasMetaFile: !!metadata };
+        })
+    };
+
+    /**
+    Load the metadata fields in the .meta file corresponding to a particular file. Returns null
+    if none is found.
+    */
+    function loadMetadataForFile(filepath) {
+        var metafilename = filepath + ".meta";
+        return obs_readFile()(metafilename, "utf8").map(([err, data]) => {
+            if (err) {
+                return null;
+            } else {
+                return $tw.utils.parseFields(data || "") as TiddlerFields;
+            }
+        })
+    };
+
+    /**
+    A default set of files for TiddlyWiki to ignore during load.
+    This matches what NPM ignores, and adds "*.meta" to ignore tiddler
+    metadata files.
+    */
+    $tw.boot.excludeRegExp = /^\.DS_Store$|^.*\.meta$|^\..*\.swp$|^\._.*$|^\.git$|^\.hg$|^\.lock-wscript$|^\.svn$|^\.wafpickle-.*$|^CVS$|^npm-debug\.log$/;
+
+
+
+    /**
+    Load all the tiddlers recursively from a directory, including honouring `tiddlywiki.files` files for drawing in external files. Returns an array of {filepath:,type:,tiddlers: [{..fields...}],hasMetaFile:}. Note that no file information is returned for externally loaded tiddlers, just the `tiddlers` property.
+    */
+    function loadTiddlersFromPath(filepath, excludeRegExp?): Observable<FileInfo> {
+        excludeRegExp = excludeRegExp || $tw.boot.excludeRegExp;
+        var tiddlers = [];
+        return obs_stat()(filepath).switchMap(([err, stat]) => {
+            if (err) {
+                return Observable.empty<FileInfo>();
+            } else {
+                if (stat.isDirectory()) {
+                    return obs_readdir()(filepath).switchMap(([err, files]) => {
+                        if (files.indexOf("tiddlywiki.files") !== -1) {
+                            return loadTiddlersFromSpecification(filepath, excludeRegExp);
+                        } else {
+                            // If not, read all the files in the directory
+                            return Observable.from(
+                                files.filter(file => {
+                                    return (!excludeRegExp.test(file) && file !== "plugin.info");
+                                })
+                            ).mergeMap(file => {
+                                return loadTiddlersFromPath(filepath + path.sep + file, excludeRegExp)
+                            }, maxConcurrent);
+                        }
+                    })
+                } else if (stat.isFile()) {
+                    return loadTiddlersFromFile(filepath)
+                } else {
+                    return Observable.empty<FileInfo>();
+                }
+            }
+        })
+    };
+
+    /**
+    Load all the tiddlers defined by a `tiddlywiki.files` specification file
+    filepath: pathname of the directory containing the specification file
+    */
+    function loadTiddlersFromSpecification(filepath, excludeRegExp) {
+        var tiddlers = [];
+        // Read the specification
+        return obs_readFile()(filepath + path.sep + "tiddlywiki.files", "utf8").switchMap((res) => {
+            var err = res[0];
+            var filesInfo = JSON.parse(res[1]);
+            return Observable.from(filesInfo.tiddlers || []).concatMap((tidInfo: TiddlerInfo) => {
+                if (tidInfo.prefix && tidInfo.suffix) {
+                    tidInfo.fields.text = { prefix: tidInfo.prefix, suffix: tidInfo.suffix };
+                } else if (tidInfo.prefix) {
+                    tidInfo.fields.text = { prefix: tidInfo.prefix };
+                } else if (tidInfo.suffix) {
+                    tidInfo.fields.text = { suffix: tidInfo.suffix };
+                }
+                return processFile(tidInfo.file, tidInfo.isTiddlerFile, tidInfo.fields);
+            }).concat(Observable.from(filesInfo.directories || []).concatMap((dirInfo: DirectoryInfo) => {
+                if (typeof dirInfo === "string") {
+                    var pathname = path.resolve(filepath, dirInfo);
+                    return obs_stat()(pathname).switchMap(([err, stat]) => {
+                        if (err || !stat.isDirectory()) return Observable.empty<FileInfo>();
+                        else return loadTiddlersFromPath(pathname, excludeRegExp)
+                    })
+                } else {
+                    // Process directory specifier
+                    var dirPath = path.resolve(filepath, dirInfo.path);
+                    return obs_readdir()(dirPath).switchMap(([err, files]) => {
+                        var fileRegExp = new RegExp(dirInfo.filesRegExp || "^.*$"),
+                            metaRegExp = /^.*\.meta$/;
+                        return Observable.from(
+                            files.filter(filename => {
+                                return filename !== "tiddlywiki.files" && !metaRegExp.test(filename) && fileRegExp.test(filename);
+                            })
+                        ).mergeMap(filename => {
+                            return processFile(dirPath + path.sep + filename, dirInfo.isTiddlerFile, dirInfo.fields);
+                        }, maxConcurrent)
+                    })
+                }
+            }))
+        })
+        // Helper to process a file
+        function processFile(filename, isTiddlerFile, fields): Observable<FileInfo> {
+            var extInfo = $tw.config.fileExtensionInfo[path.extname(filename)],
+                type = (extInfo || {}).type || fields.type || "text/plain",
+                typeInfo = $tw.config.contentTypeInfo[type] || {},
+                pathname = path.resolve(filepath, filename);
+            return obs_readFile()(pathname, typeInfo.encoding || "utf8").switchMap(([err, text]) => {
+                return loadMetadataForFile(pathname).map(metadata => [metadata || {}, text]);
+            }).map(([metadata, text]) => {
+                var fileTiddlers: TiddlerFields[];
+                if (isTiddlerFile) {
+                    fileTiddlers = $tw.wiki.deserializeTiddlers(path.extname(pathname), text, metadata) || [];
+                } else {
+                    fileTiddlers = [$tw.utils.extend({ text: text }, metadata) as TiddlerFields];
+                }
+                var combinedFields = $tw.utils.extend({}, fields, metadata) as Hashmap<FieldInfo | string | any[]>;
+                $tw.utils.each(fileTiddlers, function (tiddler) {
+                    $tw.utils.each(combinedFields, function (fieldInfo, name) {
+                        if (typeof fieldInfo === "string" || $tw.utils.isArray(fieldInfo)) {
+                            tiddler[name] = fieldInfo;
+                        } else {
+                            var value = tiddler[name];
+                            switch (fieldInfo.source) {
+                                case "filename":
+                                    value = path.basename(filename);
+                                    break;
+                                case "filename-uri-decoded":
+                                    value = decodeURIComponent(path.basename(filename));
+                                    break;
+                                case "basename":
+                                    value = path.basename(filename, path.extname(filename));
+                                    break;
+                                case "basename-uri-decoded":
+                                    value = decodeURIComponent(path.basename(filename, path.extname(filename)));
+                                    break;
+                                case "extname":
+                                    value = path.extname(filename);
+                                    break;
+                                case "created":
+                                    value = new Date(fs.statSync(pathname).birthtime);
+                                    break;
+                                case "modified":
+                                    value = new Date(fs.statSync(pathname).mtime);
+                                    break;
+                            }
+                            if (fieldInfo.prefix) {
+                                value = fieldInfo.prefix + value;
+                            }
+                            if (fieldInfo.suffix) {
+                                value = value + fieldInfo.suffix;
+                            }
+                            tiddler[name] = value;
+                        }
+                    });
+                });
+                return { tiddlers: fileTiddlers };
+            })
+        } //End processFile()
+    };
+
+    /**
+    Load the tiddlers from a plugin folder, and package them up into a proper JSON plugin tiddler
+    */
+    function loadPluginFolder(filepath, excludeRegExp?) {
+        excludeRegExp = excludeRegExp || $tw.boot.excludeRegExp;
+        //return an observable chain starting with stat'ing the folder
+        return obs_stat()(filepath).switchMap(([err, stat]) => {
+            //skip down to the catch handler if we can't load this path, but tell the handler
+            //to just return null instead of rethrowing the error.
+            if (err || !stat.isDirectory()) {
+                if (err) err.forward = false;
+                else err = { message: "Directory required", forward: false };
+                return Observable.throw(err);
+            }
+            //read the plugin info file
+            return obs_readFile()(filepath + path.sep + "plugin.info", "utf8");
+        }).switchMap(([err, data]) => {
+            if (err) throw err;
+            var pluginInfo = JSON.parse(data);
+            return loadTiddlersFromPath(filepath, excludeRegExp)
+                //loadTiddlersFromPath returns an Observable of individual files, so
+                //we need to reduce these into an array. The array will be emitted only
+                //only once only after all the files have been emited.
+                .reduce((n, e) => { n.push(e); return n; }, [])
+                //forward the plugin info
+                .map(tiddlers => [tiddlers, pluginInfo]);
+        }).map(([pluginFiles, pluginInfo]) => {
+            pluginInfo.tiddlers = pluginInfo.tiddlers || Object.create(null);
+            for (var f = 0; f < pluginFiles.length; f++) {
+                var tiddlers = pluginFiles[f].tiddlers;
+                for (var t = 0; t < tiddlers.length; t++) {
+                    var tiddler = tiddlers[t];
+                    if (tiddler.title) {
+                        pluginInfo.tiddlers[tiddler.title] = tiddler;
+                    }
+                }
+            }
+            // Give the plugin the same version number as the core if it doesn't have one
+            if (!("version" in pluginInfo)) {
+                pluginInfo.version = $tw.packageInfo.version;
+            }
+            // Use "plugin" as the plugin-type if we don't have one
+            if (!("plugin-type" in pluginInfo)) {
+                pluginInfo["plugin-type"] = "plugin";
+            }
+            pluginInfo.dependents = pluginInfo.dependents || [];
+            pluginInfo.type = "application/json";
+            // Set plugin text
+            pluginInfo.text = JSON.stringify({ tiddlers: pluginInfo.tiddlers }, null, 4);
+            delete pluginInfo.tiddlers;
+            // Deserialise array fields (currently required for the dependents field)
+            for (var field in pluginInfo) {
+                if ($tw.utils.isArray(pluginInfo[field])) {
+                    pluginInfo[field] = $tw.utils.stringifyList(pluginInfo[field]);
+                }
+            }
+            return pluginInfo;
+        }).catch(err => {
+            if (err.forward === false) return Observable.of(null);
+            else return Observable.throw(err);
+
+        })
+    };
+
+
+    /**
+    name: Name of the plugin to find
+    paths: array of file paths to search for it
+    Returns the path of the plugin folder or null
+    */
+    function findLibraryItem(name, paths) {
+        //emits the first path that exists and is a directory
+        //otherwise emits null
+        return Observable.from(paths).concatMap(itemPath => {
+            var pluginPath = path.resolve(itemPath, "./" + name);
+            return obs_stat(pluginPath)(pluginPath)
+        }).first(([err, stat, pluginPath]) => {
+            return (!err && stat.isDirectory())
+        }, ([err, stat, pluginPath]) => pluginPath, null)
+    };
+
+
+    /**
+    name: Name of the plugin to load
+    paths: array of file paths to search for it
+    */
+    function loadPlugin(name, paths): Observable<never> {
+        return findLibraryItem(name, paths).switchMap(pluginPath => {
+            if (pluginPath) return loadPluginFolder(pluginPath);
+            else return Observable.empty();
+        }).map(pluginFields => {
+            if (pluginFields) return $tw.wiki.addTiddler(pluginFields);
+        }).ignoreElements();
+    };
+
+
+    /**
+    libraryPath: Path of library folder for these plugins (relative to core path)
+    envVar: Environment variable name for these plugins
+    Returns an array of search paths
+    */
+    function getLibraryItemSearchPaths(libraryPath, envVar) {
+        var pluginPaths = [path.resolve($tw.boot.corePath, libraryPath)],
+            env = process.env[envVar];
+        if (env) {
+            env.split(path.delimiter).map(function (item) {
+                if (item) {
+                    pluginPaths.push(item)
+                }
+            });
+        }
+        return pluginPaths;
+    };
+
+    /**
+    plugins: Array of names of plugins (eg, "tiddlywiki/filesystemadaptor")
+    libraryPath: Path of library folder for these plugins (relative to core path)
+    envVar: Environment variable name for these plugins
+    */
+    function loadPlugins(plugins, libraryPath, envVar) {
+        if (plugins) {
+            var pluginPaths = getLibraryItemSearchPaths(libraryPath, envVar);
+            return Observable.from(plugins).mergeMap(plugin => {
+                return loadPlugin(plugin, pluginPaths);
+            }, maxConcurrent);
+        } else {
+            return Observable.empty();
+        }
+    };
+
+    /*
+     * Loads the tiddlers from a wiki directory
+     * @param wikiPath - path of wiki directory
+     * @param options
+     * @param options.parentPaths - array of parent paths that we mustn't recurse into
+     * @param options.readOnly - true if the tiddler file paths should not be retained
+     */
+    /**
+     * 
+     * 
+     * @param {any} wikiPath path of wiki directory
+     * @param {any} [options] 
+     * @returns 
+     */
+    function loadWikiTiddlers(wikiPath, options?) {
+        options = options || {};
+        var parentPaths = options.parentPaths || [],
+            wikiInfoPath = path.resolve(wikiPath, $tw.config.wikiInfo),
+            //wikiInfo,
+            pluginFields;
+        // Bail if we don't have a wiki info file
+        return obs_readFile()(wikiInfoPath, "utf8").concatMap(([err, wikiInfoFile]) => {
+            if (err) return Observable.empty<WikiInfo>()
+            var wikiInfo = JSON.parse(wikiInfoFile) as WikiInfo;
+            // Load any parent wikis
+            if (wikiInfo.includeWikis) {
+                parentPaths = parentPaths.slice(0);
+                parentPaths.push(wikiPath);
+                return Observable.from(wikiInfo.includeWikis).concatMap((info: { path: string, "read-only"?: boolean }) => {
+                    if (typeof info === "string") {
+                        info = { path: info };
+                    }
+                    var resolvedIncludedWikiPath = path.resolve(wikiPath, info.path);
+                    if (parentPaths.indexOf(resolvedIncludedWikiPath) === -1) {
+                        return loadWikiTiddlers(resolvedIncludedWikiPath, {
+                            parentPaths: parentPaths,
+                            readOnly: info["read-only"]
+                        }).map(subWikiInfo => {
+                            wikiInfo.build = $tw.utils.extend([], subWikiInfo.build, wikiInfo.build);
+                        });
+                    } else {
+                        $tw.utils.error("Cannot recursively include wiki " + resolvedIncludedWikiPath);
+                    }
+                }).count().mapTo(wikiInfo); //drop any output and just forward the wikiInfo.
+            }
+            return Observable.of(wikiInfo);
+        }).concatMap(wikiInfo => {
+            return Observable.concat(
+                loadPlugins(wikiInfo.plugins, $tw.config.pluginsPath, $tw.config.pluginsEnvVar),
+                loadPlugins(wikiInfo.themes, $tw.config.themesPath, $tw.config.themesEnvVar),
+                loadPlugins(wikiInfo.languages, $tw.config.languagesPath, $tw.config.languagesEnvVar)
+            ).count().mapTo(wikiInfo);
+        }).concatMap(wikiInfo => {
+            // Load the wiki files, registering them as writable
+            var resolvedWikiPath = path.resolve(wikiPath, $tw.config.wikiTiddlersSubDir);
+            return loadTiddlersFromPath(resolvedWikiPath).do(tiddlerFile => {
+                if (!options.readOnly && tiddlerFile.filepath) {
+                    $tw.utils.each(tiddlerFile.tiddlers, function (tiddler) {
+                        $tw.boot.files[tiddler.title] = {
+                            filepath: tiddlerFile.filepath,
+                            type: tiddlerFile.type,
+                            hasMetaFile: tiddlerFile.hasMetaFile
+                        };
+                    });
+                }
+                $tw.wiki.addTiddlers(tiddlerFile.tiddlers);
+            }).count().mapTo([wikiInfo, resolvedWikiPath] as [typeof wikiInfo, typeof resolvedWikiPath]);
+        }).concatMap(([wikiInfo, resolvedWikiPath]) => {
+            // Save the original tiddler file locations if requested
+            var config = wikiInfo.config || {};
+            if (config["retain-original-tiddler-path"]) {
+                var output = {};
+                for (var title in $tw.boot.files) {
+                    output[title] = path.relative(resolvedWikiPath, $tw.boot.files[title].filepath);
+                }
+                $tw.wiki.addTiddler({ title: "$:/config/OriginalTiddlerPaths", type: "application/json", text: JSON.stringify(output) });
+            }
+            // Save the path to the tiddlers folder for the filesystemadaptor
+            $tw.boot.wikiTiddlersPath = path.resolve($tw.boot.wikiPath, config["default-tiddler-location"] || $tw.config.wikiTiddlersSubDir);
+            // Load any plugins, themes and languages listed in the wiki info file
+            return Observable.from([
+                path.resolve(wikiPath, $tw.config.wikiPluginsSubDir),
+                path.resolve(wikiPath, $tw.config.wikiThemesSubDir),
+                path.resolve(wikiPath, $tw.config.wikiLanguagesSubDir)
+            ]).mergeMap(pluginPath => {
+                return obs_readdir(pluginPath)(pluginPath)
+            }).mergeMap(([err, pluginFolders, pluginPath]) => {
+                if (err) return Observable.empty();
+                else return Observable.from(pluginFolders.map(a => [a, pluginPath]))
+            }).mergeMap(([pluginFolder, pluginPath]) => {
+                return loadPluginFolder(path.resolve(pluginPath, "./" + pluginFolder));
+            }).map(pluginFields => {
+                $tw.wiki.addTiddler(pluginFields);
+            }).count().mapTo(wikiInfo);
+        }).defaultIfEmpty(null); //emit null if we don't emit anything else
+    };
+
+
+    function loadTiddlersNode() {
+        // Load the boot tiddlers
+        return Observable.merge(
+            //load the boot tiddlers
+            loadTiddlersFromPath($tw.boot.bootPath).do(tiddlerFile => {
+                $tw.wiki.addTiddlers(tiddlerFile.tiddlers);
+            }).ignoreElements(),
+            //load the core plugin
+            loadPluginFolder($tw.boot.corePath).do(coreTiddlers => {
+                $tw.wiki.addTiddler(coreTiddlers);
+            }).ignoreElements(),
+            //load the data folder, if we have one
+            ($tw.boot.wikiPath ? loadWikiTiddlers($tw.boot.wikiPath).do(wikiInfo => {
+                $tw.boot.wikiInfo = wikiInfo;
+            }) : Observable.empty())
+        ).ignoreElements();
+    };
+
+    $tw.utils.extend($tw, {
+        loadTiddlersFromFile,
+        loadMetadataForFile,
+        loadTiddlersFromPath,
+        loadTiddlersFromSpecification,
+        loadPluginFolder,
+        findLibraryItem,
+        loadPlugin,
+        getLibraryItemSearchPaths,
+        loadPlugins,
+        loadWikiTiddlers,
+        loadTiddlersNode
+    })
+
+}

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -70,7 +70,7 @@ $tw.utils.each = function(object,callback) {
 				if(next === false) {
 					break;
 				}
-		    }
+			}
 		} else {
 			var keys = Object.keys(object);
 			for (f=0, length=keys.length; f<length; f++) {
@@ -1444,6 +1444,11 @@ $tw.loadTiddlersBrowser = function() {
 	for(var t=0; t<containerIds.length; t++) {
 		$tw.wiki.addTiddlers($tw.wiki.deserializeTiddlers("(DOM)",document.getElementById(containerIds[t])));
 	}
+	return {
+		subscribe: (subscriber) => {
+			subscriber.complete();
+		}
+	}
 };
 
 } else {
@@ -1463,398 +1468,7 @@ $tw.boot.decryptEncryptedTiddlers = function(callback) {
 /////////////////////////// Node definitions
 
 if($tw.node) {
-
-/*
-Load the tiddlers contained in a particular file (and optionally extract fields from the accompanying .meta file) returned as {filepath:,type:,tiddlers:[],hasMetaFile:}
-*/
-$tw.loadTiddlersFromFile = function(filepath,fields) {
-	var ext = path.extname(filepath),
-		extensionInfo = $tw.utils.getFileExtensionInfo(ext),
-		type = extensionInfo ? extensionInfo.type : null,
-		typeInfo = type ? $tw.config.contentTypeInfo[type] : null,
-		data = fs.readFileSync(filepath,typeInfo ? typeInfo.encoding : "utf8"),
-		tiddlers = $tw.wiki.deserializeTiddlers(ext,data,fields),
-		metadata;
-	if(ext !== ".json" && tiddlers.length === 1) {
-		metadata = $tw.loadMetadataForFile(filepath);
-		tiddlers = [$tw.utils.extend({},tiddlers[0],metadata)];
-	}
-	return {filepath: filepath, type: type, tiddlers: tiddlers, hasMetaFile: !!metadata};
-};
-
-/*
-Load the metadata fields in the .meta file corresponding to a particular file
-*/
-$tw.loadMetadataForFile = function(filepath) {
-	var metafilename = filepath + ".meta";
-	if(fs.existsSync(metafilename)) {
-		return $tw.utils.parseFields(fs.readFileSync(metafilename,"utf8") || "");
-	} else {
-		return null;
-	}
-};
-
-/*
-A default set of files for TiddlyWiki to ignore during load.
-This matches what NPM ignores, and adds "*.meta" to ignore tiddler
-metadata files.
-*/
-$tw.boot.excludeRegExp = /^\.DS_Store$|^.*\.meta$|^\..*\.swp$|^\._.*$|^\.git$|^\.hg$|^\.lock-wscript$|^\.svn$|^\.wafpickle-.*$|^CVS$|^npm-debug\.log$/;
-
-/*
-Load all the tiddlers recursively from a directory, including honouring `tiddlywiki.files` files for drawing in external files. Returns an array of {filepath:,type:,tiddlers: [{..fields...}],hasMetaFile:}. Note that no file information is returned for externally loaded tiddlers, just the `tiddlers` property.
-*/
-$tw.loadTiddlersFromPath = function(filepath,excludeRegExp) {
-	excludeRegExp = excludeRegExp || $tw.boot.excludeRegExp;
-	var tiddlers = [];
-	if(fs.existsSync(filepath)) {
-		var stat = fs.statSync(filepath);
-		if(stat.isDirectory()) {
-			var files = fs.readdirSync(filepath);
-			// Look for a tiddlywiki.files file
-			if(files.indexOf("tiddlywiki.files") !== -1) {
-				Array.prototype.push.apply(tiddlers,$tw.loadTiddlersFromSpecification(filepath,excludeRegExp));
-			} else {
-				// If not, read all the files in the directory
-				$tw.utils.each(files,function(file) {
-					if(!excludeRegExp.test(file) && file !== "plugin.info") {
-						tiddlers.push.apply(tiddlers,$tw.loadTiddlersFromPath(filepath + path.sep + file,excludeRegExp));
-					}
-				});
-			}
-		} else if(stat.isFile()) {
-			tiddlers.push($tw.loadTiddlersFromFile(filepath));
-		}
-	}
-	return tiddlers;
-};
-
-/*
-Load all the tiddlers defined by a `tiddlywiki.files` specification file
-filepath: pathname of the directory containing the specification file
-*/
-$tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp) {
-	var tiddlers = [];
-	// Read the specification
-	var filesInfo = JSON.parse(fs.readFileSync(filepath + path.sep + "tiddlywiki.files","utf8"));
-	// Helper to process a file
-	var processFile = function(filename,isTiddlerFile,fields) {
-		var extInfo = $tw.config.fileExtensionInfo[path.extname(filename)],
-			type = (extInfo || {}).type || fields.type || "text/plain",
-			typeInfo = $tw.config.contentTypeInfo[type] || {},
-			pathname = path.resolve(filepath,filename),
-			text = fs.readFileSync(pathname,typeInfo.encoding || "utf8"),
-			metadata = $tw.loadMetadataForFile(pathname) || {},
-			fileTiddlers;
-		if(isTiddlerFile) {
-			fileTiddlers = $tw.wiki.deserializeTiddlers(path.extname(pathname),text,metadata) || [];
-		} else {
-			fileTiddlers =  [$tw.utils.extend({text: text},metadata)];
-		}
-		var combinedFields = $tw.utils.extend({},fields,metadata);
-		$tw.utils.each(fileTiddlers,function(tiddler) {
-			$tw.utils.each(combinedFields,function(fieldInfo,name) {
-				if(typeof fieldInfo === "string" || $tw.utils.isArray(fieldInfo)) {
-					tiddler[name] = fieldInfo;
-				} else {
-					var value = tiddler[name];
-					switch(fieldInfo.source) {
-						case "filename":
-							value = path.basename(filename);
-							break;
-						case "filename-uri-decoded":
-							value = decodeURIComponent(path.basename(filename));
-							break;
-						case "basename":
-							value = path.basename(filename,path.extname(filename));
-							break;
-						case "basename-uri-decoded":
-							value = decodeURIComponent(path.basename(filename,path.extname(filename)));
-							break;
-						case "extname":
-							value = path.extname(filename);
-							break;
-						case "created":
-							value = new Date(fs.statSync(pathname).birthtime);
-							break;
-						case "modified":
-							value = new Date(fs.statSync(pathname).mtime);
-							break;
-					}
-					if(fieldInfo.prefix) {
-						value = fieldInfo.prefix + value;
-					}
-					if(fieldInfo.suffix) {
-						value = value + fieldInfo.suffix;
-					}
-					tiddler[name] = value;
-				}
-			});
-		});
-		tiddlers.push({tiddlers: fileTiddlers});
-	};
-	// Process the listed tiddlers
-	$tw.utils.each(filesInfo.tiddlers,function(tidInfo) {
-		if(tidInfo.prefix && tidInfo.suffix) {
-			tidInfo.fields.text = {prefix: tidInfo.prefix,suffix: tidInfo.suffix};
-		} else if(tidInfo.prefix) {
-			tidInfo.fields.text = {prefix: tidInfo.prefix};
-		} else if(tidInfo.suffix) {
-			tidInfo.fields.text = {suffix: tidInfo.suffix};
-		}
-		processFile(tidInfo.file,tidInfo.isTiddlerFile,tidInfo.fields);
-	});
-	// Process any listed directories
-	$tw.utils.each(filesInfo.directories,function(dirSpec) {
-		// Read literal directories directly
-		if(typeof dirSpec === "string") {
-			var pathname = path.resolve(filepath,dirSpec);
-			if(fs.existsSync(pathname) && fs.statSync(pathname).isDirectory()) {
-				tiddlers.push.apply(tiddlers,$tw.loadTiddlersFromPath(pathname,excludeRegExp));
-			}
-		} else {
-			// Process directory specifier
-			var dirPath = path.resolve(filepath,dirSpec.path),
-				files = fs.readdirSync(dirPath),
-				fileRegExp = new RegExp(dirSpec.filesRegExp || "^.*$"),
-				metaRegExp = /^.*\.meta$/;
-			for(var t=0; t<files.length; t++) {
-				var filename = files[t];
-				if(filename !== "tiddlywiki.files" && !metaRegExp.test(filename) && fileRegExp.test(filename)) {
-					processFile(dirPath + path.sep + filename,dirSpec.isTiddlerFile,dirSpec.fields);
-				}
-			}
-		}
-	});
-	return tiddlers;
-};
-
-/*
-Load the tiddlers from a plugin folder, and package them up into a proper JSON plugin tiddler
-*/
-$tw.loadPluginFolder = function(filepath,excludeRegExp) {
-	excludeRegExp = excludeRegExp || $tw.boot.excludeRegExp;
-	if(fs.existsSync(filepath) && fs.statSync(filepath).isDirectory()) {
-		// Read the plugin information
-		var pluginInfo = JSON.parse(fs.readFileSync(filepath + path.sep + "plugin.info","utf8"));
-		// Read the plugin files
-		var pluginFiles = $tw.loadTiddlersFromPath(filepath,excludeRegExp);
-		// Save the plugin tiddlers into the plugin info
-		pluginInfo.tiddlers = pluginInfo.tiddlers || Object.create(null);
-		for(var f=0; f<pluginFiles.length; f++) {
-			var tiddlers = pluginFiles[f].tiddlers;
-			for(var t=0; t<tiddlers.length; t++) {
-				var tiddler= tiddlers[t];
-				if(tiddler.title) {
-					pluginInfo.tiddlers[tiddler.title] = tiddler;
-				}
-			}
-		}
-		// Give the plugin the same version number as the core if it doesn't have one
-		if(!("version" in pluginInfo)) {
-			pluginInfo.version = $tw.packageInfo.version;
-		}
-		// Use "plugin" as the plugin-type if we don't have one
-		if(!("plugin-type" in pluginInfo)) {
-			pluginInfo["plugin-type"] = "plugin";
-		}
-		pluginInfo.dependents = pluginInfo.dependents || [];
-		pluginInfo.type = "application/json";
-		// Set plugin text
-		pluginInfo.text = JSON.stringify({tiddlers: pluginInfo.tiddlers},null,4);
-		delete pluginInfo.tiddlers;
-		// Deserialise array fields (currently required for the dependents field)
-		for(var field in pluginInfo) {
-			if($tw.utils.isArray(pluginInfo[field])) {
-				pluginInfo[field] = $tw.utils.stringifyList(pluginInfo[field]);
-			}
-		}
-		return pluginInfo;
-	} else {
-			return null;
-	}
-};
-
-/*
-name: Name of the plugin to find
-paths: array of file paths to search for it
-Returns the path of the plugin folder
-*/
-$tw.findLibraryItem = function(name,paths) {
-	var pathIndex = 0;
-	do {
-		var pluginPath = path.resolve(paths[pathIndex],"./" + name)
-		if(fs.existsSync(pluginPath) && fs.statSync(pluginPath).isDirectory()) {
-			return pluginPath;
-		}
-	} while(++pathIndex < paths.length);
-	return null;
-};
-
-/*
-name: Name of the plugin to load
-paths: array of file paths to search for it
-*/
-$tw.loadPlugin = function(name,paths) {
-	var pluginPath = $tw.findLibraryItem(name,paths);
-	if(pluginPath) {
-		var pluginFields = $tw.loadPluginFolder(pluginPath);
-		if(pluginFields) {
-			$tw.wiki.addTiddler(pluginFields);
-		}
-	}
-};
-
-/*
-libraryPath: Path of library folder for these plugins (relative to core path)
-envVar: Environment variable name for these plugins
-Returns an array of search paths
-*/
-$tw.getLibraryItemSearchPaths = function(libraryPath,envVar) {
-	var pluginPaths = [path.resolve($tw.boot.corePath,libraryPath)],
-		env = process.env[envVar];
-	if(env) {
-		env.split(path.delimiter).map(function(item) {
-			if(item) {
-				pluginPaths.push(item)
-			}
-		});
-	}
-	return pluginPaths;
-};
-
-/*
-plugins: Array of names of plugins (eg, "tiddlywiki/filesystemadaptor")
-libraryPath: Path of library folder for these plugins (relative to core path)
-envVar: Environment variable name for these plugins
-*/
-$tw.loadPlugins = function(plugins,libraryPath,envVar) {
-	if(plugins) {
-		var pluginPaths = $tw.getLibraryItemSearchPaths(libraryPath,envVar);
-		for(var t=0; t<plugins.length; t++) {
-			$tw.loadPlugin(plugins[t],pluginPaths);
-		}
-	}
-};
-
-/*
-path: path of wiki directory
-options:
-	parentPaths: array of parent paths that we mustn't recurse into
-	readOnly: true if the tiddler file paths should not be retained
-*/
-$tw.loadWikiTiddlers = function(wikiPath,options) {
-	options = options || {};
-	var parentPaths = options.parentPaths || [],
-		wikiInfoPath = path.resolve(wikiPath,$tw.config.wikiInfo),
-		wikiInfo,
-		pluginFields;
-	// Bail if we don't have a wiki info file
-	if(fs.existsSync(wikiInfoPath)) {
-		wikiInfo = JSON.parse(fs.readFileSync(wikiInfoPath,"utf8"));
-	} else {
-		return null;
-	}
-	// Load any parent wikis
-	if(wikiInfo.includeWikis) {
-		parentPaths = parentPaths.slice(0);
-		parentPaths.push(wikiPath);
-		$tw.utils.each(wikiInfo.includeWikis,function(info) {
-			if(typeof info === "string") {
-				info = {path: info};
-			}
-			var resolvedIncludedWikiPath = path.resolve(wikiPath,info.path);
-			if(parentPaths.indexOf(resolvedIncludedWikiPath) === -1) {
-				var subWikiInfo = $tw.loadWikiTiddlers(resolvedIncludedWikiPath,{
-					parentPaths: parentPaths,
-					readOnly: info["read-only"]
-				});
-				// Merge the build targets
-				wikiInfo.build = $tw.utils.extend([],subWikiInfo.build,wikiInfo.build);
-			} else {
-				$tw.utils.error("Cannot recursively include wiki " + resolvedIncludedWikiPath);
-			}
-		});
-	}
-	// Load any plugins, themes and languages listed in the wiki info file
-	$tw.loadPlugins(wikiInfo.plugins,$tw.config.pluginsPath,$tw.config.pluginsEnvVar);
-	$tw.loadPlugins(wikiInfo.themes,$tw.config.themesPath,$tw.config.themesEnvVar);
-	$tw.loadPlugins(wikiInfo.languages,$tw.config.languagesPath,$tw.config.languagesEnvVar);
-	// Load the wiki files, registering them as writable
-	var resolvedWikiPath = path.resolve(wikiPath,$tw.config.wikiTiddlersSubDir);
-	$tw.utils.each($tw.loadTiddlersFromPath(resolvedWikiPath),function(tiddlerFile) {
-		if(!options.readOnly && tiddlerFile.filepath) {
-			$tw.utils.each(tiddlerFile.tiddlers,function(tiddler) {
-				$tw.boot.files[tiddler.title] = {
-					filepath: tiddlerFile.filepath,
-					type: tiddlerFile.type,
-					hasMetaFile: tiddlerFile.hasMetaFile
-				};
-			});
-		}
-		$tw.wiki.addTiddlers(tiddlerFile.tiddlers);
-	});
-	// Save the original tiddler file locations if requested
-	var config = wikiInfo.config || {};
-	if(config["retain-original-tiddler-path"]) {
-		var output = {};
-		for(var title in $tw.boot.files) {
-			output[title] = path.relative(resolvedWikiPath,$tw.boot.files[title].filepath);
-		}
-		$tw.wiki.addTiddler({title: "$:/config/OriginalTiddlerPaths", type: "application/json", text: JSON.stringify(output)});
-	}
-	// Save the path to the tiddlers folder for the filesystemadaptor
-	$tw.boot.wikiTiddlersPath = path.resolve($tw.boot.wikiPath,config["default-tiddler-location"] || $tw.config.wikiTiddlersSubDir);
-	// Load any plugins within the wiki folder
-	var wikiPluginsPath = path.resolve(wikiPath,$tw.config.wikiPluginsSubDir);
-	if(fs.existsSync(wikiPluginsPath)) {
-		var pluginFolders = fs.readdirSync(wikiPluginsPath);
-		for(var t=0; t<pluginFolders.length; t++) {
-			pluginFields = $tw.loadPluginFolder(path.resolve(wikiPluginsPath,"./" + pluginFolders[t]));
-			if(pluginFields) {
-				$tw.wiki.addTiddler(pluginFields);
-			}
-		}
-	}
-	// Load any themes within the wiki folder
-	var wikiThemesPath = path.resolve(wikiPath,$tw.config.wikiThemesSubDir);
-	if(fs.existsSync(wikiThemesPath)) {
-		var themeFolders = fs.readdirSync(wikiThemesPath);
-		for(var t=0; t<themeFolders.length; t++) {
-			pluginFields = $tw.loadPluginFolder(path.resolve(wikiThemesPath,"./" + themeFolders[t]));
-			if(pluginFields) {
-				$tw.wiki.addTiddler(pluginFields);
-			}
-		}
-	}
-	// Load any languages within the wiki folder
-	var wikiLanguagesPath = path.resolve(wikiPath,$tw.config.wikiLanguagesSubDir);
-	if(fs.existsSync(wikiLanguagesPath)) {
-		var languageFolders = fs.readdirSync(wikiLanguagesPath);
-		for(var t=0; t<languageFolders.length; t++) {
-			pluginFields = $tw.loadPluginFolder(path.resolve(wikiLanguagesPath,"./" + languageFolders[t]));
-			if(pluginFields) {
-				$tw.wiki.addTiddler(pluginFields);
-			}
-		}
-	}
-	return wikiInfo;
-};
-
-$tw.loadTiddlersNode = function() {
-	// Load the boot tiddlers
-	$tw.utils.each($tw.loadTiddlersFromPath($tw.boot.bootPath),function(tiddlerFile) {
-		$tw.wiki.addTiddlers(tiddlerFile.tiddlers);
-	});
-	// Load the core tiddlers
-	$tw.wiki.addTiddler($tw.loadPluginFolder($tw.boot.corePath));
-	// Load the tiddlers from the wiki directory
-	if($tw.boot.wikiPath) {
-		$tw.boot.wikiInfo = $tw.loadWikiTiddlers($tw.boot.wikiPath);
-	}
-};
-
-// End of if($tw.node)
+	require('./boot-node').bootNode($tw);
 }
 
 /////////////////////////// Main startup function called once tiddlers have been decrypted
@@ -1981,11 +1595,10 @@ $tw.boot.startup = function(options) {
 		}
 	}
 	// Load tiddlers
-	if($tw.boot.tasks.readBrowserTiddlers) {
-		$tw.loadTiddlersBrowser();
-	} else {
-		$tw.loadTiddlersNode();
-	}
+($tw.boot.tasks.readBrowserTiddlers
+	? $tw.loadTiddlersBrowser()
+	: $tw.loadTiddlersNode()
+).subscribe({ complete: () => {
 	// Load any preloaded tiddlers
 	if($tw.preloadTiddlers) {
 		$tw.wiki.addTiddlers($tw.preloadTiddlers);
@@ -2018,6 +1631,7 @@ $tw.boot.startup = function(options) {
 	$tw.boot.disabledStartupModules = $tw.boot.disabledStartupModules || [];
 	// Repeatedly execute the next eligible task
 	$tw.boot.executeNextStartupTask(options.callback);
+}})
 };
 
 /*

--- a/package.json
+++ b/package.json
@@ -23,8 +23,12 @@
     "tiddlywiki5",
     "wiki"
   ],
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "rxjs": "^5.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^7.0.31"
+  },
   "bundleDependencies": [],
   "license": "BSD",
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "listEmittedFiles": true,
+    "target": "es5",
+    "module": "commonjs",
+    "strict": false
+  }
+}


### PR DESCRIPTION
I know this is a big change, but it seems to me that it would improve things quite significantly. I definitely welcome discussion on it.

I tested load times with this along with compiling all the plugins into just plugin.info files and got some pretty impressive results (though not because of this as I first thought).

I loaded 4 separate configurations with the full edition folder. Each of these only cached the boot folder files in the nodeJS modules cache. Core and the plugins apparently are not cached by NodeJS. 

But there was a bit of loading time for RxJS (400 ms for the npm package, and 50 ms for the bundled JS file), which in this case would not be a significant problem for my TiddlyServer since I use rxjs there as well and the files would already be cached. 

|                  | Loading individual files | Loading compiled `plugin.info` |
|---|---|---|
| RxJS Boot |  1500 ms | 900 ms |
| Old Boot  |  1600 ms | 1000 ms |

These are with RxJS preloaded.

The test order is 
 - RxJS - Individual
 - RxJS - Compiled
 - Old - Individual
 - Old - Compiled

