### PR TITLE
an attempt on a regexpreplace filter

### DIFF
--- a/core/modules/filters/regexpreplace.js
+++ b/core/modules/filters/regexpreplace.js
@@ -1,0 +1,52 @@
+/*\
+title: $:/core/modules/filters/regexpreplace.js
+type: application/javascript
+module-type: filteroperator
+
+Filter operator for regexp matching
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.regexpreplace = function(source,operator,options) {
+	var results = [],
+		regexpString, replaceVariable, regexp, flags = "", match;
+	// Process flags and construct regexp
+	regexpString = operator.operand,
+	replaceVariable = operator.suffix;
+	var replaceString = operator.suffix ? options.widget.getVariable(replaceVariable) || "" : "";
+	match = /^\(\?([gim]+)\)/.exec(regexpString);
+	if(match) {
+		flags = match[1];
+		regexpString = regexpString.substr(match[0].length);
+	} else {
+		match = /\(\?([gim]+)\)$/.exec(regexpString);
+		if(match) {
+			flags = match[1];
+			regexpString = regexpString.substr(0,regexpString.length - match[0].length);
+		}
+	}
+	try {
+		regexp = new RegExp(regexpString,flags);
+	} catch(e) {
+		return ["" + e];
+	}
+	// Process the incoming tiddlers
+	source(function(tiddler,title) {
+		if(title !== null) {
+			if(!!regexp.exec(title)) {
+				results.push(title.replace(regexp,replaceString));
+			}
+		}
+	});
+	return results;
+};
+
+})();


### PR DESCRIPTION
this filter takes the input title, tests it with the operand - regex, like the regexp filter

it takes the operator-suffix as a variable name for the replace-string and replaces the regex match with the value of the given variable

example:

```
<$set name="replaceString" value="replaced ST">

{{{ [[Test String]regexpreplace:replaceString[(i)t.*st]] }}}

</$set>
```

output: `replaced STring`

in my tests it has no problems with replace variables that contain special characters