### PR TITLE
draggable widget - actions on dragstart

### DIFF
--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -43,6 +43,10 @@ exports.makeDraggable = function(options) {
 				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
 			}
 			var titleString = $tw.utils.stringifyList(titles);
+			var dragStartAction = options.draggableAction;
+			if (dragStartAction !== undefined && dragStartAction !== null) {
+				options.widget.invokeActionString(dragStartAction,options.widget,event,{actionTiddler: titleString});
+			}
 			// Check that we've something to drag
 			if(titles.length > 0 && event.target === domNode) {
 				// Mark the drag in progress

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -43,7 +43,7 @@ exports.makeDraggable = function(options) {
 				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
 			}
 			var titleString = $tw.utils.stringifyList(titles);
-			var dragStartAction = options.draggableAction;
+			var dragStartAction = options.dragActions;
 			if (dragStartAction !== undefined && dragStartAction !== null) {
 				options.widget.invokeActionString(dragStartAction,options.widget,event,{actionTiddler: titleString});
 			}

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -53,7 +53,7 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 		dragTiddlerFn: function() {return self.getAttribute("tiddler");},
 		dragFilterFn: function() {return self.getAttribute("filter");},
 		widget: this,
-		actions: this.draggableActions;
+		dragActions: this.draggableActions
 	});
 	// Insert the link into the DOM and render any children
 	parent.insertBefore(domNode,nextSibling);
@@ -68,7 +68,7 @@ DraggableWidget.prototype.execute = function() {
 	// Pick up our attributes
 	this.draggableTag = this.getAttribute("tag","div");
 	this.draggableClasses = this.getAttribute("class");
-	this.draggableActions = this.getAttriibute("actions");
+	this.draggableActions = this.getAttribute("actions");
 	// Make the child widgets
 	this.makeChildWidgets();
 };

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -52,7 +52,8 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 		domNode: domNode,
 		dragTiddlerFn: function() {return self.getAttribute("tiddler");},
 		dragFilterFn: function() {return self.getAttribute("filter");},
-		widget: this
+		widget: this,
+		actions: this.draggableActions;
 	});
 	// Insert the link into the DOM and render any children
 	parent.insertBefore(domNode,nextSibling);
@@ -67,6 +68,7 @@ DraggableWidget.prototype.execute = function() {
 	// Pick up our attributes
 	this.draggableTag = this.getAttribute("tag","div");
 	this.draggableClasses = this.getAttribute("class");
+	this.draggableActions = this.getAttriibute("actions");
 	// Make the child widgets
 	this.makeChildWidgets();
 };

--- a/editions/tw5.com/tiddlers/mechanisms/DragAndDropMechanism.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/DragAndDropMechanism.tid
@@ -20,6 +20,7 @@ The following widgets are concerned with drag and drop features:
 The general sequence of a drag and drop operation is as follows:
 
 # The user clicks down and drags the pointer on a draggable element such as the DraggableWidget, ButtonWidget or LinkWidget
+# The actions configured within the ''draggable'' widget are performed if present
 # The draggable element moves with the mouse pointer until the click is released
 # Moving the pointer over droppable elements such as the DroppableWidget displays a highlight indicating that the item can be dropped
-# The configured actions are performed if the drag ends on a droppable element
+# The actions configured within the ''droppable'' widget are performed if the drag ends on a droppable element

--- a/editions/tw5.com/tiddlers/widgets/DraggableWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DraggableWidget.tid
@@ -7,7 +7,9 @@ type: text/vnd.tiddlywiki
 
 The DraggableWidget creates a DOM element that can be dragged by the user. It only works on browsers that support drag and drop, which typically means desktop browsers, but [[there are workarounds|Mobile Drag And Drop Shim Plugin]].
 
-The draggable element can be assigned a list of tiddlers that are used as the payload. See DragAndDropMechanism for an overview.
+The draggable element can be assigned a list of tiddlers that are used as the payload and an Action String for actions that can be triggered at Drag-Start.
+
+See DragAndDropMechanism for an overview.
 
 ! Content and Attributes
 
@@ -16,6 +18,7 @@ The draggable element can be assigned a list of tiddlers that are used as the pa
 |filter |Optional filter defining the payload tiddlers for the drag |
 |class |Optional CSS classes to assign to the draggable element. The class `tc-draggable` is added automatically, and the class `tc-dragging` is applied while the element is being dragged |
 |tag |Optional tag to override the default "div" element |
+|actions |Optional Action String to be triggered at Drag-Start |
 
 Either or both of the ''tiddler'' and ''filter'' attributes must be specified in order for there to be a payload to drag.
 


### PR DESCRIPTION
this allows to dispatch an action string when dragging starts

it's useful for example to apply classes to elements when dragging starts, so that one can inherit triggering of other droppable or dropzone widgets by selectively applying certain styles like "pointer-events: none"