### PR TITLE
check if dataTransfer is undefined

### DIFF
--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -32,6 +32,9 @@ exports.makeDraggable = function(options) {
 	// Add event handlers
 	$tw.utils.addEventListeners(domNode,[
 		{name: "dragstart", handlerFunction: function(event) {
+			if(event.dataTransfer === undefined) {
+				return false;
+			}
 			// Collect the tiddlers being dragged
 			var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
 				dragFilter = options.dragFilterFn && options.dragFilterFn(),


### PR DESCRIPTION
this prevents an error when dragging elements not by mouse where dataTransfer can be undefined