### PR TITLE
Add write condition for DAT protocol

### DIFF
--- a/core/modules/savers/beaker.js
+++ b/core/modules/savers/beaker.js
@@ -51,7 +51,7 @@ BeakerSaver.prototype.info = {
 Static method that returns true if this saver is capable of working
 */
 exports.canSave = function(wiki) {
-	return !!window.DatArchive;
+	return !!window.DatArchive && location.protocol==="dat:";
 };
 
 /*


### PR DESCRIPTION
In order to write to a DAT with Beaker Browser, it needs to have access to the file via `dat:` protocol.