### PR TITLE
Update PageTemplate.tid - change 6x$set to 1x$vars

### DIFF
--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -5,17 +5,7 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 \end
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 
-<$set name="tv-config-toolbar-icons" value={{$:/config/Toolbar/Icons}}>
-
-<$set name="tv-config-toolbar-text" value={{$:/config/Toolbar/Text}}>
-
-<$set name="tv-config-toolbar-class" value={{$:/config/Toolbar/ButtonClass}}>
-
-<$set name="tv-show-missing-links" value={{$:/config/MissingLinks}}>
-
-<$set name="storyviewTitle" value={{$:/view}}>
-
-<$set name="languageTitle" value={{{ [{$:/language}get[name]] }}}>
+<$vars tv-config-toolbar-icons={{$:/config/Toolbar/Icons}} tv-config-toolbar-text={{$:/config/Toolbar/Text}} tv-config-toolbar-class={{$:/config/Toolbar/ButtonClass}} tv-show-missing-links={{$:/config/MissingLinks}} storyviewTitle={{$:/view}} currentTiddler={{$:/language}} languageTitle={{!!name}} currentTiddler="">
 
 <div class=<<containerClasses>>>
 
@@ -35,14 +25,4 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 
 </div>
 
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
+</$vars>


### PR DESCRIPTION
Would there be any reason not to use 1 `$vars` widget instead of 6 `$set` widgets?