### PR TITLE
Allow specifying a custom boot path

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1914,7 +1914,7 @@ $tw.boot.startup = function(options) {
 		// For writable tiddler files, a hashmap of title to {filepath:,type:,hasMetaFile:}
 		$tw.boot.files = Object.create(null);
 		// System paths and filenames
-		$tw.boot.bootPath = path.dirname(module.filename);
+		$tw.boot.bootPath = options.bootPath || path.dirname(module.filename);
 		$tw.boot.corePath = path.resolve($tw.boot.bootPath,"../core");
 		// If there's no arguments then default to `--help`
 		if($tw.boot.argv.length === 0) {


### PR DESCRIPTION
When testing TiddlyServer on nexe, I discovered that TiddlyWiki does not correctly load the data tiddlers because `module.filename` is not set in an nexe module. The easiest way to get around this without any other code changes within TiddlyWiki is to simply require the boot.js code as usual, and then specify a custom boot path using the modification I made here. 