### PR TITLE
Doc: Saving with TiddlyFox - change wording re latest version

### DIFF
--- a/editions/tw5.com/tiddlers/saving/Saving with TiddlyFox.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving with TiddlyFox.tid
@@ -3,14 +3,14 @@ created: 20131221085742684
 delivery: Browser Extension
 description: Browser extension for older versions of Firefox
 method: save
-modified: 20171118221027238
+modified: 20171118230504315
 tags: Saving Firefox
 title: Saving with TiddlyFox
 type: text/vnd.tiddlywiki
 
 If you're using [[Firefox for Android]], see the instructions for [[Saving with TiddlyFox on Android]].
 
-# Ensure you have a version of Firefox before version 57. ~TiddlyFox will not work with Firefox 57 and on.
+# Ensure you have a version of Firefox before version 57. ~TiddlyFox will not work with Firefox 57 and on.  For Firefox 57 and on, consider using the following instead: <<list-links filter:"[tag[Firefox]delivery[Browser Extension]] -[[Saving with TiddlyFox]]">>
 # Install the latest release of the TiddlyFox extension from:
 #* https://addons.mozilla.org/en-GB/firefox/addon/tiddlyfox/
 # Restart [[Firefox]]

--- a/editions/tw5.com/tiddlers/saving/Saving with TiddlyFox.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving with TiddlyFox.tid
@@ -3,15 +3,14 @@ created: 20131221085742684
 delivery: Browser Extension
 description: Browser extension for older versions of Firefox
 method: save
-modified: 20171113110032778
+modified: 20171118221027238
 tags: Saving Firefox
 title: Saving with TiddlyFox
 type: text/vnd.tiddlywiki
 
 If you're using [[Firefox for Android]], see the instructions for [[Saving with TiddlyFox on Android]].
 
-# Ensure you have the latest version of [[Firefox]]
-#* http://getfirefox.com
+# Ensure you have a version of Firefox before version 57. ~TiddlyFox will not work with Firefox 57 and on.
 # Install the latest release of the TiddlyFox extension from:
 #* https://addons.mozilla.org/en-GB/firefox/addon/tiddlyfox/
 # Restart [[Firefox]]


### PR DESCRIPTION
The previous instructions were recommending that users get the latest version of FF, which is no longer true.