### PR TITLE
Add callback to loadTiddlers* functions to allow async loading

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -70,7 +70,7 @@ $tw.utils.each = function(object,callback) {
 				if(next === false) {
 					break;
 				}
-		    }
+			}
 		} else {
 			var keys = Object.keys(object);
 			for (f=0, length=keys.length; f<length; f++) {
@@ -1430,7 +1430,7 @@ $tw.modules.define("$:/boot/tiddlerdeserializer/dom","tiddlerdeserializer",{
 	}
 });
 
-$tw.loadTiddlersBrowser = function() {
+$tw.loadTiddlersBrowser = function(callback) {
 	// In the browser, we load tiddlers from certain elements
 	var containerIds = [
 		"libraryModules",
@@ -1444,6 +1444,7 @@ $tw.loadTiddlersBrowser = function() {
 	for(var t=0; t<containerIds.length; t++) {
 		$tw.wiki.addTiddlers($tw.wiki.deserializeTiddlers("(DOM)",document.getElementById(containerIds[t])));
 	}
+	callback();
 };
 
 } else {
@@ -1841,7 +1842,7 @@ $tw.loadWikiTiddlers = function(wikiPath,options) {
 	return wikiInfo;
 };
 
-$tw.loadTiddlersNode = function() {
+$tw.loadTiddlersNode = function(callback) {
 	// Load the boot tiddlers
 	$tw.utils.each($tw.loadTiddlersFromPath($tw.boot.bootPath),function(tiddlerFile) {
 		$tw.wiki.addTiddlers(tiddlerFile.tiddlers);
@@ -1852,6 +1853,7 @@ $tw.loadTiddlersNode = function() {
 	if($tw.boot.wikiPath) {
 		$tw.boot.wikiInfo = $tw.loadWikiTiddlers($tw.boot.wikiPath);
 	}
+	callback();
 };
 
 // End of if($tw.node)
@@ -1982,10 +1984,11 @@ $tw.boot.startup = function(options) {
 	}
 	// Load tiddlers
 	if($tw.boot.tasks.readBrowserTiddlers) {
-		$tw.loadTiddlersBrowser();
+		$tw.loadTiddlersBrowser(finishStartup);
 	} else {
-		$tw.loadTiddlersNode();
+		$tw.loadTiddlersNode(finishStartup);
 	}
+function finishStartup(){
 	// Load any preloaded tiddlers
 	if($tw.preloadTiddlers) {
 		$tw.wiki.addTiddlers($tw.preloadTiddlers);
@@ -2018,6 +2021,8 @@ $tw.boot.startup = function(options) {
 	$tw.boot.disabledStartupModules = $tw.boot.disabledStartupModules || [];
 	// Repeatedly execute the next eligible task
 	$tw.boot.executeNextStartupTask(options.callback);
+}
+
 };
 
 /*


### PR DESCRIPTION
This is the change I mentioned in #2909. This allows anyone to overwrite the `if($tw.node)` functions very easily and add async bootup. 

There are other ways to increase boot speed quite a bit more than this, but in my tests, there did seem to be quite a bit of "program" time, where the event loop would have been able to  do other things while waiting for files to load, even though waiting for the files still took about the same amount of time.

```js
var $tw = require('tiddlywiki').TiddlyWiki();
//this method would assign other methods to the ten or so that 
//are called by $tw.loadTiddlersNode(). Since load tiddlers node now 
//uses a callback, the sequence can be made asynchronous.
changeLoadTiddlersNode($tw); 
$tw.boot.boot();
```