### PR TITLE
fix "cannot read substr of undefined" in removeprefix filter

### DIFF
--- a/core/modules/filters/removesuffix.js
+++ b/core/modules/filters/removesuffix.js
@@ -18,7 +18,7 @@ Export our filter function
 exports.removesuffix = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
-		if(title.substr(-operator.operand.length) === operator.operand) {
+		if(title && title.substr(-operator.operand.length) === operator.operand) {
 			results.push(title.substr(0,title.length - operator.operand.length));
 		}
 	});


### PR DESCRIPTION
from time to time this error appears when testing an input with the removeprefix filter and somehow there's no input title

last time it happened was when I changed a tiddler's type and a toolbar button had a show-condition using the removeprefix filter