### PR TITLE
KaTeX - EditorToolbar stamp button for wysiwyg katex snippet input

### DIFF
--- a/plugins/tiddlywiki/katex/katex-logo.tid
+++ b/plugins/tiddlywiki/katex/katex-logo.tid
@@ -1,0 +1,3 @@
+title: $:/plugins/tiddlywiki/katex/katex-logo
+
+$$\KaTeX$$

--- a/plugins/tiddlywiki/katex/snippets/logo.tid
+++ b/plugins/tiddlywiki/katex/snippets/logo.tid
@@ -1,4 +1,4 @@
 title: $:/plugins/tiddlywiki/katex/snippets/logo
-tags: $:/tags/katex
+tags: $:/tags/KaTeX/Snippet
 
 $$\KaTeX$$

--- a/plugins/tiddlywiki/katex/snippets/logo.tid
+++ b/plugins/tiddlywiki/katex/snippets/logo.tid
@@ -1,0 +1,4 @@
+title: $:/plugins/tiddlywiki/katex/snippets/logo
+tags: $:/tags/katex
+
+$$\KaTeX$$

--- a/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown.tid
+++ b/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown.tid
@@ -22,7 +22,7 @@ title: $:/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown
 </$button>
 \end
 
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/katex]!has[draft.of]sort[caption]]" variable="snippetTitle">
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/KaTeX/Snippet]!has[draft.of]sort[caption]]" variable="snippetTitle">
 
 <<toolbar-button-stamp-inner>>
 
@@ -34,7 +34,7 @@ title: $:/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown
 
 <$action-sendmessage
 	$message="tm-new-tiddler"
-	tags="$:/tags/katex"
+	tags="$:/tags/KaTeX/Snippet"
 	text="""$$snippet$$"""
 />
 

--- a/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown.tid
+++ b/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown.tid
@@ -1,0 +1,53 @@
+title: $:/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown
+
+\define toolbar-button-stamp-inner()
+<$button tag="a">
+
+<$action-sendmessage
+	$message="tm-edit-text-operation"
+	$param="replace-selection"
+	text={{$(snippetTitle)$}}
+/>
+
+<$action-deletetiddler
+	$tiddler=<<dropdown-state>>
+/>
+
+<$view tiddler=<<snippetTitle>> field="caption" mode="inline">
+
+<$transclude tiddler=<<snippetTitle>> mode="inline"/>
+
+</$view>
+
+</$button>
+\end
+
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/katex]!has[draft.of]sort[caption]]" variable="snippetTitle">
+
+<<toolbar-button-stamp-inner>>
+
+</$list>
+
+----
+
+<$button tag="a">
+
+<$action-sendmessage
+	$message="tm-new-tiddler"
+	tags="$:/tags/katex"
+	text="""$$snippet$$"""
+/>
+
+<$action-deletetiddler
+	$tiddler=<<dropdown-state>>
+/>
+
+<em>
+
+<$text text={{$:/language/Buttons/Stamp/Caption/New}}/>
+
+</em>
+
+</$button>
+
+[ext[KaTeX functions catalogue|https://khan.github.io/KaTeX/function-support.html]]

--- a/plugins/tiddlywiki/katex/ui/EditorToolbar/katex.tid
+++ b/plugins/tiddlywiki/katex/ui/EditorToolbar/katex.tid
@@ -4,5 +4,5 @@ icon: $:/plugins/tiddlywiki/katex/katex-logo
 caption: katex
 description: create and insert preconfigured KaTeX snippets
 condition: [<targetTiddler>!is[image]]
-dropdown: $:/plugins/tiddlywiki/katex/katex-dropdown
+dropdown: $:/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown
 text:

--- a/plugins/tiddlywiki/katex/ui/EditorToolbar/katex.tid
+++ b/plugins/tiddlywiki/katex/ui/EditorToolbar/katex.tid
@@ -1,0 +1,8 @@
+title: $:/plugins/tiddlywiki/katex/ui/EditorToolbar/katex
+tags: $:/tags/EditorToolbar
+icon: $:/plugins/tiddlywiki/katex/katex-logo
+caption: katex
+description: create and insert preconfigured KaTeX snippets
+condition: [<targetTiddler>!is[image]]
+dropdown: $:/plugins/tiddlywiki/katex/katex-dropdown
+text:


### PR DESCRIPTION
Hi, I'd like to propose adding a stamp button for katex, that lets you create your snippets, like the stamp button, but offers visual selecting of your snippets by showing the rendered katex snip directly