### PR TITLE
Add the "tiddlywiki" argument to the server start hook

### DIFF
--- a/core/modules/commands/listen.js
+++ b/core/modules/commands/listen.js
@@ -39,7 +39,7 @@ Command.prototype.execute = function() {
 		variables: self.params
 	});
 	var nodeServer = this.server.listen();
-	$tw.hooks.invokeHook("th-server-command-post-start",this.server,nodeServer);
+	$tw.hooks.invokeHook("th-server-command-post-start",this.server,nodeServer,"tiddlywiki");
 	return null;
 };
 

--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -46,7 +46,7 @@ Command.prototype.execute = function() {
 		}
 	});
 	var nodeServer = this.server.listen();
-	$tw.hooks.invokeHook("th-server-command-post-start",this.server,nodeServer);
+	$tw.hooks.invokeHook("th-server-command-post-start",this.server,nodeServer,"tiddlywiki");
 	return null;
 };
 

--- a/editions/dev/tiddlers/new/Hook__th-server-command-post-start.tid
+++ b/editions/dev/tiddlers/new/Hook__th-server-command-post-start.tid
@@ -14,5 +14,7 @@ Hook function parameters:
 ** Defined in core/modules/commands/server.js
 * NodeJS HTTP Server instance
 ** See the NodeJS docs at [ext[https://nodejs.org/docs/latest-v8.x/api/http.html#http_class_http_server]]
+* Name of server invoking this hook (for special handling of the NodeJS HTTP server instance argument). 
+** Current known values: `tiddlywiki`, `tiddlyserver`. 
 
 Return value is ignored.


### PR DESCRIPTION
For cross-compatibility and other reasons I've mentioned in various places, this allows a plugin to determine which server engine it is being loaded into, as TiddlyServer and TiddlyWiki provide different arguments and there may be more in the future.

As mentioned in https://github.com/Jermolene/TiddlyWiki5/issues/3573#issuecomment-441569915