### PR TITLE
Add true "single tiddler mode"

### DIFF
--- a/core/language/en-GB/SideBar.multids
+++ b/core/language/en-GB/SideBar.multids
@@ -4,6 +4,7 @@ All/Caption: All
 Contents/Caption: Contents
 Drafts/Caption: Drafts
 Explorer/Caption: Explorer
+History/Caption: History
 Missing/Caption: Missing
 More/Caption: More
 Open/Caption: Open

--- a/core/modules/filters/getstoryviewsingletiddlermode.js
+++ b/core/modules/filters/getstoryviewsingletiddlermode.js
@@ -1,0 +1,35 @@
+/*\
+title: $:/core/modules/filters/getstoryviewsingletiddlermode.js
+type: application/javascript
+module-type: filteroperator
+
+Filter operator for retrieving the single tiddler mode status of a storyview.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter functions
+*/
+
+exports.getstoryviewsingletiddlermode = function(source,operator,options) {
+	// Initialise the storyviews if they've not been done already
+	var storyviews = {};
+	$tw.modules.applyMethods("storyview",storyviews);
+	var results = [];
+	source(function(tiddler,title) {
+		var storyview = storyviews[title];
+		if(storyview && storyview.singleTiddlerMode) {
+			results.push("yes");			
+		} else {
+			results.push("no");
+		}
+	});
+	return results;
+};
+
+})();

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -39,6 +39,9 @@ var ZoominListView = function(listWidget) {
 	});
 };
 
+// Engage single tiddler mode
+ZoominListView.singleTiddlerMode = true;
+
 ZoominListView.prototype.navigateTo = function(historyInfo) {
 	var duration = $tw.utils.getAnimationDuration(),
 		listElementIndex = this.listWidget.findListItem(0,historyInfo.title);

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -116,7 +116,11 @@ NavigatorWidget.prototype.replaceFirstTitleInStory = function(storyList,oldTitle
 };
 
 NavigatorWidget.prototype.addToStory = function(title,fromTitle) {
-	this.wiki.addToStory(title,fromTitle,this.storyTitle,{openLinkFromInsideRiver: this.getAttribute("openLinkFromInsideRiver","top"),openLinkFromOutsideRiver: this.getAttribute("openLinkFromOutsideRiver","top")});
+	this.wiki.addToStory(title,fromTitle,this.storyTitle,{
+		openLinkFromInsideRiver: this.getAttribute("openLinkFromInsideRiver","top"),
+		openLinkFromOutsideRiver: this.getAttribute("openLinkFromOutsideRiver","top"),
+		singleTiddlerMode: this.getAttribute("singleTiddlerMode","no") === "yes",
+	});
 };
 
 /*

--- a/core/templates/single.tiddler.window.tid
+++ b/core/templates/single.tiddler.window.tid
@@ -12,7 +12,7 @@ title: $:/core/templates/single.tiddler.window
 
 <$importvariables filter="[[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]">
 
-<$navigator story="$:/StoryList" history="$:/HistoryList">
+<$navigator story="$:/StoryList" history="$:/HistoryList" singleTiddlerMode={{{ [{$:/view}getstoryviewsingletiddlermode[]] }}}>
 
 <$transclude mode="block"/>
 

--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -22,7 +22,7 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 
 <div class=<<containerClasses>>>
 
-<$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
+<$navigator story="$:/StoryList" history="$:/HistoryList" singleTiddlerMode={{{ [{$:/view}getstoryviewsingletiddlermode[]] }}} openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
 
 <$dropzone>
 

--- a/core/ui/SideBar/History.tid
+++ b/core/ui/SideBar/History.tid
@@ -1,0 +1,5 @@
+title: $:/core/ui/SideBar/History
+tags: $:/tags/SideBar
+caption: {{$:/language/SideBar/History/Caption}}
+
+<$list filter="[list[$:/HistoryList]limit[100]]" template="$:/core/ui/ListItemTemplate"/>

--- a/core/wiki/tags/SideBar.tid
+++ b/core/wiki/tags/SideBar.tid
@@ -1,3 +1,3 @@
 title: $:/tags/SideBar
-list: [[$:/core/ui/SideBar/Open]] [[$:/core/ui/SideBar/Recent]] [[$:/core/ui/SideBar/Tools]] [[$:/core/ui/SideBar/More]]
+list: [[$:/core/ui/SideBar/Open]] [[$:/core/ui/SideBar/History]] [[$:/core/ui/SideBar/Recent]] [[$:/core/ui/SideBar/Tools]] [[$:/core/ui/SideBar/More]]
 

--- a/editions/tw5.com/tiddlers/workingwithtw/Performance.tid
+++ b/editions/tw5.com/tiddlers/workingwithtw/Performance.tid
@@ -1,5 +1,5 @@
 created: 20150330155120127
-modified: 20160607145222633
+modified: 20180824083527982
 tags: [[Working with TiddlyWiki]]
 title: Performance
 type: text/vnd.tiddlywiki
@@ -9,4 +9,4 @@ TiddlyWiki ships with defaults that are designed to get the best out of modern d
 * ''Avoid the "Recent" tab''. It is computationally slow to generate and update in response to tiddler changes.
 * ''Use the "Vanilla" theme''. The default "Snow White" theme includes visual effects like shadows, transparency and blurring that can be slow to render on older devices
 * ''Avoid large tiddlers''. Large bitmaps can significantly slow TiddlyWiki's performance. For example, an image taken with a modern smartphone will often be 5MB or more. Use ExternalImages whenever possible
-* ''Don't have too many tiddlers open at once''. Every tiddler you have open will require processing to keep it up to date as the store changes (for example, while you type into a draft tiddler). It is particularly easy when using zoomin story view to end up with dozens of tiddlers listed in the ''Open'' tab in the sidebar. Get into the habit of periodically closing all open tiddlers with the {{$:/core/images/close-all-button}} ''close all'' button
+* ''Don't have too many tiddlers open at once''. Every tiddler you have open will require processing to keep it up to date as the store changes (for example, while you type into a draft tiddler). It is easy to end up with dozens of tiddlers listed in the ''Open'' tab in the sidebar. Get into the habit of periodically closing all open tiddlers with the {{$:/core/images/close-all-button}} ''close all'' button, or use zoomin story view which only keeps one tiddler open at a time.


### PR DESCRIPTION
As @twMat noted in #1938 nearly three years ago, the current "zoomin" storyview suffers from some annoying limitations/quirks. This PR adds a proper "single tiddler mode" to the core in which only a single tiddler is displayed in the story river.

The changes involved are:

* Storyviews now expose a static "singleTiddlerMode" property to determine if they require single tiddler mode
* Navigator widget adds a "singleTiddlerMode" attribute; when set to "yes", the story list is entirely replaced during navigation
* Navigator widget now updates "list" field of $:/HistoryList with a more accessible version of the history list
* Add a getstoryviewsingletiddlermode[] operator so that we can obtain the story view STM status for passing to the navigator widget
* Add "History" sidebar tab because it is much more useful than the existing "Open" tab when in STM. However, I do not want to add another top level sidebar tab, so will need to find another way to handle this

There are still some issues to be resolved:

* The story river isn't yet adjusted when switching to a story view with STM enabled
* The usual zoomin animation is broken
* `$:/DefaultTiddlers` isn't yet adjusted, so multiple tiddlers are currently being opened at startup
