### PR TITLE
DOCS: CREATE: Where to find plugins.tid

### DIFF
--- a/editions/tw5.com/tiddlers/plugins/Amazon Web Services Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Amazon Web Services Plugin.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 
 The Amazon Web Services Plugin provides several tools for working with Amazon Web Services:
 
-* Templates for saving a ~TiddlyWiki as a single ~JavaScript file in a ZIP file that can be executed as an AWS Lambda function. In this form, ~TiddlyWiki is a self contained single file containing both code and data, just like the standalone HTML file configuration
+* Templates for saving a TiddlyWiki as a single JavaScript file in a ZIP file that can be executed as an AWS Lambda function. In this form, ~TiddlyWiki is a self contained single file containing both code and data, just like the standalone HTML file configuration
 * Commands that can be used to interact with AWS services, under both the Node.js and Lambda configurations of ~TiddlyWiki
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/Amazon Web Services Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Amazon Web Services Plugin.tid
@@ -1,5 +1,5 @@
 created: 20170703193252423
-modified: 20170703193353918
+modified: 20190221000000000
 tags: OfficialPlugins
 title: Amazon Web Services Plugin
 type: text/vnd.tiddlywiki
@@ -8,3 +8,5 @@ The Amazon Web Services Plugin provides several tools for working with Amazon We
 
 * Templates for saving a TiddlyWiki as a single JavaScript file in a ZIP file that can be executed as an AWS Lambda function. In this form, TiddlyWiki is a self contained single file containing both code and data, just like the standalone HTML file configuration
 * Commands that can be used to interact with AWS services, under both the Node.js and Lambda configurations of TiddlyWiki
+
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/Amazon Web Services Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Amazon Web Services Plugin.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 
 The Amazon Web Services Plugin provides several tools for working with Amazon Web Services:
 
