### PR TITLE
Update Filter Operators.tid

### DIFF
--- a/editions/tw5.com/tiddlers/filters/Filter Operators.tid
+++ b/editions/tw5.com/tiddlers/filters/Filter Operators.tid
@@ -21,6 +21,8 @@ A <<.def "filter operator">> is a predefined keyword attached to an individual [
 
 ''Important:'' Each first [[step|Filter Step]] of a [[filter run|Filter Run]] not given any input titles receives the output of <$link to="all Operator">[all[tiddlers]]</$link> as its input.
 
+[[Filters]] and Filter Operators are most commonly used in the ListWidget, SetWidget and [[Filtered Transclusions|Transclusion in WikiText]] `{{{ filter }}}`
+
 The following table lists all core operators, the most common ones marked ✓. The last column indicates whether an operator allows ''negation'' using the <$link to="Filter Step"><code>!</code> prefix</$link>. For specifics as to each operator's negated output please refer to its documentation.
 
 <table>


### PR DESCRIPTION
To add an additional paragraph at the top to direct the user to common uses of Filters, in ListWidget, SetWidget and Filtered Transclusions.

Please add to this if there is common uses elsewhere for filter. 

By providing this guidance to users at the early stage of learning they will know the key places in which Widgets use filters thus have the opportunity to experiment and learn more about filters, Otherwise they remain an abstract concept.

PS I am not sure why my recent proposed changes delete the last <enter> in the file and if this is a problem, nor do I know how to reverse this.