### PR TITLE
Sidebar background field

### DIFF
--- a/core/language/en-GB/Docs/PaletteColours.multids
+++ b/core/language/en-GB/Docs/PaletteColours.multids
@@ -47,6 +47,7 @@ pre-border: Preformatted code border
 primary: General primary
 select-tag-background: `<select>` element background
 select-tag-foreground: `<select>` element text
+sidebar-background: Sidebar background
 sidebar-button-foreground: Sidebar button foreground
 sidebar-controls-foreground-hover: Sidebar controls foreground hover
 sidebar-controls-foreground: Sidebar controls foreground

--- a/core/palettes/Blanca.tid
+++ b/core/palettes/Blanca.tid
@@ -51,6 +51,7 @@ pre-border: #cccccc
 primary: #7897f3
 select-tag-background:
 select-tag-foreground:
+sidebar-background: 
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #000000
 sidebar-controls-foreground: #ccc

--- a/core/palettes/Blue.tid
+++ b/core/palettes/Blue.tid
@@ -51,6 +51,7 @@ pre-border: #cccccc
 primary: #5778d8
 select-tag-background:
 select-tag-foreground:
+sidebar-background:
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #000000
 sidebar-controls-foreground: #ffffff

--- a/core/palettes/BrightMute.tid
+++ b/core/palettes/BrightMute.tid
@@ -51,6 +51,7 @@ pre-border: #cccccc
 primary: #29a6ee
 select-tag-background:
 select-tag-foreground:
+sidebar-background:
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #000000
 sidebar-controls-foreground: #c2c1c2

--- a/core/palettes/ContrastDark.tid
+++ b/core/palettes/ContrastDark.tid
@@ -1,6 +1,6 @@
-title: $:/palettes/ContrastLight
-name: Contrast (Light)
-description: High contrast and unambiguous (light version)
+title: $:/palettes/ContrastDark
+name: Contrast (Dark)
+description: High contrast and unambiguous (dark version)
 tags: $:/tags/Palette
 type: application/x-tiddler-dictionary
 
@@ -8,7 +8,7 @@ alert-background: #f00
 alert-border: <<colour background>>
 alert-highlight: <<colour foreground>>
 alert-muted-foreground: #800
-background: #fff
+background: #000
 blockquote-bar: <<colour muted-foreground>>
 button-background: <<colour background>>
 button-foreground: <<colour foreground>>
@@ -32,7 +32,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
-foreground: #000
+foreground: #fff
 message-background: <<colour foreground>>
 message-border: <<colour background>>
 message-foreground: <<colour background>>
@@ -80,8 +80,8 @@ tab-foreground: <<colour background>>
 table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
-tag-background: #000
-tag-foreground: #fff
+tag-background: #fff
+tag-foreground: #000
 tiddler-background: <<colour background>>
 tiddler-border: <<colour foreground>>
 tiddler-controls-foreground-hover: #ddd

--- a/core/palettes/ContrastDark.tid
+++ b/core/palettes/ContrastDark.tid
@@ -51,6 +51,7 @@ pre-border: <<colour foreground>>
 primary: #00f
 select-tag-background:
 select-tag-foreground:
+sidebar-background: black
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: <<colour background>>
 sidebar-controls-foreground: <<colour foreground>>

--- a/core/palettes/ContrastLight.tid
+++ b/core/palettes/ContrastLight.tid
@@ -51,6 +51,7 @@ pre-border: <<colour foreground>>
 primary: #00f
 select-tag-background:
 select-tag-foreground:
+sidebar-background: 
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: <<colour background>>
 sidebar-controls-foreground: <<colour foreground>>

--- a/core/palettes/ContrastLight.tid
+++ b/core/palettes/ContrastLight.tid
@@ -1,6 +1,6 @@
-title: $:/palettes/ContrastDark
-name: Contrast (Dark)
-description: High contrast and unambiguous (dark version)
+title: $:/palettes/ContrastLight
+name: Contrast (Light)
+description: High contrast and unambiguous (light version)
 tags: $:/tags/Palette
 type: application/x-tiddler-dictionary
 
@@ -8,7 +8,7 @@ alert-background: #f00
 alert-border: <<colour background>>
 alert-highlight: <<colour foreground>>
 alert-muted-foreground: #800
-background: #000
+background: #fff
 blockquote-bar: <<colour muted-foreground>>
 button-background: <<colour background>>
 button-foreground: <<colour foreground>>
@@ -32,7 +32,7 @@ external-link-background: inherit
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
-foreground: #fff
+foreground: #000
 message-background: <<colour foreground>>
 message-border: <<colour background>>
 message-foreground: <<colour background>>
@@ -51,7 +51,7 @@ pre-border: <<colour foreground>>
 primary: #00f
 select-tag-background:
 select-tag-foreground:
-sidebar-background: 
+sidebar-background: white
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: <<colour background>>
 sidebar-controls-foreground: <<colour foreground>>
@@ -80,8 +80,8 @@ tab-foreground: <<colour background>>
 table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
-tag-background: #fff
-tag-foreground: #000
+tag-background: #000
+tag-foreground: #fff
 tiddler-background: <<colour background>>
 tiddler-border: <<colour foreground>>
 tiddler-controls-foreground-hover: #ddd

--- a/core/palettes/DarkPhotos.tid
+++ b/core/palettes/DarkPhotos.tid
@@ -53,6 +53,7 @@ pre-border: #cccccc
 primary: #5778d8
 select-tag-background:
 select-tag-foreground:
+sidebar-background:
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #ccf
 sidebar-controls-foreground: #fff

--- a/core/palettes/Rocker.tid
+++ b/core/palettes/Rocker.tid
@@ -51,6 +51,7 @@ pre-border: #cccccc
 primary: #cc0000
 select-tag-background:
 select-tag-foreground:
+sidebar-background:
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #000000
 sidebar-controls-foreground: #ffffff

--- a/core/palettes/SolarFlare.tid
+++ b/core/palettes/SolarFlare.tid
@@ -134,6 +134,7 @@ message-border: #cfd6e6
 modal-border: #999999
 select-tag-background:
 select-tag-foreground:
+sidebar-background:
 sidebar-controls-foreground-hover:
 sidebar-muted-foreground-hover:
 sidebar-tab-background: #ded8c5

--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -59,6 +59,7 @@ pre-border: #cccccc
 primary: #5778d8
 select-tag-background:
 select-tag-foreground:
+sidebar-background: 
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #000000
 sidebar-controls-foreground: #aaaaaa

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -39,6 +39,12 @@ $else$
 </$reveal>
 \end
 
+\define set-sidebar-background-colour()
+<$set name="css" filter="[title[$:/state/sidebar]field:text[no]]" value="" emptyValue=<<colour sidebar-background>>>
+<<css>>
+</$set>
+\end
+
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock
 
 /*
@@ -777,6 +783,7 @@ button.tc-untagged-label {
 	}
 
 	.tc-sidebar-scrollable {
+		background: <<set-sidebar-background-colour>>;
 		position: fixed;
 		top: {{$:/themes/tiddlywiki/vanilla/metrics/storytop}};
 		left: {{$:/themes/tiddlywiki/vanilla/metrics/storyright}};


### PR DESCRIPTION
PR to address issue #3503. Adds a field to palette editor to allow users to change the appearance of the sidebar background. 

Default values for ContrastLight is `white` and ContrastDark is `black`. Remains blank for other themes.