### PR TITLE
remove superfluous list item at the end of list-links-draggable

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -28,27 +28,25 @@ tags: $:/tags/Macro
 &nbsp;
 </div>
 <div>
-<$link to={{!!title}}>
 <$transclude tiddler="""$itemTemplate$""">
+<$link to={{!!title}}>
 <$transclude field="caption">
 <$view field="title"/>
 </$transclude>
-</$transclude>
 </$link>
+</$transclude>
 </div>
 </$droppable>
 </$list>
+</$type$>
 <$tiddler tiddler="">
-<$droppable actions=<<list-links-draggable-drop-actions>> tag="""$subtype$""">
+<$droppable actions=<<list-links-draggable-drop-actions>> tag="div">
 <div class="tc-droppable-placeholder">
 &nbsp;
 </div>
-<div>
-&nbsp;
-</div>
+<div style="height:0.5em;"/>
 </$droppable>
 </$tiddler>
-</$type$>
 </$vars>
 \end
 


### PR DESCRIPTION
fixes #2970

Also fixes the nesting. If a template is defined for the list item, it should define the link as is done for **list-tagged-draggable**, i.e. the template defines any link widget it contains.