### PR TITLE
include wiki in options sent to generateTiddlerFilePath

### DIFF
--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -225,7 +225,8 @@ exports.generateTiddlerFileInfo = function(tiddler,options) {
 	fileInfo.filepath = $tw.utils.generateTiddlerFilepath(tiddler.fields.title,{
 		extension: contentTypeInfo.extension,
 		directory: options.directory,
-		pathFilters: options.pathFilters
+		pathFilters: options.pathFilters,
+		wiki: options.wiki
 	});
 	return fileInfo;
 };


### PR DESCRIPTION
This adds options.wiki to the object sent to the generateTiddlerFilePath

The function generateTiddlerFilePath can take a wiki in the options object, but generateTiddlerFileInfo doesn't pass the wiki to it.

This is needed by Bob to save tiddlers in multiple wikis.