### PR TITLE
fix tiddler-info table cells

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -254,6 +254,10 @@ table tfoot tr td {
 	white-space: nowrap;
 }
 
+.tc-tiddler-info table.tc-view-field-table td:nth-child(2) {
+	word-break: break-all;
+}
+
 .tc-tiddler-frame img,
 .tc-tiddler-frame svg,
 .tc-tiddler-frame canvas,


### PR DESCRIPTION
when there's a long single-word string in a field, the tiddler-info table cells go over the right edge of the tiddler

this makes the second cell of each row always break words