### PR TITLE
In select widget, take default value into account when index attribute is used

### DIFF
--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -72,7 +72,7 @@ SelectWidget.prototype.setSelectValue = function() {
 	var value = this.selectDefault;
 	// Get the value
 	if(this.selectIndex) {
-		value = this.wiki.extractTiddlerDataItem(this.selectTitle,this.selectIndex);
+		value = this.wiki.extractTiddlerDataItem(this.selectTitle,this.selectIndex,value);
 	} else {
 		var tiddler = this.wiki.getTiddler(this.selectTitle);
 		if(tiddler) {


### PR DESCRIPTION
The default value used to be considered only when the `field` attribute was given.