### PR TITLE
fix textnodes between tags in viewtemplate

### DIFF
--- a/core/ui/TagTemplate.tid
+++ b/core/ui/TagTemplate.tid
@@ -1,5 +1,6 @@
 title: $:/core/ui/TagTemplate
 
+\whitespace trim
 <span class="tc-tag-list-item">
 <$set name="transclusion" value=<<currentTiddler>>>
 <$macrocall $name="tag-pill-body" tag=<<currentTiddler>> icon={{!!icon}} colour={{!!color}} palette={{$:/palette}} element-tag="""$button""" element-attributes="""popup=<<qualify "$:/state/popup/tag">> dragFilter='[all[current]tagging[]]' tag='span'"""/>


### PR DESCRIPTION
this removes additional text-nodes in the dom after each `tc-tag-list-item` caused by the last empty line
we could also just remove that line but I don't know if that's a permanent solution or if some mechanism will re-add that line at some point, so I go with the `whitespace trim` pragma