### PR TITLE
Add indexes to the wiki store to improve performance

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1035,9 +1035,8 @@ $tw.Wiki = function(options) {
 				shadowTiddlerTitles = Object.keys(shadowTiddlers);
 			}
 			return shadowTiddlerTitles;
-		};
-
-	var indexers = [],
+		},
+		indexers = [],
 		indexersByName = Object.create(null);
 
 	this.addIndexer = function(indexer,name) {
@@ -1323,6 +1322,10 @@ $tw.Wiki = function(options) {
 			indexer.rebuild();
 		});
 	};
+
+	if(this.addIndexersToWiki) {
+		this.addIndexersToWiki();
+	}
 };
 
 // Dummy methods that will be filled in after boot

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1036,10 +1036,15 @@ $tw.Wiki = function(options) {
 			}
 			return shadowTiddlerTitles;
 		},
+		enableIndexers = options.enableIndexers || null, // Array of indexer names to enable, or null to use all available indexers
 		indexers = [],
 		indexersByName = Object.create(null);
 
 	this.addIndexer = function(indexer,name) {
+		// Bail if this indexer is not enabled
+		if(enableIndexers && enableIndexers.indexOf(name) === -1) {
+			return;
+		}
 		indexers.push(indexer);
 		indexersByName[name] = indexer;
 	};

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1125,30 +1125,9 @@ $tw.Wiki = function(options) {
 		}
 	};
 
-	this.each.byTag = function(tag) {
-		var titles = getTiddlerTitles();
-		return self.getIndexer("TagIndexer").lookup(tag).filter(function(title) {
-			return titles.indexOf(title) !== -1;
-		});
-	};
-
-	this.each.hasNonEmptyField = function(name) {
-		var titles = getTiddlerTitles();
-		return self.getIndexer("FieldIndexer").lookupNonEmptyField(name).filter(function(title) {
-			return titles.indexOf(title) !== -1;
-		});
-	};
-
 	// Get an array of all shadow tiddler titles
 	this.allShadowTitles = function() {
 		return getShadowTiddlerTitles().slice(0);
-	};
-
-	this.allShadowTitles.byTag = function(tag) {
-		var titles = getShadowTiddlerTitles();
-		return self.getIndexer("TagIndexer").lookup(tag).filter(function(title) {
-			return titles.indexOf(title) !== -1;
-		});
 	};
 
 	// Iterate through all shadow tiddler titles
@@ -1180,10 +1159,6 @@ $tw.Wiki = function(options) {
 		}
 	};
 
-	this.eachTiddlerPlusShadows.byTag = function(tag) {
-		return self.getIndexer("TagIndexer").lookup(tag).slice(0);
-	};
-
 	// Iterate through all the shadows and then the tiddlers
 	this.eachShadowPlusTiddlers = function(callback) {
 		var index,titlesLength,title,
@@ -1204,14 +1179,6 @@ $tw.Wiki = function(options) {
 				callback(tiddlers[title],title);
 			}
 		}
-	};
-
-	this.eachShadowPlusTiddlers.byTag = function(tag) {
-		return self.getIndexer("TagIndexer").lookup(tag).slice(0);
-	};
-
-	this.eachShadowPlusTiddlers.byField = function(name,value) {
-		return self.getIndexer("FieldIndexer").lookup(name,value).slice(0);
 	};
 
 	// Test for the existence of a tiddler (excludes shadow tiddlers)

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1132,6 +1132,13 @@ $tw.Wiki = function(options) {
 		});
 	};
 
+	this.each.hasNonEmptyField = function(name) {
+		var titles = getTiddlerTitles();
+		return self.getIndexer("FieldIndexer").lookupNonEmptyField(name).filter(function(title) {
+			return titles.indexOf(title) !== -1;
+		});
+	};
+
 	// Get an array of all shadow tiddler titles
 	this.allShadowTitles = function() {
 		return getShadowTiddlerTitles().slice(0);

--- a/core/modules/filters/field.js
+++ b/core/modules/filters/field.js
@@ -53,14 +53,18 @@ exports.field = function(source,operator,options) {
 				}
 			});
 		} else {
-			source(function(tiddler,title) {
-				if(tiddler) {
-					var text = tiddler.getFieldString(fieldname);
-					if(text !== null && text === operator.operand) {
-						results.push(title);
+			if(typeof source.byField === "function") {
+				results = source.byField(fieldname,operator.operand);
+			} else {
+				source(function(tiddler,title) {
+					if(tiddler) {
+						var text = tiddler.getFieldString(fieldname);
+						if(text !== null && text === operator.operand) {
+							results.push(title);
+						}
 					}
-				}
-			});
+				});				
+			}
 		}
 	}
 	return results;

