### PR TITLE
extend LinkWidget to enforce classes

### DIFF
--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -67,18 +67,22 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	if(this.linkClasses) {
 		classes.push(this.linkClasses);
 	}
-	classes.push("tc-tiddlylink");
-	if(this.isShadow) {
-		classes.push("tc-tiddlylink-shadow");
-	}
-	if(this.isMissing && !this.isShadow) {
-		classes.push("tc-tiddlylink-missing");
-	} else {
-		if(!this.isMissing) {
-			classes.push("tc-tiddlylink-resolves");
+	if(!this.enforceClass) {
+		classes.push("tc-tiddlylink");
+		if(this.isShadow) {
+			classes.push("tc-tiddlylink-shadow");
+		}
+		if(this.isMissing && !this.isShadow) {
+			classes.push("tc-tiddlylink-missing");
+		} else {
+			if(!this.isMissing) {
+				classes.push("tc-tiddlylink-resolves");
+			}
 		}
 	}
-	domNode.setAttribute("class",classes.join(" "));
+	if(classes.length) {
+		domNode.setAttribute("class",classes.join(" "));
+	}
 	// Set an href
 	var wikilinkTransformFilter = this.getVariable("tv-filter-export-link"),
 		wikiLinkText;
@@ -169,6 +173,10 @@ LinkWidget.prototype.execute = function() {
 	this.tooltip = this.getAttribute("tooltip");
 	this["aria-label"] = this.getAttribute("aria-label");
 	this.linkClasses = this.getAttribute("class");
+	this.enforceClass = this.linkClasses ? this.linkClasses.substr(0,1) === "!" : undefined;
+	if(this.enforceClass) {
+		this.linkClasses = this.linkClasses.substr(1);
+	}
 	this.tabIndex = this.getAttribute("tabindex");
 	this.draggable = this.getAttribute("draggable","yes");
 	this.linkTag = this.getAttribute("tag","a");

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -64,10 +64,7 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	var domNode = this.document.createElement(tag);
 	// Assign classes
 	var classes = [];
-	if(this.linkClasses) {
-		classes.push(this.linkClasses);
-	}
-	if(!this.enforceClass) {
+	if(this.enforceClasses === undefined) {
 		classes.push("tc-tiddlylink");
 		if(this.isShadow) {
 			classes.push("tc-tiddlylink-shadow");
@@ -79,8 +76,12 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 				classes.push("tc-tiddlylink-resolves");
 			}
 		}
+		classes.push(this.linkClasses);
 	}
-	if(classes.length) {
+	else if (this.enforceClasses !== "") {
+		classes.push(this.enforceClasses);
+	}
+	if(classes.length > 0) {
 		domNode.setAttribute("class",classes.join(" "));
 	}
 	// Set an href
@@ -173,10 +174,7 @@ LinkWidget.prototype.execute = function() {
 	this.tooltip = this.getAttribute("tooltip");
 	this["aria-label"] = this.getAttribute("aria-label");
 	this.linkClasses = this.getAttribute("class");
-	this.enforceClass = this.linkClasses ? this.linkClasses.substr(0,1) === "!" : undefined;
-	if(this.enforceClass) {
-		this.linkClasses = this.linkClasses.substr(1);
-	}
+	this.enforceClasses = this.getAttribute("setClass");;
 	this.tabIndex = this.getAttribute("tabindex");
 	this.draggable = this.getAttribute("draggable","yes");
 	this.linkTag = this.getAttribute("tag","a");

--- a/editions/tw5.com/tiddlers/widgets/LinkWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/LinkWidget.tid
@@ -1,6 +1,6 @@
 caption: link
 created: 20131024141900000
-modified: 20171211073439080
+modified: 20171212063130159
 tags: Widgets
 title: LinkWidget
 type: text/vnd.tiddlywiki
@@ -16,7 +16,8 @@ The `link` widget generates links to tiddlers. (Use the HTML `<a>` element to ge
 |tabindex |Optional numeric [[tabindex|https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex]] |
 |draggable |"yes" to enable the link to be draggable (defaults to "yes") |
 |tag |Optional tag to override the default "a" element |
-|class|Optional css classes in addition to the defualt classes (see below)<br>» Using prefix `!` overrules the default classes|
+|class|Optional css classes __in addition to__ the default classes (see below)|
+|setClass|Optional css classes __instead of__ the default classes <<.from-version "5.1.16">>|
 
 The content of the link widget is rendered within the `<a>` tag. The draggable functionality is equivalent to using the DraggableWidget with the ''tiddler'' attribute set to the link target.
 
@@ -63,11 +64,11 @@ The link widget automatically determines and applies the following classes to li
 * `tc-tiddlylink-missing` - applied to tiddler links where the target tiddler doesn't exist
 * `tc-tiddlylink-resolves` - applied to tiddler links when the target tiddler does exist
 
-Use the `class` attribute to specify additional classes, or use the prefix `!` to only apply those classes, e.g. when used in a LinkCatcherWidget:
+Use the `class` attribute to specify additional css classes, or `setClass` to apply only that but not the above defaults, e.g. when used in a LinkCatcherWidget:
 
 <<wikitext-example-without-html """*<$link class="example">Here</$link> the `example` class is added.
-*<$link class="!example">Here</$link> only the `example` class applies.
-*<$link class="!">Here</$link> no class is set.""">>
+*<$link setClass="example">Here</$link> only the `example` class applies.
+*<$link setClass="">Here</$link> no class is set.""">>
 
 ! `href` generation
 

--- a/editions/tw5.com/tiddlers/widgets/LinkWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/LinkWidget.tid
@@ -1,6 +1,6 @@
 caption: link
 created: 20131024141900000
-modified: 20170907141926550
+modified: 20171211073439080
 tags: Widgets
 title: LinkWidget
 type: text/vnd.tiddlywiki
@@ -11,11 +11,12 @@ The `link` widget generates links to tiddlers. (Use the HTML `<a>` element to ge
 
 |!Attribute |!Description |
 |to |The title of the target tiddler for the link (defaults to the [[current tiddler|Current Tiddler]]) |
-|aria-label |Optional [[Accessibility]] label |
+|aria-label |Optional accessibility label |
 |tooltip |Optional tooltip WikiText |
 |tabindex |Optional numeric [[tabindex|https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex]] |
 |draggable |"yes" to enable the link to be draggable (defaults to "yes") |
 |tag |Optional tag to override the default "a" element |
+|class|Optional css classes in addition to the defualt classes (see below)<br>» Using prefix `!` overrules the default classes|
 
 The content of the link widget is rendered within the `<a>` tag. The draggable functionality is equivalent to using the DraggableWidget with the ''tiddler'' attribute set to the link target.
 
@@ -54,11 +55,19 @@ This causes the tooltip to be the ''tooltip'' field of the target tiddler. If th
 
 ! CSS Classes
 
+The link widget automatically determines and applies the following classes to links:
+
 * `tc-tiddlylink` - applied to all links
 * `tc-tiddlylink-external` - applied to external, non-tiddler links
 * `tc-tiddlylink-internal` - applied to tiddler links
 * `tc-tiddlylink-missing` - applied to tiddler links where the target tiddler doesn't exist
 * `tc-tiddlylink-resolves` - applied to tiddler links when the target tiddler does exist
+
+Use the `class` attribute to specify additional classes, or use the prefix `!` to only apply those classes, e.g. when used in a LinkCatcherWidget:
+
+<<wikitext-example-without-html """*<$link class="example">Here</$link> the `example` class is added.
+*<$link class="!example">Here</$link> only the `example` class applies.
+*<$link class="!">Here</$link> no class is set.""">>
 
 ! `href` generation
 


### PR DESCRIPTION
Previously, the undocumented *class* attribute only allowed to specify additional classes to be set.

Especially for use within a [LinkCatcherWidget](https://tiddlywiki.com/#LinkCatcherWidget), you can now apply / enforce only the custom classes and avoid any of the defaults being applied depending on the link target.

This will allow to implement #1161 more gracefully.