### PR TITLE
a filter that creates a hash-string from its input titles

### DIFF
--- a/core/modules/filters/numhash.js
+++ b/core/modules/filters/numhash.js
@@ -28,11 +28,7 @@ exports.numhash = function(source,operator,options) {
 			titles.push(title);
 	});
 	if(titles.length) {
-		hashString = $tw.utils.hashString(titles.join("")).toString();
-		while(hashString.length < 11) {
-			hashString = "-" + hashString;
-		}
-		results.push(hashString);
+		results.push($tw.utils.hashString(titles.join("")).toString());
 	}
 return results;
 };

--- a/core/modules/filters/numhash.js
+++ b/core/modules/filters/numhash.js
@@ -8,7 +8,7 @@ Example feeding it with a list of transclusion variables that model the path
 from a given point up to the page template (returns the same qualified string
 like the <<qualify>> macro would do at that point):
 
-filter="{|$:/core/ui/PageTemplate/story|||} {|$:/core/ui/PageTemplate|||} +[qfp[]]"
+filter="{|$:/core/ui/PageTemplate/story|||} {|$:/core/ui/PageTemplate|||} +[numhash[]]"
 
 \*/
 (function(){

--- a/core/modules/filters/numhash.js
+++ b/core/modules/filters/numhash.js
@@ -1,5 +1,5 @@
 /*\
-title: $:/core/modules/filters/qfp.js
+title: $:/core/modules/filters/numhash.js
 type: application/javascript
 module-type: filteroperator
 
@@ -20,7 +20,7 @@ filter="{|$:/core/ui/PageTemplate/story|||} {|$:/core/ui/PageTemplate|||} +[qfp[
 /*
 Export our filter function
 */
-exports.qfp = function(source,operator,options) {
+exports.numhash = function(source,operator,options) {
 	var titles = [],
 	results = [],
 	hashString;

--- a/core/modules/filters/qfp.js
+++ b/core/modules/filters/qfp.js
@@ -1,0 +1,40 @@
+/*\
+title: $:/core/modules/filters/qfp.js
+type: application/javascript
+module-type: filteroperator
+
+Filter operator that returns a "qualified" hashstring for a list of input titles
+Example feeding it with a list of transclusion variables that model the path
+from a given point up to the page template (returns the same qualified string
+like the <<qualify>> macro would do at that point):
+
+filter="{|$:/core/ui/PageTemplate/story|||} {|$:/core/ui/PageTemplate|||} +[qfp[]]"
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.qfp = function(source,operator,options) {
+	var titles = [],
+	results = [],
+	hashString;
+	source(function(tiddler,title) {
+			titles.push(title);
+	});
+	if(titles.length) {
+		hashString = $tw.utils.hashString(titles.join("")).toString();
+		while(hashString.length < 11) {
+			hashString = "-" + hashString;
+		}
+		results.push(hashString);
+	}
+return results;
+};
+
+})();


### PR DESCRIPTION
this filter takes a list of titles and creates a hashstring from them, like the qualify macro does.
it uses the same function `$tw.utils.hashString`

it's useful for example when feeding it with a list of transclusion variables that model the path to a point at the page, to get the `<<qualify>>` value at that point