### PR TITLE
Draggable links

### DIFF
--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -133,6 +133,8 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 		$tw.utils.makeDraggable({
 			domNode: domNode,
 			dragTiddlerFn: function() {return self.to;},
+			startActions: self.startActions,
+			endActions: self.endActions,
 			widget: this
 		});
 	}
@@ -177,6 +179,8 @@ LinkWidget.prototype.execute = function() {
 	this.overrideClasses = this.getAttribute("overrideClass");
 	this.tabIndex = this.getAttribute("tabindex");
 	this.draggable = this.getAttribute("draggable","yes");
+	this.startActions = this.getAttribute("startactions");
+	this.endActions = this.getAttribute("endactions");
 	this.linkTag = this.getAttribute("tag","a");
 	// Determine the link characteristics
 	this.isMissing = !this.wiki.tiddlerExists(this.to);
@@ -191,7 +195,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 LinkWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.to || changedTiddlers[this.to] || changedAttributes["aria-label"] || changedAttributes.tooltip) {
+	if(changedAttributes.to || changedTiddlers[this.to] || changedAttributes["aria-label"] || changedAttributes.tooltip || changedTiddlers.tag || changedTiddlers["class"]) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -19,7 +19,7 @@ tags: $:/tags/Macro
 <$action-listops $tiddler=<<targetTiddler>> $field=<<targetField>> $subfilter="+[insertbefore:currentTiddler<actionTiddler>]"/>
 \end
 
-\define list-links-draggable(tiddler,field:"list",type:"ul",subtype:"li",class:"",itemTemplate)
+\define list-links-draggable(tiddler,field:"list",type:"ul",subtype:"li",class:"",itemTemplate,startactions,endactions)
 <$vars targetTiddler="""$tiddler$""" targetField="""$field$""">
 <$type$ class="$class$">
 <$list filter="[list[$tiddler$!!$field$]]">
@@ -29,7 +29,7 @@ tags: $:/tags/Macro
 </div>
 <div>
 <$transclude tiddler="""$itemTemplate$""">
-<$link to={{!!title}}>
+<$link to={{!!title}} startactions="""$startactions$""" endactions="""$endactions$""">
 <$transclude field="caption">
 <$view field="title"/>
 </$transclude>
@@ -38,7 +38,6 @@ tags: $:/tags/Macro
 </div>
 </$droppable>
 </$list>
-</$type$>
 <$tiddler tiddler="">
 <$droppable actions=<<list-links-draggable-drop-actions>> tag="div">
 <div class="tc-droppable-placeholder">
@@ -47,6 +46,7 @@ tags: $:/tags/Macro
 <div style="height:0.5em;"/>
 </$droppable>
 </$tiddler>
+</$type$>
 </$vars>
 \end
 
@@ -72,7 +72,7 @@ tags: $:/tags/Macro
 </$set>
 \end
 
-\define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div")
+\define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div",startactions,endactions)
 <$set name="tag" value=<<__tag__>>>
 <$list filter="[<__tag__>tagging[]$subFilter$]" emptyMessage=<<__emptyMessage__>>>
 <$elementTag$ class="tc-menu-list-item">
@@ -82,7 +82,7 @@ tags: $:/tags/Macro
 </$elementTag$>
 <$elementTag$>
 <$transclude tiddler="""$itemTemplate$""">
-<$link to={{!!title}}>
+<$link to={{!!title}} startactions=<<__startactions__>> endactions=<<__endactions__>>>
 <$view field="title"/>
 </$link>
 </$transclude>


### PR DESCRIPTION
Hi @Jermolene,

I added startactions and endactions to the link widget so that its draggable behavior is like the draggable widget. I then changed list-links-draggable macro and the list-tagged-draggable macro so that they would support that new link behavior. As far as I can tell, these changes are entirely backwards compatible.

I also fixed what I saw as a minor formatting issue in list-links-draggable. The position of the closing </$type$> tag was placed before the final droppable-placeholder, causing that final placeholder to be of a different format from the rest of the placeholders in the list. I moved the closing tag to include the trailing placeholder.

Best wishes,
Adam

#3700 