### PR TITLE
draggable widget: actions on drag-start and drag-end

### DIFF
--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -51,7 +51,7 @@ exports.makeDraggable = function(options) {
 				// Set the dragging class on the element being dragged
 				$tw.utils.addClass(event.target,"tc-dragging");
 				// Invoke drag-start actions if given
-				if(dragStartActions !== undefined && dragStartActions !== null) {
+				if(dragStartActions !== undefined) {
 					options.widget.invokeActionString(dragStartActions,options.widget,event,{actionTiddler: titleString});
 				}
 				// Create the drag image elements
@@ -116,7 +116,7 @@ exports.makeDraggable = function(options) {
 				var titleString = $tw.utils.stringifyList(titles);
 				$tw.dragInProgress = null;
 				// Invoke drag-end actions if given
-				if(dragEndActions !== undefined && dragEndActions !== null) {
+				if(dragEndActions !== undefined) {
 					options.widget.invokeActionString(dragEndActions,options.widget,event,{actionTiddler: titleString});
 				}
 				// Remove the dragging class on the element being dragged

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -39,8 +39,7 @@ exports.makeDraggable = function(options) {
 			var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
 				dragFilter = options.dragFilterFn && options.dragFilterFn(),
 				titles = dragTiddler ? [dragTiddler] : [],
-			    	dragStartActions = options.dragStartActions,
-			    	dragEndActions = options.dragEndActions;
+			    	dragStartActions = options.dragStartActions;
 			if(dragFilter) {
 				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
 			}
@@ -108,8 +107,8 @@ exports.makeDraggable = function(options) {
 			if(event.target === domNode) {
 				$tw.dragInProgress = null;
 				// Invoke drag-end actions if given
-				if(dragEndActions !== undefined && dragEndActions !== null) {
-					options.widget.invokeActionString(dragEndActions,options.widget,event,{actionTiddler: titleString});
+				if(options.dragEndActions !== undefined && options.dragEndActions !== null) {
+					options.widget.invokeActionString(options.dragEndActions,options.widget,event,{actionTiddler: titleString});
 				}
 				// Remove the dragging class on the element being dragged
 				$tw.utils.removeClass(event.target,"tc-dragging");

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -39,7 +39,7 @@ exports.makeDraggable = function(options) {
 			var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
 				dragFilter = options.dragFilterFn && options.dragFilterFn(),
 				titles = dragTiddler ? [dragTiddler] : [],
-			    	dragStartActions = options.dragStartActions;
+			    	startActions = options.startActions;
 			if(dragFilter) {
 				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
 			}
@@ -51,8 +51,8 @@ exports.makeDraggable = function(options) {
 				// Set the dragging class on the element being dragged
 				$tw.utils.addClass(event.target,"tc-dragging");
 				// Invoke drag-start actions if given
-				if(dragStartActions !== undefined) {
-					options.widget.invokeActionString(dragStartActions,options.widget,event,{actionTiddler: titleString});
+				if(startActions !== undefined) {
+					options.widget.invokeActionString(startActions,options.widget,event,{actionTiddler: titleString});
 				}
 				// Create the drag image elements
 				dragImage = options.widget.document.createElement("div");
@@ -109,15 +109,15 @@ exports.makeDraggable = function(options) {
 				var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
 					dragFilter = options.dragFilterFn && options.dragFilterFn(),
 					titles = dragTiddler ? [dragTiddler] : [],
-			    		dragEndActions = options.dragEndActions;
+			    		endActions = options.endActions;
 				if(dragFilter) {
 					titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
 				}
 				var titleString = $tw.utils.stringifyList(titles);
 				$tw.dragInProgress = null;
 				// Invoke drag-end actions if given
-				if(dragEndActions !== undefined) {
-					options.widget.invokeActionString(dragEndActions,options.widget,event,{actionTiddler: titleString});
+				if(endActions !== undefined) {
+					options.widget.invokeActionString(endActions,options.widget,event,{actionTiddler: titleString});
 				}
 				// Remove the dragging class on the element being dragged
 				$tw.utils.removeClass(event.target,"tc-dragging");

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -53,7 +53,7 @@ exports.makeDraggable = function(options) {
 				$tw.utils.addClass(event.target,"tc-dragging");
 				// Invoke drag-start actions if given
 				if(dragStartActions !== undefined && dragStartActions !== null) {
-					self.invokeActionString(dragStartActions,this,event,{actionTiddler: titleString});
+					options.widget.invokeActionString(dragStartActions,options.widget,event,{actionTiddler: titleString});
 				}
 				// Create the drag image elements
 				dragImage = options.widget.document.createElement("div");
@@ -109,7 +109,7 @@ exports.makeDraggable = function(options) {
 				$tw.dragInProgress = null;
 				// Invoke drag-end actions if given
 				if(dragEndActions !== undefined && dragEndActions !== null) {
-					self.invokeActionString(dragEndActions,this,event,{actionTiddler: titleString});
+					options.widget.invokeActionString(dragEndActions,options.widget,event,{actionTiddler: titleString});
 				}
 				// Remove the dragging class on the element being dragged
 				$tw.utils.removeClass(event.target,"tc-dragging");

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -38,7 +38,9 @@ exports.makeDraggable = function(options) {
 			// Collect the tiddlers being dragged
 			var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
 				dragFilter = options.dragFilterFn && options.dragFilterFn(),
-				titles = dragTiddler ? [dragTiddler] : [];
+				titles = dragTiddler ? [dragTiddler] : [],
+			    	dragStartActions = options.dragStartActions,
+			    	dragEndActions = options.dragEndActions;
 			if(dragFilter) {
 				titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
 			}
@@ -49,6 +51,10 @@ exports.makeDraggable = function(options) {
 				$tw.dragInProgress = domNode;
 				// Set the dragging class on the element being dragged
 				$tw.utils.addClass(event.target,"tc-dragging");
+				// Invoke drag-start actions if given
+				if(dragStartActions !== undefined && dragStartActions !== null) {
+					self.invokeActionString(dragStartActions,this,event,{actionTiddler: titleString});
+				}
 				// Create the drag image elements
 				dragImage = options.widget.document.createElement("div");
 				dragImage.className = "tc-tiddler-dragger";
@@ -101,6 +107,10 @@ exports.makeDraggable = function(options) {
 		{name: "dragend", handlerFunction: function(event) {
 			if(event.target === domNode) {
 				$tw.dragInProgress = null;
+				// Invoke drag-end actions if given
+				if(dragEndActions !== undefined && dragEndActions !== null) {
+					self.invokeActionString(dragEndActions,this,event,{actionTiddler: titleString});
+				}
 				// Remove the dragging class on the element being dragged
 				$tw.utils.removeClass(event.target,"tc-dragging");
 				// Delete the drag image element

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -105,10 +105,19 @@ exports.makeDraggable = function(options) {
 		}},
 		{name: "dragend", handlerFunction: function(event) {
 			if(event.target === domNode) {
+				// Collect the tiddlers being dragged
+				var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
+					dragFilter = options.dragFilterFn && options.dragFilterFn(),
+					titles = dragTiddler ? [dragTiddler] : [],
+			    		dragEndActions = options.dragEndActions;
+				if(dragFilter) {
+					titles.push.apply(titles,options.widget.wiki.filterTiddlers(dragFilter,options.widget));
+				}
+				var titleString = $tw.utils.stringifyList(titles);
 				$tw.dragInProgress = null;
 				// Invoke drag-end actions if given
-				if(options.dragEndActions !== undefined && options.dragEndActions !== null) {
-					options.widget.invokeActionString(options.dragEndActions,options.widget,event,{actionTiddler: titleString});
+				if(dragEndActions !== undefined && dragEndActions !== null) {
+					options.widget.invokeActionString(dragEndActions,options.widget,event,{actionTiddler: titleString});
 				}
 				// Remove the dragging class on the element being dragged
 				$tw.utils.removeClass(event.target,"tc-dragging");

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -52,6 +52,8 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 		domNode: domNode,
 		dragTiddlerFn: function() {return self.getAttribute("tiddler");},
 		dragFilterFn: function() {return self.getAttribute("filter");},
+		dragStartActions: self.dragStartActions,
+		dragEndActions: self.dragEndActions,
 		widget: this
 	});
 	// Insert the link into the DOM and render any children
@@ -67,6 +69,8 @@ DraggableWidget.prototype.execute = function() {
 	// Pick up our attributes
 	this.draggableTag = this.getAttribute("tag","div");
 	this.draggableClasses = this.getAttribute("class");
+	this.dragStartActions = this.getAttribute("startactions");
+	this.dragEndActions = this.getAttribute("endactions");
 	// Make the child widgets
 	this.makeChildWidgets();
 };

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -52,8 +52,8 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 		domNode: domNode,
 		dragTiddlerFn: function() {return self.getAttribute("tiddler");},
 		dragFilterFn: function() {return self.getAttribute("filter");},
-		dragStartActions: self.dragStartActions,
-		dragEndActions: self.dragEndActions,
+		startActions: self.startActions,
+		endActions: self.endActions,
 		widget: this
 	});
 	// Insert the link into the DOM and render any children
@@ -69,8 +69,8 @@ DraggableWidget.prototype.execute = function() {
 	// Pick up our attributes
 	this.draggableTag = this.getAttribute("tag","div");
 	this.draggableClasses = this.getAttribute("class");
-	this.dragStartActions = this.getAttribute("startactions");
-	this.dragEndActions = this.getAttribute("endactions");
+	this.startActions = this.getAttribute("startactions");
+	this.endActions = this.getAttribute("endactions");
 	// Make the child widgets
 	this.makeChildWidgets();
 };

--- a/editions/tw5.com/tiddlers/widgets/DraggableWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DraggableWidget.tid
@@ -7,7 +7,9 @@ type: text/vnd.tiddlywiki
 
 The DraggableWidget creates a DOM element that can be dragged by the user. It only works on browsers that support drag and drop, which typically means desktop browsers, but [[there are workarounds|Mobile Drag And Drop Shim Plugin]].
 
-The draggable element can be assigned a list of tiddlers that are used as the payload. See DragAndDropMechanism for an overview.
+The draggable element can be assigned a list of tiddlers that are used as the payload.
+If desired it can invoke actions when dragging starts and when it ends.
+See DragAndDropMechanism for an overview.
 
 ! Content and Attributes
 
@@ -16,7 +18,11 @@ The draggable element can be assigned a list of tiddlers that are used as the pa
 |filter |Optional filter defining the payload tiddlers for the drag |
 |class |Optional CSS classes to assign to the draggable element. The class `tc-draggable` is added automatically, and the class `tc-dragging` is applied while the element is being dragged |
 |tag |Optional tag to override the default "div" element |
+|startactions |Optional action string that gets invoked when dragging ''starts'' |
+|endactions |Optional action string that gets invoked when dragging ''ends'' |
 
 Either or both of the ''tiddler'' and ''filter'' attributes must be specified in order for there to be a payload to drag.
+
+The ''actionTiddler'' variable is accessible in both //startactions// and //endactions//. It holds the payload tiddler(s) specified through the //tiddler// attribute.
 
 The LinkWidget incorporates the functionality of the DraggableWidget via the ''draggable'' attribute.


### PR DESCRIPTION
this allows actions on drag-start and drag-end

why: it allows selective/conditional applying of "pointer-events: none" on certain elements. Those elements can be "blocking elements" like iframes. Or droppable widgets that contain other droppable widgets, where one can either apply conditionals on the action-string to prevent undesired actions from one or more  droppable widgets, or apply different classes to the droppable div when another droppable should be triggered... and I can imagine many other things