### PR TITLE
fix missing clear: both when tiddler-body is hidden

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2128,6 +2128,7 @@ a.tc-tiddlylink.tc-plugin-info:hover .tc-plugin-info > .tc-plugin-info-chunk > s
 
 .tc-plugin-info-dropdown-body {
 	padding: 1em 1em 1em 1em;
+	clear: both;
 }
 
 .tc-check-list {


### PR DESCRIPTION
to reproduce the problem, enable sticky titles, open a plugin tiddler and open a javascript tiddler below