### PR TITLE
Fix for lazy loaded state in Reveal widget

### DIFF
--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -116,6 +116,11 @@ Read the state tiddler
 RevealWidget.prototype.readState = function() {
 	// Read the information from the state tiddler
 	var state = this.stateTitle ? this.wiki.getTextReference(this.stateTitle,this["default"],this.getVariable("currentTiddler")) : this["default"];
+	
+	// If state tiddler is not yet loaded (lazily loaded), use default value until it gets udpated
+	if(state == null)
+		state = this["default"];
+	
 	switch(this.type) {
 		case "popup":
 			this.readPopupState(state);

--- a/licenses/cla-individual.md
+++ b/licenses/cla-individual.md
@@ -331,3 +331,5 @@ Anthony Muscio, @AnthonyMuscio, 2018/05/21
 Muhammad Talha Mansoor, @talha131, 2018/07/16
 
 Bimba László, @bimlas, 2018/08/10
+
+Andres Carrera, @Lioric, 2018/10/11


### PR DESCRIPTION
In Reveal Widget execute function, the state is read "this.readState()", this method calls "wiki.getTextReference()" with the state's tiddler title as the textreference (so the actual tiddler text is requested), as no field or index is used, getTiddlerText is called to lazy load the tiddler (as it is the first time the tiddler contents are requested)

getTiddlerText dispatch the "lazyLoad" event with the title as parameter and right after that it returns "null". This return result is bubbled up to Reveal widget's readState where state is set to this "null" value and right after that, the switch paths use this "state" value (now null) in "compareStateText", which tries to execute a localCompare on this null "state" object (state.localeCompare(this.text,....)), and this results in a error exception

This fix uses the widget default value until the real state is (lazy) loaded