### PR TITLE
Use list widget for reveals in core that obstruct styling

### DIFF
--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -34,30 +34,23 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 	if(this.revealTag && $tw.config.htmlUnsafeElements.indexOf(this.revealTag) === -1) {
 		tag = this.revealTag;
 	}
-	if(this.revealTag || this.class || this.style 
-		|| this.type === "popup" || this.animate === "yes" 
-		|| this.retain === "yes" || this.nowrap === "no"
-	){
-		var domNode = this.document.createElement(tag);
-		var classes = this["class"].split(" ") || [];
-		classes.push("tc-reveal");
-		domNode.className = classes.join(" ");
-		if(this.style) {
-			domNode.setAttribute("style",this.style);
-		}
-		parent.insertBefore(domNode,nextSibling);
-		this.renderChildren(domNode,null);
-		if(!domNode.isTiddlyWikiFakeDom && this.type === "popup" && this.isOpen) {
-			this.positionPopup(domNode);
-			$tw.utils.addClass(domNode,"tc-popup"); // Make sure that clicks don't dismiss popups within the revealed content
-		}
-		if(!this.isOpen) {
-			domNode.setAttribute("hidden","true");
-		}
-		this.domNodes.push(domNode);
-	} else {
-		this.renderChildren(parent, nextSibling);
+	var domNode = this.document.createElement(tag);
+	var classes = this["class"].split(" ") || [];
+	classes.push("tc-reveal");
+	domNode.className = classes.join(" ");
+	if(this.style) {
+		domNode.setAttribute("style",this.style);
 	}
+	parent.insertBefore(domNode,nextSibling);
+	this.renderChildren(domNode,null);
+	if(!domNode.isTiddlyWikiFakeDom && this.type === "popup" && this.isOpen) {
+		this.positionPopup(domNode);
+		$tw.utils.addClass(domNode,"tc-popup"); // Make sure that clicks don't dismiss popups within the revealed content
+	}
+	if(!this.isOpen) {
+		domNode.setAttribute("hidden","true");
+	}
+	this.domNodes.push(domNode);
 };
 
 RevealWidget.prototype.positionPopup = function(domNode) {
@@ -106,7 +99,6 @@ RevealWidget.prototype.execute = function() {
 	this["default"] = this.getAttribute("default","");
 	this.animate = this.getAttribute("animate","no");
 	this.retain = this.getAttribute("retain","no");
-	this.nowrap = this.getAttribute("nowrap", "no");
 	this.openAnimation = this.animate === "no" ? undefined : "open";
 	this.closeAnimation = this.animate === "no" ? undefined : "close";
 	// Compute the title of the state tiddler and read it

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -34,7 +34,10 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 	if(this.revealTag && $tw.config.htmlUnsafeElements.indexOf(this.revealTag) === -1) {
 		tag = this.revealTag;
 	}
-	if(this.revealTag || this.class || this.style || this.type === "popup" || this.animate === "yes" || this.retain === "yes"){
+	if(this.revealTag || this.class || this.style 
+		|| this.type === "popup" || this.animate === "yes" 
+		|| this.retain === "yes" || this.nowrap === "no"
+	){
 		var domNode = this.document.createElement(tag);
 		var classes = this["class"].split(" ") || [];
 		classes.push("tc-reveal");
@@ -103,6 +106,7 @@ RevealWidget.prototype.execute = function() {
 	this["default"] = this.getAttribute("default","");
 	this.animate = this.getAttribute("animate","no");
 	this.retain = this.getAttribute("retain","no");
+	this.nowrap = this.getAttribute("nowrap", "no");
 	this.openAnimation = this.animate === "no" ? undefined : "open";
 	this.closeAnimation = this.animate === "no" ? undefined : "close";
 	// Compute the title of the state tiddler and read it

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -35,23 +35,23 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 		tag = this.revealTag;
 	}
 	if(this.revealTag || this.class || this.style || this.type === "popup" || this.animate === "yes" || this.retain === "yes"){
-	var domNode = this.document.createElement(tag);
-	var classes = this["class"].split(" ") || [];
-	classes.push("tc-reveal");
-	domNode.className = classes.join(" ");
-	if(this.style) {
-		domNode.setAttribute("style",this.style);
-	}
-	parent.insertBefore(domNode,nextSibling);
-	this.renderChildren(domNode,null);
-	if(!domNode.isTiddlyWikiFakeDom && this.type === "popup" && this.isOpen) {
-		this.positionPopup(domNode);
-		$tw.utils.addClass(domNode,"tc-popup"); // Make sure that clicks don't dismiss popups within the revealed content
-	}
-	if(!this.isOpen) {
-		domNode.setAttribute("hidden","true");
-	}
-	this.domNodes.push(domNode);
+		var domNode = this.document.createElement(tag);
+		var classes = this["class"].split(" ") || [];
+		classes.push("tc-reveal");
+		domNode.className = classes.join(" ");
+		if(this.style) {
+			domNode.setAttribute("style",this.style);
+		}
+		parent.insertBefore(domNode,nextSibling);
+		this.renderChildren(domNode,null);
+		if(!domNode.isTiddlyWikiFakeDom && this.type === "popup" && this.isOpen) {
+			this.positionPopup(domNode);
+			$tw.utils.addClass(domNode,"tc-popup"); // Make sure that clicks don't dismiss popups within the revealed content
+		}
+		if(!this.isOpen) {
+			domNode.setAttribute("hidden","true");
+		}
+		this.domNodes.push(domNode);
 	} else {
 		this.renderChildren(parent, nextSibling);
 	}

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -34,6 +34,7 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 	if(this.revealTag && $tw.config.htmlUnsafeElements.indexOf(this.revealTag) === -1) {
 		tag = this.revealTag;
 	}
+	if(this.revealTag || this.class || this.style || this.type === "popup" || this.animate === "yes" || this.retain === "yes"){
 	var domNode = this.document.createElement(tag);
 	var classes = this["class"].split(" ") || [];
 	classes.push("tc-reveal");
@@ -51,6 +52,9 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 		domNode.setAttribute("hidden","true");
 	}
 	this.domNodes.push(domNode);
+	} else {
+		this.renderChildren(parent, nextSibling);
+	}
 };
 
 RevealWidget.prototype.positionPopup = function(domNode) {

--- a/core/ui/PageControls.tid
+++ b/core/ui/PageControls.tid
@@ -5,7 +5,7 @@ $:/config/PageControlButtons/Visibility/$(listItem)$
 \end
 <div class="tc-page-controls">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
-<$reveal type="nomatch" state=<<config-title>> text="hide">
+<$reveal type="nomatch" state=<<config-title>> text="hide" nowrap="yes">
 <$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
 <$transclude tiddler=<<listItem>> mode="inline"/>
 </$set>

--- a/core/ui/PageControls.tid
+++ b/core/ui/PageControls.tid
@@ -1,15 +1,17 @@
 title: $:/core/ui/PageTemplate/pagecontrols
 
-\define config-title()
-$:/config/PageControlButtons/Visibility/$(listItem)$
+\define config-prefix()
+$:/config/PageControlButtons/Visibility/
+\end
+\define display-filter(tag)
+[all[shadows+tiddlers]tag[$tag$]!has[draft.of]] +[addprefix[$(config-prefix)$]!field:text[hide]removeprefix[$(config-prefix)$]]
 \end
 <div class="tc-page-controls">
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
-<$reveal type="nomatch" state=<<config-title>> text="hide" nowrap="yes">
+<$list filter=<<display-filter "$:/tags/PageControls">> variable="listItem">
 <$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
 <$transclude tiddler=<<listItem>> mode="inline"/>
 </$set>
-</$reveal>
 </$list>
 </div>
 
+<!--<$reveal type="nomatch" state=<<config-title>> text="hide">-->

--- a/core/ui/PageControls.tid
+++ b/core/ui/PageControls.tid
@@ -1,13 +1,7 @@
 title: $:/core/ui/PageTemplate/pagecontrols
 
-\define config-prefix()
-$:/config/PageControlButtons/Visibility/
-\end
-\define display-filter(tag)
-[all[shadows+tiddlers]tag[$tag$]!has[draft.of]] +[addprefix[$(config-prefix)$]!field:text[hide]removeprefix[$(config-prefix)$]]
-\end
 <div class="tc-page-controls">
-<$list filter=<<display-filter "$:/tags/PageControls">> variable="listItem">
+<$list filter=<<filter-list-tag-display "$:/tags/PageControls" "$:/config/PageControlButtons/Visibility/">> variable="listItem">
 <$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
 <$transclude tiddler=<<listItem>> mode="inline"/>
 </$set>

--- a/core/ui/PageTemplate/sidebar.tid
+++ b/core/ui/PageTemplate/sidebar.tid
@@ -1,21 +1,19 @@
 title: $:/core/ui/PageTemplate/sidebar
 tags: $:/tags/PageTemplate
 
-\define config-title()
-$:/config/SideBarSegments/Visibility/$(listItem)$
+\define config-prefix()
+$:/config/SideBarSegments/Visibility/
 \end
-
+\define display-filter(tag)
+[all[shadows+tiddlers]tag[$tag$]!has[draft.of]] +[addprefix[$(config-prefix)$]!field:text[hide]removeprefix[$(config-prefix)$]]
+\end
 <$scrollable fallthrough="no" class="tc-sidebar-scrollable">
 
 <$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes" animate="yes" tag="div" class="tc-sidebar-header">
 
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/SideBarSegment]!has[draft.of]]" variable="listItem">
-
-<$reveal type="nomatch" state=<<config-title>> text="hide" nowrap="yes">
+<$list filter=<<display-filter "$:/tags/SideBarSegment">> variable="listItem">
 
 <$transclude tiddler=<<listItem>> mode="block"/>
-
-</$reveal>
 
 </$list>
 

--- a/core/ui/PageTemplate/sidebar.tid
+++ b/core/ui/PageTemplate/sidebar.tid
@@ -1,17 +1,11 @@
 title: $:/core/ui/PageTemplate/sidebar
 tags: $:/tags/PageTemplate
 
-\define config-prefix()
-$:/config/SideBarSegments/Visibility/
-\end
-\define display-filter(tag)
-[all[shadows+tiddlers]tag[$tag$]!has[draft.of]] +[addprefix[$(config-prefix)$]!field:text[hide]removeprefix[$(config-prefix)$]]
-\end
 <$scrollable fallthrough="no" class="tc-sidebar-scrollable">
 
 <$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes" animate="yes" tag="div" class="tc-sidebar-header">
 
-<$list filter=<<display-filter "$:/tags/SideBarSegment">> variable="listItem">
+<$list filter=<<filter-list-tag-display "$:/tags/SideBarSegment" "$:/config/SideBarSegments/Visibility/">> variable="listItem">
 
 <$transclude tiddler=<<listItem>> mode="block"/>
 

--- a/core/ui/PageTemplate/sidebar.tid
+++ b/core/ui/PageTemplate/sidebar.tid
@@ -7,13 +7,11 @@ $:/config/SideBarSegments/Visibility/$(listItem)$
 
 <$scrollable fallthrough="no" class="tc-sidebar-scrollable">
 
-<div class="tc-sidebar-header">
-
-<$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes" animate="yes">
+<$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes" animate="yes" tag="div" class="tc-sidebar-header">
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/SideBarSegment]!has[draft.of]]" variable="listItem">
 
