### PR TITLE
List order

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -559,10 +559,10 @@ exports.sortByList = function(array,listTitle) {
 		}
 		// Finally obey the list-before and list-after fields of each tiddler in turn
 		var sortedTitles = titles.slice(0),
-			replacedTitles = {},
+			replacedTitles = Object.create(null),
 			self = this;
 		function replaceItem(title) {
-			if(!replacedTitles[title]) {
+			if(!$tw.utils.hop(replacedTitles, title)) {
 				replacedTitles[title] = true;
 				var newPos = -1,
 					tiddler = self.getTiddler(title);

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -558,39 +558,49 @@ exports.sortByList = function(array,listTitle) {
 			}
 		}
 		// Finally obey the list-before and list-after fields of each tiddler in turn
-		var sortedTitles = titles.slice(0);
-		for(t=0; t<sortedTitles.length; t++) {
-			title = sortedTitles[t];
-			var currPos = titles.indexOf(title),
-				newPos = -1,
-				tiddler = this.getTiddler(title);
-			if(tiddler) {
-				var beforeTitle = tiddler.fields["list-before"],
-					afterTitle = tiddler.fields["list-after"];
-				if(beforeTitle === "") {
-					newPos = 0;
-				} else if(afterTitle === "") {
-					newPos = titles.length;
-				} else if(beforeTitle) {
-					newPos = titles.indexOf(beforeTitle);
-				} else if(afterTitle) {
-					newPos = titles.indexOf(afterTitle);
-					if(newPos >= 0) {
-						++newPos;
+		var sortedTitles = titles.slice(0),
+			replacedTitles = {},
+			self = this;
+		function replaceItem(title) {
+			if(!replacedTitles[title]) {
+				replacedTitles[title] = true;
+				var newPos = -1,
+					tiddler = self.getTiddler(title);
+				if(tiddler) {
+					var beforeTitle = tiddler.fields["list-before"],
+						afterTitle = tiddler.fields["list-after"];
+					if(beforeTitle === "") {
+						newPos = 0;
+					} else if(afterTitle === "") {
+						newPos = titles.length;
+					} else if(beforeTitle) {
+						replaceItem(beforeTitle);
+						newPos = titles.indexOf(beforeTitle);
+					} else if(afterTitle) {
+						replaceItem(afterTitle);
+						newPos = titles.indexOf(afterTitle);
+						if(newPos >= 0) {
+							++newPos;
+						}
 					}
-				}
-				if(newPos === -1) {
-					newPos = currPos;
-				}
-				if(newPos !== currPos) {
-					titles.splice(currPos,1);
-					if(newPos >= currPos) {
-						newPos--;
+					// We get the currPos //after// figuring out the newPos, because recursive replaceItem calls might alter title's currPos
+					var currPos = titles.indexOf(title);
+					if(newPos === -1) {
+						newPos = currPos;
 					}
-					titles.splice(newPos,0,title);
+					if(newPos !== currPos) {
+						titles.splice(currPos,1);
+						if(newPos >= currPos) {
+							newPos--;
+						}
+						titles.splice(newPos,0,title);
+					}
 				}
 			}
-
+		};
+		for(t=0; t<sortedTitles.length; t++) {
+			title = sortedTitles[t];
+			replaceItem(title);
 		}
 		return titles;
 	}

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -588,7 +588,7 @@ exports.sortByList = function(array,listTitle) {
 					if(newPos === -1) {
 						newPos = currPos;
 					}
-					if(newPos !== currPos) {
+					if(currPos >= 0 && newPos !== currPos) {
 						titles.splice(currPos,1);
 						if(newPos >= currPos) {
 							newPos--;

--- a/editions/test/tiddlers/tests/test-tags.js
+++ b/editions/test/tiddlers/tests/test-tags.js
@@ -130,6 +130,15 @@ describe("Tag tests", function() {
 
 		expect(wiki.filterTiddlers("[tag[sortTag]]").join(',')).toBe("A,B,C");
 	});
+
+	it("should handle javascript-specific titles", function() {
+		var wiki = new $tw.Wiki();
+
+		wiki.addTiddler({ title: "A", text: "", tags: "sortTag"});
+		wiki.addTiddler({ title: "__proto__", text: "", tags: "sortTag", "list-before": ""});
+
+		expect(wiki.filterTiddlers("[tag[sortTag]]").join(',')).toBe("__proto__,A");
 });
+	});
 
 })();

--- a/editions/test/tiddlers/tests/test-tags.js
+++ b/editions/test/tiddlers/tests/test-tags.js
@@ -116,6 +116,20 @@ describe("Tag tests", function() {
 
 		expect(wiki.filterTiddlers("[tag[sortTag]]").join(',')).toBe("B,C,A");
 	});
+
+	// If a tiddler in the tag references a tiddler OUTSIDE of the tag
+	// with list-after/before, we need to make sure we don't accidentally
+	// handle that external tiddler, or that reference.
+	it("should gracefully handle dependencies that aren't in the tag list", function() {
+		var wiki = new $tw.Wiki();
+
+		wiki.addTiddler({ title: "A", text: "", tags: "sortTag"});
+		wiki.addTiddler({ title: "B", text: "", tags: "sortTag", "list-after": "Z"});
+		wiki.addTiddler({ title: "C", text: "", tags: "sortTag"});
+		wiki.addTiddler({ title: "Z", text: "", tags: "EXCLUDED", "list-before": ""});
+
+		expect(wiki.filterTiddlers("[tag[sortTag]]").join(',')).toBe("A,B,C");
+	});
 });
 
 })();

--- a/editions/test/tiddlers/tests/test-tags.js
+++ b/editions/test/tiddlers/tests/test-tags.js
@@ -138,7 +138,7 @@ describe("Tag tests", function() {
 		wiki.addTiddler({ title: "__proto__", text: "", tags: "sortTag", "list-before": ""});
 
 		expect(wiki.filterTiddlers("[tag[sortTag]]").join(',')).toBe("__proto__,A");
-});
 	});
