### PR TITLE
Allow nested JSONTiddlers

### DIFF
--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -791,4 +791,16 @@ exports.strEndsWith = function(str,ending,position) {
 	}
 };
 
+/*
+Allows grabbing nested properties in an object safely (without ReferenceError)
+*/
+exports.objGet = function(obj,selector) {
+  if(obj == null) { return null; }
+  if(!selector || selector.length === 0) { return obj; }
+  if("string" === typeof selector) {
+    selector = selector.split(".");
+  }
+  return exports.objGet(obj[selector.shift()], selector);
+};
+
 })();

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -680,15 +680,12 @@ exports.getTiddlerData = function(titleOrTiddler,defaultData) {
 Extract an indexed field from within a data tiddler
 */
 exports.extractTiddlerDataItem = function(titleOrTiddler,index,defaultText) {
-	var data = this.getTiddlerDataCached(titleOrTiddler,Object.create(null)),
-		text;
-	if(data && $tw.utils.hop(data,index)) {
-		text = data[index];
-	}
+	var data = this.getTiddlerDataCached(titleOrTiddler,Object.create(null));
+	var text = $tw.utils.objGet(data,index);
 	if(typeof text === "string" || typeof text === "number") {
 		return text.toString();
 	} else {
-		return defaultText;
+		return defaultText || JSON.stringify(text, null, 2);
 	}
 };
 

--- a/editions/tw5.com/tiddlers/concepts/DataTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/DataTiddlers.tid
@@ -28,6 +28,6 @@ The same is true if `MonthDays` is a [[JSONTiddler|JSONTiddlers]] with the follo
 {"oct":31,"nov":30,"dec":31}
 ```
 
-Note: //It is currently only possible to retrieve data from the immediate properties of the root object of a JSONTiddler.//
+Note: For JSONTiddler nested properties you can use //dot notation//. For arrays you can also use their numbered index. For exxample: `{{MonthDays##nov.full}}`.
 
 The widgets ActionSetFieldWidget and ActionListopsWidget can manipulate named properties of data tiddlers by indicating the name of the property in the $index attribute. To create or modify a named property with ActionSetFieldWidget, provide a $value attribute. To delete a named property with ActionSetFieldWidget, omit the $value attribute. ActionListopsWidget assigns the named property the list constructed through its $filter and $subfilter attributes.


### PR DESCRIPTION
Closes #3074

This is an implementation to improve JSON tiddler handling as described in issue #3074.

The intent is to allow dot notation to fetch nested properties of a JSONTiddler. A secondary requirement is to remain backwards compatible to current JSONTiddler usage.

Discussion of this implementation welcome.