### PR TITLE
Fix sentencecase operator, add titlecase operator

### DIFF
--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -30,6 +30,10 @@ exports.sentencecase = makeStringBinaryOperator(
 	function(a) {return [$tw.utils.toSentenceCase(a)];}
 );
 
+exports.titlecase = makeStringBinaryOperator(
+	function(a) {return [$tw.utils.toTitleCase(a)];}
+);
+
 exports.trim = makeStringBinaryOperator(
 	function(a) {return [$tw.utils.trim(a)];}
 );

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -93,12 +93,19 @@ exports.trim = function(str) {
 };
 
 /*
-Convert a string to sentence case (ie capitalise each initial letter)
+Convert a string to sentence case (ie capitalise first letter)
 */
 exports.toSentenceCase = function(str) {
-  return (str || "").toLowerCase().replace(/(^|\s)\S/g, function(c) {return c.toUpperCase();});
+	return (str || "").replace(/^\S/, function(c) {return c.toUpperCase();});
 }
 
+/*
+Convert a string to title case (ie capitalise each initial letter)
+*/
+exports.toTitleCase = function(str) {
+	return (str || "").replace(/(^|\s)\S/g, function(c) {return c.toUpperCase();});
+}
+	
 /*
 Find the line break preceding a given position in a string
 Returns position immediately after that line break, or the start of the string

--- a/editions/tw5.com/tiddlers/filters/examples/sentencecase Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/sentencecase Operator (Examples).tid
@@ -1,8 +1,10 @@
 created: 20190619110741485
-modified: 20190619110812080
+modified: 20190620140353983
 tags: [[uppercase Operator]] [[Operator Examples]]
 title: sentencecase Operator (Examples)
 type: text/vnd.tiddlywiki
 
 <<.operator-example 1 "[[abc def ghi jkl]sentencecase[]]">>
-<<.operator-example 2 "[tag[HelloThere]sentencecase[]]">>
+<<.operator-example 2 "[[abc deF gHi jKL]sentencecase[]]">>
+<<.operator-example 3 "[[abc deF gHi jKL]lowercase[]sentencecase[]]">>
+<<.operator-example 4 "[tag[HelloThere]sentencecase[]]">>

--- a/editions/tw5.com/tiddlers/filters/examples/titlecase Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/titlecase Operator (Examples).tid
@@ -1,0 +1,10 @@
+created: 20190620140005348
+modified: 20190620140412655
+tags: [[uppercase Operator]] [[Operator Examples]]
+title: sentencecase Operator (Examples)
+type: text/vnd.tiddlywiki
+
+<<.operator-example 1 "[[abc def ghi jkl]titlecase[]]">>
+<<.operator-example 2 "[[abc deF gHi jKL]titlecase[]]">>
+<<.operator-example 3 "[[abc deF gHi jKL]lowercase[]titlecase[]]">>
+<<.operator-example 4 "[tag[HelloThere]titlecase[]]">>

--- a/editions/tw5.com/tiddlers/filters/sentencecase Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/sentencecase Operator.tid
@@ -2,14 +2,16 @@ caption: sentencecase
 created: 20190619110607457
 modified: 20190619110736016
 op-input: a [[selection of titles|Title Selection]]
-op-output: the input titles with each word capitalised
-op-purpose: returns each item in the list capitalised
+op-output: the input titles with each first letter capitalised
+op-purpose: returns each item in the list with the first letter capitalised
 tags: [[Filter Operators]]
 title: sentencecase Operator
 type: text/vnd.tiddlywiki
 
 <<.from-version "5.1.20">>
 
-See also [[lowercase Operator]], [[uppercase Operator]].
+See also [[lowercase Operator]], [[uppercase Operator]], [[titlecase Operator]].
+
+<<.tip " This operator does not change anything except the first letter of each title, so `[[aBcD eFgH]]` would become `[[ABcD eFgH]]`. If you want `[[Abcd efgh]]`, then use a filter like `[lowercase[]sentencecase[]]`.">>
 
 <<.operator-examples "sentencecase">>

--- a/editions/tw5.com/tiddlers/filters/titlecase Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/titlecase Operator.tid
@@ -1,0 +1,17 @@
+caption: titlecase
+created: 20190620135008529
+modified: 20190620135008529
+op-input: a [[selection of titles|Title Selection]]
+op-output: the input titles with each word capitalised
+op-purpose: returns each item in the list with each word capitalised
+tags: [[Filter Operators]]
+title: titlecase Operator
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.20">>
+
+See also [[lowercase Operator]], [[uppercase Operator]], [[sentencecase Operator]].
+
+<<.tip " This operator does not change anything except the first letter of each word, so `[[aBcD eFgH]]` would become `[[ABcD EFgH]]`. If you want `[[Abcd Efgh]]`, then use a filter like `[lowercase[]titlecase[]]`.">>
+
+<<.operator-examples "titlecase">>


### PR DESCRIPTION
This would fix #4003 by changing the `sentencecase` operator to work how I (and others, judging from the upvotes on that issue) would expect it to work. I've also added a `titlecase` operator that capitalizes the first letter of every word in each title (the way `sentencecase` was implemented before this PR) because that's also a very useful operation in some cases.