### PR TITLE
correct tc-adjust-top-of-scroll

### DIFF
--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -71,7 +71,7 @@ PageScroller.prototype.scrollIntoView = function(element) {
 				scrollPosition = $tw.utils.getScrollPosition();
 			return {
 				left: clientBounds.left + scrollPosition.x,
-				top: clientBounds.top + scrollPosition.y,
+				top: clientBounds.top + scrollPosition.y - offset,
 				width: clientBounds.width,
 				height: clientBounds.height
 			};
@@ -104,7 +104,7 @@ PageScroller.prototype.scrollIntoView = function(element) {
 				bounds = getBounds(),
 				endX = getEndPos(bounds.left,bounds.width,scrollPosition.x,window.innerWidth),
 				endY = getEndPos(bounds.top,bounds.height,scrollPosition.y,window.innerHeight);
-			window.scrollTo(scrollPosition.x + (endX - scrollPosition.x) * t,scrollPosition.y + (endY - scrollPosition.y - offset) * t);
+			window.scrollTo(scrollPosition.x + (endX - scrollPosition.x) * t,scrollPosition.y + (endY - scrollPosition.y) * t);
 			if(t < 1) {
 				self.idRequestFrame = self.requestAnimationFrame.call(window,drawFrame);
 			}

--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -104,7 +104,7 @@ PageScroller.prototype.scrollIntoView = function(element) {
 				bounds = getBounds(),
 				endX = getEndPos(bounds.left,bounds.width,scrollPosition.x,window.innerWidth),
 				endY = getEndPos(bounds.top,bounds.height,scrollPosition.y,window.innerHeight);
-			window.scrollTo(scrollPosition.x + (endX - scrollPosition.x) * t,scrollPosition.y + (endY - scrollPosition.y) * t - offset);
+			window.scrollTo(scrollPosition.x + (endX - scrollPosition.x) * t,scrollPosition.y + (endY - scrollPosition.y - offset) * t);
 			if(t < 1) {
 				self.idRequestFrame = self.requestAnimationFrame.call(window,drawFrame);
 			}


### PR DESCRIPTION
the first fix made the scrolling jumps disappear, but the calculations were wrong

it must be done in `getBounds()`