### PR TITLE
Update wikitext-macros.tid

### DIFF
--- a/editions/tw5.com/tiddlers/system/wikitext-macros.tid
+++ b/editions/tw5.com/tiddlers/system/wikitext-macros.tid
@@ -39,6 +39,10 @@ $src$
 </div>
 \end
 
+\define wikitext-example-compact(src)
+<$macrocall $name="copy-to-clipboard-above-right" src=<<__src__>>/> `$src$` That renders as:  "$src$"
+\end
+
 \define tw-code(tiddler)
 <$codeblock language={{$tiddler$!!type}} code={{$tiddler$}}/>
 \end


### PR DESCRIPTION
Added new macro wikitext-example-compact to support the publishing of Widget variants in a more compact form.

Initially to support changes to the ViewWidget Documentation, this compact form may be used in other Widget documentation.

Variants demonstrate alternative forms of a specific widget or macro with the ability for users to copy to clipboard and use in their own wiki. In some widgets that have multi-functions there is no single form of the widget, and demonstrating some variations highlights this.