### PR TITLE
tree macro - fix for double quotes problem

### DIFF
--- a/core/wiki/macros/tree.tid
+++ b/core/wiki/macros/tree.tid
@@ -1,53 +1,64 @@
 title: $:/core/macros/tree
 tags: $:/tags/Macro
 
-\define leaf-node(prefix)
+\define leaf-link(full-title, chunk)
+<$link to=<<__full-title__>>>
+<$text text=<<__chunk__>>/>
+</$link>
+\end
+
+\define leaf-node(prefix, chunk)
 <li>
-<$list filter="""[[$prefix$$(chunk)$]is[shadow]] [[$prefix$$(chunk)$]is[tiddler]] +[removeprefix[$prefix$]] +[limit[1]]""" 
-emptyMessage="""<$text text="$prefix$$(chunk)$"/>""">
-<span>{{$:/core/images/file}}</span> <$link to="""$prefix$$(chunk)$""">
-<$view field="title"/>
-</$link> 
+<$list filter="[<__prefix__>addsuffix<__chunk__>is[shadow]] [<__prefix__>addsuffix<__chunk__>is[tiddler]]" variable="full-title">
+<$list filter="[<full-title>] +[removeprefix<__prefix__>]" variable="chunk">
+<span>{{$:/core/images/file}}</span>
+<$macrocall $name="leaf-link" full-title=<<full-title>> chunk=<<chunk>>/>
+</$list>
 </$list>
 </li>
 \end
 
-\define branch-node(prefix)
-<$reveal type="nomatch" text="" default="""$(chunk)$""">
-<li>      
-<$list filter="""[all[shadows+tiddlers]prefix[$prefix$$(chunk)$]] -[[$prefix$$(chunk)$]] +[limit[1]]""">
-<$reveal type="nomatch" state="""$:/state/tree/$prefix$$(chunk)$""" text="show">
-<$button set="""$:/state/tree/$prefix$$(chunk)$""" setTo="show" class="tc-btn-invisible">{{$:/core/images/folder}} <$text text="""$(chunk)$"""/></$button>
+\define branch-node(prefix, chunk)
+<li>
+<$set name="reveal-state" value={{{ [[$:/state/tree/]addsuffix<__prefix__>addsuffix<__chunk__>] }}}>
+<$reveal type="nomatch" state=<<reveal-state>> text="show">
+<$button set=<<reveal-state>> setTo="show" class="tc-btn-invisible">
+{{$:/core/images/folder}} <$text text=<<__chunk__>>/>
+</$button>
 </$reveal>
-<$reveal type="match" state="""$:/state/tree/$prefix$$(chunk)$""" text="show">
-<$button set="""$:/state/tree/$prefix$$(chunk)$""" setTo="hide" class="tc-btn-invisible">{{$:/core/images/folder}} <$text text="""$(chunk)$"""/></$button>
+<$reveal type="match" state=<<reveal-state>> text="show">
+<$button set=<<reveal-state>> setTo="hide" class="tc-btn-invisible">
+{{$:/core/images/folder}} <$text text=<<__chunk__>>/>
+</$button>
 </$reveal>
-</$list>
-<$list filter="""[all[shadows+tiddlers]prefix[$prefix$$(chunk)$]] -[[$prefix$$(chunk)$]] +[limit[1]]"""><span>(<$count filter="""[all[shadows+tiddlers]prefix[$prefix$$(chunk)$]] -[[$prefix$$(chunk)$]]"""/>)</span>
-<$reveal type="match" state="""$:/state/tree/$prefix$$(chunk)$""" text="show">
-<$macrocall $name="tree-node" prefix="""$prefix$$(chunk)$"""/>
+<span>
+(<$count filter="[all[shadows+tiddlers]] +[removeprefix<__prefix__>removeprefix<__chunk__>] -[<__prefix__>addsuffix<__chunk__>]"/>)
+</span>
+<$reveal type="match" state=<<reveal-state>> text="show">
+<$macrocall $name="tree-node" prefix={{{ [<__prefix__>addsuffix<__chunk__>] }}}/>
 </$reveal>
-</$list>
+</$set>
 </li>
-</$reveal>
 \end
 
 \define tree-node(prefix)
 <ol>
-<$list filter="[all[shadows+tiddlers]removeprefix[$prefix$]splitbefore[/]sort[title]] +[!suffix[/]]" variable="chunk">
-<<leaf-node """$prefix$""">>
+<$list filter="[all[shadows+tiddlers]] +[removeprefix<__prefix__>] +[splitbefore[/]] +[sort[]] +[!suffix[/]]" variable="chunk">
+<$macrocall $name="leaf-node" prefix=<<__prefix__>> chunk=<<chunk>>/>
 </$list>
-<$list filter="[all[shadows+tiddlers]removeprefix[$prefix$]splitbefore[/]sort[title]] +[suffix[/]]" variable="chunk">
-<<branch-node """$prefix$""">>
+<$list filter="[all[shadows+tiddlers]] +[removeprefix<__prefix__>] +[splitbefore[/]] +[sort[]] +[suffix[/]]" variable="chunk">
+<$macrocall $name="branch-node" prefix=<<__prefix__>> chunk=<<chunk>>/>
 </$list>
 </ol>
 \end
 
-\define tree(prefix)
+\define tree(prefix: "$:/")
 <div class="tc-tree">
-<span><$text text="""$prefix$"""/></span>
+<span>
+<$text text=<<__prefix__>>/>
+</span>
 <div>
-<$macrocall $name="tree-node" prefix="""$prefix$"""/>
+<$macrocall $name="tree-node" prefix=<<__prefix__>>/>
 </div>
 </div>
 \end


### PR DESCRIPTION
* Adding the 2nd batch of fixes (including @BurningTreeC suggestions)
* Remove a lot of redundant code (hope I didn't break anything)
* Set a default value for "tree" macro prefix parameter ($:/)
* Brushing the code a little bit (indentation)