### PR TITLE
Add meta options for tiddlywiki.files

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1595,7 +1595,7 @@ $tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp) {
 				}
 			});
 		});
-		tiddlers.push({tiddlers: fileTiddlers});
+		tiddlers.push({filepath: pathname, hasMetaFile: !!metadata && !isTiddlerFile, tiddlers: fileTiddlers});
 	};
 	// Process the listed tiddlers
 	$tw.utils.each(filesInfo.tiddlers,function(tidInfo) {


### PR DESCRIPTION
Fixes #2906

Plain text .txt files or .md files, loaded via a tiddlywiki.files declaration load in the TiddlyWiki just fine. However, editing them is problematic. They are saved to the wrong file name.

With a subdir in my tiddlers directory called "notes", containing a file "mynote.txt", editing results in a file "mynote 1.txt" and "mynote 1txt.meta" whereas I would expect the original "mynote.txt" to be updated and a .meta file created. This behavior leads to duplication of tiddler files and is rather confusing. If the intent was that files loaded in this manner should not be editable, then we should find a way to set them as read only.

Digging into the code in boot.js reveals that .txt or .md files that do not have .meta files and are loaded via a tiddlywiki.files declaration, are never added to $tw.boot.files (as they don't have their filepath set).

With this commit the files are added to $tw.boot.files and on editing are saved to the accurate and original filename, along with a .meta file for non .tid files.

Original Author: https://github.com/saqimtiaz
Original patch: https://github.com/rubaboo/TiddlyWiki5/commit/50fbe23bc97b5c87d9d544506eed4d9df9494700.patch