### PR TITLE
CodeMirror add type: integer to sensible configs

### DIFF
--- a/plugins/tiddlywiki/codemirror/config/cursorBlinkRate.tid
+++ b/plugins/tiddlywiki/codemirror/config/cursorBlinkRate.tid
@@ -1,4 +1,4 @@
 title: $:/config/codemirror/cursorBlinkRate
-type: string
+type: integer
 
 530

--- a/plugins/tiddlywiki/codemirror/config/indentUnit.tid
+++ b/plugins/tiddlywiki/codemirror/config/indentUnit.tid
@@ -1,3 +1,4 @@
 title: $:/config/codemirror/indentUnit
+type: integer
 
 2

--- a/plugins/tiddlywiki/codemirror/config/tabSize.tid
+++ b/plugins/tiddlywiki/codemirror/config/tabSize.tid
@@ -1,3 +1,4 @@
 title: $:/config/codemirror/tabSize
+type: integer
 
 4


### PR DESCRIPTION
this adds/changes the type of the config tiddlers `cursorBlinkRate`, `tabSize` and `indentUnit` to `integer` as of issue #3474