### PR TITLE
Update ViewWidget.tid to include common variants

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
@@ -39,6 +39,19 @@ The following formats can be specified in the `format` attribute:
 |''stripcomments'' |The field is interpreted as JavaScript source code and any lines beginning `\\#` are stripped |
 |''jsencoded'' |The field is displayed as a JavaScript encoded string |
 
+;The following examples are common variants
+
+!!!!View the value in a field of a named tiddler
+:<<wikitext-example-compact '<$view tiddler="ViewWidget" field="caption"/>'>>
+!!!!View the value in a date field of the currentTiddler as a relative date
+:<<wikitext-example-compact '<$view field=modified format=relativedate/>'>>
+!!!!View the value in a date field of the currentTiddler as formated date
+<<wikitext-example-compact '<$view field=created format=date template="[UTC]YYYY-0MM-0DD"/>'>>
+!!!!View a date field as its raw value
+<<wikitext-example-compact '<$view field=created format=text />'>>
+!!!!See ''String Operators'' in [[Filter Operators]] 
+:To apply similar formatting within Filters, including from titles and variables
+
 ! SubTiddler Access
 
 The view widget allows access to the individual tiddlers stored within a [[plugin|Plugins]].

--- a/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
@@ -46,9 +46,9 @@ The following formats can be specified in the `format` attribute:
 !!!!View the value in a date field of the currentTiddler as a relative date
 :<<wikitext-example-compact '<$view field=modified format=relativedate/>'>>
 !!!!View the value in a date field of the currentTiddler as formated date
-<<wikitext-example-compact '<$view field=created format=date template="[UTC]YYYY-0MM-0DD"/>'>>
+:<<wikitext-example-compact '<$view field=created format=date template="[UTC]YYYY-0MM-0DD"/>'>>
 !!!!View a date field as its raw value
-<<wikitext-example-compact '<$view field=created format=text />'>>
+:<<wikitext-example-compact '<$view field=created format=text />'>>
 !!!!See ''String Operators'' in [[Filter Operators]] 
 :To apply similar formatting within Filters, including from titles and variables
 


### PR DESCRIPTION
The provision of common variates to the view widget provides new an experience user examples of the different variants of the ViewWidget. The copy to clipboad method allows each variant to be quickly accessed and pasted into their wiki.

To facilitate this a new macro wikitext-example-compact has being added to 
$:/editions/tw5.com/wikitext-macros