### PR TITLE
add smartIndent to codemirror

### DIFF
--- a/plugins/tiddlywiki/codemirror/config/extraKeysTW.tid
+++ b/plugins/tiddlywiki/codemirror/config/extraKeysTW.tid
@@ -11,5 +11,7 @@ type: json
 	"Alt-T": "transposeChars",
 	"Alt-U": "undoSelection",
 	"Shift-Alt-U": "redoSelection",
-	"Cmd-U": ""
+	"Cmd-U": "",
+	"Tab": "indentAuto()",
+	"Enter": "newLineAndIndent()"
 }

--- a/plugins/tiddlywiki/codemirror/config/indentWithTabs.tid
+++ b/plugins/tiddlywiki/codemirror/config/indentWithTabs.tid
@@ -1,0 +1,3 @@
+title: $:/config/codemirror/indentWithTabs
+type: bool
+text: true

--- a/plugins/tiddlywiki/codemirror/config/smartIndent.tid
+++ b/plugins/tiddlywiki/codemirror/config/smartIndent.tid
@@ -1,0 +1,3 @@
+title: $:/config/codemirror/smartIndent
+type: bool
+text: true

--- a/plugins/tiddlywiki/codemirror/config/tabSize.tid
+++ b/plugins/tiddlywiki/codemirror/config/tabSize.tid
@@ -1,3 +1,3 @@
 title: $:/config/codemirror/tabSize
 type: integer
-text: 4
+text: 2


### PR DESCRIPTION
this PR makes smartIndent the default setting

it also adds the functionality that when pressing enter, inserting a new line, it follows the indentation above AND inserts tab(s) correctly. currently it inserts spaces in the new line, even if the previous line is indented with a tab

further it enables indentAuto when pressing tab

I think these are sensible defaults one would like to have when choosing codemirror. it improves usability a lot.

I also made the default indentUnit the same value as the default tabSize (both 2)

