### PR TITLE
get-index: Enable deflate and gzip compression

### DIFF
--- a/core/modules/server/routes/get-index.js
+++ b/core/modules/server/routes/get-index.js
@@ -12,14 +12,32 @@ GET /
 /*global $tw: false */
 "use strict";
 
+var zlib = require('zlib');
+
 exports.method = "GET";
 
 exports.path = /^\/$/;
 
 exports.handler = function(request,response,state) {
-	response.writeHead(200, {"Content-Type": state.server.get("root-serve-type")});
-	var text = state.wiki.renderTiddler(state.server.get("root-render-type"),state.server.get("root-tiddler"));
-	response.end(text,"utf8");
+  var acceptEncoding = request.headers['accept-encoding'];
+  if (!acceptEncoding) { acceptEncoding = ''; }
+
+  var text = state.wiki.renderTiddler(state.server.get("root-render-type"),state.server.get("root-tiddler"));
+
+  var responseHeaders = {
+    "Content-Type": state.server.get("root-serve-type")
+  };
+
+  if (/\bdeflate\b/.test(acceptEncoding)) {
+    responseHeaders['Content-Encoding'] = 'deflate';
+    text = zlib.deflateSync(text);
+  } else if (/\bgzip\b/.test(acceptEncoding)) {
+    responseHeaders['Content-Encoding'] = 'gzip';
+    text = zlib.gzipSync(text);
+  }
+
+	response.writeHead(200, responseHeaders);
+	response.end(text);
 };
 
 }());


### PR DESCRIPTION
Big wikis can take some time to load over bigger connections when using the Node server. This pull requests enables `deflate` and `gzip` compression on the `get-index` route which massively reduces the amount of transferred data.

It uses the `zlib` node module and (for simplicity) uses the `sync` versions of the functions. It's also possible to use the non-sync versions without much hassle.

I plan on abstracting this logic a big and add it to other routes which serve non-trivial amounts of data. 