### PR TITLE
Docs: Remove broken `is` operator example

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/is.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/is.tid
@@ -11,4 +11,3 @@ type: text/vnd.tiddlywiki
 <<.operator-example 5 "[all[shadows]is[system]tag[$:/tags/Stylesheet]]" "shadow system stylesheets">>
 <<.operator-example 6 "[is[shadow]]" "overridden shadow tiddlers">>
 <<.operator-example 7 "[is[missing]]" "empty because its input contains only tiddlers that exist">>
-<<.operator-example 8 "[all[tiddlers+shadows]is[tiddler+shadow]]" "contains the entire input list">>


### PR DESCRIPTION
In 737e9ae4cb136ca3f473624f64142bd83e532b9b the multiple suboperator functionality was banned, but an example is remained in the docs.