### PR TITLE
[widget.js] - avoid producing negative hash-values for qualify macro

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -229,7 +229,7 @@ Widget.prototype.getStateQualifier = function(name) {
 			}
 			node = node.parentWidget;
 		}
-		var value = $tw.utils.hashString(output.join(" ")).toString().replace(/^-/g, "0");
+		var value = $tw.utils.hashString(output.join("")).toString().replace(/^-/g, "0");
 		this.qualifiers[name] = value;
 		return value;
 	}

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -229,7 +229,7 @@ Widget.prototype.getStateQualifier = function(name) {
 			}
 			node = node.parentWidget;
 		}
-		var value = Math.abs($tw.utils.hashString(output.join(" ")));
+		var value = $tw.utils.hashString(output.join(" ")).toString().replace(/^-/g, "0");
 		this.qualifiers[name] = value;
 		return value;
 	}

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -229,7 +229,7 @@ Widget.prototype.getStateQualifier = function(name) {
 			}
 			node = node.parentWidget;
 		}
-		var value = $tw.utils.hashString(output.join(""));
+		var value = Math.abs($tw.utils.hashString(output.join(" ")));
 		this.qualifiers[name] = value;
 		return value;
 	}


### PR DESCRIPTION
Hi,

a simple Math.abs() in getStateQualifier() avoids qualified tiddlers of the form

`tiddlername--9843502839` <- note the double " - "

having this character twice in a qualified title causes problems with some filters

also, IF I would want to create multiple css class-names using `<<qualify>>` , such a name with double - would not be valid as class-name ... the css fails