### PR TITLE
Invoke hook when server starts

### DIFF
--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -143,7 +143,7 @@ SimpleServer.prototype.requestHandler = function(request,response) {
 };
 	
 SimpleServer.prototype.listen = function(port,host) {
-	http.createServer(this.requestHandler.bind(this)).listen(port,host);
+	return http.createServer(this.requestHandler.bind(this)).listen(port,host);
 };
 
 var Command = function(params,commander,callback) {

--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -299,14 +299,14 @@ Command.prototype.execute = function() {
 		password: password,
 		pathprefix: pathprefix
 	});
-	this.server.listen(port,host);
+	var nodeServer = this.server.listen(port,host);
 	$tw.utils.log("Serving on " + host + ":" + port,"brown/orange");
 	$tw.utils.log("(press ctrl-C to exit)","red");
 	// Warn if required plugins are missing
 	if(!$tw.wiki.getTiddler("$:/plugins/tiddlywiki/tiddlyweb") || !$tw.wiki.getTiddler("$:/plugins/tiddlywiki/filesystem")) {
 		$tw.utils.warning("Warning: Plugins required for client-server operation (\"tiddlywiki/filesystem\" and \"tiddlywiki/tiddlyweb\") are missing from tiddlywiki.info file");
 	}
-	$tw.hooks.invokeHook('th-server-command-start', this.server);
+	$tw.hooks.invokeHook('th-server-command-start', this.server, nodeServer);
 	return null;
 };
 

--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -306,6 +306,7 @@ Command.prototype.execute = function() {
 	if(!$tw.wiki.getTiddler("$:/plugins/tiddlywiki/tiddlyweb") || !$tw.wiki.getTiddler("$:/plugins/tiddlywiki/filesystem")) {
 		$tw.utils.warning("Warning: Plugins required for client-server operation (\"tiddlywiki/filesystem\" and \"tiddlywiki/tiddlyweb\") are missing from tiddlywiki.info file");
 	}
+	$tw.hooks.invokeHook('th-server-command-start', this.server);
 	return null;
 };
 

--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -306,7 +306,7 @@ Command.prototype.execute = function() {
 	if(!$tw.wiki.getTiddler("$:/plugins/tiddlywiki/tiddlyweb") || !$tw.wiki.getTiddler("$:/plugins/tiddlywiki/filesystem")) {
 		$tw.utils.warning("Warning: Plugins required for client-server operation (\"tiddlywiki/filesystem\" and \"tiddlywiki/tiddlyweb\") are missing from tiddlywiki.info file");
 	}
-	$tw.hooks.invokeHook('th-server-command-start', this.server, nodeServer);
+	$tw.hooks.invokeHook('th-server-command-post-start', this.server, nodeServer);
 	return null;
 };
 

--- a/editions/dev/tiddlers/new/Hook__th-server-command-post-start.tid
+++ b/editions/dev/tiddlers/new/Hook__th-server-command-post-start.tid
@@ -1,0 +1,18 @@
+created: 20180409142128584
+modified: 20180409142128584
+tags: HookMechanism
+title: Hook: th-server-command-post-start
+type: text/vnd.tiddlywiki
+
+This hook allows plugins to extend the TiddlyWiki server command after it initializes. The two 
+most obvious use cases are adding routes (such as an attachments folder for external files) 
+to the SimpleServer instance and adding a websockets handler to the HTTP server. 
+
+Hook function parameters: 
+
+* SimpleServer instance
+** Defined in core/modules/commands/server.js
+* NodeJS HTTP Server instance
+** See the NodeJS docs at [ext[https://nodejs.org/docs/latest-v8.x/api/http.html#http_class_http_server]]
+
+Return value is ignored.


### PR DESCRIPTION
Invokes the `th-server-command-start` hook when the server is started, with the server object as the parameter. This allows plugins to add custom handlers to the server, such as WebSockets. 