--- a/core/modules/filters/field.js
+++ b/core/modules/filters/field.js
@@ -16,7 +16,7 @@ Filter operator for comparing fields for equality
 Export our filter function
 */
 exports.field = function(source,operator,options) {
-	var results = [],
+	var results = [],indexedResults,
 		fieldname = (operator.suffix || operator.operator || "title").toLowerCase();
 	if(operator.prefix === "!") {
 		if(operator.regexp) {
@@ -54,17 +54,19 @@ exports.field = function(source,operator,options) {
 			});
 		} else {
 			if(source.byField) {
-				results = source.byField(fieldname,operator.operand);
-			} else {
-				source(function(tiddler,title) {
-					if(tiddler) {
-						var text = tiddler.getFieldString(fieldname);
-						if(text !== null && text === operator.operand) {
-							results.push(title);
-						}
-					}
-				});
+				indexedResults = source.byField(fieldname,operator.operand);
+				if(indexedResults) {
+					return indexedResults
+				}
 			}
+			source(function(tiddler,title) {
+				if(tiddler) {
+					var text = tiddler.getFieldString(fieldname);
+					if(text !== null && text === operator.operand) {
+						results.push(title);
+					}
+				}
+			});
 		}
 	}
 	return results;

--- a/core/modules/filters/field.js
+++ b/core/modules/filters/field.js
@@ -53,7 +53,7 @@ exports.field = function(source,operator,options) {
 				}
 			});
 		} else {
-			if(typeof source.byField === "function") {
+			if(source.byField) {
 				results = source.byField(fieldname,operator.operand);
 			} else {
 				source(function(tiddler,title) {

--- a/core/modules/filters/field.js
+++ b/core/modules/filters/field.js
@@ -63,7 +63,7 @@ exports.field = function(source,operator,options) {
 							results.push(title);
 						}
 					}
-				});				
+				});
 			}
 		}
 	}

--- a/core/modules/filters/has.js
+++ b/core/modules/filters/has.js
@@ -41,15 +41,11 @@ exports.has = function(source,operator,options) {
 				}
 			});
 		} else {
-			if(source.hasNonEmptyField) {
-				results = source.hasNonEmptyField(operator.operand);
-			} else {
-				source(function(tiddler,title) {
-					if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && !(tiddler.fields[operator.operand] === "" || tiddler.fields[operator.operand].length === 0)) {
-						results.push(title);
-					}
-				});				
-			}
+			source(function(tiddler,title) {
+				if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && !(tiddler.fields[operator.operand] === "" || tiddler.fields[operator.operand].length === 0)) {
+					results.push(title);
+				}
+			});				
 		}
 	}
 	return results;

--- a/core/modules/filters/has.js
+++ b/core/modules/filters/has.js
@@ -41,11 +41,15 @@ exports.has = function(source,operator,options) {
 				}
 			});
 		} else {
-			source(function(tiddler,title) {
-				if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && !(tiddler.fields[operator.operand] === "" || tiddler.fields[operator.operand].length === 0)) {
-					results.push(title);
-				}
-			});
+			if(source.hasNonEmptyField) {
+				results = source.hasNonEmptyField(operator.operand);
+			} else {
+				source(function(tiddler,title) {
+					if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && !(tiddler.fields[operator.operand] === "" || tiddler.fields[operator.operand].length === 0)) {
+						results.push(title);
+					}
+				});				
+			}
 		}
 	}
 	return results;

