### PR TITLE
Remove URI encoding from PUT saver

### DIFF
--- a/core/modules/savers/put.js
+++ b/core/modules/savers/put.js
@@ -47,7 +47,7 @@ var PutSaver = function(wiki) {
 };
 
 PutSaver.prototype.uri = function() {
-	return encodeURI(document.location.toString().split("#")[0]);
+	return document.location.toString().split("#")[0];
 };
 
 // TODO: in case of edit conflict


### PR DESCRIPTION
Remove URI encoding from PUT saver and let the browser handle it as necessary. This seems to be the normal way of doing things. We have confirmed that several WebDAV servers do not expect the file names to be double-encoded.