### PR TITLE
List backlinks on rename

### DIFF
--- a/core/language/en-GB/EditTemplate.multids
+++ b/core/language/en-GB/EditTemplate.multids
@@ -21,7 +21,8 @@ Tags/Dropdown/Caption: tag list
 Tags/Dropdown/Hint: Show tag list
 Title/BadCharacterWarning: Warning: avoid using any of the characters <<bad-chars>> in tiddler titles
 Title/Exists/Prompt: Target tiddler already exists
-Title/Relink/Prompt: Update ''<$text text=<<fromTitle>>/>'' to ''<$text text=<<toTitle>>/>'' in the //tags// and //list// fields of other tiddlers, backlinks in <<backlinksLink>> do not change
+Title/Relink/Prompt: Update ''<$text text=<<fromTitle>>/>'' to ''<$text text=<<toTitle>>/>'' in the //tags// and //list// fields of other tiddlers
+Title/References/Prompt: The following manual links to this tiddler will not be automatically updated
 Type/Dropdown/Caption: content type list
 Type/Dropdown/Hint: Show content type list
 Type/Delete/Caption: delete content type

--- a/core/language/en-GB/EditTemplate.multids
+++ b/core/language/en-GB/EditTemplate.multids
@@ -21,7 +21,7 @@ Tags/Dropdown/Caption: tag list
 Tags/Dropdown/Hint: Show tag list
 Title/BadCharacterWarning: Warning: avoid using any of the characters <<bad-chars>> in tiddler titles
 Title/Exists/Prompt: Target tiddler already exists
-Title/Relink/Prompt: Update ''<$text text=<<fromTitle>>/>'' to ''<$text text=<<toTitle>>/>'' in the //tags// and //list// fields of other tiddlers
+Title/Relink/Prompt: Update ''<$text text=<<fromTitle>>/>'' to ''<$text text=<<toTitle>>/>'' in the //tags// and //list// fields of other tiddlers, backlinks in <<backlinksLink>> do not change
 Type/Dropdown/Caption: content type list
 Type/Dropdown/Hint: Show content type list
 Type/Delete/Caption: delete content type

--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -2,12 +2,17 @@ title: $:/core/ui/EditTemplate/title
 tags: $:/tags/EditTemplate
 
 \define backlinksLink()
-<$button class="tc-btn-invisible tc-tiddlylink">
-<$action-setfield $tiddler="$:/temp/advancedsearch" text="""[[$(fromTitle)$]backlinks[]sort[title]]"""/>
-<$action-setfield $tiddler="$:/temp/search" text=""/>
-<$action-navigate $to="$:/core/ui/AdvancedSearch/Filter"/>
-<<lingo TiddlerInfo/References/Caption>>
+<$reveal type="nomatch" state="$:/state/showeditreferencing" text="show">
+<$button set="$:/state/showeditreferencing" setTo="show" class="tc-btn-invisible tc-tiddlylink">
+<<lingo TiddlerInfo/References/Caption>> {{$:/core/images/down-arrow}}
 </$button>
+</$reveal>
+
+<$reveal type="match" state="$:/state/showeditreferencing" text="show">
+<$button set="$:/state/showeditreferencing" setTo="hide" class="tc-btn-invisible tc-tiddlylink">
+<<lingo TiddlerInfo/References/Caption>> {{$:/core/images/up-arrow}}
+</$button>
+</$reveal>
 \end
 
 <$edit-text field="draft.title" class="tc-titlebar tc-edit-texteditor" focus="true"/>
@@ -43,6 +48,11 @@ tags: $:/tags/EditTemplate
 <$vars fromTitle={{!!draft.of}} toTitle={{!!draft.title}}>
 
 <$checkbox tiddler="$:/config/RelinkOnRename" field="text" checked="yes" unchecked="no" default="no"> {{$:/language/EditTemplate/Title/Relink/Prompt}}</$checkbox>
+
+<$reveal type="match" state="$:/state/showeditreferencing" text="show">
+<$list filter="[<fromTitle>backlinks[]sort[title]]" emptyMessage=<<lingo TiddlerInfo/References/Empty>> template="$:/core/ui/ListItemTemplate">
+</$list>
+</$reveal>
 
 </$vars>
 

--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -35,19 +35,23 @@ tags: $:/tags/EditTemplate
 
 <$checkbox tiddler="$:/config/RelinkOnRename" field="text" checked="yes" unchecked="no" default="no"> {{$:/language/EditTemplate/Title/Relink/Prompt}}</$checkbox>
 
-<$reveal type="nomatch" state="$:/state/edit/references" text="show">
-<$button set="$:/state/edit/references" setTo="show" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/down-arrow}}</$button>
+<$vars stateTiddler=<<qualify "$:/state/edit/references">> >
+
+<$reveal type="nomatch" state=<<stateTiddler>> text="show">
+<$button set=<<stateTiddler>> setTo="show" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/down-arrow}}</$button>
 </$reveal>
