### PR TITLE
add functionality to dynamically store viewport dimensions

### DIFF
--- a/plugins/tiddlywiki/dynaview/config.tid
+++ b/plugins/tiddlywiki/dynaview/config.tid
@@ -1,0 +1,8 @@
+title: $:/plugins/tiddlywiki/dynaview/config
+
+//These settings take effect after reloading your wiki//
+
+<$checkbox tiddler="$:/config/dynaview" field="viewport-dimensions" checked="yes" unchecked="">&nbsp;&nbsp;enable dynamic saving of the viewport dimensions</$checkbox>
+- //by default the values get stored in $:/viewport //
+
+specify an alternate tiddler&nbsp;&nbsp;<$edit-text tiddler="$:/config/dynaview" field="viewport-tiddler" size="30"/>

--- a/plugins/tiddlywiki/dynaview/config.tid
+++ b/plugins/tiddlywiki/dynaview/config.tid
@@ -5,4 +5,4 @@ title: $:/plugins/tiddlywiki/dynaview/config
 <$checkbox tiddler="$:/config/dynaview" field="viewport-dimensions" checked="yes" unchecked="">&nbsp;&nbsp;enable dynamic saving of the viewport dimensions</$checkbox>
 - //by default the values get stored in $:/viewport //
 
-specify an alternate tiddler&nbsp;&nbsp;<$edit-text tiddler="$:/config/dynaview" field="viewport-tiddler" size="30"/>
+specify an alternative tiddler&nbsp;&nbsp;<$edit-text tiddler="$:/config/dynaview" field="viewport-tiddler" size="30"/>

--- a/plugins/tiddlywiki/dynaview/config.tid
+++ b/plugins/tiddlywiki/dynaview/config.tid
@@ -1,8 +1,4 @@
 title: $:/plugins/tiddlywiki/dynaview/config
 
-//These settings take effect after reloading your wiki//
-
-<$checkbox tiddler="$:/config/dynaview" field="viewport-dimensions" checked="yes" unchecked="">&nbsp;&nbsp;enable dynamic saving of the viewport dimensions</$checkbox>
-- //by default the values get stored in $:/state/viewport //
-
-specify an alternative tiddler&nbsp;&nbsp;<$edit-text tiddler="$:/config/dynaview" field="viewport-tiddler" size="30"/>
+<$checkbox tiddler="$:/config/ViewportDimensions" field="text" checked="yes" unchecked="">&nbsp;&nbsp;enable dynamic saving of the viewport dimensions</$checkbox>
+- //the values get stored in // $:/state/viewport/width and $:/state/viewport/height

--- a/plugins/tiddlywiki/dynaview/config.tid
+++ b/plugins/tiddlywiki/dynaview/config.tid
@@ -3,6 +3,6 @@ title: $:/plugins/tiddlywiki/dynaview/config
 //These settings take effect after reloading your wiki//
 
 <$checkbox tiddler="$:/config/dynaview" field="viewport-dimensions" checked="yes" unchecked="">&nbsp;&nbsp;enable dynamic saving of the viewport dimensions</$checkbox>
-- //by default the values get stored in $:/viewport //
+- //by default the values get stored in $:/state/viewport //
 
 specify an alternative tiddler&nbsp;&nbsp;<$edit-text tiddler="$:/config/dynaview" field="viewport-tiddler" size="30"/>

--- a/plugins/tiddlywiki/dynaview/docs.tid
+++ b/plugins/tiddlywiki/dynaview/docs.tid
@@ -7,6 +7,7 @@ The components of this plugin include:
 * A background task that:
 ** performs specified actions when elements are scrolled into view
 ** updates certain base classes on the `document.body` according to the current zoom level
+** if enabled - stores the viewport dimensions in a dedicated tiddler
 * Pre-configured CSS classes to simplify using those base classes
 * Usage examples
 

--- a/plugins/tiddlywiki/dynaview/docs.tid
+++ b/plugins/tiddlywiki/dynaview/docs.tid
@@ -7,7 +7,7 @@ The components of this plugin include:
 * A background task that:
 ** performs specified actions when elements are scrolled into view
 ** updates certain base classes on the `document.body` according to the current zoom level
-** if enabled - stores the viewport dimensions in a dedicated tiddler
+** if enabled in the dynaview config panel - dynamically stores the viewport dimensions in $:/state/viewport/width and $:/state/viewport/height
 * Pre-configured CSS classes to simplify using those base classes
 * Usage examples
 

