### PR TITLE
Hook for closing tiddlers

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -144,6 +144,7 @@ NavigatorWidget.prototype.handleNavigateEvent = function(event) {
 
 // Close a specified tiddler
 NavigatorWidget.prototype.handleCloseTiddlerEvent = function(event) {
+	event = $tw.hooks.invokeHook("th-closing-tiddler",event);
 	var title = event.param || event.tiddlerTitle,
 		storyList = this.getStoryList();
 	// Look for tiddlers with this title to close


### PR DESCRIPTION
Hi Folks,

Most of the other common events have hooks associated. But there didn't seem to be a hook for closing tiddlers. Honestly, I'd like to put hooks on all of these events. It seems like a low-overhead way of adding some convenience for those making plugins. I figured a good place to start was with the most obvious event that didn't yet have a hook: closing tiddlers.

Best wishes!