### PR TITLE
widget.js : generate a unique widget ID

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -557,6 +557,25 @@ Widget.prototype.allowActionPropagation = function() {
 	return true;
 };
 
+Widget.prototype.generateTransclusionFootprint = function() {
+	var parentTransclusionWidget = this.findParentTransclusionWidget(),
+	    node = this,
+	    footprint = node.parentWidget.children.indexOf(node);
+	while(node = node.parentWidget && node !== parentTransclusionWidget) {
+		footprint += "" + node.parentWidget.children.indexOf(node);
+	}
+	return footprint;
+};
+
+Widget.prototype.findParentTransclusionWidget = function() {
+	var node = this;
+	var transclusionVariable = this.getVariable("transclusion");
+	while(node.getVariable("transclusion") === transclusionVariable) {
+		node = node.parentWidget;
+	}
+	return node !== this ? node : null;
+};
+
 exports.widget = Widget;
 
 })();

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -561,8 +561,12 @@ Widget.prototype.generateTransclusionFootprint = function() {
 	var parentTransclusionWidget = this.findParentTransclusionWidget(),
 	    node = this,
 	    footprint = node.parentWidget.children.indexOf(node);
-	while(node = node.parentWidget && node !== parentTransclusionWidget) {
-		footprint += "" + node.parentWidget.children.indexOf(node);
+	while(node = node.parentWidget) {
+		if(node === parentTransclusionWidget) {
+			break;
+		} else if(node.parentWidget && node.parentWidget.children) {
+			footprint = footprint + "" + node.parentWidget.children.indexOf(node);
+		}
 	}
 	return footprint;
 };

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -565,7 +565,7 @@ Widget.prototype.generateTransclusionFootprint = function() {
 		if(node === parentTransclusionWidget) {
 			break;
 		} else if(node.parentWidget && node.parentWidget.children) {
-			footprint = footprint + "" + node.parentWidget.children.indexOf(node);
+			footprint = footprint + "-" + node.parentWidget.children.indexOf(node);
 		}
 	}
 	return footprint;

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -561,7 +561,8 @@ Widget.prototype.generateTransclusionFootprint = function() {
 	var parentTransclusionWidget = this.findParentTransclusionWidget(),
 	    node = this,
 	    footprint = node.parentWidget.children.indexOf(node);
-	while(node = node.parentWidget) {
+	while(node) {
+		node = node.parentWidget;
 		if(node === parentTransclusionWidget) {
 			break;
 		} else if(node.parentWidget && node.parentWidget.children) {


### PR DESCRIPTION
this try on generating unique widget ID's does the following:

it generates a "footprint" of the form `0130` where the first digit is the index of the current widget within the array of its parentWidget's children

the next digit is the index of its parentWidget within the array of that widget's parentWidget's children, and so on, until the first widget that creates a transclusion is reached.

this generates a unique footprint among different widgets that are all at the same transclusion levels

adding this footprint to the state qualifier we get through `this.getStateQualifier` by `this.getStateQualifier + "-" + this.generateTransclusionFootprint` creates unique widget-ID's