### PR TITLE
fix bibtex import problem with unix systems 

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1999,6 +1999,7 @@ $tw.boot.startup = function(options) {
 	$tw.utils.registerFileType("application/vnd.openxmlformats-officedocument.wordprocessingml.document","base64",".docx");
 	$tw.utils.registerFileType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet","base64",".xlsx");
 	$tw.utils.registerFileType("application/vnd.openxmlformats-officedocument.presentationml.presentation","base64",".pptx");
+	$tw.utils.registerFileType("text/x-bibtex","utf8",".bib",{deserializerType:"application/x-bibtex"});
 	$tw.utils.registerFileType("application/x-bibtex","utf8",".bib");
 	$tw.utils.registerFileType("application/epub+zip","base64",".epub");
 	// Create the wiki store for the app


### PR DESCRIPTION
fix a problem with ubuntu 18.04, which returns text/x-bibtex instead of application/x-bibtex. ...

reported at: https://github.com/Jermolene/TiddlyWiki5/issues/3039#issuecomment-388743869

@gse-cc-git  can you test the attached index.zip It contains empty.html. ... It does contain the fix, but no plugins !!!!

[index.zip](https://github.com/Jermolene/TiddlyWiki5/files/2006010/index.zip)
