### PR TITLE
Better examples for mathematics operators

### DIFF
--- a/editions/tw5.com/tiddlers/filters/Mathematics Operators.tid
+++ b/editions/tw5.com/tiddlers/filters/Mathematics Operators.tid
@@ -17,15 +17,15 @@ The mathematics operators interpret their arguments as numbers according to the 
 The mathematics operators take three different forms:
 
 * ''Unary operators'' apply an operation to each number in the input list (e.g. negate, truncate, sign)
-** <<.inline-operator-example "1 2 3 4 +[negate[]]">>
-** <<.inline-operator-example "1.2 2.4 3.6 4.8 +[trunc[]]">>
-** <<.inline-operator-example "1.2 2.4 3.6 4.8 +[round[]]">>
+** <<.inline-operator-example "=1 =2 =3 =4 +[negate[]]">>
+** <<.inline-operator-example "=1.2 =2.4 =3.6 =4.8 +[trunc[]]">>
+** <<.inline-operator-example "=1.2 =2.4 =3.6 =4.8 +[round[]]">>
 * ''Binary operators'' apply an operation and operand to each number in the input list (e.g. add, multiply, remainder) 
-** <<.inline-operator-example "1 2 3 4 +[add[3]]">>
-** <<.inline-operator-example "1 2 3 4 +[multiply[8]]">>
+** <<.inline-operator-example "=1 =2 =3 =4 +[add[3]]">>
+** <<.inline-operator-example "=1 =2 =3 =4 +[multiply[8]]">>
 * ''Reducing operators'' apply an operation to all of the numbers in the input list, returning a single result (e.g. sum, product)
-** <<.inline-operator-example "1 2 3 4 +[sum[]]">>
-** <<.inline-operator-example "1 2 3 4 +[product[]]">>
+** <<.inline-operator-example "=1 =2 =3 =4 +[sum[]]">>
+** <<.inline-operator-example "=1 =2 =3 =4 +[product[]]">>
 
 Operators can be combined:
 


### PR DESCRIPTION
Include `=` before each number in the Mathematics Operators examples, so that people get used to seeing that in math examples where dupes are likely.

Only the Mathematics Operators tiddler really needed to be changed; the example tiddlers for individual operators were already using `=`.

Fixes #3979.