### PR TITLE
Allow all methods and add bodyFormat property to route definition

### DIFF
--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -200,10 +200,10 @@ Server.prototype.requestHandler = function(request,response) {
 	// TODO: Presumably this would need tweaking if we supported PUTting binary tiddlers
 	request.setEncoding("utf8");
 	// Dispatch the appropriate method
-	if(route.bodyFormat === "stream" || !route.bodyFormat || request.method === "GET" || request.method === "HEAD"){
-		//let the route handle the request stream itself if there is one
+	if(route.bodyFormat === "stream" || request.method === "GET" || request.method === "HEAD"){
+		//let the route handle the request stream itself
 		route.handler(request,response,state);
-	} else if(route.bodyFormat === "string"){
+	} else if(route.bodyFormat === "string" || !route.bodyFormat){
 		var data = "";
 		request.on("data",function(chunk) {
 			data += chunk.toString();


### PR DESCRIPTION
This allows all methods to be used as routes and also adds a `bodyFormat` property to allow routes to specify which format they want the request body in. 

 - `string` is the current method of receiving the body as a string and is set as default.
 - `buffer` dumps the chunks into an array and then calls `Buffer.concat` with the array.
 - `stream` does nothing and immediately calls the route handler.

If a route doesn't specify `bodyFormat` it defaults to `string`. 

GET and HEAD requests are always treated as `stream` requests -- `bodyFormat` is ignored.