### PR TITLE
Enhance search operator

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -40,12 +40,23 @@ function parseFilterOperation(operators,filterString,p) {
 		nextBracketPos += p;
 		var bracket = filterString.charAt(nextBracketPos);
 		operator.operator = filterString.substring(p,nextBracketPos);
-
 		// Any suffix?
 		var colon = operator.operator.indexOf(':');
 		if(colon > -1) {
+			// The raw suffix for older filters
 			operator.suffix = operator.operator.substring(colon + 1);
 			operator.operator = operator.operator.substring(0,colon) || "field";
+			// The processed suffix for newer filters
+			operator.suffixes = [];
+			$tw.utils.each(operator.suffix.split(":"),function(subsuffix) {
+				operator.suffixes.push([]);
+				$tw.utils.each(subsuffix.split(","),function(entry) {
+					entry = $tw.utils.trim(entry);
+					if(entry) {
+						operator.suffixes[operator.suffixes.length - 1].push(entry); 
+					}
+				});
+			});
 		}
 		// Empty operator means: title
 		else if(operator.operator === "") {
@@ -208,6 +219,7 @@ exports.compileFilter = function(filterString) {
 							operand: operand,
 							prefix: operator.prefix,
 							suffix: operator.suffix,
+							suffixes: operator.suffixes,
 							regexp: operator.regexp
 						},{
 							wiki: self,

--- a/core/modules/filters/search.js
+++ b/core/modules/filters/search.js
@@ -17,11 +17,19 @@ Export our filter function
 */
 exports.search = function(source,operator,options) {
 	var invert = operator.prefix === "!";
-	if(operator.suffix) {
+	if(operator.suffixes) {
+		var hasFlag = function(flag) {
+			return (operator.suffixes[1] || []).indexOf(flag) !== -1;
+		};
 		return options.wiki.search(operator.operand,{
 			source: source,
 			invert: invert,
-			field: operator.suffix
+			field: operator.suffixes[0],
+			caseSensitive: hasFlag("casesensitive"),
+			literal: hasFlag("literal"),
+			whitespace: hasFlag("whitespace"),
+			regexp: hasFlag("regexp"),
+			words: hasFlag("words")
 		});
 	} else {
 		return options.wiki.search(operator.operand,{

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -14,6 +14,26 @@ Tests the filtering mechanism.
 
 describe("Filter tests", function() {
 
+	// Test filter parsing
+	it("should parse new-style rich operator suffixes", function() {
+		expect($tw.wiki.parseFilter("[search:: four, , five,, six [operand]]")).toEqual(
+			[ { prefix : '', operators : [ { operator : 'search', suffix : ': four, , five,, six ', suffixes : [ [  ], [ 'four', 'five', 'six' ] ], operand : 'operand' } ] } ]
+		);
+		expect($tw.wiki.parseFilter("[search: one, two ,three :[operand]]")).toEqual(
+			[ { prefix : '', operators : [ { operator : 'search', suffix : ' one, two ,three :', suffixes : [ [ 'one', 'two', 'three' ], [  ] ], operand : 'operand' } ] } ]
+		);
+		expect($tw.wiki.parseFilter("[search: one, two ,three :[operand]]")).toEqual(
+			[ { prefix : '', operators : [ { operator : 'search', suffix : ' one, two ,three :', suffixes : [ [ 'one', 'two', 'three' ], [  ] ], operand : 'operand' } ] } ]
+		);
+		expect($tw.wiki.parseFilter("[search: one, two ,three : four, , five,, six [operand]]")).toEqual(
+			[ { prefix : '', operators : [ { operator : 'search', suffix : ' one, two ,three : four, , five,, six ', suffixes : [ [ 'one', 'two', 'three' ], [ 'four', 'five', 'six' ] ], operand : 'operand' } ] } ]
+		);
+		expect($tw.wiki.parseFilter("[search: , : [operand]]")).toEqual(
+			 [ { prefix : '', operators : [ { operator : 'search', suffix : ' , : ', suffixes : [ [  ], [  ] ], operand : 'operand' } ] } ]
+		);
+	});
+
+
 	// Create a wiki
 	var wiki = new $tw.Wiki({
 		shadowTiddlers: {
@@ -228,6 +248,11 @@ describe("Filter tests", function() {
 	it("should handle the search operator", function() {
 		expect(wiki.filterTiddlers("[search[the]sort[title]]").join(",")).toBe("$:/TiddlerTwo,a fourth tiddler,one,Tiddler Three,TiddlerOne");
 		expect(wiki.filterTiddlers("[search{Tiddler8}sort[title]]").join(",")).toBe("$:/TiddlerTwo,a fourth tiddler,one,Tiddler Three,TiddlerOne");
+		expect(wiki.filterTiddlers("[search:modifier[og]sort[title]]").join(",")).toBe("TiddlerOne");
+		expect(wiki.filterTiddlers("[search:modifier,authors:casesensitive[Do]sort[title]]").join(",")).toBe("$:/TiddlerTwo,a fourth tiddler,one,Tiddler Three");
+		expect(wiki.filterTiddlers("[search:modifier,authors:casesensitive[do]sort[title]]").join(",")).toBe("");
+		expect(wiki.filterTiddlers("[search:authors:casesensitive,whitespace[John    Doe]sort[title]]").join(",")).toBe("$:/TiddlerTwo");
+		expect(wiki.filterTiddlers("[search:modifier:regexp[(d|bl)o(ggs|e)]sort[title]]").join(",")).toBe("$:/TiddlerTwo,a fourth tiddler,one,Tiddler Three,TiddlerOne");
 	});
 
 	it("should handle the each operator", function() {

--- a/editions/tw5.com/tiddlers/filters/examples/search.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/search.tid
@@ -1,5 +1,5 @@
 created: 20150124104508000
-modified: 20150124110256000
+modified: 20181025082022690
 tags: [[search Operator]] [[Operator Examples]]
 title: search Operator (Examples)
 type: text/vnd.tiddlywiki
@@ -7,4 +7,7 @@ type: text/vnd.tiddlywiki
 <$macrocall $name=".operator-example" n="1" eg="[!is[system]search[table]]" ie="non-system tiddlers containing the word <<.word table>>"/>
 <$macrocall $name=".operator-example" n="2" eg="[all[shadows]search[table]]" ie="shadow tiddlers containing the word <<.word table>>"/>
 <$macrocall $name=".operator-example" n="3" eg="[search:caption[arch]]" ie="tiddlers containing `arch` in their <<.field caption>> field"/>
-
+<$macrocall $name=".operator-example" n="4" eg="[!is[system]search[the first]]" ie="non-system tiddlers containing a case-insensitive match for both the <<.word 'the'>> and <<.word 'first'>>"/>
+<$macrocall $name=".operator-example" n="5" eg="[!is[system]search::literal[the first]]" ie="non-system tiddlers containing a case-insensitive match for the literal phrase <<.word 'the first'>>"/>
+<$macrocall $name=".operator-example" n="6" eg="[!is[system]search::literal,casesensitive[The first]]" ie="non-system tiddlers containing a case-sensitive match for the literal phrase <<.word 'The first'>>"/>
+<$macrocall $name=".operator-example" n="7" eg="[search:caption,description:casesensitive,words[arch]]" ie="any tiddlers containing a case-sensitive match for the word `arch` in their <<.field caption>> or <<.field description>> fields"/>

--- a/editions/tw5.com/tiddlers/filters/search.tid
+++ b/editions/tw5.com/tiddlers/filters/search.tid
@@ -1,21 +1,41 @@
 created: 20140410103123179
-modified: 20150203191048000
+modified: 20181025082022690
 tags: [[Filter Operators]] [[Common Operators]] [[Field Operators]] [[Negatable Operators]]
 title: search Operator
 type: text/vnd.tiddlywiki
 caption: search
 op-purpose: filter the input by searching tiddler content
 op-input: a [[selection of titles|Title Selection]]
-op-suffix: optionally, the name of a [[field|TiddlerFields]]
-op-suffix-name: F
-op-parameter: one or more search terms, separated by spaces
+op-suffix: the <<.op search>> operator uses a rich suffix, see below for details
+op-parameter: one or more search terms, separated by spaces, or a literal search string
 op-output: those input tiddlers in which <<.em all>> of the search terms can be found in the value of field <<.place F>>
 op-neg-output: those input tiddlers in which <<.em not>> all of the search terms can be found
 
-When used with a suffix, the <<.op search>> operator is similar to <<.olink regexp>> but less powerful.
+<<.from-version "5.1.18">> Earlier versions do not support searching multiple fields, or the ''literal'' or ''casesensitive'' options.
 
-If the suffix is omitted, a tiddler is deemed to match if all the search terms appear in the combination of its <<.field tags>>, <<.field text>> and <<.field title>> fields.
+The <<.op search>> operator uses an extended syntax that permits multiple fields and flags to be passed:
 
-The search ignores the difference between capital and lowercase letters.
+```
+[search:<field list>:<flag list>[<operand>]]
+```
+
+* ''field list'': a comma delimited list of field names to restrict the search (defaults to <<.field tags>>, <<.field text>> or <<.field title>>) if blank
+* ''flag list'': a comma delimited list of flags (defaults to `words` if blank)
+* ''operand'': filter operand
+
+This example searches the fields <<.field title>> and <<.field caption>> for a case-sensitive match for the literal string <<.op-word "The first">>:
+
+```
+[search:title,caption:literal,casesensitive[The first]]
+```
+
+The available flags are:
+
+* Search mode - the first to be set of the following flags determines the type of search that is performed:
+** ''literal'': considers the search string to be a literal string, and requires an exact match
+** ''whitespace'': considers the search string to be a literal string, but will consider all runs of whitespace to be equivalent to a single space. Thus `A B` matches `A   B`
+** ''regexp'': treats the search string as a regular expression. Note that the ''regexp'' option obviates the need for the older <<.olink regexp>> operator.
+** ''words'': (the default) treats the search string as a list of tokens separated by whitespace, and matches if all of the tokens appear in the string (regardless of ordering and whether there is other text in between)
+* ''casesensitive'': if present, this flag forces a case-sensitive match, where upper and lower case letters are considered different. By default, upper and lower case letters are considered identical for matching purposes.
 
 <<.operator-examples "search">>


### PR DESCRIPTION
It is proposed to enhance the search operator:

* to permit an arbitrary list of fields to be specified
* to add support for flags to control the type of search performed: the current token-based search, a literal search, a whitespace-tolerant search, and a regexp search

For example:

```
[search:caption,description[this]]
[search:caption,description:literal[this phrase]]
[search:caption,description:literal,casesensitive[this phrase]]
[search::literal,casesensitive[this phrase]]
[search::regexp,casesensitive[(bl|d)o(ggs|e)]]
```

The extended syntax for operator suffixes has been implemented in a manner that allows other filter operators to opt in to using it if they want to. We should review carefully whether the proposed format will be adequate for other operators that we may want to extend.

These changes are backwards compatible as long as existing wikis are not using the search operator with fields whose names contain colons or commas.

We could extend the advanced search box to allow the new search options to be used but I'm concerned that it might be overkill for most users while adding a lot to the core, and so might be best in a plugin.