-* Templates for saving a TiddlyWiki as a single JavaScript file in a ZIP file that can be executed as an AWS Lambda function. In this form, TiddlyWiki is a self contained single file containing both code and data, just like the standalone HTML file configuration
-* Commands that can be used to interact with AWS services, under both the Node.js and Lambda configurations of TiddlyWiki
+* Templates for saving a ~TiddlyWiki as a single ~JavaScript file in a ZIP file that can be executed as an AWS Lambda function. In this form, ~TiddlyWiki is a self contained single file containing both code and data, just like the standalone HTML file configuration
+* Commands that can be used to interact with AWS services, under both the Node.js and Lambda configurations of ~TiddlyWiki
 
 {{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/BrowserStorage Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/BrowserStorage Plugin.tid
@@ -1,12 +1,12 @@
 created: 20190206181204119
-modified: 20190206181204119
+modified: 20190221000000000
 tags: OfficialPlugins
 title: BrowserStorage Plugin
 type: text/vnd.tiddlywiki
 
-The ~BrowserStorage Plugin enables TiddlyWiki to save tiddlers in [[browser local storage|https://en.wikipedia.org/wiki/Web_storage#localStorage]]. This means that changes are stored within the browser, and automatically re-applied any time the base wiki is reloaded.
+The ~BrowserStorage Plugin enables ~TiddlyWiki to save tiddlers in [[browser local storage|https://en.wikipedia.org/wiki/Web_storage#localStorage]]. This means that changes are stored within the browser, and automatically re-applied any time the base wiki is reloaded.
 
-Browser local storage is not a panacea for TiddlyWiki:
+Browser local storage is not a panacea for ~TiddlyWiki:
 
 * Browsers limit the amount of local storage available to a page, typically to 5 or 10MB
 * Keeping personal data in browser local storage can lead to unexpected privacy violations
@@ -15,4 +15,4 @@ Browser local storage is not a panacea for TiddlyWiki:
 
 Please use this plugin with caution. There are a number of unresolved issues and open questions.
 
-The ~BrowserStorage Plugin can be installed from the plugin library.
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/BrowserStorage Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/BrowserStorage Plugin.tid
@@ -4,7 +4,7 @@ tags: OfficialPlugins
 title: BrowserStorage Plugin
 type: text/vnd.tiddlywiki
 
-The ~BrowserStorage Plugin enables ~TiddlyWiki to save tiddlers in [[browser local storage|https://en.wikipedia.org/wiki/Web_storage#localStorage]]. This means that changes are stored within the browser, and automatically re-applied any time the base wiki is reloaded.
+The ~BrowserStorage Plugin enables TiddlyWiki to save tiddlers in [[browser local storage|https://en.wikipedia.org/wiki/Web_storage#localStorage]]. This means that changes are stored within the browser, and automatically re-applied any time the base wiki is reloaded.
 
 Browser local storage is not a panacea for ~TiddlyWiki:
 
@@ -14,5 +14,5 @@ Browser local storage is not a panacea for ~TiddlyWiki:
 * Browsers tie local storage to a URL which can lead to problems if you move a wiki to a URL previously occupied by a different wiki
 
 Please use this plugin with caution. There are a number of unresolved issues and open questions.
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/CodeMirror Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/CodeMirror Plugin.tid
@@ -6,6 +6,6 @@ type: text/vnd.tiddlywiki
 
 The ~CodeMirror plugin adds a sophisticated web-based editor to TiddlyWiki.
 
-See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/codemirror/|plugins/tiddlywiki/codemirror/]] for a demo.
+See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/codemirror/|plugins/tiddlywiki/codemirror/]]
 <hr>
 [[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/CodeMirror Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/CodeMirror Plugin.tid
@@ -1,10 +1,12 @@
 created: 20160107223435497
-list: 
-modified: 20170228102537972
+modified: 20190221000000000
 tags: OfficialPlugins [[Plugin Editions]]
 title: CodeMirror Plugin
 type: text/vnd.tiddlywiki
 
-The CodeMirror plugin adds a sophisticated web-based editor to TiddlyWiki.
+The ~CodeMirror plugin adds a sophisticated web-based editor to ~TiddlyWiki.
 
-See [ext[https://tiddlywiki.com/plugins/tiddlywiki/codemirror|plugins/tiddlywiki/codemirror]] for a demo.
+See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/codemirror/|plugins/tiddlywiki/codemirror/]] for a demo.
+
+{{Where to find plugins}}
+

--- a/editions/tw5.com/tiddlers/plugins/CodeMirror Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/CodeMirror Plugin.tid
@@ -4,9 +4,8 @@ tags: OfficialPlugins [[Plugin Editions]]
 title: CodeMirror Plugin
 type: text/vnd.tiddlywiki
 
-The ~CodeMirror plugin adds a sophisticated web-based editor to ~TiddlyWiki.
+The ~CodeMirror plugin adds a sophisticated web-based editor to TiddlyWiki.
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/codemirror/|plugins/tiddlywiki/codemirror/]] for a demo.
-
-{{Where to find plugins}}
-
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/D3 Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/D3 Plugin.tid
@@ -7,5 +7,5 @@ type: text/vnd.tiddlywiki
 The D3 plugin integrates the D3 visualisation library with TiddlyWiki.
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/d3/|plugins/tiddlywiki/d3/]]
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/D3 Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/D3 Plugin.tid
@@ -1,12 +1,11 @@
 created: 20160107223425581
-list: 
-modified: 20170228102531138
+modified: 20190221000000000
 tags: OfficialPlugins [[Plugin Editions]]
 title: D3 Plugin
 type: text/vnd.tiddlywiki
 
 The D3 plugin integrates the D3 visualisation library with TiddlyWiki.
 
-See https://tiddlywiki.com/plugins/tiddlywiki/d3/
+See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/d3/|plugins/tiddlywiki/d3/]]
 
-See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/d3|plugins/tiddlywiki/d3]]
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/Dynaview Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Dynaview Plugin.tid
@@ -1,5 +1,5 @@
 created: 20180111122953142
-modified: 20181113084151268
+modified: 20190221000000000
 tags: OfficialPlugins
 title: Dynaview Plugin
 type: text/vnd.tiddlywiki
@@ -10,3 +10,5 @@ The Dynaview Plugin makes it possible to build user interfaces that dynamically 
 * CSS classes that allow the opacity of DOM elements to vary according to the current zoom level
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/dynaview|plugins/tiddlywiki/dynaview]]
+
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/Dynaview Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Dynaview Plugin.tid
@@ -10,5 +10,5 @@ The Dynaview Plugin makes it possible to build user interfaces that dynamically 
 * CSS classes that allow the opacity of DOM elements to vary according to the current zoom level
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/dynaview|plugins/tiddlywiki/dynaview]]
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/External Attachments Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/External Attachments Plugin.tid
@@ -1,11 +1,11 @@
 created: 20171031172325817
