### PR TITLE
Fix list macros for special tag-names

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -16,14 +16,14 @@ tags: $:/tags/Macro
 \end
 
 \define list-links-draggable-drop-actions()
-<$action-listops $tiddler=<<targetTiddler>> $field=<<targetField>> $subfilter="+[insertbefore:currentTiddler<actionTiddler>]"/>
+<$action-listops $tiddler=<<__tiddler__>> $field=<<__field__>> $subfilter="+[insertbefore:currentTiddler<actionTiddler>]"/>
 \end
 
 \define list-links-draggable(tiddler,field:"list",type:"ul",subtype:"li",class:"",itemTemplate)
-<$vars targetTiddler="""$tiddler$""" targetField="""$field$""">
+<$vars listField={{{ [<__tiddler__>addsuffix[!!]addsuffix<__field__>] }}}>
 <$type$ class="$class$">
-<$list filter="[list[$tiddler$!!$field$]]">
-<$droppable actions=<<list-links-draggable-drop-actions>> tag="""$subtype$""">
+<$list filter="[list<listField>]">
+<$droppable actions=<<list-links-draggable-drop-actions>> tag="div">
 <div class="tc-droppable-placeholder">
 &nbsp;
 </div>
@@ -52,24 +52,24 @@ tags: $:/tags/Macro
 
 \define list-tagged-draggable-drop-actions()
 <!-- Save the current ordering of the tiddlers with this tag -->
-<$set name="order" filter="[<tag>tagging[]]">
+<$set name="order" filter="[<__tag__>tagging[]]">
 <!-- Remove any list-after or list-before fields from the tiddlers with this tag -->
-<$list filter="[<tag>tagging[]]">
+<$list filter="[<__tag__>tagging[]]">
 <$action-deletefield $field="list-before"/>
 <$action-deletefield $field="list-after"/>
 </$list>
 <!-- Assign the list field of the tag with the current ordering -->
-<$action-setfield $tiddler=<<tag>> $field="list" $value=<<order>>/>
+<$action-setfield $tiddler=<<__tag__>> $field="list" $value=<<order>>/>
 <!-- Add the newly inserted item to the list -->
-<$action-listops $tiddler=<<tag>> $field="list" $subfilter="+[insertbefore:currentTiddler<actionTiddler>]"/>
+<$action-listops $tiddler=<<__tag__>> $field="list" $subfilter="+[insertbefore:currentTiddler<actionTiddler>]"/>
 <!-- Make sure the newly added item has the right tag -->
-<$action-listops $tiddler=<<actionTiddler>> $tags="[<tag>]"/>
+<$action-listops $tiddler=<<actionTiddler>> $tags="[<__tag__>]"/>
 </$set>
 \end
 
 \define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div")
-<$set name="tag" value="""$tag$""">
-<$list filter="[<tag>tagging[]$subFilter$]" emptyMessage=<<__emptyMessage__>>>
+<$set name="tag" value=<<__tag__>>>
+<$list filter="[<__tag__>tagging[]$subFilter$]" emptyMessage=<<__emptyMessage__>>>
 <$elementTag$ class="tc-menu-list-item">
 <$droppable actions=<<list-tagged-draggable-drop-actions>>>
 <$elementTag$ class="tc-droppable-placeholder">


### PR DESCRIPTION
this fixes the list macros, especially the `list-tagged-draggable` macro for names with many quotes and `!!`