### PR TITLE
fix sticky draggable-placeholders in list macros (firefox)

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -20,13 +20,13 @@ tags: $:/tags/Macro
 \end
 
 \define list-links-draggable(tiddler,field:"list",type:"ul",subtype:"li",class:"",itemTemplate)
+\whitespace trim
+<span class="tc-links-draggable-list">
 <$vars targetTiddler="""$tiddler$""" targetField="""$field$""">
 <$type$ class="$class$">
 <$list filter="[list[$tiddler$!!$field$]]">
 <$droppable actions=<<list-links-draggable-drop-actions>> tag="""$subtype$""">
-<div class="tc-droppable-placeholder">
-&nbsp;
-</div>
+<div class="tc-droppable-placeholder"/>
 <div>
 <$transclude tiddler="""$itemTemplate$""">
 <$link to={{!!title}}>
@@ -48,6 +48,7 @@ tags: $:/tags/Macro
 </$droppable>
 </$tiddler>
 </$vars>
+</span>
 \end
 
 \define list-tagged-draggable-drop-actions(tag)
@@ -73,13 +74,13 @@ tags: $:/tags/Macro
 \end
 
 \define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div")
+\whitespace trim
+<span class="tc-tagged-draggable-list">
 <$set name="tag" value=<<__tag__>>>
 <$list filter="[<__tag__>tagging[]$subFilter$]" emptyMessage=<<__emptyMessage__>>>
 <$elementTag$ class="tc-menu-list-item">
 <$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""">
-<$elementTag$ class="tc-droppable-placeholder">
-&nbsp;
-</$elementTag$>
+<$elementTag$ class="tc-droppable-placeholder"/>
 <$elementTag$>
 <$transclude tiddler="""$itemTemplate$""">
 <$link to={{!!title}}>
@@ -92,12 +93,11 @@ tags: $:/tags/Macro
 </$list>
 <$tiddler tiddler="">
 <$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""">
-<$elementTag$ class="tc-droppable-placeholder">
-&nbsp;
-</$elementTag$>
+<$elementTag$ class="tc-droppable-placeholder"/>
 <$elementTag$ style="height:0.5em;">
 </$elementTag$>
 </$droppable>
 </$tiddler>
 </$set>
+</span>
 \end

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -388,7 +388,7 @@ a.tc-tiddlylink-external:hover {
 	cursor: move;
 }
 
-.tc-sidebar-tab-open .tc-droppable-placeholder {
+.tc-sidebar-tab-open .tc-droppable-placeholder, .tc-tagged-draggable-list .tc-droppable-placeholder, .tc-links-draggable-list .tc-droppable-placeholder {
 	line-height: 2em;
 	height: 2em;
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -388,7 +388,8 @@ a.tc-tiddlylink-external:hover {
 	cursor: move;
 }
 
-.tc-sidebar-tab-open .tc-droppable-placeholder, .tc-tagged-draggable-list .tc-droppable-placeholder, .tc-links-draggable-list .tc-droppable-placeholder {
+.tc-sidebar-tab-open .tc-droppable-placeholder, .tc-tagged-draggable-list .tc-droppable-placeholder,
+.tc-links-draggable-list .tc-droppable-placeholder {
 	line-height: 2em;
 	height: 2em;
 }


### PR DESCRIPTION
this fixes the sticky placeholders when using firefox, where the list-tagged-draggable macro is used:

- tags dropdown
- controlpanel themetweaks toolbars