### PR TITLE
fix error opening new windows with popup-blocker

### DIFF
--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -33,8 +33,16 @@ exports.startup = function() {
 			height = paramObject.height || "600",
 			variables = $tw.utils.extend({},paramObject,{currentTiddler: title});
 		// Open the window
-		var srcWindow = window.open("","external-" + title,"scrollbars,width=" + width + ",height=" + height),
+		var srcWindow,
+		    srcDocument;
+		// In case that popup blockers deny opening a new window
+		try {
+			srcWindow = window.open("","external-" + title,"scrollbars,width=" + width + ",height=" + height),
 			srcDocument = srcWindow.document;
+		}
+		catch(e) {
+			return;
+		}
 		windows[title] = srcWindow;
 		// Check for reopening the same window
 		if(srcWindow.haveInitialisedWindow) {


### PR DESCRIPTION
this prevents errors when a popup blocker blocks opening a new window from within a running TW