### PR TITLE
Update Saving on TiddlySpot.tid

### DIFF
--- a/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
@@ -8,9 +8,17 @@ method: save
 caption: TiddlySpot
 description: Free online service for hosting TiddlyWiki files
 
-TiddlySpot is a free hosting service for TiddlyWiki documents from Simon and Daniel Baird. The easiest way to get started is to sign up for a new wiki at http://tiddlyspot.com - by default you'll get the latest release of TiddlyWiki Classic.
+[[TiddlySpot|http://tiddlyspot.com]] is a free hosting service for TiddlyWiki documents from Simon Baird and Daniel Baird.
 
-You can upload an existing TiddlyWiki5 document from your local disc to TiddlySpot by following these steps:
+! Setting up a TiddlyWiki on TiddlySpot
+To set up a [[TiddlyWiki Classic|TiddlyWikiClassic]], you merely create a new wiki at http://tiddlyspot.com
+
+!!TiddlyWiki5 on TiddlySpot
+~TiddlyWiki5 also functions well on ~TiddlySpot but this version is not offered directly in the TiddlySpot set-up.
+
+The simplest way to create a new ~TiddlySpot with ~TiddlyWiki5 is probably through the community created site http://tiddlywiki5.tiddlyspot.com
+
+Alternatively, you can upload an existing ~TiddlyWiki5 document from your local disc to ~TiddlySpot by following these steps:
 
 # Sign up for a new wiki at http://tiddlyspot.com/, and remember the wiki name and password
 # Open your locally stored TiddlyWiki document in your browser


### PR DESCRIPTION
Included mention of community created (i.e created by me) "shortcut" to set up new TW5 on TS.

I have previously hesitated to propose this for the docs because cousins Baird might prefer that users go to their front page and not via an iframe as in the shortcut. I did contact them with this question a few years back but heard nothing back. BUT I figure that because they do have the service running they do want people to use it and my "shortcut" should definitely support this. Without the shortcut, it is a bit messy to get a TW5 onto TS. E.g, prof Steve Schneider rhetorically wondered on how he ever managed to use TS with his students before I created this.