### PR TITLE
[keyboard widget] - update keyInfoArray on change

### DIFF
--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -92,6 +92,10 @@ KeyboardWidget.prototype.refresh = function(changedTiddlers) {
 		this.refreshSelf();
 		return true;
 	}
+	var tempKeyInfoArray = $tw.keyboardManager.parseKeyDescriptors(this.key);
+	if(tempKeyInfoArray !== this.keyInfoArray) {
+		this.keyInfoArray = tempKeyInfoArray;
+	}
 	return this.refreshChildren(changedTiddlers);
 };
 


### PR DESCRIPTION
this updates the keyInfoArray when a key changes, so that a tiddler doesn't need to be closed and opened again to have the new key combination work.

in terms of performance I cannot tell how much this interferes, but I'm using it myself and haven't noticed issues