### PR TITLE
DOCS Update: ListWidget.tid

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/ListWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ListWidget.tid
@@ -1,6 +1,6 @@
 caption: list
 created: 20131024141900000
-modified: 20181013230425882
+modified: 20190224000000000
 tags: Widgets Lists
 title: ListWidget
 type: text/vnd.tiddlywiki
@@ -9,12 +9,49 @@ type: text/vnd.tiddlywiki
 
 The list widget displays a sequence of tiddlers that match a [[tiddler filter|Filters]]. It can be used for many purposes:
 
-* Displaying custom lists of links, like in TiddlyWiki5's sidebar
+* Displaying custom lists of links, like in TiddlyWiki's sidebar
 * Custom lists, such as "all tiddlers tagged 'task' that are not tagged 'done'"
 * Listing each of the tags applied to a tiddler
 * Handling the main story river
 
 The tiddlers are displayed by transcluding each in turn through a template. There are several ways to specify the template and for controlling the behaviour of the list.
+
+! Content and Attributes
+
+The content of the <<.wid list>> widget is an optional template to use for rendering each tiddler in the list. Alternatively, the template can be specified as a tiddler title in the <<.attr template>> attribute. As a fallback, the default template just displays the tiddler title.
+
+|!Attribute |!Description |
+|filter |The [[tiddler filter|Filters]] to display |
+|template |The title of a template tiddler for transcluding each tiddler in the list. When no template is specified, the body of the ListWidget serves as the item template. With no body, a simple link to the tiddler is returned. |
+|editTemplate |An alternative template to use for [[DraftTiddlers|DraftMechanism]] in edit mode |
+|variable |The name for a [[variable|Variables]] in which the title of each listed tiddler is stored. Defaults to ''currentTiddler'' |
+|emptyMessage |Message to be displayed when the list is empty |
+|storyview |Optional name of module responsible for animating/processing the list |
+|history |The title of the tiddler containing the navigation history |
+
+!! Edit mode
+
+The  <<.wid list>> widget can optionally render draft tiddlers through a different template to handle editing, see DraftMechanism.
+
+!!<<.attr storyview>> attribute
+
+The <<.attr storyview>> attribute specifies the name of an optional module that can animate changes to the list (including navigation). The core ships with the following storyview modules:
+
+* `classic` : renders the list as an ordered sequence of tiddlers
+* `zoomin` : just renders the current tiddler from the list, with a zoom animation for navigating between tiddlers
+* `pop` : shrinks items in and out of place
+
+In order for the storyviews to animate correctly each entry in the list should be a single block mode DOM element.
+
+!! History and navigation
+
+The optional <<.attr history>> attribute specifies the name of a tiddler that is used to track the current tiddler for navigation purposes. When the history tiddler changes the list view responds by telling the listview to handle navigating to the new tiddler. See HistoryMechanism for details.
+
+!! Additional Notes and Edge Cases
+
+* If the <<.attr filter>> attribute is not present then a default of `[!is[system]sort[title]]` is used
+* If the <<.wid list>> widget is completely empty (ie only whitespace between the opening and closing tags), then it behaves as if the content were a `div` or a `span` containing a link to the current tiddler (it’s a `div` if the <<.wid list>> widget is in block mode, or a `span` if it is in inline mode)
+* If the <<.attr template>> attribute is not present then the content of the <<.wid list>> widget will be used as the template, unless the widget is completely empty in which case a default template is used
 
 ! Examples
 
@@ -66,39 +103,3 @@ Displays as:
 
 See GroupedLists for how to generate nested and grouped lists using the ListWidget.
 
-! Content and Attributes
-
-The content of the `<$list>` widget is an optional template to use for rendering each tiddler in the list. Alternatively, the template can be specified as a tiddler title in the ``template`` attribute. As a fallback, the default template just displays the tiddler title.
-
-|!Attribute |!Description |
-|filter |The [[tiddler filter|Filters]] to display |
-|template |The title of a template tiddler for transcluding each tiddler in the list. When no template is specified, the body of the ListWidget serves as the item template. With no body, a simple link to the tiddler is returned. |
-|editTemplate |An alternative template to use for [[DraftTiddlers|DraftMechanism]] in edit mode |
-|variable |The name for a [[variable|Variables]] in which the title of each listed tiddler is stored. Defaults to ''currentTiddler'' |
-|emptyMessage |Message to be displayed when the list is empty |
-|storyview |Optional name of module responsible for animating/processing the list |
-|history |The title of the tiddler containing the navigation history |
-
-!! Edit mode
-
-The `<$list>` widget can optionally render draft tiddlers through a different template to handle editing, see DraftMechanism.
-
-!! `storyview` attribute
-
-The `storyview` attribute specifies the name of an optional module that can animate changes to the list (including navigation). The core ships with the following storyview modules:
-
-* `classic`: renders the list as an ordered sequence of tiddlers
-* `zoomin`: just renders the current tiddler from the list, with a zoom animation for navigating between tiddlers
-* `pop`: shrinks items in and out of place
-
-In order for the storyviews to animate correctly each entry in the list should be a single block mode DOM element.
-
-!! History and navigation
-
-The optional `history` attribute specifies the name of a tiddler that is used to track the current tiddler for navigation purposes. When the history tiddler changes the list view responds by telling the listview to handle navigating to the new tiddler. See HistoryMechanism for details.
-
-!! Additional Notes and Edge Cases
-
-* If the `filter` attribute is not present then a default of `[!is[system]sort[title]]` is used
-* If the list widget is completely empty (ie only whitespace between the opening and closing tags), then it behaves as if the content were a `DIV` or a `SPAN` containing a link to the current tiddler (it’s a `DIV` if the list widget is in block mode, or a SPAN if it is in inline mode)
-* If the `template` attribute is not present then the content of the list widget will be used as the template, unless the widget is completely empty in which case a default template is used


### PR DESCRIPTION
Ref: Google Groups post 2019-02-09: [list widget : Examples section needs to be moved to the bottom](https://groups.google.com/forum/#!topic/tiddlywikidocs/yxZGKBGRXtY)

The **Examples** section was placed before the **Content and Attributes** section. 
Reordered them.

Also changed instances where wikitext was used to instead use the Documentation macros.

See a preview here: [tiddlywiki.html#ListWidget](https://00ss.github.io/documentation/tiddlywiki.html#ListWidget)