### PR TITLE
Scale embedded videos and audios

### DIFF
--- a/core/modules/parsers/audioparser.js
+++ b/core/modules/parsers/audioparser.js
@@ -17,7 +17,8 @@ var AudioParser = function(type,text,options) {
 			type: "element",
 			tag: "audio",
 			attributes: {
-				controls: {type: "string", value: "controls"}
+				controls: {type: "string", value: "controls"},
+				style: {type: "string", value: "width: 100%; height: 100%; object-fit: contain"}
 			}
 		},
 		src;

--- a/core/modules/parsers/audioparser.js
+++ b/core/modules/parsers/audioparser.js
@@ -18,7 +18,7 @@ var AudioParser = function(type,text,options) {
 			tag: "audio",
 			attributes: {
 				controls: {type: "string", value: "controls"},
-				style: {type: "string", value: "width: 100%; height: 100%; object-fit: contain"}
+				style: {type: "string", value: "width: 100%; object-fit: contain"}
 			}
 		},
 		src;

--- a/core/modules/parsers/videoparser.js
+++ b/core/modules/parsers/videoparser.js
@@ -17,7 +17,8 @@ var VideoParser = function(type,text,options) {
 			type: "element",
 			tag: "video",
 			attributes: {
-				controls: {type: "string", value: "controls"}
+				controls: {type: "string", value: "controls"},
+				style: {type: "string", value: "width: 100%; height: 100%; object-fit: contain"}
 			}
 		},
 		src;

--- a/core/modules/parsers/videoparser.js
+++ b/core/modules/parsers/videoparser.js
@@ -18,7 +18,7 @@ var VideoParser = function(type,text,options) {
 			tag: "video",
 			attributes: {
 				controls: {type: "string", value: "controls"},
-				style: {type: "string", value: "width: 100%; height: 100%; object-fit: contain"}
+				style: {type: "string", value: "width: 100%; object-fit: contain"}
 			}
 		},
 		src;


### PR DESCRIPTION
Modified files:
$:/core/modules/parsers/audioparser.js
$:/core/modules/parsers/videoparser.js
Added an attribute to each to make video imported scaled to fit the parent container:
style: {type: "string", value: "width: 100%; object-fit: contain"}

Before:
![2019-05-14 12-41-01屏幕截图](https://user-images.githubusercontent.com/29735136/57904267-90c04480-78a4-11e9-9f48-401642e759db.png)
![2019-05-14 13-06-33屏幕截图](https://user-images.githubusercontent.com/29735136/57904356-fe6c7080-78a4-11e9-8b18-f348768da43d.png)

After:
![2019-05-14 12-40-15屏幕截图](https://user-images.githubusercontent.com/29735136/57904265-90c04480-78a4-11e9-9ee4-2a2b4adefc30.png)
![2019-05-14 13-06-39屏幕截图](https://user-images.githubusercontent.com/29735136/57904271-9158db00-78a4-11e9-8b7c-da563326882c.png)