### PR TITLE
Adding tv-pagetemplate variable

### DIFF
--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -27,7 +27,7 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 
 <$dropzone>
 
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageTemplate]!has[draft.of]]" variable="listItem">
+<$list filter="[subfilter<tv-pagetemplate>] ~[all[shadows+tiddlers]tag[$:/tags/PageTemplate]!has[draft.of]]" variable="listItem">
 
 <$transclude tiddler=<<listItem>>/>
 


### PR DESCRIPTION
User can define tv-pagetemplate as a global macro to list his own set of pagetemplates without overriding the core or defining multiple config tiddlers.