### PR TITLE
add resize listener utilities to dom.js + innerwiki dimension refresh

### DIFF
--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -235,8 +235,9 @@ exports.addResizeListener = function(domNode,callback) {
 				domNode.appendChild(resizeObject);
 			}
 		}
+		$tw.utils.pushTop(domNode.__resizeListeners__,callback);
 	} else if(domNode) {
-		domNode.__resizeListeners__.push(callback);
+		$tw.utils.pushTop(domNode.__resizeListeners__,callback);
 	}
 };
 

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -209,13 +209,14 @@ Listen for resize events on a given domNode and execute a callback on resize
 http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
 */
 exports.addResizeListener = function(domNode,callback) {
-	if(domNode && !domNode.__resizeListeners__) {
-		domNode.__resizeListeners__ = [];
+	if(domNode) {
+		if(!domNode.__resizeListeners__) {
+			domNode.__resizeListeners__ = [];
+		}
 		if(domNode.ownerDocument.attachEvent) {
 			domNode.__resizeTrigger__ = domNode;
 			domNode.attachEvent('onresize',$tw.utils.resizeListener);
-		}
-		else {
+		} else {
 			if(domNode.ownerDocument.defaultView.getComputedStyle(domNode).position == 'static') {
 				domNode.style.position = 'relative';
 			}
@@ -235,8 +236,6 @@ exports.addResizeListener = function(domNode,callback) {
 				domNode.appendChild(resizeObject);
 			}
 		}
-		$tw.utils.pushTop(domNode.__resizeListeners__,callback);
-	} else if(domNode) {
 		$tw.utils.pushTop(domNode.__resizeListeners__,callback);
 	}
 };

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -205,7 +205,7 @@ exports.addEventListeners = function(domNode,events) {
 };
 
 /*
-Listen for resize events on a give domNode and execute a callback on resize
+Listen for resize events on a given domNode and execute a callback on resize
 http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
 */
 exports.addResizeListener = function(domNode,callback) {

--- a/plugins/tiddlywiki/innerwiki/innerwiki.js
+++ b/plugins/tiddlywiki/innerwiki/innerwiki.js
@@ -235,6 +235,19 @@ InnerWikiWidget.prototype.refreshDimensions = function() {
 	if(!this.hasDimensionsRefreshed) {
 		this.hasDimensionsRefreshed = true;
 		// update dimensions here
+		// get the new dimensions of the domWrapper, they have changed
+		var domWrapperRect = this.domWrapper.getBoundingClientRect();
+		// get the current dimensions of the domIFrame
+		var domIFrameRect = this.domIFrame.getBoundingClientRect();
+		// calculate aspect ratio
+		var aspectRatio = domIFrameRect.width / domIFrameRect.height;
+		// adapt the height of the domWrapper
+		this.domWrapper.style.height = (domWrapperRect.width / aspectRatio) + "px";
+		// calculate the new scaleFactor
+		var newScale = domWrapperRect.width / this.clipWidth;
+		// transform the domIFrame accordingly
+		this.domIFrame.style.transform = "translate(" + (-this.clipLeft) + "px," + (-this.clipTop) + "px) scale(" + newScale + ")";
+		// update anchors here
 		
 	} else {
 		this.hasDimensionsRefreshed = null;

--- a/plugins/tiddlywiki/innerwiki/innerwiki.js
+++ b/plugins/tiddlywiki/innerwiki/innerwiki.js
@@ -135,6 +135,9 @@ InnerWikiWidget.prototype.render = function(parent,nextSibling) {
 		this.domIFrame.style.transformOrigin = this.clipLeft + "px " + this.clipTop + "px";
 		this.domIFrame.style.transform = "translate(" + (-this.clipLeft) + "px," + (-this.clipTop) + "px) scale(" + this.scale + ")";
 		this.domWrapper.style.height = (this.clipHeight * this.scale) + "px";
+		$tw.utils.addResizeListener(this.domWrapper,function() {
+			self.refreshDimensions();
+		});
 	}
 };
 
@@ -219,6 +222,22 @@ InnerWikiWidget.prototype.deleteAnchors = function() {
 		if(node.tagName === "IMG") {
 			node.parentNode.removeChild(node);
 		}
+	}
+};
+
+/*
+Refresh dimensions of domWrapper and domIFrame
+*/
+InnerWikiWidget.prototype.refreshDimensions = function() {
+	// We're setting a different height to the domWrapper
+	// That will cause the resizeListener to call refreshDimensions again
+	// this.hasDimensionsRefreshed breaks the loop
+	if(!this.hasDimensionsRefreshed) {
+		this.hasDimensionsRefreshed = true;
+		// update dimensions here
+		
+	} else {
+		this.hasDimensionsRefreshed = null;
 	}
 };
 
@@ -333,8 +352,12 @@ InnerWikiWidget.prototype.execute = function() {
 Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 */
 InnerWikiWidget.prototype.refresh = function(changedTiddlers) {
+	var self = this;
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.template || changedAttributes.width || changedAttributes.height || changedAttributes.style || changedAttributes.class) {
+		$tw.utils.removeResizeListener(this.domWrapper,function() {
+			self.refreshDimensions();
+		});
 		this.refreshSelf();
 		return true;
 	} else {

--- a/plugins/tiddlywiki/innerwiki/innerwiki.js
+++ b/plugins/tiddlywiki/innerwiki/innerwiki.js
@@ -244,11 +244,22 @@ InnerWikiWidget.prototype.refreshDimensions = function() {
 		// adapt the height of the domWrapper
 		this.domWrapper.style.height = (domWrapperRect.width / aspectRatio) + "px";
 		// calculate the new scaleFactor
-		var newScale = domWrapperRect.width / this.clipWidth;
+		this.scale = domWrapperRect.width / this.clipWidth;
 		// transform the domIFrame accordingly
-		this.domIFrame.style.transform = "translate(" + (-this.clipLeft) + "px," + (-this.clipTop) + "px) scale(" + newScale + ")";
+		this.domIFrame.style.transform = "translate(" + (-this.clipLeft) + "px," + (-this.clipTop) + "px) scale(" + this.scale + ")";
 		// update anchors here
-		
+		this.deleteAnchors();
+		this.domAnchorContainer.style.transform = "scale(" + this.scale + ")";
+		this.domAnchorContainer.removeChild(this.domAnchorBackdrop);
+		this.domAnchorBackdrop = dm("div",{
+			document: this.document,
+			style: {
+				position: "absolute",
+				display: "none"
+			}
+		});
+		this.domAnchorContainer.appendChild(this.domAnchorBackdrop);
+		this.createAnchors();
 	} else {
 		this.hasDimensionsRefreshed = null;
 	}


### PR DESCRIPTION
this adds `$tw.utils.addResizeListener(domNode,callback)` `$tw.utils.removeResizeListener(domNode,callback)` and `$tw.utils.isDOMElement(obj)`

this can be used in the innerwiki plugin for example, to listen on the `domWrapper` if its dimensions change and update the iframe accordingly

this is a `Draft PR`

Update: the innerwiki plugin updates its dimensions whenever the dimensions of the domWrapper change ... when resizing the browser, changing the sidebar state, changing the story-river width etc. No full refresh which is too heavy. Just dimensions and scaling