### PR TITLE
use stateTitle stateField setTitle ...

### DIFF
--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -41,13 +41,13 @@ $(currentTiddler)$!!popup-$(payloadTiddler)$
 <$checkbox field=<<selectionField>> checked="checked" unchecked="unchecked" default="checked"/>
 </td>
 <td>
-<$reveal type="nomatch" state=<<previewPopupState>> text="yes" tag="div">
-<$button class="tc-btn-invisible tc-btn-dropdown" set=<<previewPopupState>> setTo="yes">
+<$reveal type="nomatch" stateTitle=<<previewPopupState>> text="yes" tag="div">
+<$button class="tc-btn-invisible tc-btn-dropdown" setTitle=<<previewPopupState>> setTo="yes">
 {{$:/core/images/right-arrow}}&nbsp;<$text text=<<payloadTiddler>>/>
 </$button>
 </$reveal>
-<$reveal type="match" state=<<previewPopupState>> text="yes" tag="div">
-<$button class="tc-btn-invisible tc-btn-dropdown" set=<<previewPopupState>> setTo="no">
+<$reveal type="match" stateTitle=<<previewPopupState>> text="yes" tag="div">
+<$button class="tc-btn-invisible tc-btn-dropdown" setTitle=<<previewPopupState>> setTo="no">
 {{$:/core/images/down-arrow}}&nbsp;<$text text=<<payloadTiddler>>/>
 </$button>
 </$reveal>
@@ -58,7 +58,7 @@ $(currentTiddler)$!!popup-$(payloadTiddler)$
 </tr>
 <tr>
 <td colspan="3">
-<$reveal type="match" text="yes" state=<<previewPopupState>> tag="div">
+<$reveal type="match" text="yes" stateTitle=<<previewPopupState>> tag="div">
 <$list filter="[{$:/state/importpreviewtype}has[text]]" variable="listItem" emptyMessage={{$:/core/ui/ImportPreviews/Text}}>
 <$transclude tiddler={{$:/state/importpreviewtype}}/>
 </$list>

--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -13,8 +13,8 @@ caption: {{$:/language/TagManager/Caption}}
 \end
 \define iconEditor(title)
 <div class="tc-drop-down-wrapper">
-<$button popup=<<qualify "$:/state/popup/icon/$title$">> class="tc-btn-invisible tc-btn-dropdown">{{$:/core/images/down-arrow}}</$button>
-<$reveal state=<<qualify "$:/state/popup/icon/$title$">> type="popup" position="belowleft" text="" default="">
+<$button popupTitle=<<qualify "$:/state/popup/icon/$title$">> class="tc-btn-invisible tc-btn-dropdown">{{$:/core/images/down-arrow}}</$button>
+<$reveal stateTitle=<<qualify "$:/state/popup/icon/$title$">> type="popup" position="belowleft" text="" default="">
 <div class="tc-drop-down">
 <$linkcatcher to="$title$!!icon">
 <<iconEditorTab type:"!">>
@@ -29,13 +29,13 @@ caption: {{$:/language/TagManager/Caption}}
 $title$$(currentTiddler)$
 \end
 \define toggleButton(state)
-<$reveal state="$state$" type="match" text="closed" default="closed">
-<$button set="$state$" setTo="open" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
+<$reveal stateTitle="$state$" type="match" text="closed" default="closed">
+<$button setTitle="$state$" setTo="open" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
 {{$:/core/images/info-button}}
 </$button>
 </$reveal>
-<$reveal state="$state$" type="match" text="open" default="closed">
-<$button set="$state$" setTo="closed" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
+<$reveal stateTitle="$state$" type="match" text="open" default="closed">
+<$button setTitle="$state$" setTo="closed" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
 {{$:/core/images/info-button}}
 </$button>
 </$reveal>
@@ -64,7 +64,7 @@ $title$$(currentTiddler)$
 <tr>
 <td></td>
 <td colspan="4">
-<$reveal state=<<qualifyTitle "$:/state/tag-manager/">> type="match" text="open" default="">
+<$reveal stateTitle=<<qualifyTitle "$:/state/tag-manager/">> type="match" text="open" default="">
 <table>
 <tbody>
 <tr><td><<lingo Colour/Heading>></td><td><$edit-text field="color" tag="input" type="text" size="9"/></td></tr>

--- a/core/ui/ViewTemplate/body.tid
+++ b/core/ui/ViewTemplate/body.tid
@@ -1,7 +1,7 @@
 title: $:/core/ui/ViewTemplate/body
 tags: $:/tags/ViewTemplate
 
