### PR TITLE
Fix diff-widget undefined attributes bug

### DIFF
--- a/core/modules/widgets/diff-text.js
+++ b/core/modules/widgets/diff-text.js
@@ -39,7 +39,7 @@ DiffTextWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	// Create the diff
 	var dmpObject = new dmp.diff_match_patch(),
-		diffs = dmpObject.diff_main(this.getAttribute("source"),this.getAttribute("dest"));
+		diffs = dmpObject.diff_main(this.getAttribute("source", "diff: no source attribute"),this.getAttribute("dest", "diff: no dest attribute"));
 	// Apply required cleanup
 	switch(this.getAttribute("cleanup","semantic")) {
 		case "none":


### PR DESCRIPTION
Calling diff_main method with undefined parameters throws a (uncaught) "Null input" error.
This patch adds default values to the widget "source" and "dst" attributes so the diff method don't throw an error when widget attributes are not defined or their value is not an string object (undefined).

The default value string has been selected to help identifying the error when there is a syntax error in the widget argument names or their value is undefined. You might want to change it as you see fit.