### PR TITLE
Fix examples for sentencecase and titlecase

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/sentencecase Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/sentencecase Operator (Examples).tid
@@ -1,6 +1,6 @@
 created: 20190619110741485
 modified: 20190620140353983
-tags: [[uppercase Operator]] [[Operator Examples]]
+tags: [[sentencecase Operator]] [[Operator Examples]]
 title: sentencecase Operator (Examples)
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/filters/examples/titlecase Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/titlecase Operator (Examples).tid
@@ -1,7 +1,7 @@
 created: 20190620140005348
 modified: 20190620140412655
-tags: [[uppercase Operator]] [[Operator Examples]]
-title: sentencecase Operator (Examples)
+tags: [[titlecase Operator]] [[Operator Examples]]
+title: titlecase Operator (Examples)
 type: text/vnd.tiddlywiki
 
 <<.operator-example 1 "[[abc def ghi jkl]titlecase[]]">>


### PR DESCRIPTION
This will fix #4008. The example tiddlers for titlecase and sentencecase both had the title "sentencecase Operator (Example)", so the wiki was confused and was linking to the wrong one. While I was in there, I fixed their tags as well.