### PR TITLE
stateTitle stateField stateIndex attributes

### DIFF
--- a/core/modules/utils/dom/popup.js
+++ b/core/modules/utils/dom/popup.js
@@ -134,9 +134,13 @@ Popup.prototype.show = function(options) {
 			height: options.domNode.offsetHeight
 		};
 	}
-	options.wiki.setTextReference(options.title,
-			"(" + rect.left + "," + rect.top + "," + 
-				rect.width + "," + rect.height + ")");
+	var popupRect = "(" + rect.left + "," + rect.top + "," + 
+				rect.width + "," + rect.height + ")";
+	if(options.noStateReference) {
+		options.wiki.setText(options.title,"text",undefined,popupRect);
+	} else {
+		options.wiki.setTextReference(options.title,popupRect);
+	}
 	// Add the click handler if we have any popups
 	if(this.popups.length > 0) {
 		this.rootElement.addEventListener("click",this,true);		

--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -41,7 +41,7 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 	var domNode = this.document.createElement(tag);
 	// Assign classes
 	var classes = this["class"].split(" ") || [],
-		isPoppedUp = this.popup && this.isPoppedUp();
+		isPoppedUp = (this.popup || this.popupTitle) && this.isPoppedUp();
 	if(this.selectedClass) {
 		if((this.set || this.setTitle) && this.setTo && this.isSelected()) {
 			$tw.utils.pushTop(classes,this.selectedClass.split(" "));
@@ -129,7 +129,7 @@ ButtonWidget.prototype.isSelected = function() {
 };
 
 ButtonWidget.prototype.isPoppedUp = function() {
-	var tiddler = this.popupTitle ? this.wiki.getTiddlerText(this.popupTitle) : this.wiki.getTiddler(this.popup);
+	var tiddler = this.popupTitle ? this.wiki.getTiddler(this.popupTitle) : this.wiki.getTiddler(this.popup);
 	var result = tiddler && tiddler.fields.text ? $tw.popup.readPopupState(tiddler.fields.text) : false;
 	return result;
 };
@@ -214,7 +214,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 ButtonWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes["class"] || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle) {
+	if(changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes["class"] || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || (this.popupTitle && changedAttributes[this.popupTitle]) || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -43,7 +43,7 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 	var classes = this["class"].split(" ") || [],
 		isPoppedUp = this.popup && this.isPoppedUp();
 	if(this.selectedClass) {
-		if(this.set && this.setTo && this.isSelected()) {
+		if((this.set || this.setTitle) && this.setTo && this.isSelected()) {
 			$tw.utils.pushTop(classes,this.selectedClass.split(" "));
 		}
 		if(isPoppedUp) {
@@ -78,11 +78,11 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 			self.dispatchMessage(event);
 			handled = true;
 		}
-		if(self.popup) {
+		if(self.popup || self.popupTitle) {
 			self.triggerPopup(event);
 			handled = true;
 		}
-		if(self.set) {
+		if(self.set || self.setTitle) {
 			self.setTiddler();
 			handled = true;
 		}
@@ -122,11 +122,14 @@ ButtonWidget.prototype.getBoundingClientRect = function() {
 };
 
 ButtonWidget.prototype.isSelected = function() {
-    return this.wiki.getTextReference(this.set,this.defaultSetValue,this.getVariable("currentTiddler")) === this.setTo;
+    return this.setTitle ? (this.setField ? this.wiki.getTiddler(this.setTitle).getFieldString(this.setField) === this.setTo :
+		(this.setIndex ? this.wiki.extractTiddlerDataItem(this.setTitle,this.setIndex) === this.setTo :
+			this.wiki.getTiddlerText(this.setTitle))) || this.defaultSetValue || this.getVariable("currentTiddler") :
+		this.wiki.getTextReference(this.set,this.defaultSetValue,this.getVariable("currentTiddler")) === this.setTo;
 };
 
 ButtonWidget.prototype.isPoppedUp = function() {
-	var tiddler = this.wiki.getTiddler(this.popup);
+	var tiddler = this.popupTitle ? this.wiki.getTiddlerText(this.popupTitle) : this.wiki.getTiddler(this.popup);
 	var result = tiddler && tiddler.fields.text ? $tw.popup.readPopupState(tiddler.fields.text) : false;
 	return result;
 };
@@ -150,15 +153,30 @@ ButtonWidget.prototype.dispatchMessage = function(event) {
 };
 
 ButtonWidget.prototype.triggerPopup = function(event) {
-	$tw.popup.triggerPopup({
-		domNode: this.domNodes[0],
-		title: this.popup,
-		wiki: this.wiki
-	});
+	if(this.popupTitle) {
+		$tw.popup.triggerPopup({
+			domNode: this.domNodes[0],
+			title: this.popupTitle,
+			wiki: this.wiki,
+			noStateReference: true
+		});
+	} else {
+		$tw.popup.triggerPopup({
+			domNode: this.domNodes[0],
+			title: this.popup,
+			wiki: this.wiki
+		});
+	}
 };
 
 ButtonWidget.prototype.setTiddler = function() {
-	this.wiki.setTextReference(this.set,this.setTo,this.getVariable("currentTiddler"));
+	if(this.setTitle) {
+		this.setField ? this.wiki.setText(this.setTitle,this.setField,undefined,this.setTo) :
+				(this.setIndex ? this.wiki.setText(this.setTitle,undefined,this.setIndex,this.setTo) :
+				this.wiki.setText(this.setTitle,"text",undefined,this.setTo));
+	} else {
+		this.wiki.setTextReference(this.set,this.setTo,this.getVariable("currentTiddler"));
+	}
 };
 
 /*
@@ -183,6 +201,10 @@ ButtonWidget.prototype.execute = function() {
 	this.buttonTag = this.getAttribute("tag");
 	this.dragTiddler = this.getAttribute("dragTiddler");
 	this.dragFilter = this.getAttribute("dragFilter");
+	this.setTitle = this.getAttribute("setTitle");
+	this.setField = this.getAttribute("setField");
+	this.setIndex = this.getAttribute("setIndex");
+	this.popupTitle = this.getAttribute("popupTitle");
 	// Make child widgets
 	this.makeChildWidgets();
 };
@@ -192,7 +214,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 ButtonWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes["class"] || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup])) {
+	if(changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes["class"] || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -102,7 +102,10 @@ RevealWidget.prototype.execute = function() {
 	this.openAnimation = this.animate === "no" ? undefined : "open";
 	this.closeAnimation = this.animate === "no" ? undefined : "close";
 	// Compute the title of the state tiddler and read it
-	this.stateTitle = this.state;
+	this.stateTiddlerTitle = this.state;
+	this.stateTitle = this.getAttribute("stateTitle");
+	this.stateField = this.getAttribute("stateField");
+	this.stateIndex = this.getAttribute("stateIndex");
 	this.readState();
 	// Construct the child widgets
 	var childNodes = this.isOpen ? this.parseTreeNode.children : [];
@@ -115,7 +118,10 @@ Read the state tiddler
 */
 RevealWidget.prototype.readState = function() {
 	// Read the information from the state tiddler
-	var state = this.stateTitle ? this.wiki.getTextReference(this.stateTitle,this["default"],this.getVariable("currentTiddler")) : this["default"];
+	var state = this.stateTitle ? (this.stateField ? this.wiki.getTiddler(this.stateTitle).getFieldString(this.stateField) :
+		(this.stateIndex ? this.wiki.extractTiddlerDataItem(this.stateTitle,this.stateIndex) :
+			this.wiki.getTiddlerText(this.stateTitle))) || this["default"] || this.getVariable("currentTiddler") :
+		(this.stateTiddlerTitle ? this.wiki.getTextReference(this.state,this["default"],this.getVariable("currentTiddler")) : this["default"]);
 	switch(this.type) {
 		case "popup":
 			this.readPopupState(state);
@@ -170,13 +176,13 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 RevealWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.state || changedAttributes.type || changedAttributes.text || changedAttributes.position || changedAttributes["default"] || changedAttributes.animate) {
+	if(changedAttributes.state || changedAttributes.type || changedAttributes.text || changedAttributes.position || changedAttributes["default"] || changedAttributes.animate || changedAttributes.stateTitle || changedAttributes.stateField || changedAttributes.stateIndex) {
 		this.refreshSelf();
 		return true;
 	} else {
 		var currentlyOpen = this.isOpen;
 		this.readState();
-		if(this.isOpen !== currentlyOpen || (this.stateTitle && changedTiddlers[this.stateTitle])) {
+		if(this.isOpen !== currentlyOpen || (this.stateTiddlerTitle && changedTiddlers[this.stateTiddlerTitle])) {
 			if(this.retain === "yes") {
 				this.updateState();
 			} else {
@@ -218,7 +224,7 @@ RevealWidget.prototype.updateState = function() {
 			if(!self.isOpen) {
 				domNode.setAttribute("hidden","true");
 			}
-        	}});
+		}});
 	}
 };
 


### PR DESCRIPTION
this adds following attributes to the reveal widget:

- `stateTitle`
- `stateField`
- `stateIndex`

these attributes are new for the button widget:

-  `setTitle`
- `setField`
- `setIndex`
- `popupTitle`

<hr>

it uses `getTiddlerText` / `getFieldString` / `extractTiddlerDataItem` respectively `setText` when `stateTitle` is used ... instead of `getTextReference` / `setTextReference`

the button widget passes a `noStateReference` property to `triggerPopup` when `popupTitle` is used

from the logic this should be sufficient to make state-breaking titles work. For other attributes like `to` (button widget) there should be workarounds available

if this can get somewhere, I'd add the necessary documentation
