### PR TITLE
Fix "Filtered Attribute Values" example

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
@@ -85,6 +85,6 @@ Filtered attribute values are indicated with triple curly braces around a [[Filt
 This example shows how to add a prefix to a value:
 
 ```
-<$text text={{{ [<currentTiddler>]addPrefix[$:/myprefix/]] }}}>
+<$text text={{{ [<currentTiddler>addprefix[$:/myprefix/]] }}}>
 ```
 


### PR DESCRIPTION
syntax error, an additional "]" has being removed, and the P changed to p