### PR TITLE
Allow empty string as value parameter in SetWidget

### DIFF
--- a/core/modules/widgets/setvariable.js
+++ b/core/modules/widgets/setvariable.js
@@ -70,7 +70,7 @@ SetWidget.prototype.getValue = function() {
 		}
 	} else if(this.setFilter) {
 		var results = this.wiki.filterTiddlers(this.setFilter,this);
-		if(!this.setValue) {
+		if(this.setValue == null) {
 			var select;
 			if(this.setSelect) {
 				select = parseInt(this.setSelect,10);


### PR DESCRIPTION
When occuring in a tiddler named _New Tiddler_, the following construct should return **++** instead of **+[[New Tiddler]]+**

```
<$set name="myVariable" filter="[all[current]field:title[New Tiddler]]" value="">
+<<myVariable>>+
</$set>
```