### PR TITLE
Update url of highlight.js github project

### DIFF
--- a/plugins/tiddlywiki/highlight/readme.tid
+++ b/plugins/tiddlywiki/highlight/readme.tid
@@ -1,6 +1,6 @@
 title: $:/plugins/tiddlywiki/highlight/readme
 
-This plugin provides syntax highlighting of code blocks using v8.8.0 of [[highlight.js|https://github.com/isagalaev/highlight.js]] from Ivan Sagalaev.
+This plugin provides syntax highlighting of code blocks using v8.8.0 of [[highlight.js|https://github.com/highlightjs/highlight.js]] from Ivan Sagalaev and others.
 
 ! Usage
 


### PR DESCRIPTION
Github repo of the highlight.js project has changed from `github.com/isagalaev/highlight.js` to `github.com/highlightjs/highlight.js`.