### PR TITLE
[wip] porting the Nord palette

### DIFF
--- a/core/palettes/Nord.tid
+++ b/core/palettes/Nord.tid
@@ -1,0 +1,120 @@
+title: $:/palettes/Nord
+name: Nord
+description: An arctic, north-bluish color palette.
+tags: $:/tags/Palette
+type: application/x-tiddler-dictionary
+license: MIT, arcticicestudio, https://github.com/arcticicestudio/nord/blob/develop/LICENSE.md
+
+alert-background: #EBCB8B
+alert-border: #D08770
+alert-highlight: #B48EAD
+alert-muted-foreground: #D08770
+background: #3b4252
+blockquote-bar: <<colour muted-foreground>>
+button-background: #4C566A
+button-foreground: #D8DEE9
+button-border: transparent
+code-background: #2E3440
+code-border: #2E3440
+code-foreground: #BF616A
+diff-delete-background: #BF616A
+diff-delete-foreground: <<colour foreground>>
+diff-equal-background: 
+diff-equal-foreground: <<colour foreground>>
+diff-insert-background: #A3BE8C
+diff-insert-foreground: <<colour foreground>>
+diff-invisible-background: 
+diff-invisible-foreground: <<colour muted-foreground>>
+dirty-indicator: #BF616A
+download-background: #A3BE8C
+download-foreground: <<colour background>>
+dragger-background: <<colour foreground>>
+dragger-foreground: <<colour background>>
+dropdown-background: <<colour background>>
+dropdown-border: <<colour background>>
+dropdown-tab-background-selected: #fff
+dropdown-tab-background: #ececec
+dropzone-background: #A3BE8C
+external-link-background-hover: inherit
+external-link-background-visited: inherit
+external-link-background: inherit
+external-link-foreground-hover: inherit
+external-link-foreground-visited: #5E81AC
+external-link-foreground: #8FBCBB
+foreground: #d8dee9
+message-background: #2E3440
+message-border: #2E3440
+message-foreground: #547599
+modal-backdrop: <<colour foreground>>
+modal-background: <<colour background>>
+modal-border: #3b4252
+modal-footer-background: #3b4252
+modal-footer-border: #3b4252
+modal-header-border: #3b4252
+muted-foreground: #434C5E
+notification-background: #EBCB8B
+notification-border: #D08770
+page-background: #2e3440
+pre-background: #2E3440
+pre-border: #2E3440
+primary: #5E81AC
+select-tag-background: #3b4252
+select-tag-foreground: <<colour foreground>>
+sidebar-button-foreground: <<colour foreground>>
+sidebar-controls-foreground-hover: #4C566A
+sidebar-controls-foreground: #3B4252
+sidebar-foreground-shadow: #4C566A
+sidebar-foreground: #D8DEE9
+sidebar-muted-foreground-hover: #4C566A
+sidebar-muted-foreground: #4C566A
+sidebar-tab-background-selected: #ECEFF4
+sidebar-tab-background: #4C566A
+sidebar-tab-border-selected: <<colour tab-border-selected>>
+sidebar-tab-border: #4C566A
+sidebar-tab-divider: <<colour page-background>>
+sidebar-tab-foreground-selected: #4C566A
+sidebar-tab-foreground: <<colour tab-foreground>>
+sidebar-tiddler-link-foreground-hover: #A3BE8C
+sidebar-tiddler-link-foreground: #81A1C1
+site-title-foreground: <<colour tiddler-title-foreground>>
+static-alert-foreground: #B48EAD
+tab-background-selected: #ECEFF4
+tab-background: #4C566A
+tab-border-selected: #4C566A
+tab-border: #4C566A
+tab-divider: #4C566A
+tab-foreground-selected: #4C566A
+tab-foreground: #D8DEE9
+table-border: #434C5E
+table-footer-background: #2e3440
+table-header-background: #3B4252
+tag-background: #A3BE8C
+tag-foreground: #4C566A
+tiddler-background: <<colour background>>
+tiddler-border: <<colour background>>
+tiddler-controls-foreground-hover: 
+tiddler-controls-foreground-selected: #2E3440
+tiddler-controls-foreground: #4C566A
+tiddler-editor-background: #2e3440
+tiddler-editor-border-image: #2e3440
+tiddler-editor-border: #2e3440
+tiddler-editor-fields-even: #2e3440
+tiddler-editor-fields-odd: #2e3440
+tiddler-info-background: #2e3440
+tiddler-info-border: #2e3440
+tiddler-info-tab-background: #2e3440
+tiddler-link-background: <<colour background>>
+tiddler-link-foreground: <<colour primary>>
+tiddler-subtitle-foreground: #4C566A
+tiddler-title-foreground: #81A1C1
+toolbar-new-button: 
+toolbar-options-button: 
+toolbar-save-button: 
+toolbar-info-button: 
+toolbar-edit-button: 
+toolbar-close-button: 
+toolbar-delete-button: 
+toolbar-cancel-button: 
+toolbar-done-button: 
+untagged-background: #3B4252
+very-muted-foreground: #3B4252


### PR DESCRIPTION
https://github.com/arcticicestudio/nord

this palette is very popular, available for highlight.js, codemirror, all kinds of desktop/terminal applications ...
would be great to have it in tiddlywiki, too

this is a draft PR, certain things needs to be improved, but looks very good in tiddlywiki