### PR TITLE
CM: use hook (#3863) to update its options if changed

### DIFF
--- a/plugins/tiddlywiki/codemirror/files/startup/cm-refresh.js
+++ b/plugins/tiddlywiki/codemirror/files/startup/cm-refresh.js
@@ -1,0 +1,29 @@
+/*\
+title: $:/plugins/tiddlywiki/codemirror/modules/startup/cm-refresh.js
+type: application/javascript
+module-type: startup
+
+Intercept an input's refresh cycle and update CM's options if necessary
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+// Export name and synchronous status
+exports.name = "cm-refresh";
+exports.platforms = ["browser"];
+exports.after = ["story"];
+exports.synchronous = true;
+
+exports.startup = function() {
+
+	$tw.hooks.addHook("th-refreshing-input",function(widget,editInfo,changedTiddlers,changedAttributes) {
+		if(widget.engine.refreshCodeMirrorOptions) {
+			widget.engine.refreshCodeMirrorOptions(changedTiddlers);
+		}
+	});
+
+})();


### PR DESCRIPTION
this uses the `th-refreshing-input` hook from #3863 in a small startup module, passing the changedTiddlers object to the `refreshCodeMirrorOptions` method in codemirror's engine

the logic for assigning the codemirror options in engine.js is still the same, it's just refactored into two methods `getCmConfig` for the initial assignments (which also uses `refreshCodeMirrorOptions`) and finally `refreshCodeMirrorOptions` which updates cm options if they've changed through `cm.setOption`