### PR TITLE
Update forum icon

### DIFF
--- a/editions/tw5.com/tiddlers/hellothere/HelloThere.tid
+++ b/editions/tw5.com/tiddlers/hellothere/HelloThere.tid
@@ -19,7 +19,7 @@ Unlike conventional online services, TiddlyWiki lets you choose where to keep yo
 
 <div style="font-size:0.7em;text-align:center;margin-top:3em;margin-bottom:3em;">
 <a href="http://groups.google.com/group/TiddlyWiki" class="tc-btn-big-green" style="background-color:#FF8C19;" target="_blank" rel="noopener noreferrer">
-{{$:/core/images/list}} ~TiddlyWiki Forum
+{{$:/core/images/help}} ~TiddlyWiki Forum
 </a>
 <a href="https://www.youtube.com/c/JeremyRuston" class="tc-btn-big-green" style="background-color:#e52d27;" target="_blank" rel="noopener noreferrer">
 {{$:/core/images/video}} ~TiddlyWiki on ~YouTube


### PR DESCRIPTION
This icon is a much better clue to what the forum is about. Especially it is superior when someone is actually looking for help which, presumably, is one of the most important use cases with the tw webpage.