### PR TITLE
tags edittemplate: replace &times; with svg

### DIFF
--- a/core/ui/EditTemplate/tags.tid
+++ b/core/ui/EditTemplate/tags.tid
@@ -16,7 +16,7 @@ color:$(foregroundColor)$;
 <$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
 <span style=<<tag-styles>> class="tc-tag-label tc-tag-list-item">
 <$transclude tiddler="""$icon$"""/>&nbsp;<$view field="title" format="text" />
-<$button message="tm-remove-tag" param={{!!title}} class="tc-btn-invisible tc-remove-tag-button">&times;</$button>
+<$button message="tm-remove-tag" param={{!!title}} class="tc-btn-invisible tc-remove-tag-button">{{$:/core/images/close-button}}</$button>
 </span>
 </$vars>
 \end

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -662,6 +662,11 @@ button.tc-untagged-label {
 	vertical-align: text-bottom;
 }
 
+.tc-edit-tags button.tc-remove-tag-button svg {
+	font-size: 0.7em;
+	vertical-align: middle;
+}
+
 .tc-tag-manager-table .tc-tag-label {
 	white-space: normal;
 }


### PR DESCRIPTION
this PR just replaces the `&times;` entity of tags in the edit-template (the remove tag button) with the `$:/core/images/close-button` svg