-<$reveal tag="div" class="tc-tiddler-body" type="nomatch" state=<<folded-state>> text="hide" retain="yes" animate="yes">
+<$reveal tag="div" class="tc-tiddler-body" type="nomatch" stateTitle=<<folded-state>> text="hide" retain="yes" animate="yes">
 
 <$list filter="[all[current]!has[plugin-type]!field:hide-body[yes]]">
 

--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -36,19 +36,19 @@ tags: $:/tags/Macro
   <$set name="toc-item-class" filter=<<__itemClassFilter__>> emptyValue="toc-item" value="toc-item-selected">
     <li class=<<toc-item-class>>>
     <$link>
-      <$reveal type="nomatch" state=<<toc-state>> text="open">
-        <$button set=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
+      <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
+        <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
           {{$:/core/images/right-arrow}}
         </$button>
       </$reveal>
-      <$reveal type="match" state=<<toc-state>> text="open">
-        <$button set=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
+      <$reveal type="match" stateTitle=<<toc-state>> text="open">
+        <$button setTitle=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
           {{$:/core/images/down-arrow}}
         </$button>
       </$reveal>
       <<toc-caption>>
     </$link>
-    <$reveal type="match" state=<<toc-state>> text="open">
+    <$reveal type="match" stateTitle=<<toc-state>> text="open">
       <$macrocall $name="toc-expandable" tag=<<currentTiddler>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> exclude=<<__exclude__>> path=<<__path__>>/>
     </$reveal>
     </li>
@@ -61,19 +61,19 @@ tags: $:/tags/Macro
 <$qualify name="toc-state" title={{{ [[$:/state/toc]addsuffix<__path__>addsuffix[-]addsuffix<currentTiddler>] }}}>
   <$set name="toc-item-class" filter=<<__itemClassFilter__>> emptyValue="toc-item" value="toc-item-selected">
     <li class=<<toc-item-class>>>
-      <$reveal type="nomatch" state=<<toc-state>> text="open">
-        <$button set=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
+      <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
+        <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
           {{$:/core/images/right-arrow}}
           <<toc-caption>>
         </$button>
       </$reveal>
-      <$reveal type="match" state=<<toc-state>> text="open">
-        <$button set=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
+      <$reveal type="match" stateTitle=<<toc-state>> text="open">
+        <$button setTitle=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
           {{$:/core/images/down-arrow}}
           <<toc-caption>>
         </$button>
       </$reveal>
-      <$reveal type="match" state=<<toc-state>> text="open">
+      <$reveal type="match" stateTitle=<<toc-state>> text="open">
         <$macrocall $name="toc-expandable" tag=<<currentTiddler>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> exclude=<<__exclude__>> path=<<__path__>>/>
       </$reveal>
     </li>
@@ -103,20 +103,20 @@ tags: $:/tags/Macro
     <li class=<<toc-item-class>>>
       <$link>
           <$list filter="[all[current]tagging[]limit[1]]" variable="ignore" emptyMessage="<$button class='tc-btn-invisible'>{{$:/core/images/blank}}</$button>">
-          <$reveal type="nomatch" state=<<toc-state>> text="open">
-            <$button set=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
+          <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
+            <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
               {{$:/core/images/right-arrow}}
             </$button>
           </$reveal>
-          <$reveal type="match" state=<<toc-state>> text="open">
-            <$button set=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
+          <$reveal type="match" stateTitle=<<toc-state>> text="open">
+            <$button setTitle=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
               {{$:/core/images/down-arrow}}
             </$button>
           </$reveal>
         </$list>
         <<toc-caption>>
       </$link>
-      <$reveal type="match" state=<<toc-state>> text="open">
+      <$reveal type="match" stateTitle=<<toc-state>> text="open">
         <$macrocall $name="toc-selective-expandable" tag=<<currentTiddler>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> exclude=<<__exclude__>> path=<<__path__>>/>
       </$reveal>
     </li>
@@ -129,20 +129,20 @@ tags: $:/tags/Macro
   <$set name="toc-item-class" filter=<<__itemClassFilter__>> emptyValue="toc-item" value="toc-item-selected">
     <li class=<<toc-item-class>>>
       <$list filter="[all[current]tagging[]limit[1]]" variable="ignore" emptyMessage="<$button class='tc-btn-invisible'>{{$:/core/images/blank}}</$button> <$view field='caption'><$view field='title'/></$view>">
