### PR TITLE
Update Basics.tid

### DIFF
--- a/core/ui/ControlPanel/Basics.tid
+++ b/core/ui/ControlPanel/Basics.tid
@@ -29,3 +29,6 @@ caption: {{$:/language/ControlPanel/Basics/Caption}}
 |<<lingo SystemTiddlers/Prompt>> |<<show-filter-count "[is[system]sort[title]]">> |
 |<<lingo ShadowTiddlers/Prompt>> |<<show-filter-count "[all[shadows]sort[title]]">> |
 |<<lingo OverriddenShadowTiddlers/Prompt>> |<<show-filter-count "[is[tiddler]is[shadow]sort[title]]">> |
+<table><tbody>
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Basics]!has[draft.of]]"><$transclude/></$list>
+</tbody></table>


### PR DESCRIPTION
This will allow third party plugins and customization to add elements to the Basics table of the control panel. The lack of `<tr>` tags is intentional so each tiddler can decide if they want to add one or more than one row at a time.
Table does not merge with the one above, which may be both a good and a bad thing, I want to open the discussion about it.

Tiddlers may look like this:

```
<tr>
<td><$link to="$:/config/NewJournal/Tags"><<lingo NewJournal/Tags/Prompt>></$link> </td><td><$edit-text tiddler="$:/config/NewJournal/Tags" default="" tag="input"/></td>
</tr>
```