### PR TITLE
fix action-navigate widget for undefined event

### DIFF
--- a/core/modules/widgets/action-navigate.js
+++ b/core/modules/widgets/action-navigate.js
@@ -55,6 +55,7 @@ NavigateWidget.prototype.refresh = function(changedTiddlers) {
 Invoke the action associated with this widget
 */
 NavigateWidget.prototype.invokeAction = function(triggeringWidget,event) {
+	event = event || {};
 	var bounds = triggeringWidget && triggeringWidget.getBoundingClientRect && triggeringWidget.getBoundingClientRect(),
 		suppressNavigation = event.metaKey || event.ctrlKey || (event.button === 1);
 	if(this.actionScroll === "yes") {


### PR DESCRIPTION
we need to prevent the event from being undefined which happens when using `action-navigate` within a global keyboard shortcut