### PR TITLE
New window: add missing click listener for popups

### DIFF
--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -83,6 +83,10 @@ exports.startup = function() {
 			name: "keydown",
 			handlerObject: $tw.keyboardManager,
 			handlerMethod: "handleKeydownEvent"
+		},{
+			name: "click",
+			handlerObject: $tw.popup,
+			handlerMethod: "handleEvent"
 		}]);
 		srcWindow.haveInitialisedWindow = true;
 	});


### PR DESCRIPTION
this adds a click listener to new windows which enables us to cancel popups by clicking