### PR TITLE
[new-journal-button] respect existent journals

### DIFF
--- a/core/ui/PageControls/new-journal.tid
+++ b/core/ui/PageControls/new-journal.tid
@@ -5,13 +5,16 @@ description: {{$:/language/Buttons/NewJournal/Hint}}
 
 \define journalButton()
 <$button tooltip={{$:/language/Buttons/NewJournal/Hint}} aria-label={{$:/language/Buttons/NewJournal/Caption}} class=<<tv-config-toolbar-class>>>
-<$action-sendmessage $message="tm-new-tiddler" title=<<now """$(journalTitleTemplate)$ """>> tags=<<journalTags>> text=<<journalText>>/>
+<$vars newJournalTitle=<<now """$(journalTitleTemplate)$ """>>>
+<$action-createtiddler $basetitle=<<newJournalTitle>> $savetitle="$:/temp/new-journal-tiddler" tags=<<journalTags>> text=<<journalText>>/>
+<$action-navigate $to={{$:/temp/new-journal-tiddler}} $scroll="yes"/>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/new-journal-button}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>prefix[yes]]">
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/NewJournal/Caption}}/></span>
 </$list>
+</$vars>
 </$button>
 \end
 <$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>

--- a/core/ui/ViewToolbar/new-journal-here.tid
+++ b/core/ui/ViewToolbar/new-journal-here.tid
@@ -9,7 +9,9 @@ description: {{$:/language/Buttons/NewJournalHere/Hint}}
 \end
 \define journalButton()
 <$button tooltip={{$:/language/Buttons/NewJournalHere/Hint}} aria-label={{$:/language/Buttons/NewJournalHere/Caption}} class=<<tv-config-toolbar-class>>>
-<$action-sendmessage $message="tm-new-tiddler" title=<<now """$(journalTitleTemplate)$ """>> tags=<<journalButtonTags>>/>
+<$vars newJournalTitle=<<now """$(journalTitleTemplate)$ """>>>
+<$action-createtiddler $basetitle=<<newJournalTitle>> $savetitle="$:/temp/new-journal-tiddler" tags=tags=<<journalButtonTags>>/>
+<$action-navigate $to={{$:/temp/new-journal-tiddler}} $scroll="yes"/>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/new-journal-button}}
 </$list>

--- a/core/ui/ViewToolbar/new-journal-here.tid
+++ b/core/ui/ViewToolbar/new-journal-here.tid
@@ -20,6 +20,7 @@ description: {{$:/language/Buttons/NewJournalHere/Hint}}
 <$text text={{$:/language/Buttons/NewJournalHere/Caption}}/>
 </span>
 </$list>
+</$vars>
 </$button>
 \end
 <$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>


### PR DESCRIPTION
this creates a new journal tiddler but doesn't override one that already exists if no precise timestamp selected as journal title

see discussion: https://groups.google.com/forum/#!topic/TiddlyWiki/1DEVgjQF-fQ