### PR TITLE
fix tags not animating in viewtemplate

### DIFF
--- a/core/modules/widgets/tiddler.js
+++ b/core/modules/widgets/tiddler.js
@@ -97,7 +97,7 @@ TiddlerWidget.prototype.refresh = function(changedTiddlers) {
 	} else if(newTiddlerState.hash !== this.tiddlerState.hash) {
 		// if only tags have changed update tiddlerTagClasses and refresh children but
 		// wait for animation to finish
-		self.tiddlerState = newTiddlerState;
+		self.tiddlerState.hash = newTiddlerState.hash;
 		setTimeout(function(){
 			self.setVariable("tiddlerTagClasses",newTiddlerState.tiddlerTagClasses);
 			self.refreshChildren(self.tiddlerTitle);

--- a/core/modules/widgets/tiddler.js
+++ b/core/modules/widgets/tiddler.js
@@ -99,8 +99,9 @@ TiddlerWidget.prototype.refresh = function(changedTiddlers) {
 		// wait for animation to finish
 		setTimeout(function(){
 			self.setVariable("tiddlerTagClasses",newTiddlerState.tiddlerTagClasses);
-			self.refreshChildren(changedTiddlers);
+			self.refreshChildren(self.tiddlerTitle);
 		},$tw.utils.getAnimationDuration());
+		return this.refreshChildren(changedTiddlers);
 	} else {
 		return this.refreshChildren(changedTiddlers);		
 	}

--- a/core/modules/widgets/tiddler.js
+++ b/core/modules/widgets/tiddler.js
@@ -97,6 +97,7 @@ TiddlerWidget.prototype.refresh = function(changedTiddlers) {
 	} else if(newTiddlerState.hash !== this.tiddlerState.hash) {
 		// if only tags have changed update tiddlerTagClasses and refresh children but
 		// wait for animation to finish
+		self.tiddlerState = newTiddlerState;
 		setTimeout(function(){
 			self.setVariable("tiddlerTagClasses",newTiddlerState.tiddlerTagClasses);
 			self.refreshChildren(self.tiddlerTitle);


### PR DESCRIPTION
this fixes the tags not animating when we add/remove tags to a visible tiddler for example with a tm-add/remove-tag message

the PR creates two different tiddlerState-hashes, one with and the other without the tags. then, if the one without the tags has changed, it makes a full tiddler-widget refresh, if only the tags have changed, it gives the animation time to finish, then updates the tiddlerState-hash and refreshes the tiddler's children