### PR TITLE
fix jumpy pop storyview: don't x-overflow page

### DIFF
--- a/core/modules/storyviews/pop.js
+++ b/core/modules/storyviews/pop.js
@@ -44,7 +44,14 @@ PopStoryView.prototype.insert = function(widget) {
 			{transition: "none"},
 			{transform: "none"}
 		]);
+		$tw.utils.setStyle(widget.document.body,[
+			{"overflow-x": ""}
+		]);
 	},duration);
+	// Prevent the page from overscrolling due to the zoom factor
+	$tw.utils.setStyle(widget.document.body,[
+		{"overflow-x": "hidden"}
+	]);
 	// Set up the initial position of the element
 	$tw.utils.setStyle(targetElement,[
 		{transition: "none"},


### PR DESCRIPTION
... this makes the animation when inserting tiddlers / navigating to tiddlers in the pop storyview less jumpy

it simply sets `overflow-x` to `hidden` for the time of the insert-animation