### PR TITLE
Improve markdown renderer (allow raw HTML)

### DIFF
--- a/core/modules/widgets/raw.js
+++ b/core/modules/widgets/raw.js
@@ -29,10 +29,10 @@ Render this widget into the DOM
 RawWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.execute();
-	var div = this.document.createElement("div");
-	div.innerHTML=this.parseTreeNode.html;
-	parent.insertBefore(div,nextSibling);
-	this.domNodes.push(div);	
+	var span = this.document.createElement("span");
+	span.innerHTML=this.parseTreeNode.html;
+	parent.insertBefore(span,nextSibling);
+	this.domNodes.push(span);
 };
 
 /*

--- a/core/modules/widgets/raw.js
+++ b/core/modules/widgets/raw.js
@@ -29,10 +29,11 @@ Render this widget into the DOM
 RawWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.execute();
-	var span = this.document.createElement("span");
-	span.innerHTML=this.parseTreeNode.html;
-	parent.insertBefore(span,nextSibling);
-	this.domNodes.push(span);
+	var el_name = this.parseTreeNode.isBlock ? "div" : "span";
+	var tag = this.document.createElement(el_name);
+	tag.innerHTML = this.parseTreeNode.html;
+	parent.insertBefore(tag,nextSibling);
+	this.domNodes.push(tag);
 };
 
 /*

--- a/plugins/tiddlywiki/markdown/usage.tid
+++ b/plugins/tiddlywiki/markdown/usage.tid
@@ -1,4 +1,7 @@
+created: 20180512054948119
+modified: 20180512063423047
 title: $:/plugins/tiddlywiki/markdown/usage
+type: text/vnd.tiddlywiki
 
 ! Markdown Dialects
 
@@ -27,4 +30,27 @@ Markdown image syntax can be used to reference images by tiddler title or an ext
 ![alt text](/path/to/img.jpg "Title")
 
 ![alt text](Motovun Jack.jpg "Title")
+```
+
+! Code blocks
+
+Code blocks work and can use Tiddlywiki's highlighting mechanism.
+
+There is a [[bug|https://github.com/evilstreak/markdown-js/issues/292]] that makes code blocks containing empty lines fail to render correctly.
+
+<pre>&#96;&#96;&#96;python
+print ("Hello World!")
+&#96;&#96;&#96;
+</pre>
+
+Please not Syntax Highlighting is limited to the set of "brushes" provided by the default [[Highlight.js plugin|$:/plugins/tiddlywiki/highlight]].
+
+! Raw HTML
+
+As per the Markdown specification, it's possible to include arbitrary HTML content within a Markdown tiddly.
+
+```xml
+<iframe width='100%'
+        height='400px'
+        src='http://wikipedia.org/'></iframe>
 ```

--- a/plugins/tiddlywiki/markdown/usage.tid
+++ b/plugins/tiddlywiki/markdown/usage.tid
@@ -1,7 +1,4 @@
-created: 20180512054948119
-modified: 20180512063423047
 title: $:/plugins/tiddlywiki/markdown/usage
-type: text/vnd.tiddlywiki
 
 ! Markdown Dialects
 
@@ -36,20 +33,18 @@ Markdown image syntax can be used to reference images by tiddler title or an ext
 
 Code blocks work and can use Tiddlywiki's highlighting mechanism.
 
-There is a [[bug|https://github.com/evilstreak/markdown-js/issues/292]] that makes code blocks containing empty lines fail to render correctly.
+There is a [[bug|https://github.com/evilstreak/markdown-js/issues/292]] that makes code blocks that use triple backticks <code>&#96;&#96;&#96;</code> and containing empty lines to fail to render correctly. You may use indentation with 4 spaces instead.
 
-<pre>&#96;&#96;&#96;python
+<pre>&#96;&#96;&#96;
 print ("Hello World!")
 &#96;&#96;&#96;
 </pre>
 
-Please not Syntax Highlighting is limited to the set of "brushes" provided by the default [[Highlight.js plugin|$:/plugins/tiddlywiki/highlight]].
-
 ! Raw HTML
 
-As per the Markdown specification, it's possible to include arbitrary HTML content within a Markdown tiddly.
+As per the Markdown specification, it's possible to include arbitrary HTML content within a Markdown tiddler.
 
-```xml
+```
 <iframe width='100%'
         height='400px'
         src='http://wikipedia.org/'></iframe>

--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -38,13 +38,15 @@ function transformNode(node) {
 		}
 		widget.children = transformNodes(node.slice(p++));
 		// Respect code sections
+		if(widget.tag === "pre") {
+			if (node[1][0]==="code") {
+                            widget.type = "codeblock";
+                            widget.attributes = {code: {type: "string", value: node[1][1]}};
+                            delete widget.tag;
+                        }
+		}
 		if(widget.tag === "code") {
-			widget.children = [{type: "codeblock",
-				attributes: {
-					code: {type: "string", value: node[1]}
-				}
-			}];
-			delete widget.tag;
+                        widget.children = [{type: "text", text: node[1]}];
 		}
 		// Massage images into the image widget
 		if(widget.tag === "img") {

--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -13,7 +13,6 @@ Wraps up the markdown-js parser for use in TiddlyWiki5
 "use strict";
 
 
-const brushes = ["apache", "bash", "coffeescript", "cpp", "cs", "css", "diff", "http", "ini", "java", "javascript", "json", "makefile", "markdown", "nginx", "objectivec", "perl", "php", "python", "ruby", "sql", "xml"]
 var markdown = require("$:/plugins/tiddlywiki/markdown/markdown.js");
 
 var CONFIG_DIALECT_TIDDLER = "$:/config/markdown/dialect",
@@ -40,32 +39,12 @@ function transformNode(node) {
 		widget.children = transformNodes(node.slice(p++));
 		// Respect code sections
 		if(widget.tag === "code") {
-                        console.log(node);
-                        if (node[1].indexOf("\n") > 0) {
-                                // Multi line
-                                // Beware of empty lines! :-(
-                                // Let's keep track of an eventual fix at:
-                                // https://github.com/evilstreak/markdown-js/issues/292
-                                var lines = node[1].split("\n");
-                                var language = lines[0];
-                                if (brushes.indexOf(language) > 0) {
-                                    var code = lines.slice(1).join("\n");
-                                }
-                                else {
-                                    var code = lines.join("\n");
-                                    language = "";
-                                }
-                                widget.type = "codeblock";
-                                widget.attributes = {
-                                                code: {type: "string", value: code},
-                                                language: {type: "string", value: language}
-                                }
-                                delete widget.children;
-                                delete widget.tag;
-                        }
-                        else {
-                                widget.children = [{type: "text", text: node[1]}];
-                        }
+			widget.children = [{type: "codeblock",
+				attributes: {
+					code: {type: "string", value: node[1]}
+				}
+			}];
+			delete widget.tag;
 		}
 		// Massage images into the image widget
 		if(widget.tag === "img") {


### PR DESCRIPTION
Hi!
This PR extends the default Markdown plugin to support raw HTML (as per the [spec](https://spec.commonmark.org/0.28/#html-blocks)). In the course of implementing it, it was apparent that it would be possible to parse text as WikiText. This would give the desired effect (raw HTML possible) and also allow for macros.

Had to implement the ability to use `codeblock` widgets (ignoring syntax highlighting for now).

I made sure the examples work.