### PR TITLE
Add a missing wiki name to a command

### DIFF
--- a/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki on Node.js.tid
+++ b/editions/tw5.com/tiddlers/nodejs/Installing TiddlyWiki on Node.js.tid
@@ -21,7 +21,7 @@ type: text/vnd.tiddlywiki
 ## Try editing and creating tiddlers
 # Optionally, make an offline copy:
 #* click the {{$:/core/images/save-button}} ''save changes'' button in the sidebar, ''OR''
-#* `tiddlywiki --build index`
+#* `tiddlywiki mynewwiki --build index`
 
 
 The `-g` flag causes TiddlyWiki to be installed globally. Without it, TiddlyWiki will only be available in the directory where you installed it.


### PR DESCRIPTION
All the other commands seem to assume that the user is not in the wiki directory, but rather in the parent directory: `tiddlywiki mynewwiki --init server` and `tiddlywiki mynewwiki --server`. This is why `tiddlywiki --build index` fails. A solution to this problem is to add the wiki name (_mynewwiki_) to the command.