### PR TITLE
Update docs

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/Linking in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Linking in WikiText.tid
@@ -43,7 +43,7 @@ https://tiddlywiki.com/
 
 [[Mail me|mailto:me@where.net]]
 
-[[Open file|c://users/me/index.html]]
+[[Open file|file:///c:/users/me/index.html]]
 ```
 
 For this syntax to work, the URL has to be recognisable as a URL. Otherwise, it is treated as a tiddler title. As a result, in case you want to link to a resource locatable using a relative path, use the extended syntax:
@@ -54,6 +54,8 @@ For this syntax to work, the URL has to be recognisable as a URL. Otherwise, it 
 [ext[Open file|./index.html]]
 
 [ext[Open file|../README.md]]
+
+[ext[Open file|c:\users\me\index.html]]
 ```
 
 The extended syntax still works with full URLs, although in that case it is not necessary:
@@ -65,7 +67,7 @@ The extended syntax still works with full URLs, although in that case it is not 
 
 [ext[Mail me|mailto:me@where.net]]
 
-[ext[Open file|c://users/me/index.html]]
+[ext[Open file|file:///c:/users/me/index.html]]
 ```
 
 You can also use the extended syntax to force an external link:


### PR DESCRIPTION
- "`[[Open file|c://users/me/index.html]]`" is a wrong syntax for linking in wikitext.
- "`c://users/me/index.html`" is not even a valid URI, although "`[ext[Open file|c://users/me/index.html]]`" works with Google Chrome and Microsoft Edge on Windows 10.
- "`[ext[Open file|c:\users\me\index.html]]`" works with Chrome, Edge and Firefox on Windows 10.