### PR TITLE
Add a mechanism allowing the sync adaptor to notify the syncer of changes

### DIFF
--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -211,6 +211,13 @@ Syncer.prototype.syncFromServer = function() {
 		}
 		
 		this.syncadaptor.getSkinnyTiddlers(function(err,tiddlers) {
+			//get an array of the titles being updated
+			var titles = tiddlers.map(e => e.title);
+			//get the titles in the tiddlerInfo hashmap that are not on the server
+			var removes = Object.keys(self.tiddlerInfo).filter(e => titles.indexOf(e) === -1);
+			//assume a server delete and handle it locally
+			removes.forEach(title => self.handleServerDelete(title));
+			
 			// Trigger the next sync
 			self.pollTimerId = setTimeout(function() {
 				self.pollTimerId = null;

--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -14,7 +14,8 @@ A sync adaptor module for synchronising with the local filesystem via node.js AP
 
 // Get a reference to the file system
 var fs = $tw.node ? require("fs") : null,
-	path = $tw.node ? require("path") : null;
+	path = $tw.node ? require("path") : null,
+    	WikiExport = require('$:/core/modules/wiki.js');
 
 function FileSystemAdaptor(options) {
 	var self = this;
@@ -22,8 +23,14 @@ function FileSystemAdaptor(options) {
 	this.logger = new $tw.utils.Logger("filesystem",{colour: "blue"});
 	// Create the <wiki>/tiddlers folder if it doesn't exist
 	$tw.utils.createDirectory($tw.boot.wikiTiddlersPath);
+	this.eventListeners = this.eventListeners || {};
 }
 
+// Add event listener methods from wiki for use here
+FileSystemAdaptor.prototype.addEventListener = WikiExport.addEventListener;
+FileSystemAdaptor.prototype.removeEventListener = WikiExport.removeEventListener;
+FileSystemAdaptor.prototype.dispatchEvent = WikiExport.dispatchEvent;
+	
 FileSystemAdaptor.prototype.name = "filesystem";
 
 FileSystemAdaptor.prototype.isReady = function() {

--- a/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
+++ b/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
@@ -13,7 +13,8 @@ A sync adaptor module for synchronising with TiddlyWeb compatible servers
 "use strict";
 
 var CONFIG_HOST_TIDDLER = "$:/config/tiddlyweb/host",
-	DEFAULT_HOST_TIDDLER = "$protocol$//$host$/";
+	DEFAULT_HOST_TIDDLER = "$protocol$//$host$/",
+    	WikiExport = require('$:/core/modules/wiki.js');
 
 function TiddlyWebAdaptor(options) {
 	this.wiki = options.wiki;
@@ -21,8 +22,14 @@ function TiddlyWebAdaptor(options) {
 	this.recipe = undefined;
 	this.hasStatus = false;
 	this.logger = new $tw.utils.Logger("TiddlyWebAdaptor");
+	this.eventListeners = this.eventListeners || {};
 }
-
+	
+// Add event listener methods from wiki for use here
+TiddlyWebAdaptor.prototype.addEventListener = WikiExport.addEventListener;
+TiddlyWebAdaptor.prototype.removeEventListener = WikiExport.removeEventListener;
+TiddlyWebAdaptor.prototype.dispatchEvent = WikiExport.dispatchEvent;
+	
 TiddlyWebAdaptor.prototype.name = "tiddlyweb";
 
 TiddlyWebAdaptor.prototype.isReady = function() {


### PR DESCRIPTION
This PR adds a mechanism allowing the sync adapter to notify the syncer of change notifications from the server as they happen. I have added the skeleton code to the filesystem and tiddlyweb adapters, and implemented the handling code in syncer.js. 

The sync adapter emits a `server-update` event with type and tiddlerfields (a skinny tiddler) arguments whenever it feels like it. The syncer then handles the event as it would a normal skinny tiddler. 

I've also added a delete tiddler mechanism but it is incomplete and someone needs to make sure it works correctly. This all needs testing -- I haven't even tested it yet myself. But I got the idea and it seemed simple, so I did it. This didn't take very long to put together.
