### PR TITLE
Add flag to allow duplicates in filter output

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -72,13 +72,14 @@ $tw.utils.isArrayEqual = function(array1,array2) {
 Push entries onto an array, removing them first if they already exist in the array
 	array: array to modify (assumed to be free of duplicates)
 	value: a single value to push or an array of values to push
+	allowDuplicate: a boolean flag, if true than duplicate entries are not removed
 */
-$tw.utils.pushTop = function(array,value) {
+$tw.utils.pushTop = function(array,value, allowDuplicate) {
 	var t,p;
 	if($tw.utils.isArray(value)) {
 		// Remove any array entries that are duplicated in the new values
 		if(value.length !== 0) {
-			if(array.length !== 0) {
+			if(array.length !== 0 && !allowDuplicate) {
 				if(value.length < array.length) {
 					for(t=0; t<value.length; t++) {
 						p = array.indexOf(value[t]);
@@ -100,7 +101,7 @@ $tw.utils.pushTop = function(array,value) {
 		}
 	} else {
 		p = array.indexOf(value);
-		if(p !== -1) {
+		if(p !== -1 && !allowDuplicate) {
 			array.splice(p,1);
 		}
 		array.push(value);

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -53,7 +53,7 @@ function parseFilterOperation(operators,filterString,p) {
 				$tw.utils.each(subsuffix.split(","),function(entry) {
 					entry = $tw.utils.trim(entry);
 					if(entry) {
-						operator.suffixes[operator.suffixes.length - 1].push(entry); 
+						operator.suffixes[operator.suffixes.length - 1].push(entry);
 					}
 				});
 			});
@@ -177,6 +177,11 @@ source: an iterator function for the source tiddlers, called source(iterator), w
 widget: an optional widget node for retrieving the current tiddler etc.
 */
 exports.compileFilter = function(filterString) {
+	var allowDuplicate = false
+	if (filterString[0] === '?') {
+		allowDuplicate = true
+		filterString = filterString.slice(1)
+	}
 	var filterParseTree;
 	try {
 		filterParseTree = this.parseFilter(filterString);
@@ -246,7 +251,7 @@ exports.compileFilter = function(filterString) {
 			switch(operation.prefix || "") {
 				case "": // No prefix means that the operation is unioned into the result
 					return function(results,source,widget) {
-						$tw.utils.pushTop(results,operationSubFunction(source,widget));
+						$tw.utils.pushTop(results,operationSubFunction(source,widget), allowDuplicate);
 					};
 				case "-": // The results of this operation are removed from the main result
 					return function(results,source,widget) {
@@ -257,13 +262,13 @@ exports.compileFilter = function(filterString) {
 						// This replaces all the elements of the array, but keeps the actual array so that references to it are preserved
 						source = self.makeTiddlerIterator(results);
 						results.splice(0,results.length);
-						$tw.utils.pushTop(results,operationSubFunction(source,widget));
+						$tw.utils.pushTop(results,operationSubFunction(source,widget), allowDuplicate);
 					};
 				case "~": // This operation is unioned into the result only if the main result so far is empty
 					return function(results,source,widget) {
 						if(results.length === 0) {
 							// Main result so far is empty
-							$tw.utils.pushTop(results,operationSubFunction(source,widget));
+							$tw.utils.pushTop(results,operationSubFunction(source,widget), allowDuplicate);
 						}
 					};
 			}

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -178,9 +178,9 @@ widget: an optional widget node for retrieving the current tiddler etc.
 */
 exports.compileFilter = function(filterString) {
 	var allowDuplicate = false
-	if (filterString[0] === '?') {
+	if (filterString.trim()[0] === '?') {
 		allowDuplicate = true
-		filterString = filterString.slice(1)
+		filterString = filterString.trim().slice(1)
 	}
 	var filterParseTree;
 	try {


### PR DESCRIPTION
This is one potential way to resolve #3757  I think that it needs more testing before being considered production ready. Also it should use a better character than `?` as the prefix, it was just the first thing I thought of that wasn't in use.

This shouldn't break backwards compatibility in any way other than filters that start with ?, like `? ! . , ' "` would now strip out the `?` character and allow duplicates when they wouldn't before.