### PR TITLE
Better Editor Toolbar Conditions

### DIFF
--- a/core/ui/EditorToolbar/editor-height.tid
+++ b/core/ui/EditorToolbar/editor-height.tid
@@ -4,7 +4,7 @@ icon: $:/core/images/fixed-height
 custom-icon: yes
 caption: {{$:/language/Buttons/EditorHeight/Caption}}
 description: {{$:/language/Buttons/EditorHeight/Hint}}
-condition: [<targetTiddler>!is[image]]
+condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] +[first[]]
 dropdown: $:/core/ui/EditorToolbar/editor-height-dropdown
 
 <$reveal tag="span" state="$:/config/TextEditor/EditorHeight/Mode" type="match" text="fixed">

--- a/core/ui/EditorToolbar/excise.tid
+++ b/core/ui/EditorToolbar/excise.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/excise
 caption: {{$:/language/Buttons/Excise/Caption}}
 description: {{$:/language/Buttons/Excise/Hint}}
-condition: [<targetTiddler>!is[image]]
+condition: [<targetTiddler>type[]] [<targetTiddler>type[text/vnc.tiddlywiki]] +[first[]]
 shortcuts: ((excise))
 dropdown: $:/core/ui/EditorToolbar/excise-dropdown
 

--- a/core/ui/EditorToolbar/stamp.tid
+++ b/core/ui/EditorToolbar/stamp.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/stamp
 caption: {{$:/language/Buttons/Stamp/Caption}}
 description: {{$:/language/Buttons/Stamp/Hint}}
-condition: [<targetTiddler>!is[image]]
+condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] +[first[]]
 shortcuts: ((stamp))
 dropdown: $:/core/ui/EditorToolbar/stamp-dropdown
 text:


### PR DESCRIPTION
As part of working on a UI for creating D&D battle maps, I ran into the issue that several of the Toolbar buttons only hide themselves if the content is an image, regardless of whether they actually work with the ContentType specified.  

In this PR, I've tightened up the conditions of these Toolbar Buttons to allow new content types to more effectively specify the Toolbar buttons they need or wish to avoid.  

* The height button and snippet tool only show up on text tiddlers.
* The excise tool only shows up on tiddlers that use the tiddlywiki5 syntax.