### PR TITLE
add "isHidden" attribute to domNode

### DIFF
--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -49,6 +49,7 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 	}
 	if(!this.isOpen) {
 		domNode.setAttribute("hidden","true");
+		domNode.setAttribute("isHidden","true");
 	}
 	this.domNodes.push(domNode);
 };
@@ -230,13 +231,17 @@ RevealWidget.prototype.updateState = function() {
 	}
 	if(this.isOpen) {
 		domNode.removeAttribute("hidden");
+		domNode.removeAttribute("isHidden");
         $tw.anim.perform(this.openAnimation,domNode);
 	} else {
+		domNode.setAttribute("isHidden","true");
 		$tw.anim.perform(this.closeAnimation,domNode,{callback: function() {
 			//make sure that the state hasn't changed during the close animation
 			self.readState()
 			if(!self.isOpen) {
 				domNode.setAttribute("hidden","true");
+			} else {
+				domNode.removeAttribute("isHidden");
 			}
 		}});
 	}


### PR DESCRIPTION
this adds an additional `isHidden` attribute to domNodes but not like the "hidden" attribute after the animation is finished, but right after the state is triggered

this isn't used in the core, but it's useful if listening for the change of this hidden attribute. in that case it's better to be informed instantly when it's about to get the hidden attribute. so one listens for the `isHidden` attribute change

a proposal, but a very useful one for me :smile: