### PR TITLE
Use promise resolve when calling loadTiddlersNode

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1982,8 +1982,7 @@ $tw.boot.startup = function(options) {
 	}
 	// Load tiddlers
 	if($tw.boot.tasks.readBrowserTiddlers) {
-		$tw.loadTiddlersBrowser();
-		finishStartup();
+		Promise.resolve($tw.loadTiddlersBrowser()).then(finishStartup);
 	} else {
 		Promise.resolve($tw.loadTiddlersNode()).then(finishStartup);
 	}

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1983,9 +1983,11 @@ $tw.boot.startup = function(options) {
 	// Load tiddlers
 	if($tw.boot.tasks.readBrowserTiddlers) {
 		$tw.loadTiddlersBrowser();
+		finishStartup();
 	} else {
-		$tw.loadTiddlersNode();
+		Promise.resolve($tw.loadTiddlersNode()).then(finishStartup);
 	}
+	function finishStartup(){
 	// Load any preloaded tiddlers
 	if($tw.preloadTiddlers) {
 		$tw.wiki.addTiddlers($tw.preloadTiddlers);
@@ -2018,6 +2020,7 @@ $tw.boot.startup = function(options) {
 	$tw.boot.disabledStartupModules = $tw.boot.disabledStartupModules || [];
 	// Repeatedly execute the next eligible task
 	$tw.boot.executeNextStartupTask(options.callback);
+	}
 };
 
 /*


### PR DESCRIPTION
Per our discussion here and @sukima's comment in particular(https://github.com/Jermolene/TiddlyWiki5/pull/2914#issuecomment-311993973), I added this pull request to implement those changes. If this change is acceptable, then I won't need https://github.com/Jermolene/TiddlyWiki5/pull/2914.