### PR TITLE
CodeMirror: require modules in correct order

### DIFF
--- a/plugins/tiddlywiki/codemirror-autocomplete/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-autocomplete/files/tiddlywiki.files
@@ -5,35 +5,40 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/hint/anyword-hint.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "18"
 			}
 		},{
 			"file": "addon/hint/css-hint.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/hint/css-hint.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "21"
 			}
 		},{
 			"file": "addon/hint/html-hint.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/hint/html-hint.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "20"
 			}
 		},{
 			"file": "addon/hint/javascript-hint.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/hint/javascript-hint.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "22"
 			}
 		},{
 			"file": "addon/hint/show-hint.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/hint/show-hint.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "17"
 			}
 		},{
 			"file": "addon/hint/show-hint.css",
@@ -47,7 +52,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/hint/xml-hint.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "19"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-closebrackets/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-closebrackets/files/tiddlywiki.files
@@ -5,14 +5,16 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/edit/closebrackets.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "6"
 			}
 		},{
 			"file": "addon/edit/matchbrackets.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/edit/matchbrackets.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "7"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-closetag/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-closetag/files/tiddlywiki.files
@@ -5,14 +5,16 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/fold/xml-fold.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "8"
 			}
 		},{
 			"file": "addon/edit/closetag.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/edit/closetag.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "9"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-fullscreen-editing/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-fullscreen-editing/files/tiddlywiki.files
@@ -5,7 +5,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/fullscreen/fullscreen.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "10"
 			}
 		},{
 			"file": "addon/fullscreen/fullscreen.css",

--- a/plugins/tiddlywiki/codemirror-keymap-emacs/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-keymap-emacs/files/tiddlywiki.files
@@ -5,7 +5,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/keymap/emacs.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "25"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-keymap-sublime-text/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-keymap-sublime-text/files/tiddlywiki.files
@@ -5,7 +5,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/keymap/sublime.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "26"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-keymap-vim/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-keymap-vim/files/tiddlywiki.files
@@ -5,7 +5,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/keymap/vim.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "27"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-mode-css/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-mode-css/files/tiddlywiki.files
@@ -5,7 +5,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/mode/css/css.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "12"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-mode-htmlembedded/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-mode-htmlembedded/files/tiddlywiki.files
@@ -5,14 +5,16 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/mode/multiplex.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "15"
 			}
 		},{
 			"file": "mode/htmlembedded/htmlembedded.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/mode/htmlembedded/htmlembedded.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "16"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-mode-htmlmixed/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-mode-htmlmixed/files/tiddlywiki.files
@@ -5,7 +5,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/mode/htmlmixed/htmlmixed.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "14"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-mode-javascript/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-mode-javascript/files/tiddlywiki.files
@@ -5,7 +5,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/mode/javascript/javascript.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "13"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-mode-markdown/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-mode-markdown/files/tiddlywiki.files
@@ -5,7 +5,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/mode/markdown/markdown.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "23"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-mode-x-tiddlywiki/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-mode-x-tiddlywiki/files/tiddlywiki.files
@@ -12,7 +12,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/mode/tiddlywiki/tiddlywiki.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "24"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-mode-xml/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-mode-xml/files/tiddlywiki.files
@@ -5,7 +5,8 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/mode/xml/xml.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "11"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror-search-replace/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror-search-replace/files/tiddlywiki.files
@@ -5,21 +5,24 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/search/search.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "5"
 			}
 		},{
 			"file": "addon/search/jump-to-line.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/search/jump-to-line.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "4"
 			}
 		},{
 			"file": "addon/search/searchcursor.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/search/searchcursor.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "3"
 			}
 		}
 	]

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -20,14 +20,23 @@ CONFIG_FILTER = "[all[shadows+tiddlers]prefix[$:/config/codemirror/]]"
 if($tw.browser && !window.CodeMirror) {
 
 	var modules = $tw.modules.types["codemirror"];
-	var req = Object.getOwnPropertyNames(modules);
+	var req = Object.getOwnPropertyNames(modules),
+	    reqSorted = [];
+	if($tw.utils.isArray(req)) {
+		for(var i=0; i<req.length; i++) {
+			var moduleIndex = $tw.wiki.getTiddler(req[i]).getFieldString("require-index");
+			reqSorted[moduleIndex] = req[i];
+		}
+	}
 
 	window.CodeMirror = require("$:/plugins/tiddlywiki/codemirror/lib/codemirror.js");
 	// Install required CodeMirror plugins
 	if(req) {
 		if($tw.utils.isArray(req)) {
-			for(var index=0; index<req.length; index++) {
-				require(req[index]);
+			for(var index=0; index<reqSorted.length; index++) {
+				if(reqSorted[index]) {
+					require(reqSorted[index]);
+				}
 			}
 		} else {
 			require(req);

--- a/plugins/tiddlywiki/codemirror/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror/files/tiddlywiki.files
@@ -26,21 +26,24 @@
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/dialog/dialog.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "1"
 			}
 		},{
 			"file": "addon/selection/activeline.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/addon/selection/activeline.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "2"
 			}
 		},{
 			"file": "mode/tw-meta.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/tiddlywiki/codemirror/mode/tw-meta.js",
-				"module-type": "codemirror"
+				"module-type": "codemirror",
+				"require-index": "0"
 			}
 		}
 	]


### PR DESCRIPTION
this assigns an index to each codemirror module in each plugin by which the modules-array is sorted first, then the modules get required in the correct order, so that a module that gets required by another module is loaded first