### PR TITLE
katex dropdown: add description hint

### DIFF
--- a/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown.tid
+++ b/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown.tid
@@ -36,6 +36,7 @@ title: $:/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown
 	$message="tm-new-tiddler"
 	tags="$:/tags/KaTeX/Snippet"
 	text="""$$snippet$$"""
+	description="description shown in dropdown"
 />
 
 <$action-deletetiddler

--- a/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown.tid
+++ b/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown.tid
@@ -36,7 +36,7 @@ title: $:/plugins/tiddlywiki/katex/ui/EditorToolbar/katex-dropdown
 	$message="tm-new-tiddler"
 	tags="$:/tags/KaTeX/Snippet"
 	text="""$$snippet$$"""
-	description="description shown in dropdown"
+	caption="description shown in dropdown"
 />
 
 <$action-deletetiddler


### PR DESCRIPTION
this creates a new snippet with prefilled `description` field as a hint