### PR TITLE
Fix recursion error in toc() macro in: toc.tid

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -26,7 +26,7 @@ tags: $:/tags/Macro
 </ol>
 \end
 
-\define toc(tag,sort:"",itemClassFilter:" ")
+\define toc(tag,sort:"",itemClassFilter:" ",exclude)
 <$macrocall $name="toc-body"  tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> />
 \end
 


### PR DESCRIPTION
I noticed that if a non-existent TAG name used in a simple Table of Contents macro:
```
<div class="tc-table-of-contents"> 
<<toc "NonExistentTag">>
</div>
```
It gives a javascript recursion error.

The macro within tiddler **$:/core/macros/toc** is:
```
\define toc(tag,sort:"",itemClassFilter:" ")
<$macrocall $name="toc-body"  tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> />
\end
```
Noticing that all the other ToC macros did not have this problem, I remembered a discussion earlier in GG explaining the significance of the **exclude** parameter.

Modifying the **toc** macro by adding the `exclude` parameter appears to fix this - but I do not know if this is the right fix!

```
\define toc(tag,sort:"",itemClassFilter:" ",exclude)
<$macrocall $name="toc-body"  tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> />
\end
```

I am making a pull request just to practice using github.
Please close it if it is nonsense!