### PR TITLE
change format of draggable in the intro

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/DraggableWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DraggableWidget.tid
@@ -5,7 +5,7 @@ tags: Widgets
 title: DraggableWidget
 type: text/vnd.tiddlywiki
 
-The `draggable` widget creates a DOM element that can be dragged by the user. It only works on browsers that support drag and drop, which typically means desktop browsers, but [[there are workarounds|Mobile Drag And Drop Shim Plugin]].
+The DraggableWidget creates a DOM element that can be dragged by the user. It only works on browsers that support drag and drop, which typically means desktop browsers, but [[there are workarounds|Mobile Drag And Drop Shim Plugin]].
 
 The draggable element can be assigned a list of tiddlers that are used as the payload. See DragAndDropMechanism for an overview.
 


### PR DESCRIPTION
The change brings it into line with the format in TransculdeWidget. I think it's OK to link to the tiddler defining the widget from the tiddler.

The ListWidget tiddler uses a different convention, "The list widget" : for consistancy I think all widgets should contain a WikiLink to themselves in the introduction