--- a/plugins/tiddlywiki/dynaview/dynaview.js
+++ b/plugins/tiddlywiki/dynaview/dynaview.js
@@ -25,7 +25,7 @@ var isWaitingForAnimationFrame = false,
 if($tw.wiki.tiddlerExists("$:/config/dynaview")) {
 	var configTiddler = $tw.wiki.getTiddler("$:/config/dynaview");
 	exportViewportDimensions = configTiddler.fields["viewport-dimensions"] === "yes";
-	viewportTiddler = configTiddler.fields["viewport-tiddler"] || "$:/viewport";
+	viewportTiddler = configTiddler.fields["viewport-tiddler"] || "$:/state/viewport";
 }
 
 exports.startup = function() {

--- a/plugins/tiddlywiki/dynaview/dynaview.js
+++ b/plugins/tiddlywiki/dynaview/dynaview.js
@@ -18,15 +18,7 @@ exports.platforms = ["browser"];
 exports.after = ["render"];
 exports.synchronous = true;
 
-var isWaitingForAnimationFrame = false,
-    exportViewportDimensions = false,
-    viewportTiddler;
-
-if($tw.wiki.tiddlerExists("$:/config/dynaview")) {
-	var configTiddler = $tw.wiki.getTiddler("$:/config/dynaview");
-	exportViewportDimensions = configTiddler.fields["viewport-dimensions"] === "yes";
-	viewportTiddler = configTiddler.fields["viewport-tiddler"] || "$:/state/viewport";
-}
+var isWaitingForAnimationFrame = false;
 
 exports.startup = function() {
 	window.addEventListener("load",onScrollOrResize,false);
@@ -34,6 +26,9 @@ exports.startup = function() {
 	window.addEventListener("resize",onScrollOrResize,false);
 	$tw.hooks.addHook("th-page-refreshed",function() {
 		checkVisibility();
+    if($tw.wiki.getTiddlerText("$:/config/ViewportDimensions") === "yes") {
+      saveViewportDimensions();
+    }
 	});
 };
 
@@ -42,10 +37,8 @@ function onScrollOrResize(event) {
 		window.requestAnimationFrame(function() {
 			setZoomClasses();
 			checkVisibility();
-			if(exportViewportDimensions) {
+			if($tw.wiki.getTiddlerText("$:/config/ViewportDimensions") === "yes") {
 				saveViewportDimensions();
-			} else if($tw.wiki.tiddlerExists(viewportTiddler)) {
-				$tw.wiki.deleteTiddler(viewportTiddler);
 			}
 			isWaitingForAnimationFrame = false;
 		});
@@ -107,8 +100,8 @@ function checkVisibility() {
 function saveViewportDimensions() {
 	var viewportWidth = window.innerWidth || document.documentElement.clientWidth,
 	    viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-	$tw.wiki.setText(viewportTiddler,"viewport-width",undefined,viewportWidth, { suppressTimestamp: true });
-	$tw.wiki.setText(viewportTiddler,"viewport-height",undefined,viewportHeight, { suppressTimestamp: true });
+	$tw.wiki.setText("$:/state/viewport/width",undefined,undefined,viewportWidth.toString(),undefined);
+	$tw.wiki.setText("$:/state/viewport/height",undefined,undefined,viewportHeight.toString(),undefined);
 }
 
 })();

--- a/plugins/tiddlywiki/dynaview/dynaview.js
+++ b/plugins/tiddlywiki/dynaview/dynaview.js
@@ -107,8 +107,8 @@ function checkVisibility() {
 function saveViewportDimensions() {
 	var viewportWidth = window.innerWidth || document.documentElement.clientWidth,
 	    viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-	$tw.wiki.setText("$:/viewport","viewport-width",undefined,viewportWidth, { suppressTimestamp: true });
-	$tw.wiki.setText("$:/viewport","viewport-height",undefined,viewportHeight, { suppressTimestamp: true });
+	$tw.wiki.setText(viewportTiddler,"viewport-width",undefined,viewportWidth, { suppressTimestamp: true });
+	$tw.wiki.setText(viewportTiddler,"viewport-height",undefined,viewportHeight, { suppressTimestamp: true });
 }
 
 })();

--- a/plugins/tiddlywiki/dynaview/plugin.info
+++ b/plugins/tiddlywiki/dynaview/plugin.info
@@ -3,5 +3,5 @@
 	"description": "Dynamic scrolling and zooming effects",
 	"author": "JeremyRuston",
 	"core-version": ">=5.0.0",
-	"list": "readme docs examples"
+	"list": "readme docs examples config"
 }


### PR DESCRIPTION
Hi, as discussed [here](https://groups.google.com/forum/#!topic/tiddlywikidev/MUHKAUG-0iY) I've added my version of an implementation to store the viewport dimensions (if enabled) in $:/state/viewport or a user-specified tiddler

Simon