### PR TITLE
Scale embedded videos and audios

### DIFF
--- a/core/modules/parsers/audioparser.js
+++ b/core/modules/parsers/audioparser.js
@@ -17,7 +17,8 @@ var AudioParser = function(type,text,options) {
 			type: "element",
 			tag: "audio",
 			attributes: {
-				controls: {type: "string", value: "controls"}
+				controls: {type: "string", value: "controls"},
+				style: {type: "string", value: "width: 100%; height: 100%; object-fit: contain"}
 			}
 		},
 		src;

--- a/core/modules/parsers/videoparser.js
+++ b/core/modules/parsers/videoparser.js
@@ -17,7 +17,8 @@ var VideoParser = function(type,text,options) {
 			type: "element",
 			tag: "video",
 			attributes: {
-				controls: {type: "string", value: "controls"}
+				controls: {type: "string", value: "controls"},
+				style: {type: "string", value: "width: 100%; height: 100%; object-fit: contain"}
 			}
 		},
 		src;


### PR DESCRIPTION
Modified files:
$:/core/modules/parsers/audioparser.js
$:/core/modules/parsers/videoparser.js
Added an attribute to each to make video imported scaled to fit the parent container:
`style: {type: "string", value: "width: 100%; height: 100%; object-fit: contain"}`