### PR TITLE
Added present-but-empty list-after functionality

### DIFF
--- a/core/language/en-GB/Fields.multids
+++ b/core/language/en-GB/Fields.multids
@@ -18,7 +18,7 @@ icon: The title of the tiddler containing the icon associated with a tiddler
 library: If set to "yes" indicates that a tiddler should be saved as a JavaScript library
 list: An ordered list of tiddler titles associated with a tiddler
 list-before: If set, the title of a tiddler before which this tiddler should be added to the ordered list of tiddler titles, or at the start of the list if this field is present but empty
-list-after: If set, the title of the tiddler after which this tiddler should be added to the ordered list of tiddler titles
+list-after: If set, the title of the tiddler after which this tiddler should be added to the ordered list of tiddler titles, or at the end of the list if this field is present but empty
 modified: The date and time at which a tiddler was last modified
 modifier: The tiddler title associated with the person who last modified a tiddler
 name: The human readable name associated with a plugin tiddler

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -569,6 +569,8 @@ exports.sortByList = function(array,listTitle) {
 					afterTitle = tiddler.fields["list-after"];
 				if(beforeTitle === "") {
 					newPos = 0;
+				} else if(afterTitle === "") {
+					newPos = titles.length;
 				} else if(beforeTitle) {
 					newPos = titles.indexOf(beforeTitle);
 				} else if(afterTitle) {


### PR DESCRIPTION
This places the list item at the end of the list when its 'list-item' field is an empty string.