### PR TITLE
add escapecss filter

### DIFF
--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -101,15 +101,8 @@ exports.escaperegexp = function(source,operator,options) {
 exports.escapecss = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
-		// escape any character with a special meaning in CSS if CSS.escape is available
-		var result;
-		try {
-			result = CSS.escape(title);
-		}
-		catch(e) {
-			result = title;
-		}
-		results.push(result);
+		// escape any character with a special meaning in CSS using CSS.escape()
+		results.push(CSS.escape(title));
 	});
 	return results;
 };

--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -101,10 +101,8 @@ exports.escaperegexp = function(source,operator,options) {
 exports.escapecss = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
-		// encode the title
-		var escapedTitle = encodeURIComponent(title);
-		// escape any remaining character with a special meaning in CSS
-		results.push(escapedTitle.replace(/[\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\}\~]/g, '\\$&'));
+		// escape any character with a special meaning in CSS
+		results.push(title.replace(/[\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\}\~]/g, '\\$&'));
 	});
 	return results;
 };

--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -101,8 +101,15 @@ exports.escaperegexp = function(source,operator,options) {
 exports.escapecss = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
-		// escape any character with a special meaning in CSS
-		results.push($tw.utils.escapeCssSelector(title));
+		// escape any character with a special meaning in CSS if CSS.escape is available
+		var result;
+		try {
+			result = CSS.escape(title);
+		}
+		catch(e) {
+			result = title;
+		}
+		results.push(result);
 	});
 	return results;
 };

--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -98,4 +98,15 @@ exports.escaperegexp = function(source,operator,options) {
 	return results;
 };
 
+exports.escapecss = function(source,operator,options) {
+	var results = [];
+	source(function(tiddler,title) {
+		// encode the title
+		var escapedTitle = encodeURIComponent(title);
+		// escape any remaining character with a special meaning in CSS
+		results.push(escapedTitle.replace(/[\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\}\~]/g, '\\$&'));
+	});
+	return results;
+};
+
 })();

--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -102,7 +102,7 @@ exports.escapecss = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
 		// escape any character with a special meaning in CSS
-		results.push(title.replace(/[\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\}\~]/g, '\\$&'));
+		results.push($tw.utils.escapeCssSelector(title));
 	});
 	return results;
 };

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -780,15 +780,19 @@ exports.makeDataUri = function(text,type) {
 	return parts.join("");
 };
 
+exports.escapeCssSelector = function(selector) {
+	return selector.replace(/[!"#$%&'()*+,\-./:;<=>?@[\\\]^`{\|}~,]/mg,function(c) {
+		return "\\" + c;
+	});
+};
+
 /*
 Useful for finding out the fully escaped CSS selector equivalent to a given tag. For example:
 
 $tw.utils.tagToCssSelector("$:/tags/Stylesheet") --> tc-tagged-\%24\%3A\%2Ftags\%2FStylesheet
 */
 exports.tagToCssSelector = function(tagName) {
-	return "tc-tagged-" + encodeURIComponent(tagName).replace(/[!"#$%&'()*+,\-./:;<=>?@[\\\]^`{\|}~,]/mg,function(c) {
-		return "\\" + c;
-	});
+	return $tw.utils.escapeCssSelector("tc-tagged-" + encodeURIComponent(tagName));
 };
 
 /*

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -780,19 +780,15 @@ exports.makeDataUri = function(text,type) {
 	return parts.join("");
 };
 
-exports.escapeCssSelector = function(selector) {
-	return selector.replace(/[!"#$%&'()*+,\-./:;<=>?@[\\\]^`{\|}~,]/mg,function(c) {
-		return "\\" + c;
-	});
-};
-
 /*
 Useful for finding out the fully escaped CSS selector equivalent to a given tag. For example:
 
 $tw.utils.tagToCssSelector("$:/tags/Stylesheet") --> tc-tagged-\%24\%3A\%2Ftags\%2FStylesheet
 */
 exports.tagToCssSelector = function(tagName) {
-	return $tw.utils.escapeCssSelector("tc-tagged-" + encodeURIComponent(tagName));
+	return "tc-tagged-" + encodeURIComponent(tagName).replace(/[!"#$%&'()*+,\-./:;<=>?@[\\\]^`{\|}~,]/mg,function(c) {
+		return "\\" + c;
+	});
 };
 
 /*


### PR DESCRIPTION
this filter would allow creating valid css classes from titles containing special characters

we assign a class to an element using `encodeuricomponent[]` so that the class name is encoded

in a stylesheet we create the classname by `<title>escapecss[]` which applies the uri encoding and escapes characters that need to be escaped