### PR TITLE
tc-body background transparent if background attachment

### DIFF
--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -70,3 +70,7 @@ column-count: $columns$;
 \define if-no-sidebar(text)
 <$reveal state="$:/state/sidebar" type="nomatch" text="yes" default="yes">$text$</$reveal>
 \end
+
+\define if-background-attachment(text)
+<$reveal state="$:/themes/tiddlywiki/vanilla/settings/backgroundimage" type="nomatch" text="">$text$</$reveal>
+\end

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -85,6 +85,14 @@ body.tc-body {
 	fill: <<colour foreground>>;
 }
 
+<<if-background-attachment """
+
+body.tc-body {
+        background-color: transparent;
+}
+
+""">>
+
 h1, h2, h3, h4, h5, h6 {
 	line-height: 1.2;
 	font-weight: 300;


### PR DESCRIPTION
if a background attachment is set, tc-body should have a transparent background so that it doesn't hide the background image when going fullscreen with the fullscreen button