### PR TITLE
tv-override-missing-links: fix links to missing tiddlers

### DIFF
--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -37,9 +37,10 @@ LinkWidget.prototype.render = function(parent,nextSibling) {
 	// Get the value of the tv-wikilinks configuration macro
 	var wikiLinksMacro = this.getVariable("tv-wikilinks"),
 		useWikiLinks = wikiLinksMacro ? (wikiLinksMacro.trim() !== "no") : true,
-		missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow);
+		missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow),
+	    	overrideMissingLinksEnabled = this.getVariable("tv-override-missing-links") === "true";
 	// Render the link if required
-	if(useWikiLinks && missingLinksEnabled) {
+	if(useWikiLinks && (missingLinksEnabled || overrideMissingLinksEnabled)) {
 		this.renderLink(parent,nextSibling);
 	} else {
 		// Just insert the link text

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -191,7 +191,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 LinkWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.to || changedTiddlers[this.to] || changedAttributes["aria-label"] || changedAttributes.tooltip || changedTiddlers["$:/config/MissingLinks"]) {
+	if(changedAttributes.to || changedTiddlers[this.to] || changedAttributes["aria-label"] || changedAttributes.tooltip) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -37,10 +37,9 @@ LinkWidget.prototype.render = function(parent,nextSibling) {
 	// Get the value of the tv-wikilinks configuration macro
 	var wikiLinksMacro = this.getVariable("tv-wikilinks"),
 		useWikiLinks = wikiLinksMacro ? (wikiLinksMacro.trim() !== "no") : true,
-		missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow),
-	    	overrideMissingLinksEnabled = this.getVariable("tv-override-missing-links") === "true";
+		missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow);
 	// Render the link if required
-	if(useWikiLinks && (missingLinksEnabled || overrideMissingLinksEnabled)) {
+	if(useWikiLinks && (missingLinksEnabled || this.getVariable("tv-override-missing-links") === "true")) {
 		this.renderLink(parent,nextSibling);
 	} else {
 		// Just insert the link text

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -39,7 +39,7 @@ LinkWidget.prototype.render = function(parent,nextSibling) {
 		useWikiLinks = wikiLinksMacro ? (wikiLinksMacro.trim() !== "no") : true,
 		missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow);
 	// Render the link if required
-	if(useWikiLinks && (missingLinksEnabled || this.getVariable("tv-override-missing-links") === "true")) {
+	if(useWikiLinks && (missingLinksEnabled || this.getVariable("tv-hide-missing-links") === "no")) {
 		this.renderLink(parent,nextSibling);
 	} else {
 		// Just insert the link text

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -13,7 +13,6 @@ Link widget
 "use strict";
 
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
-var MISSING_LINK_CONFIG_TITLE = "$:/config/MissingLinks";
 
 var LinkWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
@@ -39,7 +38,7 @@ LinkWidget.prototype.render = function(parent,nextSibling) {
 		useWikiLinks = wikiLinksMacro ? (wikiLinksMacro.trim() !== "no") : true,
 		missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow);
 	// Render the link if required
-	if(useWikiLinks && (missingLinksEnabled || this.getVariable("tv-hide-missing-links") === "no")) {
+	if(useWikiLinks && missingLinksEnabled) {
 		this.renderLink(parent,nextSibling);
 	} else {
 		// Just insert the link text
@@ -182,7 +181,7 @@ LinkWidget.prototype.execute = function() {
 	// Determine the link characteristics
 	this.isMissing = !this.wiki.tiddlerExists(this.to);
 	this.isShadow = this.wiki.isShadowTiddler(this.to);
-	this.hideMissingLinks = ($tw.wiki.getTiddlerText(MISSING_LINK_CONFIG_TITLE,"yes") === "no");
+	this.hideMissingLinks = this.getVariable("tv-hide-missing-links") === "yes";
 	// Make the child widgets
 	this.makeChildWidgets();
 };
@@ -192,7 +191,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 LinkWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.to || changedTiddlers[this.to] || changedAttributes["aria-label"] || changedAttributes.tooltip || changedTiddlers[MISSING_LINK_CONFIG_TITLE]) {
+	if(changedAttributes.to || changedTiddlers[this.to] || changedAttributes["aria-label"] || changedAttributes.tooltip || changedTiddlers["$:/config/MissingLinks"]) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/ui/AdvancedSearch/FilterButtons/dropdown.tid
+++ b/core/ui/AdvancedSearch/FilterButtons/dropdown.tid
@@ -8,7 +8,7 @@ tags: $:/tags/AdvancedSearch/FilterButton
 </span>
 
 <$reveal state=<<qualify "$:/state/filterDropdown">> type="popup" position="belowleft" animate="yes">
-<$vars tv-override-missing-links="true">
+<$vars tv-hide-missing-links="no">
 <$linkcatcher to="$:/temp/advancedsearch">
 <div class="tc-block-dropdown-wrapper">
 <div class="tc-block-dropdown tc-edit-type-dropdown">

--- a/core/ui/AdvancedSearch/FilterButtons/dropdown.tid
+++ b/core/ui/AdvancedSearch/FilterButtons/dropdown.tid
@@ -8,6 +8,7 @@ tags: $:/tags/AdvancedSearch/FilterButton
 </span>
 
 <$reveal state=<<qualify "$:/state/filterDropdown">> type="popup" position="belowleft" animate="yes">
+<$vars tv-override-missing-links="true">
 <$linkcatcher to="$:/temp/advancedsearch">
 <div class="tc-block-dropdown-wrapper">
 <div class="tc-block-dropdown tc-edit-type-dropdown">
@@ -16,4 +17,5 @@ tags: $:/tags/AdvancedSearch/FilterButton
 </div>
 </div>
 </$linkcatcher>
+</$vars>
 </$reveal>

--- a/core/ui/AdvancedSearch/FilterButtons/dropdown.tid
+++ b/core/ui/AdvancedSearch/FilterButtons/dropdown.tid
@@ -8,7 +8,7 @@ tags: $:/tags/AdvancedSearch/FilterButton
 </span>
 
 <$reveal state=<<qualify "$:/state/filterDropdown">> type="popup" position="belowleft" animate="yes">
-<$vars tv-hide-missing-links="no">
+<$set name="tv-hide-missing-links" value="no">
 <$linkcatcher to="$:/temp/advancedsearch">
 <div class="tc-block-dropdown-wrapper">
 <div class="tc-block-dropdown tc-edit-type-dropdown">
@@ -17,5 +17,5 @@ tags: $:/tags/AdvancedSearch/FilterButton
 </div>
 </div>
 </$linkcatcher>
-</$vars>
+</$set>
 </$reveal>

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -65,6 +65,7 @@ $value={{$:/temp/newfieldvalue}}/>
 <$button popup=<<qualify "$:/state/popup/field-dropdown">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Field/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Field/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button>
 <$reveal state=<<qualify "$:/state/popup/field-dropdown">> type="nomatch" text="" default="">
 <div class="tc-block-dropdown tc-edit-type-dropdown">
+<$vars tv-override-missing-links="true">
 <$linkcatcher to="$:/temp/newfieldname">
 <div class="tc-dropdown-item">
 <<lingo Fields/Add/Dropdown/User>>
@@ -83,6 +84,7 @@ $value={{$:/temp/newfieldvalue}}/>
 </$link>
 </$list>
 </$linkcatcher>
+</$vars>
 </div>
 </$reveal>
 <span class="tc-edit-field-add-value">

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -65,7 +65,7 @@ $value={{$:/temp/newfieldvalue}}/>
 <$button popup=<<qualify "$:/state/popup/field-dropdown">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Field/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Field/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button>
 <$reveal state=<<qualify "$:/state/popup/field-dropdown">> type="nomatch" text="" default="">
 <div class="tc-block-dropdown tc-edit-type-dropdown">
-<$vars tv-override-missing-links="true">
+<$set name="tv-hide-missing-links" value="no">
 <$linkcatcher to="$:/temp/newfieldname">
 <div class="tc-dropdown-item">
 <<lingo Fields/Add/Dropdown/User>>
@@ -84,7 +84,7 @@ $value={{$:/temp/newfieldvalue}}/>
 </$link>
 </$list>
 </$linkcatcher>
-</$vars>
+</$set>
 </div>
 </$reveal>
 <span class="tc-edit-field-add-value">

--- a/core/ui/EditTemplate/type.tid
+++ b/core/ui/EditTemplate/type.tid
@@ -7,7 +7,7 @@ tags: $:/tags/EditTemplate
 </$fieldmangler></div>
 
 <div class="tc-block-dropdown-wrapper">
-<$vars tv-override-missing-links="true">
+<$set name="tv-hide-missing-links" value="no">
 <$reveal state=<<qualify "$:/state/popup/type-dropdown">> type="nomatch" text="" default="">
 <div class="tc-block-dropdown tc-edit-type-dropdown">
 <$linkcatcher to="!!type">
@@ -21,5 +21,5 @@ tags: $:/tags/EditTemplate
 </$linkcatcher>
 </div>
 </$reveal>
-</$vars>
+</$set>
 </div>

--- a/core/ui/EditTemplate/type.tid
+++ b/core/ui/EditTemplate/type.tid
@@ -7,6 +7,7 @@ tags: $:/tags/EditTemplate
 </$fieldmangler></div>
 
 <div class="tc-block-dropdown-wrapper">
+<$vars tv-override-missing-links="true">
 <$reveal state=<<qualify "$:/state/popup/type-dropdown">> type="nomatch" text="" default="">
 <div class="tc-block-dropdown tc-edit-type-dropdown">
 <$linkcatcher to="!!type">
@@ -20,4 +21,5 @@ tags: $:/tags/EditTemplate
 </$linkcatcher>
 </div>
 </$reveal>
+</$vars>
 </div>

--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -11,6 +11,8 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 
 <$set name="tv-config-toolbar-class" value={{$:/config/Toolbar/ButtonClass}}>
 
+<$set name="tv-hide-missing-links" value={{$:/config/MissingLinks}}>
+
 <$set name="storyviewTitle" value={{$:/view}}>
 
 <$set name="currentTiddler" value={{$:/language}}>
@@ -36,6 +38,8 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 </$navigator>
 
 </div>
+
+</$set>
 
 </$set>
 

--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -16,13 +16,11 @@ caption: {{$:/language/TagManager/Caption}}
 <$button popup=<<qualify "$:/state/popup/icon/$title$">> class="tc-btn-invisible tc-btn-dropdown">{{$:/core/images/down-arrow}}</$button>
 <$reveal state=<<qualify "$:/state/popup/icon/$title$">> type="popup" position="belowleft" text="" default="">
 <div class="tc-drop-down">
-<$vars tv-override-missing-links="true">
 <$linkcatcher to="$title$!!icon">
 <<iconEditorTab type:"!">>
 <hr/>
 <<iconEditorTab type:"">>
 </$linkcatcher>
-</$vars>
 </div>
 </$reveal>
 </div>

--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -16,11 +16,13 @@ caption: {{$:/language/TagManager/Caption}}
 <$button popup=<<qualify "$:/state/popup/icon/$title$">> class="tc-btn-invisible tc-btn-dropdown">{{$:/core/images/down-arrow}}</$button>
 <$reveal state=<<qualify "$:/state/popup/icon/$title$">> type="popup" position="belowleft" text="" default="">
 <div class="tc-drop-down">
+<$vars tv-override-missing-links="true">
 <$linkcatcher to="$title$!!icon">
 <<iconEditorTab type:"!">>
 <hr/>
 <<iconEditorTab type:"">>
 </$linkcatcher>
+</$vars>
 </div>
 </$reveal>
 </div>


### PR DESCRIPTION
this adds a variable `tv-override-missing-links` that gets detected by the `link widget`

that enables us to render links like in the `Filter` dropdown of the `Advanced Search` , even if  `enable links to missing tiddlers` is unchecked in the Control-Panel-Settings-Tab

See discussion in the groups: https://groups.google.com/forum/#!topic/TiddlyWiki/E7qL1-hOOxM

fixes:

- filter dropdown in AdvancedSearch
- type dropdown in EditTemplate
- field-name dropdown in EditTemplate
