### PR TITLE
add th-refreshing-input hook to factory.js

### DIFF
--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -214,7 +214,6 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 			this.refreshSelf();
 			return true;
 		} else if(changedTiddlers[this.editTitle]) {
-			$tw.hooks.invokeHook("th-refreshing-input-text",this,editInfo,changedTiddlers,changedAttributes);
 			this.updateEditor(editInfo.value,editInfo.type);
 		}
 		this.engine.fixHeight();

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -206,13 +206,14 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 	*/
 	EditTextWidget.prototype.refresh = function(changedTiddlers) {
-		var changedAttributes = this.computeAttributes();
+		var changedAttributes = this.computeAttributes(),
+			editInfo = this.getEditInfo();
+		$tw.hooks.invokeHook("th-refreshing-input",this,editInfo,changedTiddlers,changedAttributes);
 		// Completely rerender if any of our attributes have changed
 		if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes["default"] || changedAttributes["class"] || changedAttributes.placeholder || changedAttributes.size || changedAttributes.autoHeight || changedAttributes.minHeight || changedAttributes.focusPopup ||  changedAttributes.rows || changedAttributes.tabindex || changedTiddlers[HEIGHT_MODE_TITLE] || changedTiddlers[ENABLE_TOOLBAR_TITLE]) {
 			this.refreshSelf();
 			return true;
 		} else if(changedTiddlers[this.editTitle]) {
-			var editInfo = this.getEditInfo();
 			this.updateEditor(editInfo.value,editInfo.type);
 		}
 		this.engine.fixHeight();

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -208,7 +208,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	EditTextWidget.prototype.refresh = function(changedTiddlers) {
 		var changedAttributes = this.computeAttributes(),
 			editInfo = this.getEditInfo();
-		$tw.hooks.invokeHook("th-refreshing-input",this,editInfo,changedTiddlers,changedAttributes);
+		$tw.hooks.invokeHook("th-edit-text-widget-refreshing",this,editInfo,changedTiddlers,changedAttributes);
 		// Completely rerender if any of our attributes have changed
 		if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes["default"] || changedAttributes["class"] || changedAttributes.placeholder || changedAttributes.size || changedAttributes.autoHeight || changedAttributes.minHeight || changedAttributes.focusPopup ||  changedAttributes.rows || changedAttributes.tabindex || changedTiddlers[HEIGHT_MODE_TITLE] || changedTiddlers[ENABLE_TOOLBAR_TITLE]) {
 			this.refreshSelf();

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -214,6 +214,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 			this.refreshSelf();
 			return true;
 		} else if(changedTiddlers[this.editTitle]) {
+			$tw.hooks.invokeHook("th-refreshing-input-text",this,editInfo,changedTiddlers,changedAttributes);
 			this.updateEditor(editInfo.value,editInfo.type);
 		}
 		this.engine.fixHeight();


### PR DESCRIPTION
this adds a `th-refreshing-input` hook in the EditTextFactory's refresh method

it passes the widget, the editInfo, the changedTiddlers object and the newly computed attributes