### PR TITLE
add new-tiddler new-journal new-image keyboard shortcuts

### DIFF
--- a/core/ui/Actions/new-image.tid
+++ b/core/ui/Actions/new-image.tid
@@ -1,0 +1,10 @@
+title: $:/core/ui/Actions/new-image
+tags: $:/tags/Actions
+description: create a new image tiddler
+
+\define get-type()
+image/$(imageType)$
+\end
+<$vars imageType={{$:/config/NewImageType}}>
+<$action-sendmessage $message="tm-new-tiddler" type=<<get-type>>/>
+</$vars>

--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -1,0 +1,14 @@
+title: $:/core/ui/Actions/new-journal
+tags: $:/tags/Actions
+description: create a new journal tiddler
+
+<$vars journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags}} journalText={{$:/config/NewJournal/Text}}>
+<$wikify name="journalTitle" text="""<$macrocall $name="now" format=<<journalTitleTemplate>>/>""">
+<$reveal type="nomatch" state=<<journalTitle>> text="">
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<journalTags>> text={{{ [<journalTitle>get[]] }}}/>
+</$reveal>
+<$reveal type="match" state=<<journalTitle>> text="">
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<journalTags>> text=<<journalText>>/>
+</$reveal>
+</$wikify>
+</$vars>

--- a/core/ui/Actions/new-tiddler.tid
+++ b/core/ui/Actions/new-tiddler.tid
@@ -1,0 +1,5 @@
+title: $:/core/ui/Actions/new-tiddler
+tags: $:/tags/Actions
+description: create a new empty tiddler
+
+<$action-sendmessage $message="tm-new-tiddler"/>

--- a/core/ui/KeyboardShortcuts/new-image.tid
+++ b/core/ui/KeyboardShortcuts/new-image.tid
@@ -1,0 +1,7 @@
+title: $:/core/ui/KeyboardShortcuts/new-image
+tags: $:/tags/KeyboardShortcut
+key: ((new-image))
+
+<$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
+{{$:/core/ui/Actions/new-image}}
+</$navigator>

--- a/core/ui/KeyboardShortcuts/new-journal.tid
+++ b/core/ui/KeyboardShortcuts/new-journal.tid
@@ -1,0 +1,7 @@
+title: $:/core/ui/KeyboardShortcuts/new-journal
+tags: $:/tags/KeyboardShortcut
+key: ((new-journal))
+
+<$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
+{{$:/core/ui/Actions/new-journal}}
+</$navigator>

--- a/core/ui/KeyboardShortcuts/new-tiddler.tid
+++ b/core/ui/KeyboardShortcuts/new-tiddler.tid
@@ -1,0 +1,7 @@
+title: $:/core/ui/KeyboardShortcuts/new-tiddler
+tags: $:/tags/KeyboardShortcut
+key: ((new-tiddler))
+
+<$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
+{{$:/core/ui/Actions/new-tiddler}}
+</$navigator>

--- a/core/ui/PageControls/new-image.tid
+++ b/core/ui/PageControls/new-image.tid
@@ -3,8 +3,7 @@ tags: $:/tags/PageControls
 caption: {{$:/core/images/new-image-button}} {{$:/language/Buttons/NewImage/Caption}}
 description: {{$:/language/Buttons/NewImage/Hint}}
 
-<$button tooltip={{$:/language/Buttons/NewImage/Hint}} aria-label={{$:/language/Buttons/NewImage/Caption}} class=<<tv-config-toolbar-class>>>
-<$action-sendmessage $message="tm-new-tiddler" type="image/jpeg"/>
+<$button tooltip={{$:/language/Buttons/NewImage/Hint}} aria-label={{$:/language/Buttons/NewImage/Caption}} class=<<tv-config-toolbar-class>> actions={{$:/core/ui/actions/new-image}}>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/new-image-button}}
 </$list>

--- a/core/ui/PageControls/new-journal.tid
+++ b/core/ui/PageControls/new-journal.tid
@@ -3,19 +3,8 @@ tags: $:/tags/PageControls
 caption: {{$:/core/images/new-journal-button}} {{$:/language/Buttons/NewJournal/Caption}}
 description: {{$:/language/Buttons/NewJournal/Hint}}
 
-\define journalActions()
-<$wikify name="journalTitle" text="""<$macrocall $name="now" format=<<journalTitleTemplate>>/>""">
-<$reveal type="nomatch" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<journalTags>> text={{{ [<journalTitle>get[]] }}}/>
-</$reveal>
-<$reveal type="match" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<journalTags>> text=<<journalText>>/>
-</$reveal>
-</$wikify>
-\end
-
 \define journalButton()
