### PR TITLE
Fix highlighting when inputs have CRLF line endings.

### DIFF
--- a/licenses/cla-individual.md
+++ b/licenses/cla-individual.md
@@ -357,3 +357,5 @@ Adam Sherwood, @admls, 2019/01/27
 Joshua Fontany, @joshuafontany, 2019/03/07
 
 Irene Castaños, @jdjdjdjdjdjd, 2019/03/11
+
+Porama Ruengrairatanaroj @Seally 2019/03/23

--- a/plugins/tiddlywiki/highlight/highlightblock.js
+++ b/plugins/tiddlywiki/highlight/highlightblock.js
@@ -29,6 +29,14 @@ CodeBlockWidget.prototype.postRender = function() {
 	}
 	if(language && hljs.listLanguages().indexOf(language) !== -1) {
 		domNode.className = language.toLowerCase() + " hljs";
+
+		// Change input line endings to LF since Highlight.js seems to balk if
+		// it isn't. Tends to happen on .js files loaded from TiddlyWikiFolders
+		// if the files were saved with CRLF endings.
+		if(domNode.textContent) {
+			domNode.textContent = domNode.textContent.replace(/\r\n?/g, "\n");
+		}
+
 		if($tw.browser && !domNode.isTiddlyWikiFakeDom) {
 			hljs.highlightBlock(domNode);			
 		} else {


### PR DESCRIPTION
If the source text uses CRLF line endings, syntax highlighting will get "shifted" a little, slowly worsening as the text goes on. This tends to happen if the file was referenced directly from a TiddlyWikiFolder and it happened to be saved with CRLF endings (obviously, this can be fixed by changing most editor's settings, but potentially annoying and unexpected).

This fix might make loading particularly large files take longer though, but I'm hoping it won't be that significant. 