### PR TITLE
Update macro: unusedtitle - parameter name change

### DIFF
--- a/core/modules/macros/uniquetitle.js
+++ b/core/modules/macros/uniquetitle.js
@@ -17,18 +17,18 @@ Information about this macro
 exports.name = "unusedtitle";
 
 exports.params = [
-	{name: "baseName"},
+	{name: "baseTitle"},
 	{name: "options"}
 ];
 
 /*
 Run the macro
 */
-exports.run = function(baseName, options) {
-	if(!baseName) {
-		baseName = $tw.language.getString("DefaultNewTiddlerTitle");
+exports.run = function(baseTitle, options) {
+	if(!baseTitle) {
+		baseTitle = $tw.language.getString("DefaultNewTiddlerTitle");
 	}
-	return this.wiki.generateNewTitle(baseName, options);
+	return this.wiki.generateNewTitle(baseTitle, options);
 };
 
 })();

--- a/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
@@ -10,7 +10,7 @@ It uses the same method as the create new tiddler button, a number is appended t
 
 !! Parameters
 
-;baseName
+;baseTitle
 : A string specifying the desired base name, defaulting to `New Tiddler`
 
 <<.macro-examples "unusedtitle">>

--- a/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
+++ b/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
@@ -4,4 +4,4 @@ type: text/vnd.tiddlywiki
 
 <$macrocall $name=".example" n="1" eg="""<<unusedtitle>>"""/>
 <$macrocall $name=".example" n="2" eg="""<<unusedtitle AnotherBase>>"""/>
-<$macrocall $name=".example" n="3" eg="""<<unusedtitle TiddlyWiki>>"""/>
+<$macrocall $name=".example" n="3" eg="""<<unusedtitle baseTitle:"TiddlyWiki">>"""/>


### PR DESCRIPTION
As discussed in #3882 and suggested by @inmysocks - I propose to change the parameter name:

From: baseName
To: baseTitle

**basename** already has a different definition in TiddlyWiki as mentioned in #3880 
It is defined in the tiddler: [tiddlywiki.files Files](https://tiddlywiki.com/prerelease/#tiddlywiki.files%20Files) as: 
>_basename_ the filename of the file containing the tiddler without any extension

Also changing the parameter to **baseTitle** is consistent with the description in the macro's Documentation tiddler: [unusedtitle Macro](https://tiddlywiki.com/prerelease/#unusedtitle%20Macro) : where it says:
> Optionally you can provide a base title to generate the new title.

Also as mentioned in the post where the original issue arose: [Add uniquetitle macro](https://github.com/Jermolene/TiddlyWiki5/pull/3880#issuecomment-477318721) - the parameter **baseTitle** is preferred over **basetitle** as it conforms strongly with the naming of other core macro parameters.

