### PR TITLE
update CodeMirror config tiddlers

### DIFF
--- a/plugins/tiddlywiki/codemirror/config/cursorBlinkRate.tid
+++ b/plugins/tiddlywiki/codemirror/config/cursorBlinkRate.tid
@@ -1,4 +1,3 @@
 title: $:/config/codemirror/cursorBlinkRate
 type: string
-
-530
+text: 530

--- a/plugins/tiddlywiki/codemirror/config/cursorBlinkRate.tid
+++ b/plugins/tiddlywiki/codemirror/config/cursorBlinkRate.tid
@@ -1,3 +1,3 @@
 title: $:/config/codemirror/cursorBlinkRate
-type: string
+type: integer
 text: 530

--- a/plugins/tiddlywiki/codemirror/config/indentUnit.tid
+++ b/plugins/tiddlywiki/codemirror/config/indentUnit.tid
@@ -1,2 +1,3 @@
 title: $:/config/codemirror/indentUnit
+type: integer
 text: 2

--- a/plugins/tiddlywiki/codemirror/config/indentUnit.tid
+++ b/plugins/tiddlywiki/codemirror/config/indentUnit.tid
@@ -1,3 +1,2 @@
 title: $:/config/codemirror/indentUnit
-
-2
+text: 2

--- a/plugins/tiddlywiki/codemirror/config/inputStyle.tid
+++ b/plugins/tiddlywiki/codemirror/config/inputStyle.tid
@@ -1,4 +1,3 @@
 title: $:/config/codemirror/inputStyle
 type: string
-
-textarea
+text: textarea

--- a/plugins/tiddlywiki/codemirror/config/keyMap.tid
+++ b/plugins/tiddlywiki/codemirror/config/keyMap.tid
@@ -1,4 +1,3 @@
 title: $:/config/codemirror/keyMap
 type: string
-
-default
+text: default

--- a/plugins/tiddlywiki/codemirror/config/lineNumbers.tid
+++ b/plugins/tiddlywiki/codemirror/config/lineNumbers.tid
@@ -1,4 +1,3 @@
 title: $:/config/codemirror/lineNumbers
 type: bool
-
-false
+text: false

--- a/plugins/tiddlywiki/codemirror/config/lineWrapping.tid
+++ b/plugins/tiddlywiki/codemirror/config/lineWrapping.tid
@@ -1,4 +1,3 @@
 title: $:/config/codemirror/lineWrapping
 type: bool
-
-true
+text: true

--- a/plugins/tiddlywiki/codemirror/config/showCursorWhenSelecting.tid
+++ b/plugins/tiddlywiki/codemirror/config/showCursorWhenSelecting.tid
@@ -1,4 +1,3 @@
 title: $:/config/codemirror/showCursorWhenSelecting
 type: bool
-
-true
+text: true

--- a/plugins/tiddlywiki/codemirror/config/styleActiveLine.tid
+++ b/plugins/tiddlywiki/codemirror/config/styleActiveLine.tid
@@ -1,4 +1,3 @@
 title: $:/config/codemirror/styleActiveLine
 type: bool
-
-false
+text: false

--- a/plugins/tiddlywiki/codemirror/config/tabSize.tid
+++ b/plugins/tiddlywiki/codemirror/config/tabSize.tid
@@ -1,3 +1,3 @@
 title: $:/config/codemirror/tabSize
-
-4
+type: integer
+text: 4

--- a/plugins/tiddlywiki/codemirror/config/theme.tid
+++ b/plugins/tiddlywiki/codemirror/config/theme.tid
@@ -1,4 +1,3 @@
 title: $:/config/codemirror/theme
 type: string
-
-default
+text: default


### PR DESCRIPTION
this uses the "text" field configuration scheme for the CM config tiddlers 

AND

sets the type of cursorBlinkRate, indentUnit and tabSize to `integer` as of issue #3474 