### PR TITLE
Update RenderCommand.tid

### DIFF
--- a/editions/tw5.com/tiddlers/commands/RenderCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/RenderCommand.tid
@@ -6,3 +6,10 @@ title: RenderCommand
 type: text/vnd.tiddlywiki
 
 {{$:/language/Help/render}}
+
+<$button class="tc-btn-invisible" style="text-decoration:underline">
+Show available rendering templates
+<$action-setfield $tiddler="$:/temp/advancedsearch" text="[all[shadows]prefix[$:/core/templates/]]"/>
+<$action-setfield $tiddler="$:/state/tab--1498284803" text="$:/core/ui/AdvancedSearch/Filter"/>
+<$action-navigate $to="$:/AdvancedSearch"/>
+</$button>


### PR DESCRIPTION
Adds a link that opens the advanced search with a filter to list all the template tiddlers.
This is instead of #3260 

Not sure if we should put it between small tags

```
,,<$button class="tc-btn-invisible" style="text-decoration:underline">
Show available rendering templates
<$action-setfield $tiddler="$:/temp/advancedsearch" text="[all[shadows]prefix[$:/core/templates/]]"/>
<$action-setfield $tiddler="$:/state/tab--1498284803" text="$:/core/ui/AdvancedSearch/Filter"/>
<$action-navigate $to="$:/AdvancedSearch"/>
</$button>,,
```
