### PR TITLE
update wrap-selection text-operation

### DIFF
--- a/core/modules/editor/operations/text/wrap-selection.js
+++ b/core/modules/editor/operations/text/wrap-selection.js
@@ -16,14 +16,12 @@ exports["wrap-selection"] = function(event,operation) {
 	if(operation.selStart === operation.selEnd) {
 		// No selection; check if we're within the prefix/suffix
 		if(operation.text.substring(operation.selStart - event.paramObject.prefix.length,operation.selStart + event.paramObject.suffix.length) === event.paramObject.prefix + event.paramObject.suffix) {
-			// Remove the prefix and suffix unless they comprise the entire text
-			if(operation.selStart > event.paramObject.prefix.length || (operation.selEnd + event.paramObject.suffix.length) < operation.text.length ) {
-				operation.cutStart = operation.selStart - event.paramObject.prefix.length;
-				operation.cutEnd = operation.selEnd + event.paramObject.suffix.length;
-				operation.replacement = "";
-				operation.newSelStart = operation.cutStart;
-				operation.newSelEnd = operation.newSelStart;
-			}
+			// Remove the prefix and suffix
+			operation.cutStart = operation.selStart - event.paramObject.prefix.length;
+			operation.cutEnd = operation.selEnd + event.paramObject.suffix.length;
+			operation.replacement = "";
+			operation.newSelStart = operation.cutStart;
+			operation.newSelEnd = operation.newSelStart;
 		} else {
 			// Wrap the cursor instead
 			operation.cutStart = operation.selStart;


### PR DESCRIPTION
this is only a proposal and I make this because I don't understand why this doesn't remove a prefix and suffix wrapped around the cursor only when it's at the start of the editor and there's no other text

in all other cases it does remove them, so it comes totally unexpected that only in the case when there are only the given prefix and suffix the text-operation doesn't remove them