### PR TITLE
Solving issue mentioned in devgroup (each filter)

### DIFF
--- a/core/modules/filters/each.js
+++ b/core/modules/filters/each.js
@@ -19,11 +19,11 @@ Export our filter function
 exports.each = function(source,operator,options) {
 	var results =[] ,
 		value,values = {},
-		field = operator.operand || "title";
+		field = operator.operand || "";
 	if(operator.suffix !== "list-item") {
 		source(function(tiddler,title) {
-			if(tiddler) {
-				value = (field === "title") ? title : tiddler.getFieldString(field);
+			if(tiddler || field === "") {
+				value = (field === "") ? title : tiddler.getFieldString(field);
 				if(!$tw.utils.hop(values,value)) {
 					values[value] = true;
 					results.push(title);

--- a/editions/tw5.com/tiddlers/filters/each.tid
+++ b/editions/tw5.com/tiddlers/filters/each.tid
@@ -7,7 +7,7 @@ caption: each
 op-purpose: select one of each group of input titles by field
 op-input: a [[selection of titles|Title Selection]]
 op-suffix: optionally, `list-item`
-op-parameter: the name of a [[field|TiddlerFields]], defaulting to <<.field title>>
+op-parameter: the name of a [[field|TiddlerFields]], defaulting to the tiddler's title
 op-parameter-name: F
 op-output: a selection containing the first input title encountered for each distinct value of field <<.place F>>
 
@@ -15,6 +15,8 @@ Each input title is processed in turn. The value of field <<.place F>> in the co
 
 ;each
 :As long as the value of the field is unique (i.e. has not been encountered before), the title is appended to the output.
+:''Note:'' if the parameter is empty, the title of the tiddler is used without checking that there actually is a field "title".
+:This way it is possible to also filter non-existing tiddlers. If the parameter is present and is "title", the title field has to exist.
 ;each:list-item
 :The value is treated as a [[title list|Title List]]. Each title in the list considered in turn. If it has not been encountered before, it is appended to the output.
 


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/tiddlywikidev/St9Yc8DqjNY

each only processes existing tiddlers.

With an empty parameter it will now process non existing tiddlers as well, checking just their title.