### PR TITLE
add findParentTransclusionWidget prototype for unique widget-ID's

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -42,6 +42,7 @@ Widget.prototype.initialise = function(parseTreeNode,options) {
 	this.document = options.document;
 	this.attributes = {};
 	this.children = [];
+	this.transclusionWidgets = [];
 	this.domNodes = [];
 	this.eventListeners = {};
 	// Hashmap of the widget classes
@@ -555,6 +556,15 @@ Widget.prototype.invokeActionString = function(actions,triggeringWidget,event,va
 
 Widget.prototype.allowActionPropagation = function() {
 	return true;
+};
+
+Widget.prototype.findParentTranscludeWidget = function() {
+	var node = this;
+	var transclusionVariable = this.getVariable("transclusion");
+	while(node.getVariable("transclusion") === transclusionVariable) {
+		node = node.parentWidget;
+	}
+	return node !== this ? node : null;
 };
 
 exports.widget = Widget;


### PR DESCRIPTION
this prototype returns the parent widget (if present) that changes the `transclusion` variable
this allows us to push widgets to the `transclusionWidgets` array of the `parentTransclusionWidget` , so that we can iterate over that array to get the index of our widget within the same `transclusion-level`

this can be useful when we need unique id's for widgets but there are more widgets with a similar "footprint" within the same "transclusion-level", where `widget.getStateQualifier` also returns the same value for all of them. adding the index we get by iterating over the `transclusionWidgets` array, detecting the current widget within it and adding its index within that array to our ID makes the ID unique