### PR TITLE
Restore ability to use sub-filter with image-picker macro

### DIFF
--- a/core/wiki/macros/image-picker.tid
+++ b/core/wiki/macros/image-picker.tid
@@ -1,5 +1,8 @@
-title: $:/core/macros/image-picker
+created: 20170715180840889
+modified: 20170715180914005
 tags: $:/tags/Macro
+title: $:/core/macros/image-picker
+type: text/vnd.tiddlywiki
 
 \define image-picker-thumbnail(actions)
 <$button tag="a" tooltip="""$(imageTitle)$""">
@@ -14,7 +17,7 @@ $actions$
 </$list>
 \end
 
-\define image-picker(actions,filter:"[all[shadows+tiddlers]is[image]] -[type[application/pdf]] +[!has[draft.of]sort[title]]")
+\define image-picker(actions,filter:"[all[shadows+tiddlers]is[image]] -[type[application/pdf]] +[!has[draft.of]$subfilter$sort[title]]",subfilter:"")
 <div class="tc-image-chooser">
 <$vars state-system=<<qualify "$:/state/image-picker/system">>>
 <$checkbox tiddler=<<state-system>> field="text" checked="show" unchecked="hide" default="hide">


### PR DESCRIPTION
The subfilter option seems to have been accidentally dropped -- examples don't work correctly for instance.