### PR TITLE
Update StartupActions.tid

### DIFF
--- a/editions/tw5.com/tiddlers/features/StartupActions.tid
+++ b/editions/tw5.com/tiddlers/features/StartupActions.tid
@@ -10,7 +10,7 @@ During startup, TiddlyWiki executes any ActionWidgets found in tiddlers with the
 * <<tag "$:/tags/StartupAction/Browser">> (only executed when running in the browser)
 * <<tag "$:/tags/StartupAction/Node">> (only executed when running under Node.js)
 
-Startup actions are useful for customising TiddlyWiki according to environmental factors such as the screen size. For example, the following action widgets when placed in a tiddler tagged <<tag "$:/tags/StartupAction/Browser">> will cause the sidebar to be hidden by default when the screen width is less than 1000 pixels:
+Startup actions are useful for customising TiddlyWiki according to environmental factors such as the screen size. For example, the following action widgets when placed in a tiddler tagged `$:/tags/StartupAction/Browser` will cause the sidebar to be hidden by default when the screen width is less than 1000 pixels:
 
 ```
 <$reveal type="lt" state="$:/info/browser/screen/width" text="3000">


### PR DESCRIPTION
Regarding the bulleted tag pills; they should probably also be changed into text but I see value in keeping them as pills for the sake of being able to easily peek at what they tag. We should probably have a section under Ctrlpanel>Settings where any startupaction-tiddlers are listed but since we don't yet, then the mentioned tag pills could perhaps remain.... except for the one in the PR.