### PR TITLE
Add `text/asciidoc` MIME type

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1998,6 +1998,7 @@ $tw.boot.startup = function(options) {
 	$tw.utils.registerFileType("audio/mp4","base64",[".mp4",".m4a"]);
 	$tw.utils.registerFileType("text/markdown","utf8",[".md",".markdown"],{deserializerType:"text/x-markdown"});
 	$tw.utils.registerFileType("text/x-markdown","utf8",[".md",".markdown"]);
+	$tw.utils.registerFileType("text/asciidoc","utf8",[".ad",".adoc",".asciidoc"]);
 	$tw.utils.registerFileType("application/enex+xml","utf8",".enex");
 	$tw.utils.registerFileType("application/vnd.openxmlformats-officedocument.wordprocessingml.document","base64",".docx");
 	$tw.utils.registerFileType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet","base64",".xlsx");


### PR DESCRIPTION
This type is not registered yet officially (https://github.com/asciidoctor/asciidoctor/issues/2502), but used by "Asciidoctor for TiddlyWiki" plugin (https://bimlas.gitlab.io/tw5-asciidoctor/).