### PR TITLE
correct scrolling with tc-adjust-top-of-scroll

### DIFF
--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -104,7 +104,7 @@ PageScroller.prototype.scrollIntoView = function(element) {
 				bounds = getBounds(),
 				endX = getEndPos(bounds.left,bounds.width,scrollPosition.x,window.innerWidth),
 				endY = getEndPos(bounds.top,bounds.height,scrollPosition.y,window.innerHeight);
-			window.scrollTo(scrollPosition.x + (endX - scrollPosition.x) * t,scrollPosition.y + (endY - scrollPosition.y) * t - offset);
+			window.scrollTo(scrollPosition.x + (endX - scrollPosition.x) * t,scrollPosition.y + (endY - scrollPosition.y - offset) * t);
 			if(t < 1) {
 				self.idRequestFrame = self.requestAnimationFrame.call(window,drawFrame);
 			}


### PR DESCRIPTION
not multiplying `offset` with t causes jumps at the first animation steps, where the offset value is bigger than `endY - scrollPosition.y`