### PR TITLE
Modify the is operator to allow multiple types to be specified.

### DIFF
--- a/core/modules/filters/is.js
+++ b/core/modules/filters/is.js
@@ -26,15 +26,21 @@ function getIsFilterOperators() {
 Export our filter function
 */
 exports.is = function(source,operator,options) {
-	// Dispatch to the correct isfilteroperator
+	// Get our isfilteroperators
 	var isFilterOperators = getIsFilterOperators();
-	if(operator.operand) {
-		var isFilterOperator = isFilterOperators[operator.operand];
-		if(isFilterOperator) {
-			return isFilterOperator(source,operator.prefix,options);
-		} else {
-			return [$tw.language.getString("Error/IsFilterOperator")];
+// Cycle through the isfilteroperators accumulating their results
+	var results = [];
+  if(operator.operand) {
+		var subops = operator.operand.split("+");
+		for (var t=0; t<subops.length; t++) {
+			var subop = isFilterOperators[subops[t]];
+			if(subop) {
+				$tw.utils.pushTop(results,subop(source,operator.prefix,options));
+			} else {
+				return [$tw.language.getString("Error/IsFilterOperator")];
+			}
 		}
+		return results;
 	} else {
 		// Return all tiddlers if the operand is missing
 		var results = [];

--- a/core/modules/filters/is.js
+++ b/core/modules/filters/is.js
@@ -28,9 +28,9 @@ Export our filter function
 exports.is = function(source,operator,options) {
 	// Get our isfilteroperators
 	var isFilterOperators = getIsFilterOperators();
-    // Cycle through the isfilteroperators accumulating their results
+	// Cycle through the isfilteroperators accumulating their results
 	var results = [];
-    if(operator.operand) {
+	if(operator.operand) {
 		var subops = operator.operand.split("+");
 		for (var t=0; t<subops.length; t++) {
 			var subop = isFilterOperators[subops[t]];

--- a/core/modules/filters/is.js
+++ b/core/modules/filters/is.js
@@ -28,9 +28,9 @@ Export our filter function
 exports.is = function(source,operator,options) {
 	// Get our isfilteroperators
 	var isFilterOperators = getIsFilterOperators();
-// Cycle through the isfilteroperators accumulating their results
+    // Cycle through the isfilteroperators accumulating their results
 	var results = [];
-  if(operator.operand) {
+    if(operator.operand) {
 		var subops = operator.operand.split("+");
 		for (var t=0; t<subops.length; t++) {
 			var subop = isFilterOperators[subops[t]];

--- a/core/modules/filters/is.js
+++ b/core/modules/filters/is.js
@@ -26,22 +26,9 @@ function getIsFilterOperators() {
 Export our filter function
 */
 exports.is = function(source,operator,options) {
-	// Get our isfilteroperators
-	var isFilterOperators = getIsFilterOperators();
-	// Cycle through the isfilteroperators accumulating their results
-	var results = [];
-	if(operator.operand) {
-		var subops = operator.operand.split("+");
-		for (var t=0; t<subops.length; t++) {
-			var subop = isFilterOperators[subops[t]];
-			if(subop) {
-				$tw.utils.pushTop(results,subop(source,operator.prefix,options));
-			} else {
-				return [$tw.language.getString("Error/IsFilterOperator")];
-			}
-		}
-		return results;
-	} else {
+
+
+	if( !operator.operand) {
 		// Return all tiddlers if the operand is missing
 		var results = [];
 		source(function(tiddler,title) {
@@ -49,6 +36,31 @@ exports.is = function(source,operator,options) {
 		});
 		return results;
 	}
+
+	// Get our isfilteroperators
+	var isFilterOperators = getIsFilterOperators(),
+	    subops = operator.operand.split("+"),
+		filteredResults = {},
+		results = [];
+	for (var t=0; t<subops.length; t++) {
+		var subop = isFilterOperators[subops[t]];
+		if(subop) {
+			filteredResults[subops[t]] = subop(source,operator.prefix,options);
+		} else {
+			return [$tw.language.getString("Error/IsFilterOperator")];
+		}
+		
+	}
+	
+    source(function(tiddler,title) {
+        for (var t=0; t<subops.length; t++) {
+            if (filteredResults[subops[t]].indexOf(title) != -1){
+                results.push(title);
+                break;
+            }
+        }
+    });
+	return results;
 };
 
 })();

--- a/editions/tw5.com/tiddlers/filters/examples/is.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/is.tid
@@ -11,3 +11,4 @@ type: text/vnd.tiddlywiki
 <<.operator-example 5 "[all[shadows]is[system]tag[$:/tags/Stylesheet]]" "shadow system stylesheets">>
 <<.operator-example 6 "[is[shadow]]" "overridden shadow tiddlers">>
 <<.operator-example 7 "[is[missing]]" "empty because its input contains only tiddlers that exist">>
+<<.operator-example 7 "[all[tiddlers+shadows]is[tiddler+shadow]]" "contains the entire input list">>

--- a/editions/tw5.com/tiddlers/filters/is.tid
+++ b/editions/tw5.com/tiddlers/filters/is.tid
@@ -11,7 +11,11 @@ op-parameter-name: C
 op-output: those input tiddlers that belong to category <<.place C>>
 op-neg-output: those input tiddlers that do <<.em not>> belong to category <<.place C>>
 
-The parameter <<.place C>> is one of the following fundamental categories:
+The parameter <<.place C>> specifies zero or more fundamental categories using the following syntax:
+
+<$railroad text="""
+[{: ("current" | "missing" |: "orphans" | "shadows" | "tags" | "tiddlers" ) +"+" }]
+"""/>
 
 |!Category |!Matches any tiddler that... |
 |^`current` |is the [[current tiddler|Current Tiddler]] |


### PR DESCRIPTION
This change allows you to specify `is` filters with multiple fundamental categories ala the `all` operator.  An example would be `is[tiddler+shadow]`.