-<$reveal type="match" state="$:/state/edit/references" text="show">
-<$button set="$:/state/edit/references" setTo="hide" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/up-arrow}}</$button>
+<$reveal type="match" state=<<stateTiddler>> text="show">
+<$button set=<<stateTiddler>> setTo="hide" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/up-arrow}}</$button>
 </$reveal>
 <<lingo EditTemplate/Title/References/Prompt>>:
 
-<$reveal type="match" state="$:/state/edit/references" text="show">
+<$reveal type="match" state=<<stateTiddler>> text="show">
 <$tiddler tiddler=<<fromTitle>> >
 <$transclude tiddler="$:/core/ui/TiddlerInfo/References"/>
 </$tiddler>
 </$reveal>
+
+</$vars>
 
 </$vars>
 

--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -1,6 +1,15 @@
 title: $:/core/ui/EditTemplate/title
 tags: $:/tags/EditTemplate
 
+\define backlinksLink()
+<$button class="tc-btn-invisible tc-tiddlylink">
+<$action-setfield $tiddler="$:/temp/advancedsearch" text="""[[$(fromTitle)$]backlinks[]sort[title]]"""/>
+<$action-setfield $tiddler="$:/temp/search" text=""/>
+<$action-navigate $to="$:/core/ui/AdvancedSearch/Filter"/>
+<<lingo TiddlerInfo/References/Caption>>
+</$button>
+\end
+
 <$edit-text field="draft.title" class="tc-titlebar tc-edit-texteditor" focus="true"/>
 
 <$vars pattern="""[\|\[\]{}]""" bad-chars="""`| [ ] { }`""">
@@ -40,5 +49,3 @@ tags: $:/tags/EditTemplate
 </$list>
 
 </$reveal>
-
-

--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -50,9 +50,9 @@ tags: $:/tags/EditTemplate
 <$checkbox tiddler="$:/config/RelinkOnRename" field="text" checked="yes" unchecked="no" default="no"> {{$:/language/EditTemplate/Title/Relink/Prompt}}</$checkbox>
 
 <$reveal type="match" state="$:/state/showeditreferencing" text="show">
-<$vars operandTitle=<<fromTitle>> >
-{{$:/core/ui/TiddlerInfo/References}}
-</$vars>
+<$tiddler tiddler=<<fromTitle>> >
+<$transclude tiddler="$:/core/ui/TiddlerInfo/References"/>
+</$tiddler>
 </$reveal>
 
 </$vars>

--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -1,20 +1,6 @@
 title: $:/core/ui/EditTemplate/title
 tags: $:/tags/EditTemplate
 
-\define backlinksLink()
-<$reveal type="nomatch" state="$:/state/showeditreferencing" text="show">
-<$button set="$:/state/showeditreferencing" setTo="show" class="tc-btn-invisible tc-tiddlylink">
-<<lingo TiddlerInfo/References/Caption>> {{$:/core/images/down-arrow}}
-</$button>
-</$reveal>
-
-<$reveal type="match" state="$:/state/showeditreferencing" text="show">
-<$button set="$:/state/showeditreferencing" setTo="hide" class="tc-btn-invisible tc-tiddlylink">
-<<lingo TiddlerInfo/References/Caption>> {{$:/core/images/up-arrow}}
-</$button>
-</$reveal>
-\end
-
 <$edit-text field="draft.title" class="tc-titlebar tc-edit-texteditor" focus="true"/>
 
 <$vars pattern="""[\|\[\]{}]""" bad-chars="""`| [ ] { }`""">
@@ -48,6 +34,14 @@ tags: $:/tags/EditTemplate
 <$vars fromTitle={{!!draft.of}} toTitle={{!!draft.title}}>
 
 <$checkbox tiddler="$:/config/RelinkOnRename" field="text" checked="yes" unchecked="no" default="no"> {{$:/language/EditTemplate/Title/Relink/Prompt}}</$checkbox>
+
+<$reveal type="nomatch" state="$:/state/showeditreferencing" text="show">
+<$button set="$:/state/showeditreferencing" setTo="show" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/down-arrow}}</$button>
+</$reveal>
+<$reveal type="match" state="$:/state/showeditreferencing" text="show">
+<$button set="$:/state/showeditreferencing" setTo="hide" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/up-arrow}}</$button>
+</$reveal>
+<<lingo EditTemplate/Title/References/Prompt>>:
 
 <$reveal type="match" state="$:/state/showeditreferencing" text="show">
 <$tiddler tiddler=<<fromTitle>> >

