### PR TITLE
Fix WebDAV by requesting new ETag.

### DIFF
--- a/core/modules/savers/put.js
+++ b/core/modules/savers/put.js
@@ -19,12 +19,14 @@ to the current URL, such as a WebDAV server.
 Retrieve ETag if available
 */
 var RetrieveETag = function(self) {
+	var headers = { "Accept": "*/*;charset=UTF-8" };
 	$tw.utils.httpRequest({
 		url: self.uri(),
 		type: "HEAD",
+		headers: headers,
 		callback: function(err, data, xhr) {
 			if(!err) {
-				self.etag = xhr.getResponseHeader("ETag");
+				self.etag = xhr.getResponseHeader("ETag").replace(/^W\//,"");
 			}
 		}
 	});

--- a/core/modules/savers/put.js
+++ b/core/modules/savers/put.js
@@ -16,6 +16,22 @@ to the current URL, such as a WebDAV server.
 "use strict";
 
 /*
+Retrieve ETag if available
+*/
+var RetrieveETag = function(self) {
+	$tw.utils.httpRequest({
+		url: self.uri(),
+		type: "HEAD",
+		callback: function(err, data, xhr) {
+			if(!err) {
+				self.etag = xhr.getResponseHeader("ETag");
+			}
+		}
+	});
+};
+
+
+/*
 Select the appropriate saver module and set it up
 */
 var PutSaver = function(wiki) {
@@ -34,16 +50,7 @@ var PutSaver = function(wiki) {
 			}
 		}
 	});
-	// Retrieve ETag if available
-	$tw.utils.httpRequest({
-		url: uri,
-		type: "HEAD",
-		callback: function(err, data, xhr) {
-			if(!err) {
-				self.etag = xhr.getResponseHeader("ETag");
-			}
-		}
-	});
+	RetrieveETag(this);
 };
 
 PutSaver.prototype.uri = function() {
@@ -69,15 +76,20 @@ PutSaver.prototype.save = function(text, method, callback) {
 		data: text,
 		callback: function(err, data, xhr) {
 			if(err) {
-				callback(err);
-			} else if(xhr.status === 200 || xhr.status === 201) {
-				self.etag = xhr.getResponseHeader("ETag");
-				callback(null); // success
-			} else if(xhr.status === 412) { // edit conflict
-				var message = $tw.language.getString("Error/EditConflict");
-				callback(message);
+				// response is textual: "XMLHttpRequest error code: 412"
+				const status = Number(err.substring(err.indexOf(':') + 2, err.length))
+				if(status === 412) { // edit conflict
+					var message = $tw.language.getString("Error/EditConflict");
+					callback(message);
+				} else {
+					callback(err); // fail
+				}
 			} else {
-				callback(xhr.responseText); // fail
+				self.etag = xhr.getResponseHeader("ETag");
+				if (self.etag == null) {
+					RetrieveETag(self);
+				}
+				callback(null); // success
 			}
 		}
 	});


### PR DESCRIPTION
This fixes saving for me. Probably fixes https://github.com/Jermolene/TiddlyWiki5/issues/2995 and improves #3073 .

ETag is supposed to verify we're not overwriting a previously changed
file. That's pretty cool.

I figured this was saving only the first time subsequently failing and
revised the requests, noticing it didn't get a new ETag after saving.

In my WebDAV service (WsgiDAV) - ETag is only served from a HEAD
request.