-<$reveal type="nomatch" state=<<config-title>> text="hide"  tag="div">
+<$reveal type="nomatch" state=<<config-title>> text="hide" nowrap="yes">
 
 <$transclude tiddler=<<listItem>> mode="block"/>
 
@@ -22,7 +20,5 @@ $:/config/SideBarSegments/Visibility/$(listItem)$
 </$list>
 
 </$reveal>
-
-</div>
 
 </$scrollable>

--- a/core/ui/TopRightBar/menu.tid
+++ b/core/ui/TopRightBar/menu.tid
@@ -1,9 +1,9 @@
 title: $:/core/ui/TopBar/menu
 tags: $:/tags/TopRightBar
 
-<$reveal state="$:/state/sidebar" type="nomatch" text="no">
+<$list filter="[[$:/state/sidebar]] +[!field:text[no]]">
 <$button set="$:/state/sidebar" setTo="no" tooltip={{$:/language/Buttons/HideSideBar/Hint}} aria-label={{$:/language/Buttons/HideSideBar/Caption}} class="tc-btn-invisible">{{$:/core/images/chevron-right}}</$button>
-</$reveal>
-<$reveal state="$:/state/sidebar" type="match" text="no">
+</$list>
+<$list filter="[[$:/state/sidebar]] +[field:text[no]]">
 <$button set="$:/state/sidebar" setTo="yes" tooltip={{$:/language/Buttons/ShowSideBar/Hint}} aria-label={{$:/language/Buttons/ShowSideBar/Caption}} class="tc-btn-invisible">{{$:/core/images/chevron-left}}</$button>