+});
 
 })();

--- a/editions/test/tiddlers/tests/test-tags.js
+++ b/editions/test/tiddlers/tests/test-tags.js
@@ -86,6 +86,36 @@ describe("Tag tests", function() {
 		expect(wiki.filterTiddlers("[tag[TiddlerSeventh]]").join(",")).toBe("Tiddler10,TiddlerOne,Tiddler Three,Tiddler11,Tiddler9,a fourth tiddler");
 	});
 
+	// Tests for issue (#3296)
+	it("should apply tag ordering in order of dependency", function () {
+		var wiki = new $tw.Wiki();
+
+		wiki.addTiddler({ title: "A", text: "", tags: "sortTag", "list-after": "B"});
+		wiki.addTiddler({ title: "B", text: "", tags: "sortTag", "list-after": "C"});
+		wiki.addTiddler({ title: "C", text: "", tags: "sortTag"});
+
+		expect(wiki.filterTiddlers("[tag[sortTag]]").join(',')).toBe("C,B,A");
+	});
+
+	it("should handle self-referencing dependency without looping infinitely", function() {
+		var wiki = new $tw.Wiki();
+
+		wiki.addTiddler({ title: "A", text: "", tags: "sortTag"});
+		wiki.addTiddler({ title: "B", text: "", tags: "sortTag", "list-after": "B"});
+		wiki.addTiddler({ title: "C", text: "", tags: "sortTag"});
+
+		expect(wiki.filterTiddlers("[tag[sortTag]]").join(',')).toBe("A,B,C");
+	});
+
+	it("should handle empty list-after ordering", function() {
+		var wiki = new $tw.Wiki();
+
+		wiki.addTiddler({ title: "A", text: "", tags: "sortTag", "list-after": ""});
+		wiki.addTiddler({ title: "B", text: "", tags: "sortTag"});
+		wiki.addTiddler({ title: "C", text: "", tags: "sortTag"});
+
+		expect(wiki.filterTiddlers("[tag[sortTag]]").join(',')).toBe("B,C,A");
+	});
 });
 
 })();


### PR DESCRIPTION
Fix for (#3296), custom tag ordering could mess up when some instances of `list-after` and `list-before` are processed in a bad order.

This solution creates a function which is called for every title in the list instead of just a loop. That way, this function can be recursively called on titles further down the list if they need to be placed before the current title can be ordered around it.

For tests, I created new tests that individually test the problems, instead of working with the amalgamate test that was already there. In my experience, those kind of individual tests are easier to diagnose and understand when something goes wrong. Also added a test for the blank `list-after` feature added last month.