### PR TITLE
make stamp-button optionally wrap selection

### DIFF
--- a/core/ui/EditorToolbar/stamp-dropdown.tid
+++ b/core/ui/EditorToolbar/stamp-dropdown.tid
@@ -3,11 +3,27 @@ title: $:/core/ui/EditorToolbar/stamp-dropdown
 \define toolbar-button-stamp-inner()
 <$button tag="a">
 
+<$list filter="[[$(snippetTitle)$]addsuffix[/prefix]is[missing]removesuffix[/prefix]addsuffix[/suffix]is[missing]]">
+
 <$action-sendmessage
 	$message="tm-edit-text-operation"
 	$param="replace-selection"
 	text={{$(snippetTitle)$}}
 />
+
+</$list>
+
+
+<$list filter="[[$(snippetTitle)$]addsuffix[/prefix]is[missing]removesuffix[/prefix]addsuffix[/suffix]!is[missing]] [[$(snippetTitle)$]addsuffix[/prefix]!is[missing]removesuffix[/prefix]addsuffix[/suffix]is[missing]] [[$(snippetTitle)$]addsuffix[/prefix]!is[missing]removesuffix[/prefix]addsuffix[/suffix]!is[missing]]">
+
+<$action-sendmessage
+	$message="tm-edit-text-operation"
+	$param="wrap-selection"
+	prefix={{{ [[$(snippetTitle)$]addsuffix[/prefix]get[text]] }}}
+suffix={{{ [[$(snippetTitle)$]addsuffix[/suffix]get[text]] }}}
+/>
+
+</$list>
 
 <$action-deletetiddler
 	$tiddler=<<dropdown-state>>

--- a/editions/tw5.com/tiddlers/howtos/Using Stamp.tid
+++ b/editions/tw5.com/tiddlers/howtos/Using Stamp.tid
@@ -9,8 +9,20 @@ You can insert preconfigured snippets of text to use stamp from toolbar. Click '
 
 ! Create a snippet
 # Click ''stamp'' ({{$:/core/images/stamp}})
-# Create a snippet tiddler to use "//Add your own//" menu
-# Type some text of snippet for the tiddler, and caption for the name as shown in menu
+# Create a snippet tiddler through the "//Add your own//" menu entry
+# Type some text as snippet for the tiddler, add a caption for the name as shown in the menu
 # Click the {{$:/core/images/done-button}} ''ok'' button
 
-''Tip:'' You can also create a snippet tiddler using the ''new tiddler'' {{$:/core/images/new-button}} button in the sidebar, and add tag ''~$:/tags/TextEditor/Snippet''
+<<.tip """''Tip:'' You can also create a snippet tiddler using the ''new tiddler'' {{$:/core/images/new-button}} button in the sidebar, and add tag ''~$:/tags/TextEditor/Snippet''""">>
+
+
+!!<<.from-version "5.1.20">> Adding a prefix and/or suffix to a selection
+
+# Click ''stamp'' ({{$:/core/images/stamp}})
+# Create a snippet tiddler through the "//Add your own//" menu entry
+# Add a caption for the name as shown in the menu
+# Create a tiddler with the same title but add the suffix `/prefix`
+# Insert the prefix in its text field
+# Create a tiddler with the same title but add the suffix `/suffix`
+# Insert the suffix in its text field
+# Click the {{$:/core/images/done-button}} ''ok'' button


### PR DESCRIPTION
This PR makes the stamp button wrap the selection if one of the tiddlers titled like the stamp tiddler but suffixed with either `/prefix` or `/suffix` or `both` exist

if none of both tiddlers exist it works the standard way