-</$reveal>
+</$list>

--- a/core/wiki/macros/list-tag-display-filter.tid
+++ b/core/wiki/macros/list-tag-display-filter.tid
@@ -1,0 +1,7 @@
+title: $:/core/macros/list-tag-display-filter
+tags: $:/tags/Macro
+
+
+\define filter-list-tag-display(tag, prefix)
+[all[shadows+tiddlers]tag[$tag$]!has[draft.of]] +[addprefix[$prefix$]!field:text[hide]removeprefix[$prefix$]]
+\end


### PR DESCRIPTION
There are certain places in the core where a reveal widget is used without any class added. In these cases this behavior obstructs CSS inheritance because the reveal widget is sometimes parent to the div you are trying to work with. If it is child to the div, it is just a minor annoyance, but still unnecessary.

At the beginning of this PR I modified the reveal widget to not insert a div tag unless it is actually needed, but after feedback from Jeremy I changed the offending locations to use the list widget (in the case of `$:/tags/SideBarSegment` and `$:/tags/PageControls`) or just added the class to the reveal widget and removed the extra div (in the case of `tc-sidebar-header`). A hidden reveal widget has the hidden attribute set so it is still possible to style it accordingly if desired. This is probably the preferred method. 

I've also added a global macro that streamlines using the list widget to "OPTIONALLY" display items like the page toolbar, edit toolbar, and view toolbar. Since this is a common paradigm it makes sense to use a single filter macro for two reasons. First because it cuts down on code duplication. Second because it can easily be updated if we find a filter string which has better performance. 