### PR TITLE
only uses qualify for tabs if state explicitly defined

### DIFF
--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -2,7 +2,7 @@ title: $:/core/macros/tabs
 tags: $:/tags/Macro
 
 \define tabs(tabsList,default,state,class,template,buttonTemplate)
-<$set name=tab-state filter="$state$" emptyValue=<<qualify "$:/state/tab">>>
+<$set name=tab-state filter="""$state$""" emptyValue=<<qualify "$:/state/tab">>>
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
 <$list filter="$tabsList$" variable="currentTab"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<tab-state>> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>

--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -1,10 +1,11 @@
 title: $:/core/macros/tabs
 tags: $:/tags/Macro
 
-\define tabs(tabsList,default,state:"$:/state/tab",class,template,buttonTemplate)
+\define tabs(tabsList,default,state,class,template,buttonTemplate)
+<$set name=tab-state filter="$state$" emptyValue=<<qualify "$:/state/tab">>>
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
-<$list filter="$tabsList$" variable="currentTab"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
+<$list filter="$tabsList$" variable="currentTab"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<tab-state>> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
 <$tiddler tiddler=<<save-currentTiddler>>>
 <$set name="tv-wikilinks" value="no">
 <$transclude tiddler="$buttonTemplate$" mode="inline">
@@ -18,7 +19,7 @@ tags: $:/tags/Macro
 <div class="tc-tab-content $class$">
 <$list filter="$tabsList$" variable="currentTab">
 
-<$reveal type="match" state=<<qualify "$state$">> text=<<currentTab>> default="$default$">
+<$reveal type="match" state=<<tab-state>> text=<<currentTab>> default="$default$">
 
 <$transclude tiddler="$template$" mode="block">
 
@@ -31,4 +32,5 @@ tags: $:/tags/Macro
 </$list>
 </div>
 </div>
+</$set>
 \end

--- a/editions/tw5.com/tiddlers/macros/TabsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TabsMacro.tid
@@ -1,6 +1,6 @@
 caption: tabs
 created: 20131228162203521
-modified: 20171113135543552
+modified: 20171214071137376
 tags: Macros [[Core Macros]]
 title: tabs Macro
 type: text/vnd.tiddlywiki
@@ -18,7 +18,7 @@ By default the tabs are arranged horizontally above the content. To get vertical
 ;default
 : The title of the tiddler whose tab is to be selected by default
 ;state
-: The prefix for the title of a [[state tiddler|StateMechanism]] for noting the currently selected tab, defaulting to `$:/state/tab`. It is recommended that this be a [[system tiddler|SystemTiddlers]]
+: The title of a [[state tiddler|StateMechanism]] persisting the currently selected tab. It is recommended that this be a [[system tiddler|SystemTiddlers]] path like `$:/state/tab/my-tabs`. If not specified, defaults to the value of <$link to="qualify Macro">`<<qualify "$:/state/tab">>`</$link>.
 ;class
 : Additional [[CSS|Cascading Style Sheets]] classes for the generated `div` elements. Multiple classes can be separated with spaces
 ;template
@@ -26,14 +26,20 @@ By default the tabs are arranged horizontally above the content. To get vertical
 ;buttonTemplate
 : Optionally, the title of a tiddler to use as a [[template|TemplateTiddlers]] for transcluding the content of the button for the selected tab
 
-Within the template, the title of the selected tab is available in the <<.var currentTab>> variable.
+!! Current Tab
 
-The <<.vlink currentTiddler>> variable is not affected by the <<.var tabs>> macro. This can put you in trouble if the list of tabs includes tiddlers that depend on the value of the <<.vlink currentTiddler>>, for example tiddlers listing children based on its own name. To overcome this problem you can use a [[TemplateTiddler|TemplateTiddlers]] like the following:
+Within the template, the title of the selected tab is available in the <<.var currentTab>> [[variable|Variables]].
+
+The <<.vlink currentTiddler>> variable is not affected by the <<.var tabs>> macro. Should the contents of one or all tabs depend on the value of the <<.vlink currentTiddler>> use the TiddlerWidget within a [[TemplateTiddler|TemplateTiddlers]] as follows to ensure the right context:
 
 ```
 <$tiddler tiddler=<<currentTab>>>
 <$transclude mode="block" />
 </$tiddler>
 ```
+
+!! State
+
+If the same tabset is displayed in various places and unless the [[qualify Macro]] or another mechanism is used to define separate states, clicking a tab in one instance will <<.em "update all">> instances of the tabset at the same time. To see the difference, compare the first and fourth and then the fourth and fifth example below.
 
 <<.macro-examples "tabs">>

--- a/editions/tw5.com/tiddlers/macros/examples/tabs.tid
+++ b/editions/tw5.com/tiddlers/macros/examples/tabs.tid
@@ -1,5 +1,5 @@
 created: 20150221211317000
-modified: 20150221211719000
+modified: 20171214070409412
 tags: [[tabs Macro]] [[Macro Examples]]
 title: tabs Macro (Examples)
 type: text/vnd.tiddlywiki
@@ -12,3 +12,9 @@ eg="""<<tabs "[tag[sampletab]]" "SampleTabTwo" "$:/state/tab2" "tc-vertical">>""
 
 <$macrocall $name=".example" n="3"
 eg="""<<tabs "[tag[sampletab]nsort[order]]" "SampleTabThree" "$:/state/tab3" "tc-vertical">>"""/>
+
+<$macrocall $name=".example" n="4"
+eg="""<<tabs "SampleTabOne SampleTabTwo SampleTabThree SampleTabFour" "SampleTabOne" "$:/state/tab1">>"""/>
+
+<$macrocall $name=".example" n="5"
+eg="""<<tabs "SampleTabOne SampleTabTwo SampleTabThree SampleTabFour" "SampleTabOne" "$:/state/tab5">>"""/>


### PR DESCRIPTION
provides the groundworks for #3057

This finally allows to address explicit tab states while
having all tabsets implementing the same state change at once
**if the user explicitly defines a state**.

While this may break a few use cases that depended on qualified state.
However, those use cases where brittle in the first place in that their
dependency to qualified pointer was unreliable to begin with.

Now, those implementations can finally use reliable and predictable
pointers.

What's more, the current tab-state is now also available as a variable
and this allows to switch more easily from one tab to another via
dedicated buttons.

**demo**: http://tab-state.tiddlyspot.com