### PR TITLE
Add name field to server start hook

### DIFF
--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -309,7 +309,7 @@ Command.prototype.execute = function() {
 	if(!$tw.wiki.getTiddler("$:/plugins/tiddlywiki/tiddlyweb") || !$tw.wiki.getTiddler("$:/plugins/tiddlywiki/filesystem")) {
 		$tw.utils.warning("Warning: Plugins required for client-server operation (\"tiddlywiki/filesystem\" and \"tiddlywiki/tiddlyweb\") are missing from tiddlywiki.info file");
 	}
-	$tw.hooks.invokeHook('th-server-command-post-start', this.server, nodeServer);
+	$tw.hooks.invokeHook('th-server-command-post-start', this.server, nodeServer, "tiddlywiki");
 	return null;
 };
 

--- a/editions/dev/tiddlers/new/Hook__th-server-command-post-start.tid
+++ b/editions/dev/tiddlers/new/Hook__th-server-command-post-start.tid
@@ -14,5 +14,7 @@ Hook function parameters:
 ** Defined in core/modules/commands/server.js
 * NodeJS HTTP Server instance
 ** See the NodeJS docs at [ext[https://nodejs.org/docs/latest-v8.x/api/http.html#http_class_http_server]]
+* Name of server invoking this hook (for special handling of the NodeJS HTTP server instance). 
+** Known values: `tiddlywiki`, `tiddlyserver`. 
 
 Return value is ignored.


### PR DESCRIPTION
This allows other server implementations (such as TiddlyServer) to provide custom support for features a plugin wishes to add by access the Node server object. The main example is WebSockets, since many data folders are loaded into TiddlyServer and therefore cannot extend the NodeJS server object. 

Even if they could, TiddlyServer uses two separate server instances. So it's better to do it like this. TiddlyServer uses the SimpleServer router so the first argument of the hook still works fine and is not affected.