### PR TITLE
Add support of language aliases in highlight.js plugin

### DIFF
--- a/plugins/tiddlywiki/highlight/highlightblock.js
+++ b/plugins/tiddlywiki/highlight/highlightblock.js
@@ -27,7 +27,7 @@ CodeBlockWidget.prototype.postRender = function() {
 	if(tiddler) {
 		language = tiddler.fields.text || "";
 	}
-	if(language && hljs.listLanguages().indexOf(language) !== -1) {
+	if(language && hljs.getLanguage(language)) {
 		domNode.className = language.toLowerCase() + " hljs";
 		if($tw.browser && !domNode.isTiddlyWikiFakeDom) {
 			hljs.highlightBlock(domNode);			


### PR DESCRIPTION
listLanguages() returns a list of supported languages. It does not
return language aliases.

highlight.js has extensive support of language aliases which can be 
viewed here

https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html#language-names-and-aliases

But because of using listLanguages(), TW does not take advantage of 
alias.

getLanguage() method on the other hand supports aliases.

https://highlightjs.readthedocs.io/en/latest/api.html#getlanguage-name

To summarize, now user can use javascript, js or jsx for the code block. getLanguage() will return an object which means highlight.js supports
this language.