### PR TITLE
attempt on fixing the sticky dropzone on firefox

### DIFF
--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -42,7 +42,8 @@ DropZoneWidget.prototype.render = function(parent,nextSibling) {
 		{name: "dragover", handlerObject: this, handlerMethod: "handleDragOverEvent"},
 		{name: "dragleave", handlerObject: this, handlerMethod: "handleDragLeaveEvent"},
 		{name: "drop", handlerObject: this, handlerMethod: "handleDropEvent"},
-		{name: "paste", handlerObject: this, handlerMethod: "handlePasteEvent"}
+		{name: "paste", handlerObject: this, handlerMethod: "handlePasteEvent"},
+		{name: "dragend", handlerObject: this, handlerMethod: "handleDragEndEvent"}
 	]);
 	domNode.addEventListener("click",function (event) {
 	},false);
@@ -101,6 +102,10 @@ DropZoneWidget.prototype.handleDragOverEvent  = function(event) {
 
 DropZoneWidget.prototype.handleDragLeaveEvent  = function(event) {
 	this.leaveDrag(event);
+};
+
+DropZoneWidget.prototype.handleDragEndEvent = function(event) {
+	$tw.utils.removeClass(this.domNodes[0],"tc-dragover");
 };
 
 DropZoneWidget.prototype.handleDropEvent  = function(event) {


### PR DESCRIPTION
in my tests listening for the dragend event and removing the tc-dragover class in that case removes the `tc-dragover` every time it should ...

without this, firefox often doesn't remove it and the green bar sticks at the top

investigating now if the droppable widget has a similar problem