### PR TITLE
Add means of halting newTiddlerEvent to hook

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -398,6 +398,9 @@ NavigatorWidget.prototype.handleCancelTiddlerEvent = function(event) {
 // If a draft of the target tiddler already exists then it is reused
 NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 	event = $tw.hooks.invokeHook("th-new-tiddler", event);
+	if(!event) {
+		return false;
+	}
 	// Get the story details
 	var storyList = this.getStoryList(),
 		templateTiddler, additionalFields, title, draftTitle, existingTiddler;


### PR DESCRIPTION
Hi Folks,

Most of the other hooks I've been looking at have means of aborting the native event handling by returning an empty event or false value. The "tm-new-tiddler" event appears to be an exception. To my mind, the hooks, without exception, ought to be able to capable of being used to stop the native handling entirely.

I love the hook system by the way. It seems like a fantastic way of opening up Tiddlywiki to really extensive augmentations. I'd love to see it expanded! It is such a low-overhead way of making tiddlywiki endlessly adaptable without overwriting any core tiddlers.

Best wishes