### PR TITLE
Cancel non-ancestor popups when showing a new popup

### DIFF
--- a/core/modules/utils/dom/popup.js
+++ b/core/modules/utils/dom/popup.js
@@ -110,10 +110,32 @@ Popup.prototype.popupInfo = function(domNode) {
 Display a popup by adding it to the stack
 */
 Popup.prototype.show = function(options) {
-	// Find out what was clicked on
-	var info = this.popupInfo(options.domNode);
-	// Cancel any higher level popups
-	this.cancel(info.popupLevel);
+	var cancelLevel;
+	// Cancel any popups who aren't an ancestor of the current node
+	for(var t=0; t<this.popups.length; t++) {
+		var popup = this.popups[t];
+
+		var node = options.domNode;
+		var isFound = false;
+
+		while(node) {
+			if(node == popup.domNode) {
+				isFound = true;
+				break;
+			}
+			node = node.parentNode;
+		}
+
+		if(!isFound) {
+			cancelLevel = t;
+			break;
+		}
+	}
+
+	if(cancelLevel !== undefined) {
+		this.cancel(cancelLevel);
+	}
+
 	// Store the popup details if not already there
 	if(!options.floating && this.findPopup(options.title) === -1) {
 		this.popups.push({


### PR DESCRIPTION
Addresses GH #3484

As far as I can tell, the popup level checks in this module are meant to handle nested popups.  It seems to me that the goal is for at most a single hierarchy of popups to exist at any given time - bearing that in mind, this change checks any popups currently tracked by the module, canceling any that don't share an element hierarchy with the new popup.