-list: 
-modified: 20171031172440017
+modified: 20190221000000000
 tags: OfficialPlugins [[Plugin Editions]]
 title: External Attachments Plugin
 type: text/vnd.tiddlywiki
 
-The External Attachments Plugin provides support for importing tiddlers as external attachments. That means that instead of importing binary files as self-contained tiddlers, they are imported as "skinny" tiddlers that reference the original file via the ''_canonical_uri'' field. This reduces the size of the wiki and thus improves performance. However, it does mean that the wiki is no longer fully self-contained.
+The External Attachments Plugin provides support for importing tiddlers as external attachments. That means that instead of importing binary files as self-contained tiddlers, they are imported as "skinny" tiddlers that reference the original file via the <<.field '_canonical_uri>> field. This reduces the size of the wiki and thus improves performance. However, it does mean that the wiki is no longer fully self-contained.
 
-This plugin only works when using TiddlyWiki with platforms such as TiddlyDesktop that support the ''path'' attribute for imported/dragged files.
+This plugin only works when using ~TiddlyWiki with platforms such as [[TiddlyDesktop]] that support the <<.attr path>> attribute for imported/dragged files.
 
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/External Attachments Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/External Attachments Plugin.tid
@@ -4,8 +4,8 @@ tags: OfficialPlugins [[Plugin Editions]]
 title: External Attachments Plugin
 type: text/vnd.tiddlywiki
 
-The External Attachments Plugin provides support for importing tiddlers as external attachments. That means that instead of importing binary files as self-contained tiddlers, they are imported as "skinny" tiddlers that reference the original file via the <<.field '_canonical_uri>> field. This reduces the size of the wiki and thus improves performance. However, it does mean that the wiki is no longer fully self-contained.
+The External Attachments Plugin provides support for importing tiddlers as external attachments. That means that instead of importing binary files as self-contained tiddlers, they are imported as "skinny" tiddlers that reference the original file via the <<.field _canonical_uri>> field. This reduces the size of the wiki and thus improves performance. However, it does mean that the wiki is no longer fully self-contained.
 
-This plugin only works when using ~TiddlyWiki with platforms such as [[TiddlyDesktop]] that support the <<.attr path>> attribute for imported/dragged files.
-
-{{Where to find plugins}}
+This plugin only works when using [[TiddlyWiki]] with platforms such as [[TiddlyDesktop]] that support the <<.attr path>> attribute for imported/dragged files.
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/Highlight Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Highlight Plugin.tid
@@ -1,10 +1,11 @@
 created: 20160107223417655
-list: 
-modified: 20170228102525208
+modified: 20190221000000000
 tags: OfficialPlugins [[Plugin Editions]]
 title: Highlight Plugin
 type: text/vnd.tiddlywiki
 
 The Highlight plugin provides the ability to apply syntax colouring to text.
 
-See [ext[https://tiddlywiki.com/plugins/tiddlywiki/highlight|plugins/tiddlywiki/highlight]]
+See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/highlight/|plugins/tiddlywiki/highlight/]]
+
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/Highlight Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Highlight Plugin.tid
@@ -7,5 +7,5 @@ type: text/vnd.tiddlywiki
 The Highlight plugin provides the ability to apply syntax colouring to text.
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/highlight/|plugins/tiddlywiki/highlight/]]
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/Innerwiki Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Innerwiki Plugin.tid
@@ -1,11 +1,13 @@
 created: 20190127104143725
-modified: 20190127104143725
+modified: 20190221000000000
 tags: OfficialPlugins
 title: Innerwiki Plugin
 type: text/vnd.tiddlywiki
 
-The Innerwiki Plugin enables TiddlyWiki to embed a modified copy of itself (an "innerwiki"). The primary motivation is to be able to produce screenshot illustrations that are automatically up-to-date with the appearance of TiddlyWiki as it changes over time, or to produce the same screenshot in different languages.
+The Innerwiki Plugin enables ~TiddlyWiki to embed a modified copy of itself (an <<.word innerwiki>>). The primary motivation is to be able to produce screenshot illustrations that are automatically up-to-date with the appearance of ~TiddlyWiki as it changes over time, or to produce the same screenshot in different languages.
 
 In the browser, innerwikis are displayed as an embedded iframe. Under Node.js [[Google's Puppeteer|https://pptr.dev/]] is used to load the innerwikis as off-screen web pages and then snapshot them as a PNG image.
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/innerwiki|plugins/tiddlywiki/innerwiki]]
+
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/Innerwiki Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Innerwiki Plugin.tid
@@ -4,10 +4,10 @@ tags: OfficialPlugins
 title: Innerwiki Plugin
 type: text/vnd.tiddlywiki
 