-        <$reveal type="nomatch" state=<<toc-state>> text="open">
-          <$button set=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
+        <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
+          <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
             {{$:/core/images/right-arrow}}
             <<toc-caption>>
           </$button>
         </$reveal>
-        <$reveal type="match" state=<<toc-state>> text="open">
-          <$button set=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
+        <$reveal type="match" stateTitle=<<toc-state>> text="open">
+          <$button setTitle=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
             {{$:/core/images/down-arrow}}
             <<toc-caption>>
           </$button>
         </$reveal>
       </$list>
-      <$reveal type="match" state=<<toc-state>> text="open">
+      <$reveal type="match" stateTitle=<<toc-state>> text="open">
         <$macrocall $name="toc-selective-expandable" tag=<<currentTiddler>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> exclude=<<__exclude__>> path=<<__path__>>/>
       </$reveal>
     </li>
@@ -175,13 +175,13 @@ tags: $:/tags/Macro
       </div>
     </$linkcatcher>
     <div class="tc-tabbed-table-of-contents-content">
-      <$reveal state=<<__selectedTiddler__>> type="nomatch" text="">
+      <$reveal stateTitle=<<__selectedTiddler__>> type="nomatch" text="">
         <$transclude mode="block" tiddler=<<__template__>>>
           <h1><<toc-caption>></h1>
           <$transclude mode="block">$missingText$</$transclude>
         </$transclude>
       </$reveal>
-      <$reveal state=<<__selectedTiddler__>> type="match" text="">
+      <$reveal stateTitle=<<__selectedTiddler__>> type="match" text="">
         $unselectedText$
       </$reveal>
     </div>

--- a/core/wiki/macros/tree.tid
+++ b/core/wiki/macros/tree.tid
@@ -16,15 +16,15 @@ emptyMessage="""<$text text="$prefix$$(chunk)$"/>""">
 <$reveal type="nomatch" text="" default="""$(chunk)$""">
 <li>      
 <$list filter="""[all[shadows+tiddlers]prefix[$prefix$$(chunk)$]] -[[$prefix$$(chunk)$]] +[limit[1]]""">
-<$reveal type="nomatch" state="""$:/state/tree/$prefix$$(chunk)$""" text="show">
-<$button set="""$:/state/tree/$prefix$$(chunk)$""" setTo="show" class="tc-btn-invisible">{{$:/core/images/folder}} <$text text="""$(chunk)$"""/></$button>
+<$reveal type="nomatch" stateTitle="""$:/state/tree/$prefix$$(chunk)$""" text="show">
+<$button setTitle="""$:/state/tree/$prefix$$(chunk)$""" setTo="show" class="tc-btn-invisible">{{$:/core/images/folder}} <$text text="""$(chunk)$"""/></$button>
 </$reveal>
-<$reveal type="match" state="""$:/state/tree/$prefix$$(chunk)$""" text="show">
-<$button set="""$:/state/tree/$prefix$$(chunk)$""" setTo="hide" class="tc-btn-invisible">{{$:/core/images/folder}} <$text text="""$(chunk)$"""/></$button>
+<$reveal type="match" stateTitle="""$:/state/tree/$prefix$$(chunk)$""" text="show">
+<$button setTitle="""$:/state/tree/$prefix$$(chunk)$""" setTo="hide" class="tc-btn-invisible">{{$:/core/images/folder}} <$text text="""$(chunk)$"""/></$button>
 </$reveal>
 </$list>
 <$list filter="""[all[shadows+tiddlers]prefix[$prefix$$(chunk)$]] -[[$prefix$$(chunk)$]] +[limit[1]]"""><span>(<$count filter="""[all[shadows+tiddlers]prefix[$prefix$$(chunk)$]] -[[$prefix$$(chunk)$]]"""/>)</span>
-<$reveal type="match" state="""$:/state/tree/$prefix$$(chunk)$""" text="show">
+<$reveal type="match" stateTitle="""$:/state/tree/$prefix$$(chunk)$""" text="show">
 <$macrocall $name="tree-node" prefix="""$prefix$$(chunk)$"""/>
 </$reveal>
 </$list>


### PR DESCRIPTION
this replaces `state=...` , `set=...` and `popup=...` where tiddler titles are used for the states with

- `stateTitle=...`
- `setTitle=...`
- `popupTitle=...`

I've grepped for the affected files and I hope I got them all:

- toc macros
- tree macros
- Tag Manager
- folded-state in body-viewtemplate
- import listings (preview dropdowns)