-<$button tooltip={{$:/language/Buttons/NewJournal/Hint}} aria-label={{$:/language/Buttons/NewJournal/Caption}} class=<<tv-config-toolbar-class>> actions=<<journalActions>>>
+<$button tooltip={{$:/language/Buttons/NewJournal/Hint}} aria-label={{$:/language/Buttons/NewJournal/Caption}} class=<<tv-config-toolbar-class>> actions={{$:/core/ui/Actions/new-journal}}>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/new-journal-button}}
 </$list>
@@ -24,8 +13,4 @@ description: {{$:/language/Buttons/NewJournal/Hint}}
 </$list>
 </$button>
 \end
-<$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
-<$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
-<$set name="journalText" value={{$:/config/NewJournal/Text}}>
 <<journalButton>>
-</$set></$set></$set>

--- a/core/ui/PageControls/newtiddler.tid
+++ b/core/ui/PageControls/newtiddler.tid
@@ -3,7 +3,7 @@ tags: $:/tags/PageControls
 caption: {{$:/core/images/new-button}} {{$:/language/Buttons/NewTiddler/Caption}}
 description: {{$:/language/Buttons/NewTiddler/Hint}}
 
-<$button actions={{||$:/core/ui/Actions/new-tiddler}} tooltip={{$:/language/Buttons/NewTiddler/Hint}} aria-label={{$:/language/Buttons/NewTiddler/Caption}} class=<<tv-config-toolbar-class>>>
+<$button actions={{$:/core/ui/Actions/new-tiddler}} tooltip={{$:/language/Buttons/NewTiddler/Hint}} aria-label={{$:/language/Buttons/NewTiddler/Caption}} class=<<tv-config-toolbar-class>>>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/new-button}}
 </$list>

--- a/core/ui/PageControls/newtiddler.tid
+++ b/core/ui/PageControls/newtiddler.tid
@@ -3,7 +3,7 @@ tags: $:/tags/PageControls
 caption: {{$:/core/images/new-button}} {{$:/language/Buttons/NewTiddler/Caption}}
 description: {{$:/language/Buttons/NewTiddler/Hint}}
 
-<$button message="tm-new-tiddler" tooltip={{$:/language/Buttons/NewTiddler/Hint}} aria-label={{$:/language/Buttons/NewTiddler/Caption}} class=<<tv-config-toolbar-class>>>
+<$button actions={{||$:/core/ui/Actions/new-tiddler}} tooltip={{$:/language/Buttons/NewTiddler/Hint}} aria-label={{$:/language/Buttons/NewTiddler/Caption}} class=<<tv-config-toolbar-class>>>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/new-button}}
 </$list>

--- a/core/wiki/config/NewImageType.tid
+++ b/core/wiki/config/NewImageType.tid
@@ -1,0 +1,3 @@
+title: $:/config/NewImageType
+
+jpeg

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -15,6 +15,9 @@ list-bullet: {{$:/language/Buttons/ListBullet/Hint}}
 list-number: {{$:/language/Buttons/ListNumber/Hint}}
 mono-block: {{$:/language/Buttons/MonoBlock/Hint}}
 mono-line: {{$:/language/Buttons/MonoLine/Hint}}
+new-image: {{$:/language/Buttons/NewImage/Hint}}
+new-journal: {{$:/language/Buttons/NewJournal/Hint}}
+new-tiddler: {{$:/language/Buttons/NewTiddler/Hint}}
 picture: {{$:/language/Buttons/Picture/Hint}}
 preview: {{$:/language/Buttons/Preview/Hint}}
 quote: {{$:/language/Buttons/Quote/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -14,6 +14,9 @@ list-bullet: ctrl-shift-L
 list-number: ctrl-shift-N
 mono-block: ctrl-shift-M
 mono-line: ctrl-M
+new-image: alt-I
+new-journal: alt-J
+new-tiddler: alt-N
 picture: ctrl-shift-I
 preview: alt-P
 quote: ctrl-Q

--- a/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting NewImageType.tid
+++ b/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting NewImageType.tid
@@ -1,0 +1,7 @@
+title: Hidden Setting: New-Image Type
+tags: [[Hidden Setting]]
+type: text/vnd.tiddlywiki
+
+By default new images are created with the image-type `jpeg`
+
+The hidden setting in $:/config/NewImageType can be set to another Image-Type which is used for new Image Tiddlers, like `png`


### PR DESCRIPTION
this adds global keyboard shortcuts for `new-tiddler`, `new-journal` and `new-image`

it also refactors the involved actions into `action-tiddlers` ($:/core/ui/Actions/new-tiddler ...) and makes the PageControls Buttons use them

for the new-image action it also adds a `$:/config/NewImageType` setting for jpeg/png which is jpeg by default. the corresponding action tiddler uses that config for the new-image type (probably a separate PR but maybe it's ok here?)