### PR TITLE
delete-button: close tiddler if it's missing

### DIFF
--- a/core/ui/EditToolbar/delete.tid
+++ b/core/ui/EditToolbar/delete.tid
@@ -3,7 +3,11 @@ tags: $:/tags/EditToolbar $:/tags/ViewToolbar
 caption: {{$:/core/images/delete-button}} {{$:/language/Buttons/Delete/Caption}}
 description: {{$:/language/Buttons/Delete/Hint}}
 
+<$list filter="[all[current]!is[missing]" variable="ignore" emptyMessage="""
+<$button message="tm-close-tiddler" tooltip={{$:/language/Buttons/Delete/Hint}} aria-label={{$:/language/Buttons/Delete/Caption}} class=<<tv-config-toolbar-class>>>
+""">
 <$button message="tm-delete-tiddler" tooltip={{$:/language/Buttons/Delete/Hint}} aria-label={{$:/language/Buttons/Delete/Caption}} class=<<tv-config-toolbar-class>>>
+</$list>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/delete-button}}
 </$list>


### PR DESCRIPTION
this closes a missing tiddler if the delete button is clicked on it ... it's already "deleted" and I can't imagine that there's another intention than removing it from the story when clicking this button