### PR TITLE
Add switch for enabling duplicates within filters

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -76,34 +76,42 @@ Push entries onto an array, removing them first if they already exist in the arr
 $tw.utils.pushTop = function(array,value) {
 	var t,p;
 	if($tw.utils.isArray(value)) {
-		// Remove any array entries that are duplicated in the new values
-		if(value.length !== 0) {
-			if(array.length !== 0) {
-				if(value.length < array.length) {
-					for(t=0; t<value.length; t++) {
-						p = array.indexOf(value[t]);
-						if(p !== -1) {
-							array.splice(p,1);
+		if($tw.config._temp_allowDuplicates) {
+			Array.prototype.push.apply(array,value);
+		} else {
+			// Remove any array entries that are duplicated in the new values
+			if(value.length !== 0) {
+				if(array.length !== 0) {
+					if(value.length < array.length) {
+						for(t=0; t<value.length; t++) {
+							p = array.indexOf(value[t]);
+							if(p !== -1) {
+								array.splice(p,1);
+							}
 						}
-					}
-				} else {
-					for(t=array.length-1; t>=0; t--) {
-						p = value.indexOf(array[t]);
-						if(p !== -1) {
-							array.splice(t,1);
+					} else {
+						for(t=array.length-1; t>=0; t--) {
+							p = value.indexOf(array[t]);
+							if(p !== -1) {
+								array.splice(t,1);
+							}
 						}
 					}
 				}
-			}
-			// Push the values on top of the main array
-			array.push.apply(array,value);
+				// Push the values on top of the main array
+				Array.prototype.push.apply(array,value);
+			}			
 		}
 	} else {
-		p = array.indexOf(value);
-		if(p !== -1) {
-			array.splice(p,1);
+		if($tw.config._temp_allowDuplicates) {
+			array.push(value);
+		} else {
+			p = array.indexOf(value);
+			if(p !== -1) {
+				array.splice(p,1);
+			}
+			array.push(value);
 		}
-		array.push(value);
 	}
 	return array;
 };
@@ -339,7 +347,7 @@ $tw.utils.parseStringArray = function(value, allowDuplicate) {
 			match = memberRegExp.exec(value);
 			if(match) {
 				var item = match[1] || match[2];
-				if(item !== undefined && (!$tw.utils.hop(names,item) || allowDuplicate)) {
+				if(item !== undefined && (!$tw.utils.hop(names,item) || allowDuplicate || $tw.config._temp_allowDuplicates)) {
 					results.push(item);
 					names[item] = true;
 				}
@@ -2021,14 +2029,24 @@ $tw.loadTiddlersNode = function() {
 Startup TiddlyWiki
 */
 $tw.boot.startup = function(options) {
+	var _temp_allowDuplicates;
 	options = options || {};
 	// Get the URL hash and check for safe mode
 	$tw.locationHash = "#";
 	if($tw.browser && !$tw.node) {
 		if(location.hash === "#:safe") {
 			$tw.safeMode = true;
+		} else if(location.hash === "#dupes") {
+			_temp_allowDuplicates = true;
+			$tw.locationHash = $tw.utils.getLocationHash();
 		} else {
 			$tw.locationHash = $tw.utils.getLocationHash();
+		}
+	} else {
+		var p = $tw.boot.argv.indexOf("--dupes");
+		if(p !== -1) {
+			_temp_allowDuplicates = true;
+			$tw.boot.argv.splice(p,1);
 		}
 	}
 	// Initialise some more $tw properties
@@ -2038,6 +2056,7 @@ $tw.boot.startup = function(options) {
 			types: {} // hashmap by module type of hashmap of exports
 		},
 		config: { // Configuration overridables
+			_temp_allowDuplicates: _temp_allowDuplicates,
 			pluginsPath: "../plugins/",
 			themesPath: "../themes/",
 			languagesPath: "../languages/",
@@ -2171,6 +2190,14 @@ $tw.boot.startup = function(options) {
 	// Make sure the crypto state tiddler is up to date
 	if($tw.crypto) {
 		$tw.crypto.updateCryptoStateTiddler();
+	}
+	// Warn if using duplicates mode
+	console.log("\x1b[0;31m--------=====>>>>>> " + $tw.wiki.getTiddler("$:/core/_temp_allowDuplicates/Heading").fields.text + "\x1b[0m");
+	console.log("\x1b[0;34m--------=====>>>>>> " + $tw.wiki.getTiddler("$:/core/_temp_allowDuplicates/Warning").fields.text + "\x1b[0m");
+	if($tw.config._temp_allowDuplicates) {
+		console.log("\x1b[0;31m--------=====>>>>>> " + $tw.wiki.getTiddler("$:/core/_temp_allowDuplicates/StatusOn").fields.text + "\x1b[0m");
+	} else {
+		console.log("\x1b[0;32m--------=====>>>>>> " + $tw.wiki.getTiddler("$:/core/_temp_allowDuplicates/StatusOff").fields.text + "\x1b[0m");
 	}
 	// Gather up any startup modules
 	$tw.boot.remainingStartupModules = []; // Array of startup modules

--- a/core/_temp_allowDuplicates.tid
+++ b/core/_temp_allowDuplicates.tid
@@ -1,0 +1,92 @@
+title: $:/core/_temp_allowDuplicates
+tags: $:/tags/AboveStory
+
+<div class="marching-ants-box" style="
+    position: fixed;
+    top: 100px;
+    left: -4px;
+    max-width: 50%;
+    z-index: 1000;
+    padding: 1em;
+    border-top-right-radius: 16px;
+    border-bottom-right-radius: 16px;
+    color: #fff;">
+
+<$reveal type="match" state="$:/state/_temp_allowDuplicatesWarning" text="hide" default="show">
+
+<$button set="$:/state/_temp_allowDuplicatesWarning" setTo="show" class="tc-btn-invisible" style="
+    width: 100%;
+    text-align: left;
+    fill: #ff0;">
+
+{{$:/core/images/warning}}
+
+</$button>
+
+</$reveal>
+
+<$reveal type="nomatch" state="$:/state/_temp_allowDuplicatesWarning" text="hide" default="show">
+
+<$button set="$:/state/_temp_allowDuplicatesWarning" setTo="hide" class="tc-btn-invisible" style="
+    width: 100%;
+    text-align: left;
+    fill: #ff0;">
+
+<span style="float:right;">{{$:/core/images/chevron-left}}</span> {{$:/core/images/warning}}
+
+</$button>
+
+<div style="
+	font-weight: bold;">
+
+{{$:/core/_temp_allowDuplicates/Heading}}
+
+</div>
+
+<div style="">
+
+{{$:/core/_temp_allowDuplicates/Warning}}
+
+</div>
+
+<$list filter="1 1 1 1 +[butfirst[]limit[1]]" emptyMessage="""
+
+<div style="
+	font-weight: bold;
+	color: #0f0;">
+
+{{$:/core/_temp_allowDuplicates/StatusOff}}
+
+//Append `#dupes` to the browser address bar to enable//
+
+</div>
+""">
+
+<div style="
+	font-weight: bold;
+	color: #fff;
+	font-size: 1.5em;
+	padding: 4px;" class="marching-ants-box">
+
+{{$:/core/_temp_allowDuplicates/StatusOn}}
+
+//Remove `#dupes` from the browser address bar to disable//
+
+</div>
+
+</$list>
+
+</$reveal>
+
+</div>
+
+<style>
+@keyframes marching-ants { to { background-position: 100% 100% } }
+
+.marching-ants-box {
+	border: 4px solid transparent;
+	background: linear-gradient(#d85858, #d85858) padding-box,
+	            repeating-linear-gradient(-45deg, #f00 0, #f00 25%, transparent 0, transparent 50%) 0 / 12px 12px;
+	animation: marching-ants 12s linear infinite;
+}
+</style>

--- a/core/messages.multids
+++ b/core/messages.multids
@@ -1,0 +1,6 @@
+title: $:/core/_temp_allowDuplicates/
+
+Heading: Important Warning
+Warning: This is a special prerelease version of TW5 for experimenting with a potentially incompatible change to the core logic of filter processing. It is only intended to be used for evaluation and testing
+StatusOff: The allow duplicates setting is currently: OFF
+StatusOn: The allow duplicates setting is currently: ON


### PR DESCRIPTION
This PR explores one possible fix for #3757: to entirely switch off the suppression of duplicates during filter processing.

Despite being an incompatible change to the core, early suggestions are that it has little or no impact on the normal operation of TiddlyWiki.

Thus, I'm making the changes available so that other people can experiment with them to evaluate their impact. 

To enable the new behaviour:

* Add `#dupes` to the browser address bar and refresh the page
* Use the `--dupe` command line switch under Node.js

I've added some suitably eye catching notification messages:

![dupe-warning](https://user-images.githubusercontent.com/174761/53181065-bfed4f80-35ee-11e9-9ce9-a5d5bb9c76ad.gif)

<img width="1204" alt="screenshot 2019-02-21 15 41 37" src="https://user-images.githubusercontent.com/174761/53181286-2ffbd580-35ef-11e9-96a3-63beff19970f.png">

I've also uploaded this new branch to TiddlySpot:

http://allow-filter-duplicates.tiddlyspot.com/#dupes
