### PR TITLE
Fix the TagManager

### DIFF
--- a/core/ui/TagManager.tid
+++ b/core/ui/TagManager.tid
@@ -13,10 +13,10 @@ caption: {{$:/language/TagManager/Caption}}
 \end
 \define iconEditor(title)
 <div class="tc-drop-down-wrapper">
-<$button popupTitle=<<qualify "$:/state/popup/icon/$title$">> class="tc-btn-invisible tc-btn-dropdown">{{$:/core/images/down-arrow}}</$button>
-<$reveal stateTitle=<<qualify "$:/state/popup/icon/$title$">> type="popup" position="belowleft" text="" default="">
+<$button popupTitle={{{ [[$:/state/popup/icon/]addsuffix<__title__>] }}} class="tc-btn-invisible tc-btn-dropdown">{{$:/core/images/down-arrow}}</$button>
+<$reveal stateTitle={{{ [[$:/state/popup/icon/]addsuffix<__title__>] }}} type="popup" position="belowleft" text="" default="">
 <div class="tc-drop-down">
-<$linkcatcher to="$title$!!icon">
+<$linkcatcher actions="""<$action-setfield $tiddler=<<__title__>> icon=<<navigateTo>>/>""">
 <<iconEditorTab type:"!">>
 <hr/>
 <<iconEditorTab type:"">>
@@ -25,17 +25,14 @@ caption: {{$:/language/TagManager/Caption}}
 </$reveal>
 </div>
 \end
-\define qualifyTitle(title)
-$title$$(currentTiddler)$
-\end
 \define toggleButton(state)
-<$reveal stateTitle="$state$" type="match" text="closed" default="closed">
-<$button setTitle="$state$" setTo="open" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
+<$reveal stateTitle=<<__state__>> type="match" text="closed" default="closed">
+<$button setTitle=<<__state__>> setTo="open" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
 {{$:/core/images/info-button}}
 </$button>
 </$reveal>
-<$reveal stateTitle="$state$" type="match" text="open" default="closed">
-<$button setTitle="$state$" setTo="closed" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
+<$reveal stateTitle=<<__state__>> type="match" text="open" default="closed">
+<$button setTitle=<<__state__>> setTo="closed" class="tc-btn-invisible tc-btn-dropdown" selectedClass="tc-selected">
 {{$:/core/images/info-button}}
 </$button>
 </$reveal>
@@ -52,19 +49,19 @@ $title$$(currentTiddler)$
 <$list filter="[tags[]!is[system]sort[title]]">
 <tr>
 <td><$edit-text field="color" tag="input" type="color"/></td>
-<td><$macrocall $name="tag" tag=<<currentTiddler>>/></td>
+<td>{{||$:/core/ui/TagTemplate}}</td>
 <td><$count filter="[all[current]tagging[]]"/></td>
 <td>
 <$macrocall $name="iconEditor" title={{!!title}}/>
 </td>
 <td>
-<$macrocall $name="toggleButton" state=<<qualifyTitle "$:/state/tag-manager/">> /> 
+<$macrocall $name="toggleButton" state={{{ [[$:/state/tag-manager/]addsuffix<currentTiddler>] }}} /> 
 </td>
 </tr>
 <tr>
 <td></td>
 <td colspan="4">
-<$reveal stateTitle=<<qualifyTitle "$:/state/tag-manager/">> type="match" text="open" default="">
+<$reveal stateTitle={{{ [[$:/state/tag-manager/]addsuffix<currentTiddler>] }}} type="match" text="open" default="">
 <table>
 <tbody>
 <tr><td><<lingo Colour/Heading>></td><td><$edit-text field="color" tag="input" type="text" size="9"/></td></tr>


### PR DESCRIPTION
now the tag manager needs some fixes for breaking titles, too

- the `<<__variable__>>` syntax needs to be used
- the `tag-pills` don't use the tag-pill macro, but `{{||$:/core/ui/TagTemplate}}` directly
- some already sufficiently qualified states in the `iconEditor` macro are reduced not to use the `qualify` macro anymore