--- a/core/modules/filters/tag.js
+++ b/core/modules/filters/tag.js
@@ -36,7 +36,7 @@ exports.tag = function(source,operator,options) {
 			});
 		} else {
 			// Returns empty results if operator.operand is missing
-			if(typeof source.byTag === "function") {
+			if(source.byTag) {
 				results = source.byTag(operator.operand);
 			} else {
 				tiddlers = options.wiki.getTiddlersWithTag(operator.operand);

--- a/core/modules/filters/tag.js
+++ b/core/modules/filters/tag.js
@@ -25,9 +25,10 @@ exports.tag = function(source,operator,options) {
 		});
 	} else {
 		// Old semantics:
-		var tiddlers = options.wiki.getTiddlersWithTag(operator.operand);
+		var tiddlers;
 		if(operator.prefix === "!") {
 			// Returns a copy of the input if operator.operand is missing
+			tiddlers = options.wiki.getTiddlersWithTag(operator.operand);
 			source(function(tiddler,title) {
 				if(tiddlers.indexOf(title) === -1) {
 					results.push(title);
@@ -35,12 +36,17 @@ exports.tag = function(source,operator,options) {
 			});
 		} else {
 			// Returns empty results if operator.operand is missing
-			source(function(tiddler,title) {
-				if(tiddlers.indexOf(title) !== -1) {
-					results.push(title);
-				}
-			});
-			results = options.wiki.sortByList(results,operator.operand);
+			if(typeof source.byTag === "function") {
+				results = source.byTag(operator.operand);
+			} else {
+				tiddlers = options.wiki.getTiddlersWithTag(operator.operand);
+				source(function(tiddler,title) {
+					if(tiddlers.indexOf(title) !== -1) {
+						results.push(title);
+					}
+				});
+				results = options.wiki.sortByList(results,operator.operand);
+			}
 		}		
 	}
 	return results;

--- a/core/modules/filters/tag.js
+++ b/core/modules/filters/tag.js
@@ -16,7 +16,7 @@ Filter operator for checking for the presence of a tag
 Export our filter function
 */
 exports.tag = function(source,operator,options) {
-	var results = [];
+	var results = [],indexedResults;
 	if((operator.suffix || "").toLowerCase() === "strict" && !operator.operand) {
 		// New semantics:
 		// Always return copy of input if operator.operand is missing
@@ -37,7 +37,10 @@ exports.tag = function(source,operator,options) {
 		} else {
 			// Returns empty results if operator.operand is missing
 			if(source.byTag) {
-				results = source.byTag(operator.operand);
+				indexedResults = source.byTag(operator.operand);
+				if(indexedResults) {
+					return indexedResults;
+				}
 			} else {
 				tiddlers = options.wiki.getTiddlersWithTag(operator.operand);
 				source(function(tiddler,title) {

--- a/core/modules/indexers/field-indexer.js
+++ b/core/modules/indexers/field-indexer.js
@@ -15,7 +15,21 @@ Indexes the tiddlers with each field value
 function FieldIndexer(wiki) {
 	this.wiki = wiki;
 	this.index = null;
+	this.addIndexMethods();
 }
+
+FieldIndexer.prototype.addIndexMethods = function() {
+	var self = this;
+	this.wiki.each.hasNonEmptyField = function(name) {
+		var titles = self.wiki.allTitles();
+		return self.lookupNonEmptyField(name).filter(function(title) {
+			return titles.indexOf(title) !== -1;
+		});
+	};
+	this.wiki.eachShadowPlusTiddlers.byField = function(name,value) {
+		return self.lookup(name,value).slice(0);
+	};
+};
 
 /*
 Tear down and then rebuild the index as if all tiddlers have changed

--- a/core/modules/indexers/field-indexer.js
+++ b/core/modules/indexers/field-indexer.js
@@ -115,6 +115,7 @@ FieldIndexer.prototype.update = function(oldTiddler,newTiddler) {
 		$tw.utils.each(this.index,function(indexEntry,name) {
 			if(name in newTiddler.fields) {
 				var value = newTiddler.getFieldString(name);
+				indexEntry[value] = indexEntry[value] || [];
 				indexEntry[value].push(newTiddler.fields.title);
 			}
 		});		

--- a/core/modules/indexers/field-indexer.js
+++ b/core/modules/indexers/field-indexer.js
@@ -91,7 +91,6 @@ FieldIndexer.prototype.lookup = function(name,value) {
 
 // Lookup the given field returning a list of tiddler titles
 FieldIndexer.prototype.lookupNonEmptyField = function(name) {
-console.log("Looking up",name)
 	// Update the index if it has yet to be built
 	if(this.index === null || !this.index[name]) {
 		this.buildIndexForField(name);
@@ -101,7 +100,7 @@ console.log("Looking up",name)
 		results = [];
 	$tw.utils.each(Object.keys(baseIndex),function(value) {
 		if(value) {
-			$tw.utils.pushTop(results,baseIndex[name]);
+			$tw.utils.pushTop(results,baseIndex[value]);
 		}
 	});
 	return results;

--- a/core/modules/indexers/field-indexer.js
+++ b/core/modules/indexers/field-indexer.js
@@ -36,9 +36,11 @@ FieldIndexer.prototype.buildIndexForField = function(name) {
 	var baseIndex = this.index[name];
 	// Update the index for each tiddler
 	this.wiki.eachTiddlerPlusShadows(function(tiddler,title) {
-		var value = tiddler.getFieldString(name);
-		baseIndex[value] = baseIndex[value] || [];
-		baseIndex[value].push(title);
+		if(name in tiddler.fields) {
+			var value = tiddler.getFieldString(name);
+			baseIndex[value] = baseIndex[value] || [];
+			baseIndex[value].push(title);			
+		}
 	});
 };
 
@@ -85,6 +87,24 @@ FieldIndexer.prototype.lookup = function(name,value) {
 		this.buildIndexForField(name);
 	}
 	return this.index[name][value] || [];
+};
+
+// Lookup the given field returning a list of tiddler titles
+FieldIndexer.prototype.lookupNonEmptyField = function(name) {
+console.log("Looking up",name)
+	// Update the index if it has yet to be built
+	if(this.index === null || !this.index[name]) {
+		this.buildIndexForField(name);
+	}
+	// Collect the tiddlers with this field
+	var baseIndex = this.index[name],
+		results = [];
+	$tw.utils.each(Object.keys(baseIndex),function(value) {
+		if(value) {
+			$tw.utils.pushTop(results,baseIndex[name]);
+		}
+	});
+	return results;
 };
 
 exports.FieldIndexer = FieldIndexer;

--- a/core/modules/indexers/field-indexer.js
+++ b/core/modules/indexers/field-indexer.js
@@ -1,0 +1,92 @@
+/*\
+title: $:/core/modules/indexers/field-indexer.js
+type: application/javascript
+module-type: indexer
+
+Indexes the tiddlers with each field value
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global modules: false */
+"use strict";
+
+function FieldIndexer(wiki) {
+	this.wiki = wiki;
+	this.index = null;
+}
+
+/*
+Tear down and then rebuild the index as if all tiddlers have changed
+*/
+FieldIndexer.prototype.rebuild = function() {
+	// Invalidate the index so that it will be rebuilt when it is next used
+	this.index = null;
+};
+
+/*
+Build the index for a particular field
+*/
+FieldIndexer.prototype.buildIndexForField = function(name) {
+	var self = this;
+	// Hashmap by field name of hashmap by field value of array of tiddler titles
+	this.index = this.index || Object.create(null);
+	this.index[name] = Object.create(null);
+	var baseIndex = this.index[name];
+	// Update the index for each tiddler
+	this.wiki.eachTiddlerPlusShadows(function(tiddler,title) {
+		var value = tiddler.getFieldString(name);
+		baseIndex[value] = baseIndex[value] || [];
+		baseIndex[value].push(title);
+	});
+};
+
+/*
+Update the index in the light of a tiddler value changing; note that the title must be identical. (Renames are handled as a separate delete and create)
+oldTiddler: old tiddler value, or null for creation
+newTiddler: new tiddler value, or null for deletion
+*/
+FieldIndexer.prototype.update = function(oldTiddler,newTiddler) {
+	// Don't do anything if the index hasn't been built yet
+	if(this.index === null) {
+		return;
+	}
+	// Remove the old tiddler from the index
+	if(oldTiddler) {
+		$tw.utils.each(this.index,function(indexEntry,name) {
+			if(name in oldTiddler.fields) {
+				var value = oldTiddler.getFieldString(name),
+					tiddlerList = indexEntry[value];
+				if(tiddlerList) {
+					var index = tiddlerList.indexOf(oldTiddler.fields.title);
+					if(index !== -1) {
+						tiddlerList.splice(index,1);
+					}
+				}
+			}
+		});
+	}
+	// Add the new tiddler to the index
+	if(newTiddler) {
+		$tw.utils.each(this.index,function(indexEntry,name) {
+			if(name in newTiddler.fields) {
+				var value = newTiddler.getFieldString(name);
+				indexEntry[value].push(newTiddler.fields.title);
+			}
+		});		
+	}
+};
+
+// Lookup the given field returning a list of tiddler titles
+FieldIndexer.prototype.lookup = function(name,value) {
+	// Update the index if it has yet to be built
+	if(this.index === null || !this.index[name]) {
+		this.buildIndexForField(name);
+	}
+	return this.index[name][value] || [];
+};
+
+exports.FieldIndexer = FieldIndexer;
+
+})();

--- a/core/modules/indexers/field-indexer.js
+++ b/core/modules/indexers/field-indexer.js
@@ -26,6 +26,33 @@ FieldIndexer.prototype.addIndexMethods = function() {
 			return titles.indexOf(title) !== -1;
 		});
 	};
+	this.wiki.eachShadow.hasNonEmptyField = function(name) {
+		var titles = self.wiki.allShadowTitles();
+		return self.lookupNonEmptyField(name).filter(function(title) {
+			return titles.indexOf(title) !== -1;
+		});
+	};
+	this.wiki.eachTiddlerPlusShadows.hasNonEmptyField = function(name) {
+		return self.lookupNonEmptyField(name).slice(0);
+	};
+	this.wiki.eachShadowPlusTiddlers.hasNonEmptyField = function(name) {
+		return self.lookupNonEmptyField(name).slice(0);
+	};
+	this.wiki.each.byField = function(name,value) {
+		var titles = self.wiki.allTitles();
+		return self.lookup(name,value).filter(function(title) {
+			return titles.indexOf(title) !== -1;
+		});
+	};
+	this.wiki.eachShadow.byField = function(name,value) {
+		var titles = self.wiki.allShadowTitles();
+		return self.lookup(name,value).filter(function(title) {
+			return titles.indexOf(title) !== -1;
+		});
+	};
+	this.wiki.eachTiddlerPlusShadows.byField = function(name,value) {
+		return self.lookup(name,value).slice(0);
+	};
 	this.wiki.eachShadowPlusTiddlers.byField = function(name,value) {
 		return self.lookup(name,value).slice(0);
 	};

--- a/core/modules/indexers/tag-indexer.js
+++ b/core/modules/indexers/tag-indexer.js
@@ -26,7 +26,7 @@ TagIndexer.prototype.addIndexMethods = function() {
 			return titles.indexOf(title) !== -1;
 		});
 	};
-	this.wiki.allShadowTitles.byTag = function(tag) {
+	this.wiki.eachShadow.byTag = function(tag) {
 		var titles = self.wiki.allShadowTitles();
 		return self.lookup(tag).filter(function(title) {
 			return titles.indexOf(title) !== -1;

--- a/core/modules/indexers/tag-indexer.js
+++ b/core/modules/indexers/tag-indexer.js
@@ -15,7 +15,30 @@ Indexes the tiddlers with each tag
 function TagIndexer(wiki) {
 	this.wiki = wiki;
 	this.index = null;
+	this.addIndexMethods();
 }
+
+TagIndexer.prototype.addIndexMethods = function() {
+	var self = this;
+	this.wiki.each.byTag = function(tag) {
+		var titles = self.wiki.allTitles();
+		return self.lookup(tag).filter(function(title) {
+			return titles.indexOf(title) !== -1;
+		});
+	};
+	this.wiki.allShadowTitles.byTag = function(tag) {
+		var titles = self.wiki.allShadowTitles();
+		return self.lookup(tag).filter(function(title) {
+			return titles.indexOf(title) !== -1;
+		});
+	};
+	this.wiki.eachTiddlerPlusShadows.byTag = function(tag) {
+		return self.lookup(tag).slice(0);
+	};
+	this.wiki.eachShadowPlusTiddlers.byTag = function(tag) {
+		return self.lookup(tag).slice(0);
+	};
+};
 
 /*
 Tear down and then rebuild the index as if all tiddlers have changed

--- a/core/modules/indexers/tag-indexer.js
+++ b/core/modules/indexers/tag-indexer.js
@@ -1,0 +1,108 @@
+/*\
+title: $:/core/modules/indexers/tag-indexer.js
+type: application/javascript
+module-type: indexer
+
+Indexes the tiddlers with each tag
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global modules: false */
+"use strict";
+
+function TagIndexer(wiki) {
+	this.wiki = wiki;
+	this.index = null;
+}
+
+/*
+Tear down and then rebuild the index as if all tiddlers have changed
+*/
+TagIndexer.prototype.rebuild = function() {
+	var self = this;
+	// Hashmap by tag of array of {isSorted:, titles:[]}
+	this.index = Object.create(null);
+	// Add all the tags
+	this.wiki.eachTiddlerPlusShadows(function(tiddler,title) {
+		$tw.utils.each(tiddler.fields.tags,function(tag) {
+			if(!self.index[tag]) {
+				self.index[tag] = {isSorted: false, titles: [title]};
+			} else {
+				self.index[tag].titles.push(title);
+			}
+		});		
+	});
+};
+
+/*
+Update the index in the light of a tiddler value changing; note that the title must be identical. (Renames are handled as a separate delete and create)
+oldTiddler: old tiddler value, or null for creation
+newTiddler: new tiddler value, or null for deletion
+*/
+TagIndexer.prototype.update = function(oldTiddler,newTiddler) {
+	// Don't update the index if it has yet to be built
+	if(this.index === null) {
+		return;
+	}
+	var self = this,
+		title = oldTiddler ? oldTiddler.fields.title : newTiddler.fields.title;
+	// Handle changes to the tags
+	var oldTiddlerTags = (oldTiddler ? (oldTiddler.fields.tags || []) : []),
+		newTiddlerTags = (newTiddler ? (newTiddler.fields.tags || []) : []);
+	$tw.utils.each(oldTiddlerTags,function(oldTag) {
+		if(newTiddlerTags.indexOf(oldTag) === -1) {
+			// Deleted tag
+			var indexRecord = self.index[oldTag],
+				pos = indexRecord.titles.indexOf(title);
+			if(pos !== -1) {
+				indexRecord.titles.splice(pos,1);
+			}
+		}
+	});
+	$tw.utils.each(newTiddlerTags,function(newTag) {
+		if(oldTiddlerTags.indexOf(newTag) === -1) {
+			// New tag
+			var indexRecord = self.index[newTag];
+			if(!indexRecord) {
+				self.index[newTag] = {isSorted: false, titles: [title]};
+			} else {
+				indexRecord.titles.push(title);
+				indexRecord.isSorted = false;
+			}
+		}
+	});
+	// Handle changes to the list field of tags
+	var oldTiddlerList = (oldTiddler ? (oldTiddler.fields.list || []) : []),
+		newTiddlerList = (newTiddler ? (newTiddler.fields.list || []) : []);
+	if(!$tw.utils.isArrayEqual(oldTiddlerList,newTiddlerList)) {
+		if(self.index[title]) {
+			self.index[title].isSorted = false;			
+		}
+	}
+};
+
+// Lookup the given tag returning an ordered list of tiddler titles
+TagIndexer.prototype.lookup = function(tag) {
+	// Update the index if it has yet to be built
+	if(this.index === null) {
+		this.rebuild();
+	}
+	var indexRecord = this.index[tag];
+	if(indexRecord) {
+		if(!indexRecord.isSorted) {
+			if(this.wiki.sortByList) {
+				indexRecord.titles = this.wiki.sortByList(indexRecord.titles,tag);
+			}			
+			indexRecord.isSorted = true;
+		}
+		return indexRecord.titles;
+	} else {
+		return [];
+	}
+};
+
+exports.TagIndexer = TagIndexer;
+
+})();

--- a/core/modules/startup/load-modules.js
+++ b/core/modules/startup/load-modules.js
@@ -27,6 +27,9 @@ exports.startup = function() {
 	$tw.Tiddler.fieldModules = $tw.modules.getModulesByTypeAsHashmap("tiddlerfield");
 	$tw.modules.applyMethods("tiddlermethod",$tw.Tiddler.prototype);
 	$tw.modules.applyMethods("wikimethod",$tw.Wiki.prototype);
+	$tw.utils.each($tw.modules.applyMethods("indexer"),function(Indexer,name) {
+		$tw.wiki.addIndexer(new Indexer($tw.wiki),name);
+	});
 	$tw.modules.applyMethods("tiddlerdeserializer",$tw.Wiki.tiddlerDeserializerModules);
 	$tw.macros = $tw.modules.getModulesByTypeAsHashmap("macro");
 	$tw.wiki.initParsers();

--- a/core/modules/startup/load-modules.js
+++ b/core/modules/startup/load-modules.js
@@ -27,9 +27,7 @@ exports.startup = function() {
 	$tw.Tiddler.fieldModules = $tw.modules.getModulesByTypeAsHashmap("tiddlerfield");
 	$tw.modules.applyMethods("tiddlermethod",$tw.Tiddler.prototype);
 	$tw.modules.applyMethods("wikimethod",$tw.Wiki.prototype);
-	$tw.utils.each($tw.modules.applyMethods("indexer"),function(Indexer,name) {
-		$tw.wiki.addIndexer(new Indexer($tw.wiki),name);
-	});
+	$tw.wiki.addIndexersToWiki();
 	$tw.modules.applyMethods("tiddlerdeserializer",$tw.Wiki.tiddlerDeserializerModules);
 	$tw.macros = $tw.modules.getModulesByTypeAsHashmap("macro");
 	$tw.wiki.initParsers();

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -28,6 +28,16 @@ var USER_NAME_TITLE = "$:/status/UserName",
 	TIMESTAMP_DISABLE_TITLE = "$:/config/TimestampDisable";
 
 /*
+Add available indexers to this wiki
+*/
+exports.addIndexersToWiki = function() {
+	var self = this;
+	$tw.utils.each($tw.modules.applyMethods("indexer"),function(Indexer,name) {
+		self.addIndexer(new Indexer(self),name);
+	});
+};
+
+/*
 Get the value of a text reference. Text references can have any of these forms:
 	<tiddlertitle>
 	<tiddlertitle>!!<fieldname>

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -478,45 +478,7 @@ exports.getOrphanTitles = function() {
 Retrieves a list of the tiddler titles that are tagged with a given tag
 */
 exports.getTiddlersWithTag = function(tag) {
-	var self = this;
-	return this.getGlobalCache("taglist-" + tag,function() {
-		var tagmap = self.getTagMap();
-		return self.sortByList(tagmap[tag],tag);
-	});
-};
-
-/*
-Get a hashmap by tag of arrays of tiddler titles
-*/
-exports.getTagMap = function() {
-	var self = this;
-	return this.getGlobalCache("tagmap",function() {
-		var tags = Object.create(null),
-			storeTags = function(tagArray,title) {
-				if(tagArray) {
-					for(var index=0; index<tagArray.length; index++) {
-						var tag = tagArray[index];
-						if($tw.utils.hop(tags,tag)) {
-							tags[tag].push(title);
-						} else {
-							tags[tag] = [title];
-						}
-					}
-				}
-			},
-			title, tiddler;
-		// Collect up all the tags
-		self.eachShadow(function(tiddler,title) {
-			if(!self.tiddlerExists(title)) {
-				tiddler = self.getTiddler(title);
-				storeTags(tiddler.fields.tags,title);
-			}
-		});
-		self.each(function(tiddler,title) {
-			storeTags(tiddler.fields.tags,title);
-		});
-		return tags;
-	});
+	return this.getIndexer("TagIndexer").lookup(tag);
 };
 
 /*

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -488,7 +488,52 @@ exports.getOrphanTitles = function() {
 Retrieves a list of the tiddler titles that are tagged with a given tag
 */
 exports.getTiddlersWithTag = function(tag) {
-	return this.getIndexer("TagIndexer").lookup(tag);
+	// Try to use the indexer
+	var self = this,
+		tagIndexer = this.getIndexer("TagIndexer"),
+		results = tagIndexer && tagIndexer.lookup(tag);
+	if(!results) {
+		// If not available, perform a manual scan
+		results = this.getGlobalCache("taglist-" + tag,function() {
+			var tagmap = self.getTagMap();
+			return self.sortByList(tagmap[tag],tag);
+		});
+	}
+	return results;
+};
+
+/*
+Get a hashmap by tag of arrays of tiddler titles
+*/
+exports.getTagMap = function() {
+	var self = this;
+	return this.getGlobalCache("tagmap",function() {
+		var tags = Object.create(null),
+			storeTags = function(tagArray,title) {
+				if(tagArray) {
+					for(var index=0; index<tagArray.length; index++) {
+						var tag = tagArray[index];
+						if($tw.utils.hop(tags,tag)) {
+							tags[tag].push(title);
+						} else {
+							tags[tag] = [title];
+						}
+					}
+				}
+			},
+			title, tiddler;
+		// Collect up all the tags
+		self.eachShadow(function(tiddler,title) {
+			if(!self.tiddlerExists(title)) {
+				tiddler = self.getTiddler(title);
+				storeTags(tiddler.fields.tags,title);
+			}
+		});
+		self.each(function(tiddler,title) {
+			storeTags(tiddler.fields.tags,title);
+		});
+		return tags;
+	});
 };
 
 /*

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -40,6 +40,7 @@ describe("Filter tests", function() {
 
 	describe("With all indexers", function() {
 		var wiki = setupWiki();
+		wiki.getIndexer("FieldIndexer").setMaxIndexedValueLength(8); // Note that JoeBloggs is 9, and JohnDoe is 7
 		runTests(wiki);
 	});
 
@@ -144,6 +145,12 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[field:modifier[JoeBloggs]]").join(",")).toBe("TiddlerOne");
 		expect(wiki.filterTiddlers("[!field:modifier[JoeBloggs]]").join(",")).toBe("$:/TiddlerTwo,Tiddler Three,a fourth tiddler,one");
 		expect(wiki.filterTiddlers("[!is[system]!field:modifier[JoeBloggs]]").join(",")).toBe("Tiddler Three,a fourth tiddler,one");
+		expect(wiki.filterTiddlers("[modifier[JohnDoe]]").join(",")).toBe("$:/TiddlerTwo,Tiddler Three,a fourth tiddler,one");
+		expect(wiki.filterTiddlers("[!modifier[JohnDoe]]").join(",")).toBe("TiddlerOne");
+		expect(wiki.filterTiddlers("[!is[system]!modifier[JohnDoe]]").join(",")).toBe("TiddlerOne");
+		expect(wiki.filterTiddlers("[field:modifier[JohnDoe]]").join(",")).toBe("$:/TiddlerTwo,Tiddler Three,a fourth tiddler,one");
+		expect(wiki.filterTiddlers("[!field:modifier[JohnDoe]]").join(",")).toBe("TiddlerOne");
+		expect(wiki.filterTiddlers("[!is[system]!field:modifier[JohnDoe]]").join(",")).toBe("TiddlerOne");
 	});
 
 	it("should handle the regexp operator", function() {
@@ -355,7 +362,7 @@ function runTests(wiki) {
 			type: "widget",
 			children: [{type: "widget", children: []}]
 		},{
-			wiki: $tw.wiki,
+			wiki: wiki,
 			document: $tw.document
 		});
 		rootWidget.makeChildWidgets();

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -33,9 +33,19 @@ describe("Filter tests", function() {
 		);
 	});
 
+	describe("With no indexers", function() {
+		var wiki = setupWiki({enableIndexers: []});
+		runTests(wiki);
+	});
 
+	describe("With all indexers", function() {
+		var wiki = setupWiki();
+		runTests(wiki);
+	});
+
+function setupWiki(wikiOptions) {
 	// Create a wiki
-	var wiki = new $tw.Wiki({
+	var wiki = new $tw.Wiki($tw.utils.extend({
 		shadowTiddlers: {
 			"$:/TiddlerFive": {
 				tiddler: new $tw.Tiddler({title: "$:/TiddlerFive",
@@ -64,8 +74,8 @@ describe("Filter tests", function() {
 				})
 			}
 		}
-	});
-
+	},
+	wikiOptions));
 	// Add a few  tiddlers
 	wiki.addTiddler({
 		title: "TiddlerOne",
@@ -99,8 +109,11 @@ describe("Filter tests", function() {
 		list: "[[Tiddler Three]] [[TiddlerOne]]",
 		empty: "",
 		modifier: "JohnDoe"});
+	return wiki;
+}
 
-	// Our tests
+// Our tests
+function runTests(wiki) {
 
 	it("should handle the ~ prefix", function() {
 		expect(wiki.filterTiddlers("[modifier[JoeBloggs]] ~[[No such tiddler]]").join(",")).toBe("TiddlerOne");
@@ -387,6 +400,8 @@ describe("Filter tests", function() {
 		expect(wiki.filterTiddlers("1 2 3 4 +[max[2]]").join(",")).toBe("2,2,3,4");
 		expect(wiki.filterTiddlers("1 2 3 4 +[min[2]]").join(",")).toBe("1,2,2,2");
 	});
+
+}
 
 });
 

--- a/editions/test/tiddlers/tests/test-tags.js
+++ b/editions/test/tiddlers/tests/test-tags.js
@@ -14,8 +14,21 @@ Tests the tagging mechanism.
 
 describe("Tag tests", function() {
 
+describe("With no indexers", function() {
+	var wikiOptions = {enableIndexers: []},
+		wiki = setupWiki(wikiOptions);
+	runTests(wiki,wikiOptions);
+});
+
+describe("With all indexers", function() {
+	var wikiOptions = {enableIndexers: []},
+		wiki = setupWiki();
+	runTests(wiki,wikiOptions);
+});
+
+function setupWiki(wikiOptions) {
 	// Create a wiki
-	var wiki = new $tw.Wiki();
+	var wiki = new $tw.Wiki(wikiOptions);
 
 	// Add a few  tiddlers
 	wiki.addTiddler({
@@ -79,8 +92,11 @@ describe("Tag tests", function() {
 		text: "Another tiddler",
 		tags: ["TiddlerSeventh"],
 		"list-after": "Tiddler Three"});
+	return wiki;
+}
 
 	// Our tests
+function runTests(wiki,wikiOptions) {
 
 	it("should handle custom tag ordering", function() {
 		expect(wiki.filterTiddlers("[tag[TiddlerSeventh]]").join(",")).toBe("Tiddler10,TiddlerOne,Tiddler Three,Tiddler11,Tiddler9,a fourth tiddler");
@@ -88,7 +104,7 @@ describe("Tag tests", function() {
 
 	// Tests for issue (#3296)
 	it("should apply tag ordering in order of dependency", function () {
-		var wiki = new $tw.Wiki();
+		var wiki = new $tw.Wiki(wikiOptions);
 
 		wiki.addTiddler({ title: "A", text: "", tags: "sortTag", "list-after": "B"});
 		wiki.addTiddler({ title: "B", text: "", tags: "sortTag", "list-after": "C"});
@@ -98,7 +114,7 @@ describe("Tag tests", function() {
 	});
 
 	it("should handle self-referencing dependency without looping infinitely", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = new $tw.Wiki(wikiOptions);
 
 		wiki.addTiddler({ title: "A", text: "", tags: "sortTag"});
 		wiki.addTiddler({ title: "B", text: "", tags: "sortTag", "list-after": "B"});
@@ -108,7 +124,7 @@ describe("Tag tests", function() {
 	});
 
 	it("should handle empty list-after ordering", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = new $tw.Wiki(wikiOptions);
 
 		wiki.addTiddler({ title: "A", text: "", tags: "sortTag", "list-after": ""});
 		wiki.addTiddler({ title: "B", text: "", tags: "sortTag"});
@@ -121,7 +137,7 @@ describe("Tag tests", function() {
 	// with list-after/before, we need to make sure we don't accidentally
 	// handle that external tiddler, or that reference.
 	it("should gracefully handle dependencies that aren't in the tag list", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = new $tw.Wiki(wikiOptions);
 
 		wiki.addTiddler({ title: "A", text: "", tags: "sortTag"});
 		wiki.addTiddler({ title: "B", text: "", tags: "sortTag", "list-after": "Z"});
@@ -132,13 +148,16 @@ describe("Tag tests", function() {
 	});
 
 	it("should handle javascript-specific titles", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = new $tw.Wiki(wikiOptions);
 
 		wiki.addTiddler({ title: "A", text: "", tags: "sortTag"});
 		wiki.addTiddler({ title: "__proto__", text: "", tags: "sortTag", "list-before": ""});
 
 		expect(wiki.filterTiddlers("[tag[sortTag]]").join(',')).toBe("__proto__,A");
 	});
+
+}
+
 });
 
 })();


### PR DESCRIPTION
When it is running, TiddlyWiki stores tiddlers in pretty much the simplest possible way: as a JavaScript [object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) where the properties are the fields, and the values of those properties are the values of the fields. In general, operations such as finding all the tiddlers with a particular tag require scanning through all the tiddlers in the store.

The implementation of the tiddler store has always been carefully encapsulated to permit it to be changed without disturbing the rest of the core. In particular, it was expected that some form of indexing would be required to get reasonable performance with large numbers of tiddlers.

As it's turned out, the optimisations that have been implemented so far have all been small tweaks that haven't changed the overall logic:

* Every time there's a tag lookup we cache the results (although the cache is cleared whenever any tiddler is modified, so this optimisation doesn't help much if tiddlers are changing rapidly)
* We cache the list of tiddler titles because `Object.keys()` can be slow in some situations

Over the last two years @Jermolene's work at https://github.com/Federatial has involved working with some very large wikis (up to 80MB with 60,000 tiddlers). Performance has been reasonable for simple operations but analysing the CPU usage shows that filter operations take a substantial amount of the overall time to refresh the page (the recent work on performance instrumentation in e8d1fbba6c109ccbeaedc1b34e47677c0ada7529 makes it much easier to make these measurements).

So, I've started exploring adding proper indexes to the store: the idea is to maintain, say, an index of which tiddler fields have which value, so that one can instantly look them up.

There are several parts to this work:

* Establishing a new "indexer" module type that handles creating, updating and utilising particular indexes
* Updating the wiki store to update these indexes whenever a tiddler value changes. This is done by patching the store to invoke a set of "indexer" objects for each tiddler modification
* Utilising the indexes when performing lookups. This is done by adding special indexed methods to the "source" tiddler iterator
* Thinking about efficiency (for example, the field indexer included in the initial commit only indexes fields when a search has been performed on them)

Most of those issues are addressed in the initial version of the code, but there are several things to do:

* The store object in boot.js currently "knows" about individual indexers, whereas it shouldn't have any prior knowledge of any of them
* The field indexer is incomplete (it only adds its indexed method to `wiki.eachShadowPlusTiddlers`, and not to the other tiddler iterators