-The Innerwiki Plugin enables ~TiddlyWiki to embed a modified copy of itself (an <<.word innerwiki>>). The primary motivation is to be able to produce screenshot illustrations that are automatically up-to-date with the appearance of ~TiddlyWiki as it changes over time, or to produce the same screenshot in different languages.
+The Innerwiki Plugin enables [[TiddlyWiki]] to embed a modified copy of itself (an <<.word innerwiki>>). The primary motivation is to be able to produce screenshot illustrations that are automatically up-to-date with the appearance of ~TiddlyWiki as it changes over time, or to produce the same screenshot in different languages.
 
 In the browser, innerwikis are displayed as an embedded iframe. Under Node.js [[Google's Puppeteer|https://pptr.dev/]] is used to load the innerwikis as off-screen web pages and then snapshot them as a PNG image.
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/innerwiki|plugins/tiddlywiki/innerwiki]]
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/KaTeX Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/KaTeX Plugin.tid
@@ -1,10 +1,11 @@
 created: 20160107223410181
-list: 
-modified: 20170228102517666
+modified: 20190221000000000
 tags: OfficialPlugins [[Plugin Editions]]
 title: KaTeX Plugin
 type: text/vnd.tiddlywiki
 
 This plugin adds the ability to display mathematical notation written in ~LaTeX.
 
-See [ext[https://tiddlywiki.com/plugins/tiddlywiki/katex|plugins/tiddlywiki/katex]]
+See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/katex/|plugins/tiddlywiki/katex/]]
+
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/KaTeX Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/KaTeX Plugin.tid
@@ -7,5 +7,5 @@ type: text/vnd.tiddlywiki
 This plugin adds the ability to display mathematical notation written in ~LaTeX.
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/katex/|plugins/tiddlywiki/katex/]]
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/Markdown Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Markdown Plugin.tid
@@ -7,5 +7,5 @@ type: text/vnd.tiddlywiki
 The Markdown plugin enables you to use tiddlers that are written in standard Markdown markup.
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/markdown/|plugins/tiddlywiki/markdown/]]
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/Markdown Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Markdown Plugin.tid
@@ -1,10 +1,11 @@
 created: 20160107223401584
-list: 
-modified: 20170228102511347
+modified: 20190221000000000
 tags: OfficialPlugins [[Plugin Editions]]
 title: Markdown Plugin
 type: text/vnd.tiddlywiki
 
 The Markdown plugin enables you to use tiddlers that are written in standard Markdown markup.
 
-See [ext[https://tiddlywiki.com/plugins/tiddlywiki/markdown|plugins/tiddlywiki/markdown]]
+See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/markdown/|plugins/tiddlywiki/markdown/]]
+
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/Mobile Drag And Drop Shim Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Mobile Drag And Drop Shim Plugin.tid
@@ -4,6 +4,6 @@ tags: OfficialPlugins
 title: Mobile Drag And Drop Shim Plugin
 type: text/vnd.tiddlywiki
 
