### PR TITLE
Documentation change to "tiddlywiki.info Files"

### DIFF
--- a/editions/tw5.com/tiddlers/nodejs/tiddlywiki.info_Files.tid
+++ b/editions/tw5.com/tiddlers/nodejs/tiddlywiki.info_Files.tid
@@ -43,7 +43,7 @@ For example:
 		"tiddlywiki/filesystem"
 	],
 	"includeWikis": [
-		"../tw5.com"
+		{"path": "../tw5.com", "read-only": true}
 	],
 	"build": {
 		"index": [


### PR DESCRIPTION
Correct syntax to include of read-only parameter in "includeWiki" - shown in example