### PR TITLE
Improvements to the static single tiddler view as well as documentation.

### DIFF
--- a/core/modules/server/routes/get-tiddler-html.js
+++ b/core/modules/server/routes/get-tiddler-html.js
@@ -14,7 +14,7 @@ GET /:title
 
 exports.method = "GET";
 
-exports.path = /^\/view\/([^\/]+)$/;
+exports.path = /^\/([^\/]+)$/;
 
 exports.handler = function(request,response,state) {
 	var title = decodeURIComponent(state.params[0]),

--- a/core/modules/server/routes/get-tiddler-html.js
+++ b/core/modules/server/routes/get-tiddler-html.js
@@ -18,10 +18,10 @@ exports.path = /^\/view\/([^\/]+)$/;
 
 exports.handler = function(request,response,state) {
 	var title = decodeURIComponent(state.params[0]),
-	    tiddler = state.wiki.getTiddler(title);
+		tiddler = state.wiki.getTiddler(title);
 	if(tiddler) {
 		var renderType = tiddler.getFieldString("_render_type"),
-		    renderTemplate = tiddler.getFieldString("_render_template");
+			renderTemplate = tiddler.getFieldString("_render_template");
 		// Tiddler fields '_render_type' and '_render_template' overwrite
 		// system wide settings for render type and template
 		if(state.wiki.isSystemTiddler(title)) {

--- a/core/modules/server/routes/get-tiddler-html.js
+++ b/core/modules/server/routes/get-tiddler-html.js
@@ -14,22 +14,24 @@ GET /:title
 
 exports.method = "GET";
 
-exports.path = /^\/([^\/]+)$/;
+exports.path = /^\/view\/([^\/]+)$/;
 
 exports.handler = function(request,response,state) {
 	var title = decodeURIComponent(state.params[0]),
 		tiddler = state.wiki.getTiddler(title);
 	if(tiddler) {
-		var renderType,template;
-		// Render ordinary tiddlers as HTML, and system tiddlers in plain text
+        var renderType = tiddler.getFieldString("_render_type"),
+            renderTemplate = tiddler.getFieldString("_render_template");
+        // Tiddler fields '_render_type' and '_render_template' overwrite
+        // system wide settings for render type and template
 		if(state.wiki.isSystemTiddler(title)) {
-			renderType = state.server.get("system-tiddler-render-type");
-			template = state.server.get("system-tiddler-template");
+			renderType = renderType || state.server.get("system-tiddler-render-type");
+			renderTemplate = renderTemplate || state.server.get("system-tiddler-render-template");
 		} else {
-			renderType = state.server.get("tiddler-render-type");
-			template = state.server.get("tiddler-template");
+			renderType = renderType || state.server.get("tiddler-render-type");
+			renderTemplate = renderTemplate || state.server.get("tiddler-render-template");
 		}
-		var text = state.wiki.renderTiddler(renderType,template,{parseAsInline: true, variables: {currentTiddler: title}});
+		var text = state.wiki.renderTiddler(renderType,renderTemplate,{parseAsInline: true, variables: {currentTiddler: title}});
 		// Naughty not to set a content-type, but it's the easiest way to ensure the browser will see HTML pages as HTML, and accept plain text tiddlers as CSS or JS
 		response.writeHead(200);
 		response.end(text,"utf8");

--- a/core/modules/server/routes/get-tiddler-html.js
+++ b/core/modules/server/routes/get-tiddler-html.js
@@ -18,12 +18,12 @@ exports.path = /^\/view\/([^\/]+)$/;
 
 exports.handler = function(request,response,state) {
 	var title = decodeURIComponent(state.params[0]),
-		tiddler = state.wiki.getTiddler(title);
+	    tiddler = state.wiki.getTiddler(title);
 	if(tiddler) {
-        var renderType = tiddler.getFieldString("_render_type"),
-            renderTemplate = tiddler.getFieldString("_render_template");
-        // Tiddler fields '_render_type' and '_render_template' overwrite
-        // system wide settings for render type and template
+		var renderType = tiddler.getFieldString("_render_type"),
+		    renderTemplate = tiddler.getFieldString("_render_template");
+		// Tiddler fields '_render_type' and '_render_template' overwrite
+		// system wide settings for render type and template
 		if(state.wiki.isSystemTiddler(title)) {
 			renderType = renderType || state.server.get("system-tiddler-render-type");
 			renderTemplate = renderTemplate || state.server.get("system-tiddler-render-template");

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -81,9 +81,9 @@ Server.prototype.defaultVariables = {
 	"root-render-type": "text/plain",
 	"root-serve-type": "text/html",
 	"tiddler-render-type": "text/html",
-	"tiddler-template": "$:/core/templates/server/static.tiddler.html",
+	"tiddler-render-template": "$:/core/templates/server/static.tiddler.html",
 	"system-tiddler-render-type": "text/plain",
-	"system-tiddler-template": "$:/core/templates/wikified-tiddler",
+	"system-tiddler-render-template": "$:/core/templates/wikified-tiddler",
 	"debug-level": "none"
 };
 

--- a/editions/tw5.com/tiddlers/webserver/Using the read-only single tiddler view.tid
+++ b/editions/tw5.com/tiddlers/webserver/Using the read-only single tiddler view.tid
@@ -1,22 +1,22 @@
 created: 20180703095435813
-modified: 20180808094239047
+modified: 20180810052903401
 tags: [[WebServer Guides]]
 title: Using the read-only single tiddler view
 type: text/vnd.tiddlywiki
 
 TiddlyWiki's experimental single tiddler per page, read-only view uses a simplified page layout, and implements links between tiddlers, but there are no other interactive features. Compared to a full TiddlyWiki user interface, it is very lightweight and usable even over very slow connections.
 
-Alongside serving the full interactive wiki at the path `/` (e.g. http://127.0.0.1:8080/), TiddlyWiki serves each tiddler at the path `/<url-encoded-tiddler-title>`. For example:
+Alongside serving the full interactive wiki at the path `/` (e.g. http://127.0.0.1:8080/), TiddlyWiki serves each tiddler at the path `/view/<url-encoded-tiddler-title>`. For example:
 
-* http://127.0.0.1:8080/HelloThere
-* http://127.0.0.1:8080/Philosophy%20of%20Tiddlers
+* http://127.0.0.1:8080/view/HelloThere
+* http://127.0.0.1:8080/view/Philosophy%20of%20Tiddlers
 
-Ordinary, non-system tiddlers are rendered through a special view template while system tiddlers are rendered through a template that returns the raw text of the rendered output. In this way ordinary tiddlers can be browsed by end users while system tiddlers can be included in their raw form to use them as JS, HTML or CSS templates.
+Ordinary, non-system tiddlers are rendered through a special view template while system tiddlers are rendered through a template that returns the raw text of the rendered output. In this way ordinary tiddlers can be browsed by end users while system tiddlers can be included in their raw form to use them as JS, HTML or CSS templates. Additionally these defaults can be overwritten on a per tiddler basis by specifying the `_render_type` and `_render_template` fields accordingly.
 
 The templates are controlled by these parameters:
 
 * [[system-tiddler-render-type|WebServer Parameter: system-tiddler-render-type]]
-* [[system-tiddler-template|WebServer Parameter: system-tiddler-template]]
+* [[system-tiddler-template|WebServer Parameter: system-tiddler-render-template]]
 * [[tiddler-render-type|WebServer Parameter: tiddler-render-type]]
-* [[tiddler-template|WebServer Parameter: tiddler-template]]
+* [[tiddler-template|WebServer Parameter: tiddler-render-template]]
 

--- a/editions/tw5.com/tiddlers/webserver/Using the read-only single tiddler view.tid
+++ b/editions/tw5.com/tiddlers/webserver/Using the read-only single tiddler view.tid
@@ -1,15 +1,15 @@
 created: 20180703095435813
-modified: 20180810052903401
+modified: 20180824073211367
 tags: [[WebServer Guides]]
 title: Using the read-only single tiddler view
 type: text/vnd.tiddlywiki
 
 TiddlyWiki's experimental single tiddler per page, read-only view uses a simplified page layout, and implements links between tiddlers, but there are no other interactive features. Compared to a full TiddlyWiki user interface, it is very lightweight and usable even over very slow connections.
 
-Alongside serving the full interactive wiki at the path `/` (e.g. http://127.0.0.1:8080/), TiddlyWiki serves each tiddler at the path `/view/<url-encoded-tiddler-title>`. For example:
+Alongside serving the full interactive wiki at the path `/` (e.g. http://127.0.0.1:8080/), TiddlyWiki serves each tiddler at the path `/<url-encoded-tiddler-title>`. For example:
 
-* http://127.0.0.1:8080/view/HelloThere
-* http://127.0.0.1:8080/view/Philosophy%20of%20Tiddlers
+* http://127.0.0.1:8080/HelloThere
+* http://127.0.0.1:8080/Philosophy%20of%20Tiddlers
 
 Ordinary, non-system tiddlers are rendered through a special view template while system tiddlers are rendered through a template that returns the raw text of the rendered output. In this way ordinary tiddlers can be browsed by end users while system tiddlers can be included in their raw form to use them as JS, HTML or CSS templates. Additionally these defaults can be overwritten on a per tiddler basis by specifying the `_render_type` and `_render_template` fields accordingly.
 

--- a/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ system-tiddler-render-template.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ system-tiddler-render-template.tid
@@ -1,8 +1,10 @@
 caption: system-tiddler-render-template
 created: 20180808094408813
-modified: 20180808094527464
+modified: 20180810053154669
 tags: [[WebServer Parameters]]
 title: WebServer Parameter: system-tiddler-render-template
 type: text/vnd.tiddlywiki
 
 The [[web server configuration parameter|WebServer Parameters]] ''system-tiddler-render-template'' is used to specify the template for serving system tiddlers in the [[read-only single tiddler view|Using the read-only single tiddler view]]. The default value is `$:/core/templates/wikified-tiddler` which renders the tiddler raw, without any special viewing template.
+
+<<.tip "This setting may be overwritten by specifying the `_render_template` field of a tiddler.">>

--- a/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ system-tiddler-render-type.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ system-tiddler-render-type.tid
@@ -1,8 +1,10 @@
 caption: system-tiddler-render-type
 created: 20180808092758577
-modified: 20180808093056528
+modified: 20180810053136312
 tags: [[WebServer Parameters]]
 title: WebServer Parameter: system-tiddler-render-type
 type: text/vnd.tiddlywiki
 
 The [[web server configuration parameter|WebServer Parameters]] ''system-tiddler-render-type'' is used to specify the render type for serving system tiddlers in the [[read-only single tiddler view|Using the read-only single tiddler view]]. The default value is `text/plain`, causing the raw text of rendered system tiddlers to be returned. Alternatively, `text/html` can be used to cause the full HTML of the rendered tiddlers to be returned.
+
+<<.tip "This setting may be overwritten by specifying the `_render_type` field of a tiddler.">>

--- a/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ tiddler-render-template.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ tiddler-render-template.tid
@@ -1,8 +1,10 @@
 caption: tiddler-render-template
 created: 20180808094255388
-modified: 20180808094407363
+modified: 20180810053232494
 tags: [[WebServer Parameters]]
 title: WebServer Parameter: tiddler-render-template
 type: text/vnd.tiddlywiki
 
 The [[web server configuration parameter|WebServer Parameters]] ''tiddler-render-template'' is used to specify the template for serving ordinary, non-system tiddlers in the [[read-only single tiddler view|Using the read-only single tiddler view]]. The default value is `$:/core/templates/server/static.tiddler.html` which renders tiddlers in a lightweight page with a simple sidebar.
+
+<<.tip "This setting may be overwritten by specifying the `_render_template` field of a tiddler.">>

--- a/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ tiddler-render-type.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ tiddler-render-type.tid
@@ -1,8 +1,10 @@
 caption: tiddler-render-type
 created: 20180808093108099
-modified: 20180808093218128
+modified: 20180810053128531
 tags: [[WebServer Parameters]]
 title: WebServer Parameter: tiddler-render-type
 type: text/vnd.tiddlywiki
 
 The [[web server configuration parameter|WebServer Parameters]] ''tiddler-render-type'' is used to specify the render type for serving ordinary, non-system tiddlers in the [[read-only single tiddler view|Using the read-only single tiddler view]]. The default value is `text/html`, causing the full HTML of the rendered output to be returned. Alternatively, `text/html` can be used to cause the raw text of rendered system tiddlers to be returned.
+
+<<.tip "This setting may be overwritten by specifying the `_render_type` field of a tiddler.">>


### PR DESCRIPTION
This adds the following things:

* Path to the single tiddler view is now `/view/<tiddler title>`. This prevents name conflicts with api endpoints such as `/status` or `/login-basic` as well as any future plugin-defined paths (since the current regex almost always takes precedence)

* Added per tiddler options to overwrite the default render type and render template via the fields `_render_type` and `_render_template`

* Sanitized parameters to conform to the same format

This also comes with updated documentation.

/Andreas