### PR TITLE
fix for "Open" tab placeholders in FireFox

### DIFF
--- a/core/ui/SideBar/Open.tid
+++ b/core/ui/SideBar/Open.tid
@@ -26,7 +26,7 @@ $button$
 <div class="tc-sidebar-tab-open">
 <$list filter="[list[$:/StoryList]]" history="$:/HistoryList" storyview="pop">
 <div class="tc-sidebar-tab-open-item">
-<$macrocall $name="droppable-item" button="""<$button message="tm-close-tiddler" tooltip={{$:/language/Buttons/Close/Hint}} aria-label={{$:/language/Buttons/Close/Caption}} class="tc-btn-invisible tc-btn-mini">&times;</$button>&nbsp;<$link to={{!!title}}><$view field="title"/></$link>"""/>
+<$macrocall $name="droppable-item" button="""<$button message="tm-close-tiddler" tooltip={{$:/language/Buttons/Close/Hint}} aria-label={{$:/language/Buttons/Close/Caption}} class="tc-btn-invisible tc-btn-mini">{{$:/core/images/close-button}}</$button>&nbsp;<$link to={{!!title}}><$view field="title"/></$link>"""/>
 </div>
 </$list>
 <$tiddler tiddler="">

--- a/core/ui/SideBar/Open.tid
+++ b/core/ui/SideBar/Open.tid
@@ -9,23 +9,29 @@ caption: {{$:/language/SideBar/Open/Caption}}
 <$action-listops $tiddler="$:/StoryList" $subfilter="+[insertbefore:currentTiddler<actionTiddler>]"/>
 \end
 
-<$list filter="[list[$:/StoryList]]" history="$:/HistoryList" storyview="pop">
-<div style="position: relative;">
-<$droppable actions=<<drop-actions>>>
-<div class="tc-droppable-placeholder">
-&nbsp;
+\define placeholder()
+\whitespace trim
+<div class="tc-droppable-placeholder" style="line-height:2em;height:2em;">
 </div>
+\end
+
+\define droppable-item(button)
+\whitespace trim
+<$droppable actions=<<drop-actions>>>
+<<placeholder>>
 <div>
-<$button message="tm-close-tiddler" tooltip={{$:/language/Buttons/Close/Hint}} aria-label={{$:/language/Buttons/Close/Caption}} class="tc-btn-invisible tc-btn-mini">&times;</$button> <$link to={{!!title}}><$view field="title"/></$link>
+$button$
 </div>
 </$droppable>
+\end
+
+<$list filter="[list[$:/StoryList]]" history="$:/HistoryList" storyview="pop">
+<div style="position: relative;">
+<$macrocall $name="droppable-item" button="""<$button message="tm-close-tiddler" tooltip={{$:/language/Buttons/Close/Hint}} aria-label={{$:/language/Buttons/Close/Caption}} class="tc-btn-invisible tc-btn-mini">&times;</$button> <$link to={{!!title}}><$view field="title"/></$link>"""/>
 </div>
 </$list>
 <$tiddler tiddler="">
-<$droppable actions=<<drop-actions>>>
-<div class="tc-droppable-placeholder">
-&nbsp;
+<div>
+<$macrocall $name="droppable-item" button="""<$button message="tm-close-all-tiddlers" class="tc-btn-invisible tc-btn-mini"><<lingo Button>></$button>"""/>
 </div>
-<$button message="tm-close-all-tiddlers" class="tc-btn-invisible tc-btn-mini"><<lingo Button>></$button>
-</$droppable>
 </$tiddler>

--- a/core/ui/SideBar/Open.tid
+++ b/core/ui/SideBar/Open.tid
@@ -10,9 +10,7 @@ caption: {{$:/language/SideBar/Open/Caption}}
 \end
 
 \define placeholder()
-\whitespace trim
-<div class="tc-droppable-placeholder" style="line-height:2em;height:2em;">
-</div>
+<div class="tc-droppable-placeholder"/>
 \end
 
 \define droppable-item(button)
@@ -25,9 +23,10 @@ $button$
 </$droppable>
 \end
 
+<div class="tc-sidebar-tab-open">
 <$list filter="[list[$:/StoryList]]" history="$:/HistoryList" storyview="pop">
-<div style="position: relative;">
-<$macrocall $name="droppable-item" button="""<$button message="tm-close-tiddler" tooltip={{$:/language/Buttons/Close/Hint}} aria-label={{$:/language/Buttons/Close/Caption}} class="tc-btn-invisible tc-btn-mini">&times;</$button> <$link to={{!!title}}><$view field="title"/></$link>"""/>
+<div class="tc-sidebar-tab-open-item">
+<$macrocall $name="droppable-item" button="""<$button message="tm-close-tiddler" tooltip={{$:/language/Buttons/Close/Hint}} aria-label={{$:/language/Buttons/Close/Caption}} class="tc-btn-invisible tc-btn-mini">&times;</$button>&nbsp;<$link to={{!!title}}><$view field="title"/></$link>"""/>
 </div>
 </$list>
 <$tiddler tiddler="">
@@ -35,3 +34,4 @@ $button$
 <$macrocall $name="droppable-item" button="""<$button message="tm-close-all-tiddlers" class="tc-btn-invisible tc-btn-mini"><<lingo Button>></$button>"""/>
 </div>
 </$tiddler>
+</div>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -384,6 +384,20 @@ a.tc-tiddlylink-external:hover {
 	cursor: move;
 }
 
+.tc-sidebar-tab-open .tc-droppable-placeholder {
+	line-height: 2em;
+	height: 2em;
+}
+
+.tc-sidebar-tab-open-item {
+	position: relative;
+}
+
+.tc-sidebar-tab-open .tc-btn-invisible.tc-btn-mini svg {
+	font-size: 0.7em;
+	fill: <<colour muted-foreground>>;
+}
+
 /*
 ** Plugin reload warning
 */


### PR DESCRIPTION
this PR fixes the placeholders in FireFox not being removed on drag-leave from time to time

it consists of 2 mods where apparently both are needed:

- creating a `droppable-item` macro where whitespace is trimmed. that macro contains the droppable and inserts the placeholders
- removing the `&nbsp;` entity in favor of an inline style `height:2em;` on the placeholder div, putting it in a macro where whitespace can be trimmed, too

I'm investigating if there's a similar fix for the top page dropzone