### PR TITLE
DOCS: CREATE: Where to find plugins.tid

### DIFF
--- a/editions/tw5.com/tiddlers/plugins/Where to find plugins.tid
+++ b/editions/tw5.com/tiddlers/plugins/Where to find plugins.tid
@@ -1,0 +1,9 @@
+created: 20190221000000000
+modified: 20190221000000000
+tags: Plugins
+title: Where to find plugins
+
+Plugins can be found by opening the <<.button control-panel>>. On the <<.controlpanel-tab Plugins>> tab, click on the
+{{$:/core/ui/ControlPanel/Plugins/AddPlugins}} button, then search for the plugin's name.
+
+For installing a plugin, see [[Installing a plugin from the plugin library]].


### PR DESCRIPTION
In response to Issue: #3723 

Created one New tiddler (this one) and transcluded it into the bottom of all 15 tiddlers tagged `OfficialPlugins`

This is being done on the `Master` branch because of the needed fix made in #3741 will only be available in the next release 5.1.20