### PR TITLE
Allow savers to receive options and variables

### DIFF
--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -143,9 +143,9 @@ Save the wiki contents. Options are:
 */
 SaverHandler.prototype.saveWiki = function(options) {
 	options = options || {};
+	options.variables = options.variables || {};
 	var self = this,
 		method = options.method || "save",
-		variables = options.variables || {},
 		template = options.template || "$:/core/save/all",
 		downloadType = options.downloadType || "text/plain",
 		text = this.wiki.renderTiddler(downloadType,template,options),
@@ -171,7 +171,7 @@ SaverHandler.prototype.saveWiki = function(options) {
 	// Call the highest priority saver that supports this method
 	for(var t=this.savers.length-1; t>=0; t--) {
 		var saver = this.savers[t];
-		if(saver.info.capabilities.indexOf(method) !== -1 && saver.save(text,method,callback,{variables: {filename: variables.filename}})) {
+		if(saver.info.capabilities.indexOf(method) !== -1 && saver.save(text,method,callback,options)) {
 			this.logger.log("Saving wiki with method",method,"through saver",saver.info.name);
 			return true;
 		}


### PR DESCRIPTION
This pull request allows sending options to the savers. This may be useful if you want to configure the way the saver behaves when you send the save event, or even to allow communication between savers (or the same saver) if you save mechanism happens in two phases/steps. 

The previous code was a bit confusing because it was saving `optioins.variables`  into variables just for rebuilt the same object later `{variables: { filename: variables.filename}}`.