### PR TITLE
Customise syntax highlighting languages

### DIFF
--- a/plugins/tiddlywiki/highlight/readme.tid
+++ b/plugins/tiddlywiki/highlight/readme.tid
@@ -46,3 +46,12 @@ The plugin includes support for the following languages (referred to as "brushes
 * xml
 
 You can also specify the language as a MIME content type (eg `text/html` or `text/css`). The mapping is accomplished via mapping tiddlers whose titles start with `$:/config/HighlightPlugin/TypeMappings/`.
+
+! Supporting Additional Languages
+
+The [[highlight.js|https://github.com/highlightjs/highlight.js]] project supports many languages. Only a subset of these languages are supported by the plugin. It is possible for users to change the set of languages supported by the plugin by following these steps:
+
+# Go to the highlight.js project [[download page|https://highlightjs.org/download/]], select the language definitions to include, and press the Download button to download a zip archive containing customised support files for a highlight.js syntax highlighting server
+# Locate the `highlight.pack.js` file in the highlight plugin -- on a stock Debian 8 system running Tiddlywiki5 under node-js it is located at `/usr/local/lib/node_modules/tiddlywiki/plugins/tiddlywiki/highlight/files/highlight.pack.js`
+# Replace the plugin `highlight.pack.js` file located in step 2 with the one from the downloaded archive obtained in step 1
+# Restart the TW5 server


### PR DESCRIPTION
Add to highlight plugin's `readme.tid` instructions for customising (changing) the set of languages supported by the highlight plugin. This involves:

* Selecting languages on the highlight.js download page
* Downloading a zip archive of the customised highlight.js server
* Extracting the archive's `highlight.pack.js` file
* Using it to replace the `highlight.pack.js` file from the TW5 plugin