### PR TITLE
Make macro parameters available as variables in wikified macros

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/Macro Definitions in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Macro Definitions in WikiText.tid
@@ -1,9 +1,9 @@
+caption: Macro Definitions
 created: 20150220181617000
-modified: 20150221221642000
+modified: 20171215152754837
 tags: WikiText
 title: Macro Definitions in WikiText
 type: text/vnd.tiddlywiki
-caption: Macro Definitions
 
 A [[macro|Macros]] is defined using a `\define` [[pragma|Pragma]]. Like any pragma, this can only appear at the start of a tiddler.
 
@@ -34,6 +34,36 @@ eg="""<$set name="address" value="Rabbit Hole Hill">
 <<say-hi-using-variables>>
 </$set>"""/>
 </$importvariables>
+
+!! Parameters as Variables
+
+The parameters to a wikitext macro are also available as special variables named as the parameter name wrapped in double underscores. For example, the example above could also be expressed as:
+
+```
+\define sayhi(name:"Bugs Bunny") Hi, I'm <$text text=<<__name__>>/>.
+```
+
+Accessing parameters as variables only works in macros that are wikified and not, for example, when a macro is used as an attribute value. The advantage of the technique is that it avoids the parameter value being substituted into the macro as a literal string, which in turn can help avoid issues with parameters that contain quotes.
+
+For example, consider this macro. It is intended to wrap a DIV around another macro invocation, passing through the single parameter to the inner macro:
+
+```
+\define related-tags(base-tag)
+<div class="wrapper">
+<$macrocall $name="anothermacro" param="""$base-tag$"""/>
+</div>
+\end
+```
+
+The code above will fail if the macro is invoked with the argument containing triple double quotes (for example `<<related-tags 'Triple """ Quotes'>>`). Using parameter variables offers a workaround:
+
+```
+\define related-tags(base-tag)
+<div class="wrapper">
+<$macrocall $name="anothermacro" param=<<__base-tag__>>/>
+</div>
+\end
+```
 
 !! Scope
 


### PR DESCRIPTION
Within wikitext macros, make the values of the parameters available as variables. Rather than overloading the parameter names themselves to be the variable names, we instead wrap the parameter name in double underscores. For example:

```
\define sayhi(name:"Bugs Bunny") Hi, I'm <$text text=<<__name__>>/>.
```

The advantage is that it helps to avoid situations where parameter values containing quotes can cause problems.

For example, consider this macro. It is intended to wrap a DIV around another macro invocation, passing through the single parameter to the inner macro:

```
\define related-tags(base-tag)
<div class="wrapper">
<$macrocall $name="anothermacro" param="""$base-tag$"""/>
</div>
\end
```

The code above will fail if the macro is invoked with the argument containing triple double quotes (for example `<<related-tags 'Triple """ Quotes'>>`). Using parameter variables offers a workaround:

```
\define related-tags(base-tag)
<div class="wrapper">
<$macrocall $name="anothermacro" param=<<__base-tag__>>/>
</div>
\end
```