-The Mobile Drag And Drop Shim Plugin provides a "shim" that enables HTML 5 compatible drag and drop operations on mobile browsers, including iOS and Android. The shim was created by Tim Ruffles and is published at [ext[https://github.com/timruffles/ios-html5-drag-drop-shim|https://github.com/timruffles/ios-html5-drag-drop-shim]].
-
-{{Where to find plugins}}
+The Mobile Drag And Drop Shim Plugin provides a <<.word shim>> that enables HTML 5 compatible drag and drop operations on mobile browsers, including iOS and Android. The shim was created by Tim Ruffles and is published at [ext[https://github.com/timruffles/ios-html5-drag-drop-shim|https://github.com/timruffles/ios-html5-drag-drop-shim]].
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/Mobile Drag And Drop Shim Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Mobile Drag And Drop Shim Plugin.tid
@@ -1,7 +1,9 @@
 created: 20170328173820802
-modified: 20170328174328792
+modified: 20190221000000000
 tags: OfficialPlugins
 title: Mobile Drag And Drop Shim Plugin
 type: text/vnd.tiddlywiki
 
-The Mobile Drag And Drop Shim Plugin provides a "shim" that enables HTML 5 compatible drag and drop operations on mobile browsers, including iOS and Android. The shim was created by Tim Ruffles and is published at https://github.com/timruffles/ios-html5-drag-drop-shim.
+The Mobile Drag And Drop Shim Plugin provides a "shim" that enables HTML 5 compatible drag and drop operations on mobile browsers, including iOS and Android. The shim was created by Tim Ruffles and is published at [ext[https://github.com/timruffles/ios-html5-drag-drop-shim|https://github.com/timruffles/ios-html5-drag-drop-shim]].
+
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/Railroad Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Railroad Plugin.tid
@@ -8,5 +8,5 @@ type: text/vnd.tiddlywiki
 
 {{$:/plugins/tiddlywiki/railroad/syntax}}
 
----
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/Railroad Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Railroad Plugin.tid
@@ -1,6 +1,5 @@
 created: 20160107223348621
-list: 
-modified: 20170228102501706
+modified: 20190221000000000
 tags: OfficialPlugins [[Plugin Editions]]
 title: Railroad Plugin
 type: text/vnd.tiddlywiki
@@ -8,3 +7,6 @@ type: text/vnd.tiddlywiki
 {{$:/plugins/tiddlywiki/railroad/readme}}
 
 {{$:/plugins/tiddlywiki/railroad/syntax}}
+
+---
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/SaveTrail Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/SaveTrail Plugin.tid
@@ -4,7 +4,7 @@ tags: OfficialPlugins
 title: SaveTrail Plugin
 type: text/vnd.tiddlywiki
 
-This plugin causes ~TiddlyWiki to continuously download (as a JSON file) the contents of any tiddler that is manually changed by any of several means:
+This plugin causes [[TiddlyWiki]] to continuously download (as a JSON file) the contents of any tiddler that is manually changed by any of several means:
 
 * Confirming an edit
 * Deleting tiddlers
@@ -13,5 +13,5 @@ This plugin causes ~TiddlyWiki to continuously download (as a JSON file) the con
 * Optionally, typing in draft tiddlers can trigger a download
 
 Where appropriate, separate 'before' and 'after' files are downloaded. Configured correctly, the browser will download the files silently in the background, and they can be used as a backup in case of accidental data loss.
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/SaveTrail Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/SaveTrail Plugin.tid
@@ -1,10 +1,10 @@
 created: 20170210074840860
-modified: 20170328173912704
+modified: 20190221000000000
 tags: OfficialPlugins
 title: SaveTrail Plugin
 type: text/vnd.tiddlywiki
 
-This plugin causes TiddlyWiki to continuously download (as a JSON file) the contents of any tiddler that is manually changed by any of several means:
+This plugin causes ~TiddlyWiki to continuously download (as a JSON file) the contents of any tiddler that is manually changed by any of several means:
 
 * Confirming an edit
 * Deleting tiddlers
@@ -14,3 +14,4 @@ This plugin causes TiddlyWiki to continuously download (as a JSON file) the cont
 
 Where appropriate, separate 'before' and 'after' files are downloaded. Configured correctly, the browser will download the files silently in the background, and they can be used as a backup in case of accidental data loss.
 
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/TW2Parser Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/TW2Parser Plugin.tid
@@ -1,10 +1,11 @@
 created: 20160107223340750
-list: 
-modified: 20170228102455677
+modified: 20190221000000000
 tags: OfficialPlugins [[Plugin Editions]]
 title: TW2Parser Plugin
 type: text/vnd.tiddlywiki
 
-This experimental plugin adds the ability to display WikiText written for the original Classic version of TiddlyWiki.
+This experimental plugin adds the ability to display WikiText written for the original Classic version of ~TiddlyWiki.
 
-See [ext[https://tiddlywiki.com/plugins/tiddlywiki/tw2parser|plugins/tiddlywiki/tw2parser]]
+See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/tw2parser/|plugins/tiddlywiki/tw2parser/]]
+
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/TW2Parser Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/TW2Parser Plugin.tid
@@ -4,8 +4,8 @@ tags: OfficialPlugins [[Plugin Editions]]
 title: TW2Parser Plugin
 type: text/vnd.tiddlywiki
 
-This experimental plugin adds the ability to display WikiText written for the original Classic version of ~TiddlyWiki.
+This experimental plugin adds the ability to display [[WikiText]] written for the original Classic version of [[TiddlyWiki]].
 
 See the demo at [ext[https://tiddlywiki.com/plugins/tiddlywiki/tw2parser/|plugins/tiddlywiki/tw2parser/]]
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/Twitter Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Twitter Plugin.tid
@@ -4,10 +4,10 @@ tags: OfficialPlugins
 title: Twitter Plugin
 type: text/vnd.tiddlywiki
 
-This plugin adds a `<$twitter>` widget that can embed a variety of entities from twitter.com:
+This plugin adds a <<.wid twitter>> widget that can embed a variety of entities from twitter.com:
 
 * Individual tweets and conversation threads
 * Buttons to tweet a hashtag/account, follow/like an account, or share a URL
 * Timelines showing tweets from a user, hashtag, list or collection
-
-{{Where to find plugins}}
+<hr>
+[[How to get this plugin|Where to find official plugins]].

--- a/editions/tw5.com/tiddlers/plugins/Twitter Plugin.tid
+++ b/editions/tw5.com/tiddlers/plugins/Twitter Plugin.tid
@@ -1,5 +1,5 @@
 created: 20170227223209558
-modified: 20170328173919702
+modified: 20190221000000000
 tags: OfficialPlugins
 title: Twitter Plugin
 type: text/vnd.tiddlywiki
@@ -9,3 +9,5 @@ This plugin adds a `<$twitter>` widget that can embed a variety of entities from
 * Individual tweets and conversation threads
 * Buttons to tweet a hashtag/account, follow/like an account, or share a URL
 * Timelines showing tweets from a user, hashtag, list or collection
+
+{{Where to find plugins}}

--- a/editions/tw5.com/tiddlers/plugins/Where to find official plugins.tid
+++ b/editions/tw5.com/tiddlers/plugins/Where to find official plugins.tid
@@ -1,0 +1,11 @@
+created: 20190221000000000
+modified: 20190221000000000
+tags: Plugins
+title: Where to find official plugins
+
+You can find official plugins by opening the <<.button control-panel>>, and on the <<.controlpanel-tab Plugins>> tab, click on the
+{{$:/core/ui/ControlPanel/Plugins/AddPlugins}} button.
+
+Search for the plugin by its name.
+
+Further instructions can be found at  [[Installing a plugin from the plugin library]].

--- a/editions/tw5.com/tiddlers/plugins/Where to find official plugins.tid
+++ b/editions/tw5.com/tiddlers/plugins/Where to find official plugins.tid
@@ -8,4 +8,4 @@ You can find official plugins by opening the <<.button control-panel>>, and on t
 
 Search for the plugin by its name.
 
-Further instructions can be found at  [[Installing a plugin from the plugin library]].
+Before installing the plugin, follow the instructions at [[Installing a plugin from the plugin library]].

--- a/editions/tw5.com/tiddlers/plugins/Where to find plugins.tid
+++ b/editions/tw5.com/tiddlers/plugins/Where to find plugins.tid
@@ -1,0 +1,7 @@
+created: 20190221000000000
+modified: 20190221000000000
+tags: Plugins
+title: Where to find plugins
+
+To find the plugin, search for its name by opening the <<.button control-panel>>, then on the <<.controlpanel-tab Plugins>> tab, click on the
+{{$:/core/ui/ControlPanel/Plugins/AddPlugins}} button. For installing a plugin, see [[Installing a plugin from the plugin library]].

--- a/editions/tw5.com/tiddlers/plugins/Where to find plugins.tid
+++ b/editions/tw5.com/tiddlers/plugins/Where to find plugins.tid
@@ -1,7 +1,0 @@
-created: 20190221000000000
-modified: 20190221000000000
-tags: Plugins
-title: Where to find plugins
-
-To find the plugin, search for its name by opening the <<.button control-panel>>, then on the <<.controlpanel-tab Plugins>> tab, click on the
-{{$:/core/ui/ControlPanel/Plugins/AddPlugins}} button. For installing a plugin, see [[Installing a plugin from the plugin library]].


### PR DESCRIPTION
In response to Issue: #3723

Create one New tiddler (`Where to find plugins.tid`) and transclude it into the bottom of all 15 tiddlers tagged `OfficialPlugins`

This is being done on the `Master` branch because of the needed fix made in #3741 will only be available in the next release 5.1.20