--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -50,8 +50,9 @@ tags: $:/tags/EditTemplate
 <$checkbox tiddler="$:/config/RelinkOnRename" field="text" checked="yes" unchecked="no" default="no"> {{$:/language/EditTemplate/Title/Relink/Prompt}}</$checkbox>
 
 <$reveal type="match" state="$:/state/showeditreferencing" text="show">
-<$list filter="[<fromTitle>backlinks[]sort[title]]" emptyMessage=<<lingo TiddlerInfo/References/Empty>> template="$:/core/ui/ListItemTemplate">
-</$list>
+<$vars operandTitle=<<fromTitle>> >
+{{$:/core/ui/TiddlerInfo/References}}
+</$vars>
 </$reveal>
 
 </$vars>

--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -35,15 +35,15 @@ tags: $:/tags/EditTemplate
 
 <$checkbox tiddler="$:/config/RelinkOnRename" field="text" checked="yes" unchecked="no" default="no"> {{$:/language/EditTemplate/Title/Relink/Prompt}}</$checkbox>
 
-<$reveal type="nomatch" state="$:/state/showeditreferencing" text="show">
-<$button set="$:/state/showeditreferencing" setTo="show" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/down-arrow}}</$button>
+<$reveal type="nomatch" state="$:/state/edit/references" text="show">
+<$button set="$:/state/edit/references" setTo="show" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/down-arrow}}</$button>
 </$reveal>
-<$reveal type="match" state="$:/state/showeditreferencing" text="show">
-<$button set="$:/state/showeditreferencing" setTo="hide" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/up-arrow}}</$button>
+<$reveal type="match" state="$:/state/edit/references" text="show">
+<$button set="$:/state/edit/references" setTo="hide" class="tc-btn-invisible tc-tiddlylink">{{$:/core/images/up-arrow}}</$button>
 </$reveal>
 <<lingo EditTemplate/Title/References/Prompt>>:
 
-<$reveal type="match" state="$:/state/showeditreferencing" text="show">
+<$reveal type="match" state="$:/state/edit/references" text="show">
 <$tiddler tiddler=<<fromTitle>> >
 <$transclude tiddler="$:/core/ui/TiddlerInfo/References"/>
 </$tiddler>

--- a/core/ui/TiddlerInfo/References.tid
+++ b/core/ui/TiddlerInfo/References.tid
@@ -3,5 +3,5 @@ tags: $:/tags/TiddlerInfo
 caption: {{$:/language/TiddlerInfo/References/Caption}}
 
 \define lingo-base() $:/language/TiddlerInfo/
-<$list filter="[all[current]backlinks[]sort[title]]" emptyMessage=<<lingo References/Empty>> template="$:/core/ui/ListItemTemplate">
+<$list filter="[<operandTitle>] [all[current]] +[each[]first[]backlinks[]sort[title]]" emptyMessage=<<lingo References/Empty>> template="$:/core/ui/ListItemTemplate">
 </$list>

--- a/core/ui/TiddlerInfo/References.tid
+++ b/core/ui/TiddlerInfo/References.tid
@@ -3,5 +3,5 @@ tags: $:/tags/TiddlerInfo
 caption: {{$:/language/TiddlerInfo/References/Caption}}
 
 \define lingo-base() $:/language/TiddlerInfo/
-<$list filter="[<operandTitle>] [all[current]] +[each[]first[]backlinks[]sort[title]]" emptyMessage=<<lingo References/Empty>> template="$:/core/ui/ListItemTemplate">
+<$list filter="[all[current]backlinks[]sort[title]]" emptyMessage=<<lingo References/Empty>> template="$:/core/ui/ListItemTemplate">
 </$list>


### PR DESCRIPTION
Currently, the user is **not warned that the links will not be modified** and the related tiddlers are "difficult" to find (you have to open Advanced Search, or exit from edit mode and look at Info -> References.

![image](https://user-images.githubusercontent.com/7034200/48313002-7bddbe00-e5ae-11e8-85f5-886735704190.png)

This PR tries to solve it (partially solves #196 too).

---

### 4c01a811d8a7bb8aaf22d4cb2e2b25386bd7e613 opens up Advanced Search to find backlinks:

![image](https://user-images.githubusercontent.com/7034200/48312947-e5110180-e5ad-11e8-94e6-f624b6334235.png)
...
![image](https://user-images.githubusercontent.com/7034200/48312955-f528e100-e5ad-11e8-98b4-94da9ac9a86c.png)

---

### 6a09661b121226d370577472854e9b5d2769cab7 listing the references inplace:

![image](https://user-images.githubusercontent.com/7034200/48312921-a2e7c000-e5ad-11e8-9d9c-4c25f52ad6da.png)

---

I prefer the latter one, but I'm not sure that it suits for you as well.
