### PR TITLE
change name/value to name:value

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/DictionaryTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/DictionaryTiddlers.tid
@@ -3,7 +3,7 @@ modified: 20141228094500000
 tags: Concepts
 title: DictionaryTiddlers
 
-A dictionary tiddler is a [[data tiddler|DataTiddlers]] containing a simple list of name/value pairs.
+A dictionary tiddler is a [[data tiddler|DataTiddlers]] containing a simple list of name:value pairs.
 
 Its [[ContentType]] is `application/x-tiddler-dictionary`.
 


### PR DESCRIPTION
`name:value` is used in TiddlerFields and TiddlerFiles.

For the ordinary user the term `name-value pair` (or attribute-value pairs as Wikipedia uses) might be outside of their knowledge.

I don't know what is best.... `name:value`, `attribute-value` .... as an ordinary user i think there is value in using the latter: attribute is a word used a lot in TW's documentation

Any thoughts? 

[1] https://en.wikipedia.org/wiki/Attribute%E2%80%93value_pair