### PR TITLE
Make the tag pills looks like buttons

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -641,6 +641,8 @@ button.tc-tag-label, span.tc-tag-label {
 	vertical-align: baseline;
 	background-color: <<colour tag-background>>;
 	border-radius: 1em;
+	border-top: 1px solid rgba(255, 255, 255, 0.9);
+	box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.3);
 }
 
 .tc-untagged-separator {


### PR DESCRIPTION
Based on their appearance, it is not clear that the tag pill is a button that can be pressed.

Add a shadow to make it clearer.

Before:

![vivaldi_2019-05-15_00-27-35](https://user-images.githubusercontent.com/7034200/57736562-c13b8f00-76a8-11e9-892e-a25a6ac12944.png)

After:

![vivaldi_2019-05-15_00-27-44](https://user-images.githubusercontent.com/7034200/57736577-cac4f700-76a8-11e9-8d67-f0510948a87b.png)
