### PR TITLE
fix NewImageType config

### DIFF
--- a/core/wiki/config/NewImageType.tid
+++ b/core/wiki/config/NewImageType.tid
@@ -1,6 +1,2 @@
-created: 20181107160106381
-modified: 20181107160110163
 title: $:/config/NewImageType
-type: text/vnd.tiddlywiki
-
-jpeg
+text: jpeg

--- a/core/wiki/config/NewImageType.tid
+++ b/core/wiki/config/NewImageType.tid
@@ -1,3 +1,6 @@
+created: 20181107160106381
+modified: 20181107160110163
 title: $:/config/NewImageType
+type: text/vnd.tiddlywiki
 
 jpeg


### PR DESCRIPTION
the NewImageType config is erraneous

somehow I couldn't create a config tiddler without new-line at the end other than from within a tiddlywiki