### PR TITLE
Fix new journal button

### DIFF
--- a/core/ui/PageControls/new-journal.tid
+++ b/core/ui/PageControls/new-journal.tid
@@ -5,7 +5,7 @@ description: {{$:/language/Buttons/NewJournal/Hint}}
 
 \define journalButton()
 <$button tooltip={{$:/language/Buttons/NewJournal/Hint}} aria-label={{$:/language/Buttons/NewJournal/Caption}} class=<<tv-config-toolbar-class>>>
-<$action-sendmessage $message="tm-new-tiddler" title=<<now "$(journalTitleTemplate)$">> tags="$(journalTags)$" text="$(journalText)$"/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<now """$(journalTitleTemplate)$ """>> tags=<<journalTags>> text=<<journalText>>/>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/new-journal-button}}
 </$list>
@@ -17,5 +17,5 @@ description: {{$:/language/Buttons/NewJournal/Hint}}
 <$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
 <$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
 <$set name="journalText" value={{$:/config/NewJournal/Text}}>
-<<journalButton>>
+<<journalButton {{$:/config/NewJournal/Title}}>>
 </$set></$set></$set>

--- a/core/ui/PageControls/new-journal.tid
+++ b/core/ui/PageControls/new-journal.tid
@@ -17,5 +17,5 @@ description: {{$:/language/Buttons/NewJournal/Hint}}
 <$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
 <$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
 <$set name="journalText" value={{$:/config/NewJournal/Text}}>
-<<journalButton {{$:/config/NewJournal/Title}}>>
+<<journalButton>>
 </$set></$set></$set>


### PR DESCRIPTION
To reproduce: 

 - open ControlPanel: Basic
 - use a double-quote somewhere in 
   - journal title
   - journal text
   - journal tag

The NewJournal button breaks 

This PR fixes the problem.

also see: https://groups.google.com/d/msg/tiddlywiki/8cf1lR8Gtdk/Lx6eiq6IAQAJ