### PR TITLE
adding optional tabindex attr to simple, framed and cm engines

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -70,6 +70,9 @@ function FramedEngine(options) {
 	if(this.widget.editRows) {
 		this.domNode.setAttribute("rows",this.widget.editRows);
 	}
+	if(this.widget.editTabIndex) {
+		this.iframeNode.setAttribute("tabindex",this.widget.editTabIndex);
+	}
 	// Copy the styles from the dummy textarea
 	this.copyStyles();
 	// Add event listeners

--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -49,6 +49,9 @@ function SimpleEngine(options) {
 	if(this.widget.editClass) {
 		this.domNode.className = this.widget.editClass;
 	}
+	if(this.widget.editTabIndex) {
+		this.domNode.setAttribute("tabindex",this.widget.editTabIndex);
+	}
 	// Add an input event handler
 	$tw.utils.addEventListeners(this.domNode,[
 		{name: "focus", handlerObject: this, handlerMethod: "handleFocusEvent"},

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -208,7 +208,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	EditTextWidget.prototype.refresh = function(changedTiddlers) {
 		var changedAttributes = this.computeAttributes();
 		// Completely rerender if any of our attributes have changed
-		if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes["default"] || changedAttributes["class"] || changedAttributes.placeholder || changedAttributes.size || changedAttributes.autoHeight || changedAttributes.minHeight || changedAttributes.focusPopup ||  changedAttributes.rows || changedTiddlers[HEIGHT_MODE_TITLE] || changedTiddlers[ENABLE_TOOLBAR_TITLE]) {
+		if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes["default"] || changedAttributes["class"] || changedAttributes.placeholder || changedAttributes.size || changedAttributes.autoHeight || changedAttributes.minHeight || changedAttributes.focusPopup ||  changedAttributes.rows || changedAttributes.tabindex || changedTiddlers[HEIGHT_MODE_TITLE] || changedTiddlers[ENABLE_TOOLBAR_TITLE]) {
 			this.refreshSelf();
 			return true;
 		} else if(changedTiddlers[this.editTitle]) {

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -176,6 +176,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		this.editMinHeight = this.getAttribute("minHeight",DEFAULT_MIN_TEXT_AREA_HEIGHT);
 		this.editFocusPopup = this.getAttribute("focusPopup");
 		this.editFocus = this.getAttribute("focus");
+		this.editTabIndex = this.getAttribute("tabindex");
 		// Get the default editor element tag and type
 		var tag,type;
 		if(this.editField === "text") {

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -217,7 +217,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		}
 		this.engine.fixHeight();
 		if(this.editShowToolbar) {
-			return this.refreshChildren(changedTiddlers);			
+			return this.refreshChildren(changedTiddlers);
 		} else {
 			return false;
 		}
@@ -267,7 +267,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 				    el.dispatchEvent(clickEvent);
 					event.preventDefault();
 					event.stopPropagation();
-					return true;			
+					return true;
 				}
 			}
 		}

--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -46,6 +46,7 @@ EditWidget.prototype.execute = function() {
 	this.editIndex = this.getAttribute("index");
 	this.editClass = this.getAttribute("class");
 	this.editPlaceholder = this.getAttribute("placeholder");
+	this.editTabIndex = this.getAttribute("tabindex");
 	// Choose the appropriate edit widget
 	this.editorType = this.getEditorType();
 	// Make the child widgets
@@ -56,7 +57,8 @@ EditWidget.prototype.execute = function() {
 			field: {type: "string", value: this.editField},
 			index: {type: "string", value: this.editIndex},
 			"class": {type: "string", value: this.editClass},
-			"placeholder": {type: "string", value: this.editPlaceholder}
+			"placeholder": {type: "string", value: this.editPlaceholder},
+			"tabindex": {type: "string", value: this.editTabIndex}
 		},
 		children: this.parseTreeNode.children
 	}]);
@@ -90,7 +92,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 EditWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	// Refresh if an attribute has changed, or the type associated with the target tiddler has changed
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || (changedTiddlers[this.editTitle] && this.getEditorType() !== this.editorType)) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tabindex || (changedTiddlers[this.editTitle] && this.getEditorType() !== this.editorType)) {
 		this.refreshSelf();
 		return true;
 	} else {

--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -96,7 +96,7 @@ EditWidget.prototype.refresh = function(changedTiddlers) {
 		this.refreshSelf();
 		return true;
 	} else {
-		return this.refreshChildren(changedTiddlers);		
+		return this.refreshChildren(changedTiddlers);
 	}
 };
 

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -106,6 +106,9 @@ function CodeMirrorEngine(options) {
 
 	config.mode = options.type;
 	config.value = options.value;
+	if(this.widget.editTabIndex) {
+		config["tabindex"] = this.widget.editTabIndex;
+	}
 	// Create the CodeMirror instance
 	this.cm = window.CodeMirror(function(cmDomNode) {
 		// Note that this is a synchronous callback that is called before the constructor returns


### PR DESCRIPTION
we could add a configuration option in the control panel to enable a tabindex on the input and textarea fields of the edit template, for example