### PR TITLE
Dynaview: add element height to state tiddler

### DIFF
--- a/editions/dynaviewdemo/tiddlers/ViewTemplate.tid
+++ b/editions/dynaviewdemo/tiddlers/ViewTemplate.tid
@@ -7,6 +7,9 @@ tc-tiddler-frame tc-tiddler-view-frame $(missingTiddlerClass)$ $(shadowTiddlerCl
 \define folded-state()
 $:/state/folded/$(currentTiddler)$
 \end
+\define hidden-styles()
+height: $(tiddlerHeight)$
+\end
 <$vars storyTiddler=<<currentTiddler>> tiddlerInfoState=<<qualify "$:/state/popup/tiddler-info">> userClass={{!!class}}>
 <$tiddler tiddler=<<currentTiddler>>>
 <div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class=<<frame-classes>>>
@@ -20,8 +23,10 @@ $:/state/folded/$(currentTiddler)$
 </div>
 </$reveal>
 <$reveal state=<<state>> type="nomatch" text="true" tag="div">
-<div class="tc-dynaview-set-tiddler-when-visible tc-dynaview-expand-viewport" style="min-height: 5em;" data-dynaview-set-tiddler=<<state>> data-dynaview-set-value="true" data-dynaview-unset-tiddler=<<state>> data-dynaview-unset-value="false" data-dynaview-has-triggered={{{ [<state>get[text]] }}}>
+<$vars tiddlerHeight={{{ [<state>get[height]] }}}>
+<div class="tc-dynaview-set-tiddler-when-visible tc-dynaview-expand-viewport" style=<<hidden-styles>> data-dynaview-set-tiddler=<<state>> data-dynaview-set-value="true" data-dynaview-unset-tiddler=<<state>> data-dynaview-unset-value="false" data-dynaview-has-triggered={{{ [<state>get[text]] }}}>
 </div>
+</$vars>
 </$reveal>
 </$set>
 

--- a/editions/dynaviewdemo/tiddlers/ViewTemplate.tid
+++ b/editions/dynaviewdemo/tiddlers/ViewTemplate.tid
@@ -15,6 +15,7 @@ height: $(tiddlerHeight)$
 <div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class=<<frame-classes>>>
 
 <$set name="state" value={{{ [[$:/state/viewtemplate/visibility/]addsuffix<currentTiddler>] }}}>
+<$vars tiddlerHeight={{{ [<state>get[height]] }}}>
 <$reveal state=<<state>> type="match" text="true" tag="div">
 <div class="tc-dynaview-set-tiddler-when-visible tc-dynaview-expand-viewport" data-dynaview-set-tiddler=<<state>> data-dynaview-set-value="true" data-dynaview-unset-tiddler=<<state>> data-dynaview-unset-value="false" data-dynaview-has-triggered={{{ [<state>get[text]] }}}>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate]!has[draft.of]]" variable="listItem">
@@ -23,11 +24,10 @@ height: $(tiddlerHeight)$
 </div>
 </$reveal>
 <$reveal state=<<state>> type="nomatch" text="true" tag="div">
-<$vars tiddlerHeight={{{ [<state>get[height]] }}}>
 <div class="tc-dynaview-set-tiddler-when-visible tc-dynaview-expand-viewport" style=<<hidden-styles>> data-dynaview-set-tiddler=<<state>> data-dynaview-set-value="true" data-dynaview-unset-tiddler=<<state>> data-dynaview-unset-value="false" data-dynaview-has-triggered={{{ [<state>get[text]] }}}>
 </div>
-</$vars>
 </$reveal>
+</$vars>
 </$set>
 
 </div>

--- a/plugins/tiddlywiki/dynaview/dynaview.js
+++ b/plugins/tiddlywiki/dynaview/dynaview.js
@@ -118,7 +118,7 @@ function checkVisibility() {
 				tiddler = element.getAttribute("data-dynaview-unset-tiddler");
 				value = element.getAttribute("data-dynaview-unset-value") || "";
 				if(tiddler && $tw.wiki.getTiddlerText(tiddler) !== value) {
-					$tw.wiki.addTiddler(new $tw.Tiddler({title: tiddler, text: value}));
+					$tw.wiki.addTiddler(new $tw.Tiddler({title: tiddler, text: value, height: elementRect.height + "px"}));
 				}
 				element.setAttribute("data-dynaview-has-triggered","false");				
 			}


### PR DESCRIPTION
this would allow us to reuse the height of a shown element for the hidden element

I tried it in the new dynaview demo replacing `style="min-height:5em"` with `style="height: $(height-in-statetiddler)$` and scrolling up/down becomes smooth