### PR TITLE
Add en-US localization

### DIFF
--- a/editions/tw5.com/tiddlers/images/external/tiddlywiki.files
+++ b/editions/tw5.com/tiddlers/images/external/tiddlywiki.files
@@ -55,6 +55,15 @@
 			}
 		},
 		{
+			"file": "../../../../../languages/en-US/icon.tid",
+			"isTiddlerFile": true,
+			"fields": {
+				"title": "Language Icon: en-US",
+				"language": "en-US",
+				"tags": "Language Icon"
+			}
+		},
+		{
 			"file": "../../../../../languages/es-ES/icon.tid",
 			"isTiddlerFile": true,
 			"fields": {

--- a/languages/en-US/Buttons.multids
+++ b/languages/en-US/Buttons.multids
@@ -1,0 +1,7 @@
+title: $:/language/Buttons/
+
+Clear/Hint: Clear image to solid color
+Paint/Caption: paint color
+Paint/Hint: Set painting color
+Palette/Hint: Choose the color palette
+StoryView/Hint: Choose the story visualization

--- a/languages/en-US/Misc.multids
+++ b/languages/en-US/Misc.multids
@@ -1,0 +1,6 @@
+title: $:/language/
+
+Manager/Item/Colour: Color
+TagManager/Colour/Heading: Color
+RecentChanges/DateFormat: MMM DD, YYYY
+Tiddler/DateFormat: MMM DD, YYYY at hh12:0mm am

--- a/languages/en-US/icon.tid
+++ b/languages/en-US/icon.tid
@@ -1,0 +1,29 @@
+title: $:/languages/en-US/icon
+type: image/svg+xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1235" height="650" viewBox="0 0 7410 3900">
+<rect width="7410" height="3900" fill="#b22234"/>
+<path d="M0,450H7410m0,600H0m0,600H7410m0,600H0m0,600H7410m0,600H0" stroke="#fff" stroke-width="300"/>
+<rect width="2964" height="2100" fill="#3c3b6e"/>
+<g fill="#fff">
+<g id="s18">
+<g id="s9">
+<g id="s5">
+<g id="s4">
+<path id="s" d="M247,90 317.534230,307.082039 132.873218,172.917961H361.126782L176.465770,307.082039z"/>
+<use xlink:href="#s" y="420"/>
+<use xlink:href="#s" y="840"/>
+<use xlink:href="#s" y="1260"/>
+</g>
+<use xlink:href="#s" y="1680"/>
+</g>
+<use xlink:href="#s4" x="247" y="210"/>
+</g>
+<use xlink:href="#s9" x="494"/>
+</g>
+<use xlink:href="#s18" x="988"/>
+<use xlink:href="#s9" x="1976"/>
+<use xlink:href="#s5" x="2470"/>
+</g>
+</svg>

--- a/languages/en-US/plugin.info
+++ b/languages/en-US/plugin.info
@@ -1,0 +1,10 @@
+{
+	"title": "$:/languages/en-US",
+	"name": "en-US",
+	"plugin-type": "language",
+	"description": "English (US)",
+	"author": "Ben Webber",
+	"core-version": ">=5.0.0",
+	"dependents": ["$:/languages/en-GB"],
+	"plugin-priority": 110
+}


### PR DESCRIPTION
I am working on a plugin that references the wiki language for internal localization. The idea is that switching the wiki language will also translate plugin strings.

I need to include a few US English variants in the plugin, so offering it in the drop-down menu would be very helpful.

I sourced the flag icon from [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Flag_of_the_United_States.svg). 