### PR TITLE
preventDefault drag behaviour inside textarea

### DIFF
--- a/plugins/tiddlywiki/codemirror/files/codemirror.js
+++ b/plugins/tiddlywiki/codemirror/files/codemirror.js
@@ -3901,6 +3901,7 @@
   }
 
   function onDragStart(cm, e) {
+    e.preventDefault();
     if (ie && (!cm.state.draggingText || +new Date - lastDrop < 100)) { e_stop(e); return; }
     if (signalDOMEvent(cm, e) || eventInWidget(cm.display, e)) return;
 


### PR DESCRIPTION
fixes errors when trying to drag inside textarea while an eventhandler is listening for drag events