### PR TITLE
Update: $:/core/macros/list

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -76,11 +76,12 @@ tags: $:/tags/Macro
 </$set>
 \end
 
-\define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div")
+\define list-tagged-draggable(tag,subFilter,type:"ul",subtype:"li",class:"",emptyMessage,itemTemplate,elementTag:"div")
 <$set name="tag" value=<<__tag__>>>
+<$type$ class="$class$">
 <$list filter="[<__tag__>tagging[]$subFilter$]" emptyMessage=<<__emptyMessage__>>>
 <$elementTag$ class="tc-menu-list-item">
-<$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""">
+<$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""" tag="""$subtype$""">
 <$elementTag$ class="tc-droppable-placeholder">
 &nbsp;
 </$elementTag$>
@@ -94,6 +95,7 @@ tags: $:/tags/Macro
 </$droppable>
 </$elementTag$>
 </$list>
+</$type$>
 <$tiddler tiddler="">
 <$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""">
 <$elementTag$ class="tc-droppable-placeholder">

--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -76,12 +76,11 @@ tags: $:/tags/Macro
 </$set>
 \end
 
-\define list-tagged-draggable(tag,subFilter,type:"ul",subtype:"li",class:"",emptyMessage,itemTemplate,elementTag:"div")
+\define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div")
 <$set name="tag" value=<<__tag__>>>
-<$type$ class="$class$">
 <$list filter="[<__tag__>tagging[]$subFilter$]" emptyMessage=<<__emptyMessage__>>>
 <$elementTag$ class="tc-menu-list-item">
-<$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""" tag="""$subtype$""">
+<$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""">
 <$elementTag$ class="tc-droppable-placeholder">
 &nbsp;
 </$elementTag$>
@@ -95,7 +94,6 @@ tags: $:/tags/Macro
 </$droppable>
 </$elementTag$>
 </$list>
-</$type$>
 <$tiddler tiddler="">
 <$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""">
 <$elementTag$ class="tc-droppable-placeholder">

--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -6,9 +6,11 @@ tags: $:/tags/Macro
 <$list filter="$filter$" emptyMessage=<<__emptyMessage__>>>
 <$subtype$>
 <$link to={{!!title}}>
+<$set name="tv-wikilinks" value="no">
 <$transclude field="caption">
 <$view field="title"/>
 </$transclude>
+</$set>
 </$link>
 </$subtype$>
 </$list>
@@ -30,9 +32,11 @@ tags: $:/tags/Macro
 <div>
 <$transclude tiddler="""$itemTemplate$""">
 <$link to={{!!title}}>
+<$set name="tv-wikilinks" value="no">
 <$transclude field="caption">
 <$view field="title"/>
 </$transclude>
+</$set>
 </$link>
 </$transclude>
 </div>


### PR DESCRIPTION
Resolving issue #3771 where CamelCase in caption fields mess up the links created. 

Used the same technique adopted in [$:/core/macros/toc](https://github.com/Jermolene/TiddlyWiki5/blob/master/core/wiki/macros/toc.tid) - by wrapping the `<$transclude`> widget with `<$set name="tv-wikilinks" value="no">`