### PR TITLE
DOCS: Correction: How to change the sort order of sub-branches in a TOC macro.tid

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/How to change the sort order of sub-branches in a TOC macro.tid
+++ b/editions/tw5.com/tiddlers/howtos/How to change the sort order of sub-branches in a TOC macro.tid
@@ -1,5 +1,5 @@
 created: 20161209172820513
-modified: 20161209174234840
+modified: 20190220000000000
 tags: Learning
 title: How to change the sort order of sub-branches in a TOC macro
 type: text/vnd.tiddlywiki
@@ -7,7 +7,7 @@ type: text/vnd.tiddlywiki
 Imagine that you are using a [[Table of Contents|Table-of-Contents Macros]] macro similar to this:
 
 ```
-<<toc-selective-expandable  "TableOfContents" "sort[title]" >>
+<<toc-selective-expandable  "TableOfContents" "sort[title]">>
 ```
 
 The sorting is fine for most cases, but you would like all your items tagged `Journal` to be sorted by the `created` field. How can you apply a separate sort order to just those sub-items tagged `Journal`?
@@ -17,7 +17,7 @@ The trick is to add a field to the parent tagging tiddler (i.e. `Journal`) that 
 Now change your [[Table of Contents|Table-of-Contents Macros]] to look like this:
 
 ```
-<<toc-selective-expandable  "TableOfContents" "sort{fuzzy}" >>
+<<toc-selective-expandable  "TableOfContents" "sort{!!fuzzy}">>
 ```
 
 Now your Table of Contents will sort by title everywhere, except for the children of the `Journal` tiddler, which will sort by the `created `date.


### PR DESCRIPTION
Changed line
`<<toc-selective-expandable  "TableOfContents" "sort{fuzzy}">>`
to
`<<toc-selective-expandable  "TableOfContents" "sort{!!fuzzy}">>`

Tested that this is the correct code.