### PR TITLE
fix for #3547

### DIFF
--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -109,6 +109,7 @@ function CodeMirrorEngine(options) {
 	// Create the CodeMirror instance
 	this.cm = window.CodeMirror(function(cmDomNode) {
 		// Note that this is a synchronous callback that is called before the constructor returns
+		Object.defineProperty(cmDomNode,"parentNode",{writable: true});
 		self.domNode.appendChild(cmDomNode);
 	},config);
 

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -109,8 +109,9 @@ function CodeMirrorEngine(options) {
 	// Create the CodeMirror instance
 	this.cm = window.CodeMirror(function(cmDomNode) {
 		// Note that this is a synchronous callback that is called before the constructor returns
-		Object.defineProperty(cmDomNode,"parentNode",{writable: true});
-		self.domNode.appendChild(cmDomNode);
+		if(!self.widget.document.isTiddlyWikiFakeDom) {
+			self.domNode.appendChild(cmDomNode);
+		}
 	},config);
 
 	// Set up a change event handler


### PR DESCRIPTION
see https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty

because of "strict mode" - the `parentNode` property may not be writable and causes an error in `fakedom.js` (appendChild)

to reproduce: install CodeMirror, install "Tools for exploring internals of TW", open a heavy Tiddler like the Control-Panel in edit-mode, toggle preview on, switch to "parse tree" or "widget tree"