### PR TITLE
make tag-icons use the tag-pill-styles

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -640,7 +640,6 @@ button.tc-untagged-label {
 .tc-tag-label svg, .tc-tag-label img {
 	height: 1em;
 	width: 1em;
-	fill: <<colour tag-foreground>>;
 	vertical-align: text-bottom;
 }
 


### PR DESCRIPTION
this line inherits the `fill: $(foregroundColor)$` from `<<tag-pill-styles>>` in `$:/core/macros/tags`
deleting the line makes the tag-icons fill with the computed color