### PR TITLE
Add howto for changing highlight languages

### DIFF
--- a/plugins/tiddlywiki/highlight/howto.tid
+++ b/plugins/tiddlywiki/highlight/howto.tid
@@ -1,0 +1,10 @@
+title: $:/plugins/tiddlywiki/highlight/howto
+
+! Supporting Additional Languages
+ 
+The [[highlight.js|https://github.com/highlightjs/highlight.js]] project supports many languages. Only a subset of these languages are supported by the plugin. It is possible for users to change the set of languages supported by the plugin by following these steps:
+ 
+# Go to the highlight.js project [[download page|https://highlightjs.org/download/]], select the language definitions to include, and press the Download button to download a zip archive containing customised support files for a highlight.js syntax highlighting server.
+# Locate the `highlight.pack.js` file in the highlight plugin -- on a stock Debian 8 system running Tiddlywiki5 under node-js it is located at `/usr/local/lib/node_modules/tiddlywiki/plugins/tiddlywiki/highlight/files/highlight.pack.js`.
+# Replace the plugin `highlight.pack.js` file located in step 2 with the one from the downloaded archive obtained in step 1.
+# Restart the Tiddlywiki server.

--- a/plugins/tiddlywiki/highlight/plugin.info
+++ b/plugins/tiddlywiki/highlight/plugin.info
@@ -3,5 +3,5 @@
 	"description": "Highlight.js: syntax highlighting",
 	"author": "JoaoBolila",
 	"core-version": ">=5.0.0",
-	"list": "readme usage license"
+	"list": "readme usage howto license"
 }


### PR DESCRIPTION
Add howto to the highlight plugin for changing the set of languages supported by the plugin. These instructions work for TW5 under nodejs -- I'm not sure which other TW configurations the instructions would work for, or whether additional information is required for other TW configurations.

These instructions are basically about downloading a custom highlight.js server (which involved selecting the languages to be supported), taking the `highlight.pack.js` file from the downloaded files, and using it to replace the `highlight.pack.js` file from the TW highlight plugin.