### PR TITLE
fixing edit-field state mirrored in each tiddler

### DIFF
--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -11,12 +11,12 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 \end
 
 \define new-field()
-<$vars name={{{ [[$(newFieldTempTiddler)$]get[]] }}}>
+<$vars name={{{ [[$(newFieldTempTiddler)$]get[text]] }}}>
 <$reveal type="nomatch" text="" default=<<name>>>
 <$button>
 <$action-sendmessage $message="tm-add-field"
 $name=<<name>>
-$value={{{ [[$(newFieldValueTempTiddler)$]get[]] }}}/>
+$value={{{ [[$(newFieldValueTempTiddler)$]get[text]] }}}/>
 <$action-deletetiddler $tiddler="$(newFieldTempTiddler)$"/>
 <$action-deletetiddler $tiddler="$(newFieldValueTempTiddler)$"/>
 <<lingo Fields/Add/Button>>
@@ -56,7 +56,7 @@ $value={{{ [[$(newFieldValueTempTiddler)$]get[]] }}}/>
 
 <$wikify name="newFieldTempTiddler" text="""<<qualify "$:/temp/newfieldname">>""">
 <$wikify name="newFieldValueTempTiddler" text="""<<qualify "$:/temp/newfieldvalue">>""">
-<$vars newFieldTitle={{{ [<newFieldTempTiddler>get[]] }}} newFieldValue={{{ [<newFieldValueTempTiddler>get[]] }}}>
+<$vars newFieldTitle={{{ [<newFieldTempTiddler>get[text]] }}} newFieldValue={{{ [<newFieldValueTempTiddler>get[text]] }}}>
 <$fieldmangler>
 <div class="tc-edit-field-add">
 <em class="tc-edit">

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -11,14 +11,14 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 \end
 
 \define new-field()
-<$vars name={{$:/temp/newfieldname}}>
+<$vars name={{{ [[$(newFieldTempTiddler)$]get[]] }}}>
 <$reveal type="nomatch" text="" default=<<name>>>
 <$button>
 <$action-sendmessage $message="tm-add-field"
 $name=<<name>>
-$value={{$:/temp/newfieldvalue}}/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldname"/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldvalue"/>
+$value={{{ [[$(newFieldValueTempTiddler)$]get[]] }}}/>
+<$action-deletetiddler $tiddler="$(newFieldTempTiddler)$"/>
+<$action-deletetiddler $tiddler="$(newFieldValueTempTiddler)$"/>
 <<lingo Fields/Add/Button>>
 </$button>
 </$reveal>
@@ -54,13 +54,16 @@ $value={{$:/temp/newfieldvalue}}/>
 </table>
 </div>
 
+<$wikify name="newFieldTempTiddler" text="""<<qualify "$:/temp/newfieldname">>""">
+<$wikify name="newFieldValueTempTiddler" text="""<<qualify "$:/temp/newfieldvalue">>""">
+<$vars newFieldTitle={{{ [<newFieldTempTiddler>get[]] }}} newFieldValue={{{ [<newFieldValueTempTiddler>get[]] }}}>
 <$fieldmangler>
 <div class="tc-edit-field-add">
 <em class="tc-edit">
 <<lingo Fields/Add/Prompt>>
 </em>
 <span class="tc-edit-field-add-name">
-<$edit-text tiddler="$:/temp/newfieldname" tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Name/Placeholder}} focusPopup=<<qualify "$:/state/popup/field-dropdown">> class="tc-edit-texteditor tc-popup-handle"/>
+<$edit-text tiddler=<<newFieldTempTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Name/Placeholder}} focusPopup=<<qualify "$:/state/popup/field-dropdown">> class="tc-edit-texteditor tc-popup-handle"/>
 </span>
 <$button popup=<<qualify "$:/state/popup/field-dropdown">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Field/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Field/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button>
 <$reveal state=<<qualify "$:/state/popup/field-dropdown">> type="nomatch" text="" default="">
@@ -69,7 +72,7 @@ $value={{$:/temp/newfieldvalue}}/>
 <div class="tc-dropdown-item">
 <<lingo Fields/Add/Dropdown/User>>
 </div>
-<$list filter="[!is[shadow]!is[system]fields[]search:title{$:/temp/newfieldname}sort[]] -created -creator -draft.of -draft.title -modified -modifier -tags -text -title -type"  variable="currentField">
+<$list filter="[!is[shadow]!is[system]fields[]search:title<newFieldTitle>sort[]] -created -creator -draft.of -draft.title -modified -modifier -tags -text -title -type"  variable="currentField">
 <$link to=<<currentField>>>
 <<currentField>>
 </$link>
@@ -77,7 +80,7 @@ $value={{$:/temp/newfieldvalue}}/>
 <div class="tc-dropdown-item">
 <<lingo Fields/Add/Dropdown/System>>
 </div>
-<$list filter="[fields[]search:title{$:/temp/newfieldname}sort[]] -[!is[shadow]!is[system]fields[]]" variable="currentField">
+<$list filter="[fields[]search:title<newFieldTitle>sort[]] -[!is[shadow]!is[system]fields[]]" variable="currentField">
 <$link to=<<currentField>>>
 <<currentField>>
 </$link>
@@ -86,10 +89,13 @@ $value={{$:/temp/newfieldvalue}}/>
 </div>
 </$reveal>
 <span class="tc-edit-field-add-value">
-<$edit-text tiddler="$:/temp/newfieldvalue" tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor"/>
+<$edit-text tiddler=<<newFieldValueTempTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor"/>
 </span>
 <span class="tc-edit-field-add-button">
 <$macrocall $name="new-field"/>
 </span>
 </div>
 </$fieldmangler>
+</$vars>
+</$wikify>
+</$wikify>


### PR DESCRIPTION
this fixes that editing a field shows the text for name and value in each tiddler that's opened for editing