### PR TITLE
[proposal] add editorManager to edit widgets / engines

### DIFF
--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -162,6 +162,9 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	Compute the internal state of the widget
 	*/
 	EditTextWidget.prototype.execute = function() {
+		this.editorStateQualifier = this.getVariable("storyTiddler");
+		$tw.editorManager = $tw.editorManager || [],
+		$tw.editorManager[this.editorStateQualifier] = $tw.editorManager[this.editorStateQualifier] || {};
 		// Get our parameters
 		this.editTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
 		this.editField = this.getAttribute("field","text");

--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -40,6 +40,9 @@ var EDITOR_MAPPING_PREFIX = "$:/config/EditorTypeMappings/";
 Compute the internal state of the widget
 */
 EditWidget.prototype.execute = function() {
+	this.editorStateQualifier = this.getVariable("storyTiddler");
+	$tw.editorManager = $tw.editorManager || [];
+	$tw.editorManager[this.editorStateQualifier] = $tw.editorManager[this.editorStateQualifier] || {};
 	// Get our parameters
 	this.editTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
 	this.editField = this.getAttribute("field","text");

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -187,14 +187,14 @@ Scroll the cursor into view
 */
 CodeMirrorEngine.prototype.scrollIntoView = function() {
 	var selections = this.cm.listSelections();
+	var scrollInfo = this.cm.getScrollInfo(),
+		viewportHeight = window.innerHeight || this.domNode.ownerDocument.documentElement.clientHeight;
+	var scrollMargin = this.widget.wiki.getTiddlerText("$:/config/TextEditor/EditorHeight/Mode") === "fixed" ? 
+	    			scrollInfo.clientHeight / 4 : viewportHeight / 4;
 	var anchorPos = this.cm.indexFromPos(selections[0].anchor),
 		headPos = this.cm.indexFromPos(selections[0].head);
-	var scrollMargin = 200; //ToDo: calculate scroll margin using editor height
-	if(anchorPos < headPos) {
-		this.cm.scrollIntoView(selections[0].anchor,scrollMargin);
-	} else {
-		this.cm.scrollIntoView(selections[0].head,scrollMargin);
-	}
+	anchorPos < headPos ? this.cm.scrollIntoView(selections[0].anchor,scrollMargin) : 
+				this.cm.scrollIntoView(selections[0].head,scrollMargin);
 };
 
 /*

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -132,10 +132,14 @@ function CodeMirrorEngine(options) {
 	});
 	// On focus, if there are saved selections, restore them
 	this.cm.on("focus",function(cm,event) {
-		if(self.editorManager.selectionStart && self.editorManager.selectionEnd) {
+		if(!self.focusClick && self.editorManager.selectionStart && self.editorManager.selectionEnd) {
 			cm.setSelection(cm.posFromIndex(self.editorManager.selectionStart),cm.posFromIndex(self.editorManager.selectionEnd), { scroll: false });
 			self.scrollIntoView();
+			self.focusClick = false;
 		}	
+	});
+	this.cm.on("mousedown",function() {
+		self.focusClick = true;
 	});
 }
 

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -204,8 +204,8 @@ CodeMirrorEngine.prototype.createTextOperation = function() {
 	}
 	var operation = {
 		text: this.cm.getValue(),
-		selStart: self.editorManager.selectionStart || Math.min(anchorPos,headPos),
-		selEnd: self.editorManager.selectionEnd || Math.max(anchorPos,headPos),
+		selStart: this.editorManager.selectionStart || Math.min(anchorPos,headPos),
+		selEnd: this.editorManager.selectionEnd || Math.max(anchorPos,headPos),
 		cutStart: null,
 		cutEnd: null,
 		replacement: null,


### PR DESCRIPTION
this adds `$tw.editorManager` which in this PR is used in the CodeMirror engine to:

- fix the focus-loss when clicking toolbar buttons
- restore cursor position / selections when opening/closing the preview
- scrolling those cursor positions / selections into view

this could be used for all kinds of improvements, like restoring focus on the tags input when clicking "add" or the fieldname input when clicking "add" ...

also the framed engine could profit, restoring selections, cursor position, setting focus on the previously focused input field when re-opening a tiddler etc