### PR TITLE
Fix th-renaming-tiddler (see #4023)

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -601,9 +601,7 @@ NavigatorWidget.prototype.handleRenameTiddlerEvent = function(event) {
 	var paramObject = event.paramObject || {},
 		from = paramObject.from || event.tiddlerTitle,
 		to = paramObject.to;
-	var oldTiddler = this.getTiddler(from),
-		newTiddler = new $tw.Tiddler(oldTiddler,{title: to},this.getModificationFields());
-	$tw.wiki.renameTiddler(oldTiddler,newTiddler);
+	$tw.wiki.renameTiddler(from,to);
 };
 
 exports.navigator = NavigatorWidget;

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -598,11 +598,12 @@ NavigatorWidget.prototype.handleUnfoldAllTiddlersEvent = function(event) {
 };
 
 NavigatorWidget.prototype.handleRenameTiddlerEvent = function(event) {
-	event = $tw.hooks.invokeHook("th-renaming-tiddler", event);
 	var paramObject = event.paramObject || {},
 		from = paramObject.from || event.tiddlerTitle,
 		to = paramObject.to;
-	$tw.wiki.renameTiddler(from,to);
+	var oldTiddler = this.getTiddler(from),
+		newTiddler = new $tw.Tiddler(oldTiddler,{title: to},this.getModificationFields());
+	$tw.wiki.renameTiddler(oldTiddler,newTiddler);
 };
 
 exports.navigator = NavigatorWidget;


### PR DESCRIPTION
This removes the th-renaming-tiddler hook added in #3206 in favour of the version added in 2397f0a.

As discussed in #4023 the th-renaming-tiddler hook usage is inconsistent.
The invocation added in #3206 is redundant because it is called in the renameTiddler function.