### PR TITLE
make dragging links do more

### DIFF
--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -44,12 +44,25 @@ exports.makeDraggable = function(options) {
 			}
 			var titleString = $tw.utils.stringifyList(titles);
 			// Check if ctrl key is pressed - if true, transclude tiddler instead of linking
-			if(event.ctrlKey) {
+			if(event.ctrlKey && !event.shiftKey) {
 				// If it's a system tiddler
 				if(/^\$:\/.*/.test(titleString)) {
 					titleString = '{{' + titleString + '}}';
 				} else {
 					titleString = titleString.replace(/\[/g, '{').replace(/]/g, '}');
+				}
+			}
+			// Shift key alters the title-string by user-defined prefix and suffix
+			if (event.shiftKey && !event.ctrlKey) {
+                    		var dragShiftTiddler = $tw.wiki.getTiddler("$:/config/DragLinkShift");
+                		if(dragShiftTiddler.fields["text"] === "yes" && dragShiftTiddler.fields["prefix"] !== undefined && dragShiftTiddler.fields["suffix"] !== undefined) {
+                        		var titleStringPrefix = dragShiftTiddler.fields["prefix"];
+                        		var titleStringSuffix = dragShiftTiddler.fields["suffix"];
+                        		if(/^\$:\/.*/.test(titleString)) {
+                                		titleString = titleStringPrefix + titleString + titleStringSuffix;
+                        		} else {
+                                		titleString = titleStringPrefix + titleString.replace(/\[/g, '{').replace(/]/g, '}') + titleStringSuffix;
+                        		}
 				}
 			}
 			// Check that we've something to drag

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -54,17 +54,28 @@ exports.makeDraggable = function(options) {
 			}
 			// Shift key alters the title-string by user-defined prefix and suffix
 			if (event.shiftKey && !event.ctrlKey) {
-                    		var dragShiftTiddler = $tw.wiki.getTiddler("$:/config/DragLinkShift");
-                		if(dragShiftTiddler.fields["prefix"] !== undefined && dragShiftTiddler.fields["suffix"] !== undefined) {
-                        		var titleStringPrefix = dragShiftTiddler.fields["prefix"];
-                        		var titleStringSuffix = dragShiftTiddler.fields["suffix"];
-                        		if(/^\$:\/.*/.test(titleString)) {
-                                		titleString = titleStringPrefix + titleString + titleStringSuffix;
-                        		} else {
-                                		titleString = titleStringPrefix + titleString.replace(/\[/g, '').replace(/]/g, '') + titleStringSuffix;
-                        		}
+			  var dragShiftTiddler = $tw.wiki.getTiddler("$:/config/DragLinkShift");
+			  if(dragShiftTiddler.fields["prefix"] !== undefined && dragShiftTiddler.fields["suffix"] !== undefined) {
+			    var titleStringPrefix = dragShiftTiddler.fields["prefix"];
+			    var titleStringSuffix = dragShiftTiddler.fields["suffix"];
+			    if(/^\$:\/.*/.test(titleString)) {
+			      titleString = titleStringPrefix + titleString + titleStringSuffix;
+			    } else {
+			      titleString = titleStringPrefix + titleString.replace(/\[/g, '').replace(/]/g, '') + titleStringSuffix;
+			    }
 				}
 			}
+			var isUrl = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/.test(titleString); // see https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
+			// Check for CamelCase only if CamelCase linking is enabled
+			var isCamelCaseEnabled = $tw.wiki.getTiddlerText("$:/config/WikiParserRules/Inline/wikilink") === "enable";
+			var isCamelCase = false;
+			// If the string starts lowercase or isn't valid CamelCase - skip
+      if(isCamelCaseEnabled && !/^\[\[.*/.test(titleString) && /^[A-Z].*/.test(titleString) && /([a-z]*)([A-Z]*?)([A-Z][a-z]+)/.test(titleString)) {
+        isCamelCase = (titleString.length - titleString.replace(/[A-Z]/g, '').length) > 1 ? true : false;
+      }
+			if (!event.shiftKey && !event.ctrlKey && !/^\[\[.*/.test(titleString) && !/^\$:\/.*/.test(titleString) && !isCamelCase && !isUrl) {
+        titleString = '[[' + titleString + ']]';
+      }
 			// Check that we've something to drag
 			if(titles.length > 0 && event.target === domNode) {
 				// Mark the drag in progress

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -61,7 +61,7 @@ exports.makeDraggable = function(options) {
                         		if(/^\$:\/.*/.test(titleString)) {
                                 		titleString = titleStringPrefix + titleString + titleStringSuffix;
                         		} else {
-                                		titleString = titleStringPrefix + titleString.replace(/\[/g, '{').replace(/]/g, '}') + titleStringSuffix;
+                                		titleString = titleStringPrefix + titleString.replace(/\[/g, '').replace(/]/g, '') + titleStringSuffix;
                         		}
 				}
 			}

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -55,7 +55,7 @@ exports.makeDraggable = function(options) {
 			// Shift key alters the title-string by user-defined prefix and suffix
 			if (event.shiftKey && !event.ctrlKey) {
                     		var dragShiftTiddler = $tw.wiki.getTiddler("$:/config/DragLinkShift");
-                		if(dragShiftTiddler.fields["text"] === "yes" && dragShiftTiddler.fields["prefix"] !== undefined && dragShiftTiddler.fields["suffix"] !== undefined) {
+                		if(dragShiftTiddler.fields["prefix"] !== undefined && dragShiftTiddler.fields["suffix"] !== undefined) {
                         		var titleStringPrefix = dragShiftTiddler.fields["prefix"];
                         		var titleStringSuffix = dragShiftTiddler.fields["suffix"];
                         		if(/^\$:\/.*/.test(titleString)) {

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -43,6 +43,15 @@ exports.makeDraggable = function(options) {
 				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
 			}
 			var titleString = $tw.utils.stringifyList(titles);
+			// Check if ctrl key is pressed - if true, transclude tiddler instead of linking
+			if(event.ctrlKey) {
+				// If it's a system tiddler
+				if(/^\$:\/.*/.test(titleString)) {
+					titleString = '{{' + titleString + '}}';
+				} else {
+					titleString = titleString.replace(/\[/g, '{').replace(/]/g, '}');
+				}
+			}
 			// Check that we've something to drag
 			if(titles.length > 0 && event.target === domNode) {
 				// Mark the drag in progress

--- a/editions/tw5.com/tiddlers/features/Drag and Drop Modifier Keys.tid
+++ b/editions/tw5.com/tiddlers/features/Drag and Drop Modifier Keys.tid
@@ -1,0 +1,15 @@
+tags: Features
+title: Drag and Drop Modifier Keys
+type: text/vnd.tiddlywiki
+
+The result of dragging links into input fields or textareas can be modified holding one of these ''modifier keys'':
+
+* Ctrl
+* Shift
+
+Holding the `Ctrl` key while dragging a link results in a ''transclusion'' of the dragged title, like `{{dragged-tiddler-title}}`
+Holding the `Shift` key takes a user-defined prefix and suffix and adds them to the dragged title
+
+The prefix and suffix for the `Shift` modifier can be defined in the tiddler [[$:/config/DragLinkShift]]
+To do so, add a field called "prefix" to define the prefix, and a field "suffix" for your suffix
+Both fields must be existent but can be empty

--- a/editions/tw5.com/tiddlers/features/Drag and Drop.tid
+++ b/editions/tw5.com/tiddlers/features/Drag and Drop.tid
@@ -16,6 +16,7 @@ Tiddler manipulation via drag and drop is supported by the core user interface i
 * Entries in the [[control panel|$:/ControlPanel]] "Appearance"/"Toolbars" tab can be reordered by drag and drop. (Less usefully, new entries can be added to the toolbars by dragging their titles into the list)
 
 All tiddler links are draggable by default. They can be dragged within a browser window for manipulating tiddlers, or dragged to a different browser window to initiate an [[import operation|Importing Tiddlers]]
+<<.from-version "5.1.16">> The behaviour of dragging links into input fields or textareas can be modified while dragging by using the [[keyboard's modifier keys|Drag and Drop Modifier Keys]] Ctrl and Shift
 
 Tag pills are also draggable, and are equivalent to simultaneously dragging all of the individual tiddlers carrying the tag.
 

--- a/editions/tw5.com/tiddlers/features/Drag and Drop.tid
+++ b/editions/tw5.com/tiddlers/features/Drag and Drop.tid
@@ -16,7 +16,7 @@ Tiddler manipulation via drag and drop is supported by the core user interface i
 * Entries in the [[control panel|$:/ControlPanel]] "Appearance"/"Toolbars" tab can be reordered by drag and drop. (Less usefully, new entries can be added to the toolbars by dragging their titles into the list)
 
 All tiddler links are draggable by default. They can be dragged within a browser window for manipulating tiddlers, or dragged to a different browser window to initiate an [[import operation|Importing Tiddlers]]
-<<.from-version "5.1.16">> The behaviour of dragging links into input fields or textareas can be modified while dragging by using the [[keyboard's modifier keys|Drag and Drop Modifier Keys]] Ctrl and Shift
+<<.from-version "5.1.16">> The behaviour of dragging links into input fields or textareas can be modified while dragging by using the [[keyboard modifier keys|Drag and Drop Modifier Keys]] Ctrl and Shift
 
 Tag pills are also draggable, and are equivalent to simultaneously dragging all of the individual tiddlers carrying the tag.
 


### PR DESCRIPTION
one can just press the ctrl key while dragging so that dragged links create transclusions
normal: [[tiddler title]]
with ctrl: {{tiddler title}}
with shift: **your prefix**tiddler title**your suffix**

This works for me, though I don't know if it breaks something somewhere else
Simon