### PR TITLE
Cast count to a number for comparison

### DIFF
--- a/core/modules/editor/operations/text/prefix-lines.js
+++ b/core/modules/editor/operations/text/prefix-lines.js
@@ -17,8 +17,10 @@ exports["prefix-lines"] = function(event,operation) {
 	operation.cutStart = $tw.utils.findPrecedingLineBreak(operation.text,operation.selStart);
 	// Cut to just past the following line break, or to the end of the text
 	operation.cutEnd = $tw.utils.findFollowingLineBreak(operation.text,operation.selEnd);
+	// paramsObject offers count as a string not number
+	var prefixCount = parseInt(event.paramObject.count,10);
 	// Compose the required prefix
-	var prefix = $tw.utils.repeat(event.paramObject.character,event.paramObject.count);
+	var prefix = $tw.utils.repeat(event.paramObject.character,prefixCount);
 	// Process each line
 	var lines = operation.text.substring(operation.cutStart,operation.cutEnd).split(/\r?\n/mg);
 	$tw.utils.each(lines,function(line,index) {
@@ -33,7 +35,7 @@ exports["prefix-lines"] = function(event,operation) {
 			line = line.substring(1);
 		}
 		// We're done if we removed the exact required prefix, otherwise add it
-		if(count !== event.paramObject.count) {
+		if(count !== prefixCount) {
 			// Apply the prefix
 			line =  prefix + " " + line;
 		}


### PR DESCRIPTION
Prior to this change, the `count` provided was a string. However, our use for it is as a number. Though there are some cases where type coercion is desired in this case it conflates the readbility of the code.

This change casts the `count` to a number before using it in numeric comparisons.

Fixes issue #3912