### PR TITLE
[keyboard widget]refresh if config tiddler changes

### DIFF
--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -79,6 +79,7 @@ KeyboardWidget.prototype.execute = function() {
 	this.tag = this.getAttribute("tag");
 	this.keyInfoArray = $tw.keyboardManager.parseKeyDescriptors(this.key);
 	this["class"] = this.getAttribute("class");
+	this.shortcutKeyDescriptor = this.key.match(/^\(\(.*\)\)$/g) ? this.key.replace(/^\(\(/,'').replace(/\)\)$/,'') : undefined;
 	// Make child widgets
 	this.makeChildWidgets();
 };
@@ -88,7 +89,8 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 KeyboardWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.message || changedAttributes.param || changedAttributes.key || changedAttributes["class"] || changedAttributes.tag) {
+	if(changedAttributes.message || changedAttributes.param || changedAttributes.key || changedAttributes["class"] || changedAttributes.tag ||
+	  (this.shortcutKeyDescriptor && changedTiddlers["$:/config/shortcuts/" + this.shortcutKeyDescriptor])) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -79,6 +79,7 @@ KeyboardWidget.prototype.execute = function() {
 	this.tag = this.getAttribute("tag");
 	this.keyInfoArray = $tw.keyboardManager.parseKeyDescriptors(this.key);
 	this["class"] = this.getAttribute("class");
+	this.shortcutKeyDescriptor = this.key.match(/^\(\(.*\)\)$/g) ? this.key.replace(/^\(\(/,'').replace(/\)\)$/,'') : undefined;
 	// Make child widgets
 	this.makeChildWidgets();
 };
@@ -89,7 +90,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 KeyboardWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.message || changedAttributes.param || changedAttributes.key || changedAttributes["class"] || changedAttributes.tag ||
-	  ($tw.keyboardManager.parseKeyDescriptors(this.key) !== this.keyInfoArray)) {
+	  (this.shortcutKeyDescriptor && changedTiddlers["$:/config/shortcuts/" + this.shortcutKeyDescriptor])) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -79,7 +79,6 @@ KeyboardWidget.prototype.execute = function() {
 	this.tag = this.getAttribute("tag");
 	this.keyInfoArray = $tw.keyboardManager.parseKeyDescriptors(this.key);
 	this["class"] = this.getAttribute("class");
-	this.shortcutKeyDescriptor = this.key.match(/^\(\(.*\)\)$/g) ? this.key.replace(/^\(\(/,'').replace(/\)\)$/,'') : undefined;
 	// Make child widgets
 	this.makeChildWidgets();
 };
@@ -90,7 +89,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 KeyboardWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.message || changedAttributes.param || changedAttributes.key || changedAttributes["class"] || changedAttributes.tag ||
-	  (this.shortcutKeyDescriptor && changedTiddlers["$:/config/shortcuts/" + this.shortcutKeyDescriptor])) {
+	  ($tw.keyboardManager.parseKeyDescriptors(this.key) !== this.keyInfoArray)) {
 		this.refreshSelf();
 		return true;
 	}


### PR DESCRIPTION
this makes the keyboard widget refresh, if the config tiddler changes ("$:/config/shortcuts/...")
so one can change a shortcut for the text-editor without having to close and open the tiddler again in order to have the new shortcut applied