### PR TITLE
Update ListWidget.tid

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/ListWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ListWidget.tid
@@ -75,7 +75,7 @@ The content of the `<$list>` widget is an optional template to use for rendering
 |template |The title of a template tiddler for transcluding each tiddler in the list. When no template is specified, the body of the ListWidget serves as the item template. With no body, a simple link to the tiddler is returned. |
 |editTemplate |An alternative template to use for [[DraftTiddlers|DraftMechanism]] in edit mode |
 |variable |The name for a [[variable|Variables]] in which the title of each listed tiddler is stored. Defaults to ''currentTiddler'' |
-|emptyMessage |Message to be displayed when the list is empty |
+|emptyMessage |Message to be displayed when the list is empty. Commands in the widget body are left unevaluated. |
 |storyview |Optional name of module responsible for animating/processing the list |
 |history |The title of the tiddler containing the navigation history |
 


### PR DESCRIPTION
Clarification of emptyMessage attribute, i.e that it is not possible to further process the empty message within the widget. For example, this does not work to get the content of the Alert tiddler:

```
<$list filter="" emptyMessage=Alert>
<$transclude/>
</$list>
```