### PR TITLE
Returns text of input selection that matches regexpr

### DIFF
--- a/core/modules/filters/regexps.js
+++ b/core/modules/filters/regexps.js
@@ -66,7 +66,7 @@ exports.regexps = function(source,operator,options) {
 				ret = text.match(regexp) ;
 				if(ret !==null) {
 					if(global) {
-						results = ret  ;
+						results.push.apply(results,ret)  ; //DEBUG
 					} else {
 						// if there are  sub groups return sub groups START
 						if(ret.length > 1)  {     // return sub groups

--- a/core/modules/filters/regexps.js
+++ b/core/modules/filters/regexps.js
@@ -1,0 +1,85 @@
+/*\
+title: $:/core/modules/filters/regexps.js
+type: application/javascript
+module-type: filteroperator
+
+Filter operator for regexp matching and returning result. All results are returned if global flag used. All sub-groups are returned if not global and sub-group hits are found.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.regexps = function(source,operator,options) {
+	var results = [],
+		fieldname = (operator.suffix || "title").toLowerCase(),
+		regexpString, regexp, flags = "", match, global,
+		getFieldString = function(tiddler,title) {
+			if(tiddler) {
+				return tiddler.getFieldString(fieldname);
+			} else if(fieldname === "title") {
+				return title;
+			} else {
+				return null;
+			}
+		};
+	// Process flags and construct regexp
+	regexpString = operator.operand;
+	match = /^\(\?([gim]+)\)/.exec(regexpString);
+	if(match) {
+		flags = match[1];
+		regexpString = regexpString.substr(match[0].length);
+	} else {
+		match = /\(\?([gim]+)\)$/.exec(regexpString);
+		if(match) {
+			flags = match[1];
+			regexpString = regexpString.substr(0,regexpString.length - match[0].length);
+		}
+	}
+	try {
+		regexp = new RegExp(regexpString,flags);
+	} catch(e) {
+		return ["" + e];
+	}
+
+	global = /g/.test(flags) ;
+
+	// Process the incoming tiddlers
+	if(operator.prefix === "!") {
+		source(function(tiddler,title) {
+			var text = getFieldString(tiddler,title);
+			if(text !== null) {
+				if(!regexp.exec(text)) {
+					results.push(title);
+				}
+			}
+		});
+	} else {
+		source(function(tiddler,title) {
+			var text = getFieldString(tiddler,title), ret="";
+			if(text !== null) {
+				ret = text.match(regexp) ;
+				if(ret !==null) {
+					if(global) {
+						results = ret  ;
+					} else {
+						// if there are  sub groups return sub groups START
+						if(ret.length > 1)  {     // return sub groups
+							results = results.concat(ret.slice(1)) ;
+						} else { // if no sub-groups
+							results.push(ret[0]);
+						} 
+					}
+				}
+			}
+		});
+	}
+	return results;
+};
+
+})();

--- a/editions/tw5.com/tiddlers/filters/examples/regexps Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/regexps Operator (Examples).tid
@@ -1,0 +1,40 @@
+created: 20170924213312793
+modified: 20170924233417820
+tags: [[String Operators]] [[Operator Examples]] [[regexps Operator]]
+title: regexps Operator (Examples)
+type: text/vnd.tiddlywiki
+
+!! Find the major categories of configuration tiddlers
+
+Note that we do this by looking for the text between the ``$:/conf/`` prefix and the first subsequent forward slash (``/``):
+
+<<.operator-example 1 "[all[system+shadows]regexps[\$:/config/(.+?)/]unique[]]" "The major categories of configuration tiddlers">>
+
+----
+!! Find the first 5 url references from the [[Release 5.1.14]] notes page.
+
+Note that we use the `(?g)` global modifier and that we need to assign our regular expression using the [[Vars Widget|VarsWidget]]. Because this expression is global, grouping is not possible and we use a separate ``removeprefix`` filter to trim the end of each result :
+
+<$macrocall
+$name="wikitext-example-without-html"
+src="""<$vars ex1="(?g)http.+?\]\]" brackets="]]">
+<<list-links "[[Release 5.1.14]regexps:text<ex1>removesuffix<brackets>limit[5]]">>
+</$vars>
+"""/>
+
+----
+
+!! Using regular expression grouping to split input into multiple text
+
+In this example the first 3 tiddlers tagged as "Resources" are split into their topic and authors. The result is a list of 6 items. Once again, we need to place our regular expression inside a variable in order to get around filter limitations (caused by the internal double quotes) :
+
+<$macrocall
+$name="wikitext-example-without-html"
+src="""<$vars ex2='"(.+)" by (.*)$'>
+<<list-links '[tag[Resources]limit[3]regexps<ex2>]'>>
+</$vars>"""/>
+
+
+
+
+

--- a/editions/tw5.com/tiddlers/filters/regexps.tid
+++ b/editions/tw5.com/tiddlers/filters/regexps.tid
@@ -1,0 +1,29 @@
+caption: regexps
+created: 20170924210519129
+modified: 20170924234326021
+op-input: a [[selection of titles|Title Selection]]
+op-neg-output: those input tiddlers in which field <<.place F>> does <<.em not>> match <<.place X>>
+op-output: one or more sub-strings of input tiddlers in which <<.place X>> matches contents of field <<.place F>>
+op-parameter: a regular expression
+op-parameter-name: X
+op-purpose: find sub-string(s) of input tiddlers
+op-suffix: the name of a [[field|TiddlerFields]]
+op-suffix-name: F
+tags: [[String Operators]] [[Filter Operators]] [[Field Operators]] [[Negatable Operators]]
+title: regexps
+type: text/vnd.tiddlywiki
+
+<<.def "Regular expressions">> are concise strings of characters that denote patterns of text to search for. The format used in ~TiddlyWiki is fully defined in [[this Mozilla reference|https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions]].
+
+The [[filter syntax|Filter Run]] makes it impossible to directly specify a regular expression that contains square brackets. The solution is to store the expression in a [[variable|Variables]]. See the <<.operator-examples "regexps" "examples">>.
+
+The parameter <<.place X>> can optionally start or end with a string of flags:
+
+<$railroad text=""" "(?" { ("i"|"m"|:"g") } ")" """/>
+
+The `i` flag is is used to force the difference between capital and lowercase letters to be ignored. The `m` flag is not generally useful.
+
+The `g` flag is used to determine if all matches of the regular expression will be returned. If sub-groups are used (indicated by paired `(` and `)` symbols) they will be ignored if the `g` flag is used. If the `g` flag is not used, then all matching sub-groups will be returned. If the `g` flag is not used and sub-groups are not used, then just the first match will be returned.
+
+
+<<.operator-examples "regexps">>

--- a/editions/tw5.com/tiddlers/filters/regexps_Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/regexps_Operator.tid
@@ -1,0 +1,29 @@
+caption: regexps
+created: 20170924210519129
+modified: 20181017155814981
+op-input: a [[selection of titles|Title Selection]]
+op-neg-output: those input tiddlers in which field <<.place F>> does <<.em not>> match <<.place X>>
+op-output: one or more sub-strings of input tiddlers in which <<.place X>> matches contents of field <<.place F>>
+op-parameter: a regular expression
+op-parameter-name: X
+op-purpose: find sub-string(s) of input tiddlers
+op-suffix: the name of a [[field|TiddlerFields]]
+op-suffix-name: F
+tags: [[String Operators]] [[Filter Operators]] [[Field Operators]] [[Negatable Operators]]
+title: regexps Operator
+type: text/vnd.tiddlywiki
+
+<<.def "Regular expressions">> are concise strings of characters that denote patterns of text to search for. The format used in ~TiddlyWiki is fully defined in [[this Mozilla reference|https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions]].
+
+The [[filter syntax|Filter Run]] makes it impossible to directly specify a regular expression that contains square brackets. The solution is to store the expression in a [[variable|Variables]]. See the <<.operator-examples "regexps" "examples">>.
+
+The parameter <<.place X>> can optionally start or end with a string of flags:
+
+<$railroad text=""" "(?" { ("i"|"m"|:"g") } ")" """/>
+
+The `i` flag is is used to force the difference between capital and lowercase letters to be ignored. The `m` flag is not generally useful.
+
+The `g` flag is used to determine if all matches of the regular expression will be returned. If sub-groups are used (indicated by paired `(` and `)` symbols) they will be ignored if the `g` flag is used. If the `g` flag is not used, then all matching sub-groups will be returned. If the `g` flag is not used and sub-groups are not used, then just the first match will be returned.
+
+
+<<.operator-examples "regexps">>


### PR DESCRIPTION

Returns all matching text of input selection (if global) or sub-group text if not global.
!regexps same as !regexp

I can add documentation to this commit if it appears from discussion that it is likely to be approved.