### PR TITLE
Update Plugins.tid

### DIFF
--- a/editions/tw5.com/tiddlers/plugins/Plugins.tid
+++ b/editions/tw5.com/tiddlers/plugins/Plugins.tid
@@ -1,10 +1,10 @@
 created: 20140910215514237
-modified: 20160107224627982
+modified: 20190108000000000
 tags: Concepts TableOfContents
 title: Plugins
 type: text/vnd.tiddlywiki
 
-Plugins in TiddlyWiki5 are used to distribute optional components that customise and extend TiddlyWiki. You can install them from the [[official plugin library|Installing a plugin from the plugin library]] or from [[community sites|Resources]].
+Plugins in TiddlyWiki5 can be used to distribute optional components that customise and extend TiddlyWiki. You can install them from the [[official plugin library|Installing a plugin from the plugin library]] or from [[community sites|Resources]].
 
 {{$:/core/ui/ControlPanel/Plugins/AddPlugins}}
 
@@ -14,3 +14,5 @@ Plugins can contain JavaScript modules, style sheets, and templates. Plugins can
 
 
 <<list-links "[tag[Plugins]]">>
+
+<$macrocall $name=".note" _="There is a plugin called $:/core that contains the main core code of ~TiddlyWiki. It is always present, and it is the source of default [[Shadow tiddlers|ShadowTiddlers]]. You can see the details of this in the <<.button control-panel>> on the <<.controlpanel-tab Plugins>> sub-tab."> 


### PR DESCRIPTION
In response to the two Jeremy Ruston posts at: https://groups.google.com/forum/#!topic/tiddlywiki/aPjljLW1yHE/discussion



>  The missing piece is that there is a plugin called $:/core that contains the main core code of TiddlyWiki. It is always present, and it is the source of the shadow tiddlers you are seeing. You can see it listed in the "Plugins" tab of the control panel.


> Perhaps it should say "plugins can be used to distribute optional, custom components" to make it clearer that not all plugins are for that purpose.
> 
> Plugins are a general purpose mechanism for packing multiple tiddlers into the same container tiddler.  They are used for a number of different purposes around the system, but their behaviour is always the same: when activated, their payload tiddlers become visible as shadow tiddlers.