### PR TITLE
Update Linking in WikiText.tid

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/Linking in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Linking in WikiText.tid
@@ -42,6 +42,8 @@ https://tiddlywiki.com/
 [[TW5|https://tiddlywiki.com/]]
 
 [[Mail me|mailto:me@where.net]]
+
+[[Open file|c://users/me/index.html]]
 ```
 
 For this syntax to work, the URL has to be recognisable as a URL. Otherwise, it is treated as a tiddler title. As a result, in case you want to link to a resource locatable using a relative path, use the extended syntax:
@@ -60,6 +62,10 @@ The extended syntax still works with full URLs, although in that case it is not 
 [ext[https://tiddlywiki.com]]
 
 [ext[TW5|https://tiddlywiki.com]]
+
+[ext[Mail me|mailto:me@where.net]]
+
+[ext[Open file|c://users/me/index.html]]
 ```
 
 You can also use the extended syntax to force an external link:


### PR DESCRIPTION
For clarity, the absolute file syntax needs to be added in the first section before relative links are shown.

All the examples from the top section should be echoed in the extended section.