### PR TITLE
outsource tags, searchresults, type and fields filters

### DIFF
--- a/core/ui/DefaultSearchResultList.tid
+++ b/core/ui/DefaultSearchResultList.tid
@@ -5,11 +5,11 @@ caption: {{$:/language/Search/DefaultResults/Caption}}
 \define searchResultList()
 //<small>{{$:/language/Search/Matches/Title}}</small>//
 
-<$list filter="[!is[system]search:title{$(searchTiddler)$}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+<$list filter="[subfilter{$:/core/filters/SearchResults/Matches}]" template="$:/core/ui/ListItemTemplate"/>
 
 //<small>{{$:/language/Search/Matches/All}}</small>//
 
-<$list filter="[!is[system]search{$(searchTiddler)$}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+<$list filter="[subfilter{$:/core/filters/SearchResults/AllMatches}]" template="$:/core/ui/ListItemTemplate"/>
 
 \end
 <<searchResultList>>

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -70,7 +70,7 @@ $value={{$:/temp/newfieldvalue}}/>
 <div class="tc-dropdown-item">
 <<lingo Fields/Add/Dropdown/User>>
 </div>
-<$list filter="[!is[shadow]!is[system]fields[]search:title{$:/temp/newfieldname}sort[]] -created -creator -draft.of -draft.title -modified -modifier -tags -text -title -type"  variable="currentField">
+<$list filter="[subfilter{$:/core/filters/Fields}]"  variable="currentField">
 <$link to=<<currentField>>>
 <<currentField>>
 </$link>
@@ -78,7 +78,7 @@ $value={{$:/temp/newfieldvalue}}/>
 <div class="tc-dropdown-item">
 <<lingo Fields/Add/Dropdown/System>>
 </div>
-<$list filter="[fields[]search:title{$:/temp/newfieldname}sort[]] -[!is[shadow]!is[system]fields[]]" variable="currentField">
+<$list filter="[subfilter{$:/core/filters/Fields/System}]" variable="currentField">
 <$link to=<<currentField>>>
 <<currentField>>
 </$link>

--- a/core/ui/EditTemplate/type.tid
+++ b/core/ui/EditTemplate/type.tid
@@ -11,11 +11,11 @@ tags: $:/tags/EditTemplate
 <$reveal state=<<qualify "$:/state/popup/type-dropdown">> type="nomatch" text="" default="">
 <div class="tc-block-dropdown tc-edit-type-dropdown">
 <$linkcatcher to="!!type">
-<$list filter='[all[shadows+tiddlers]prefix[$:/language/Docs/Types/]each[group]sort[group-sort]]'>
+<$list filter='[subfilter{$:/core/filters/Types/GroupSort}]'>
 <div class="tc-dropdown-item">
 <$text text={{!!group}}/>
 </div>
-<$list filter="[all[shadows+tiddlers]prefix[$:/language/Docs/Types/]group{!!group}] +[sort[description]]"><$link to={{!!name}}><$view field="description"/> (<$view field="name"/>)</$link>
+<$list filter="[subfilter{$:/core/filters/Types}]"><$link to={{!!name}}><$view field="description"/> (<$view field="name"/>)</$link>
 </$list>
 </$list>
 </$linkcatcher>

--- a/core/wiki/Filters.multids
+++ b/core/wiki/Filters.multids
@@ -1,6 +1,9 @@
 title: $:/core/filters/
 
+Fields: [!is[shadow]!is[system]fields[]search:title{$:/temp/newfieldname}sort[]] -created -creator -draft.of -draft.title -modified -modifier -tags -text -title -type
+Fields/System: [fields[]search:title{$:/temp/newfieldname}sort[]] -[!is[shadow]!is[system]fields[]]
 SearchResults/AllMatches: [!is[system]search{$(searchTiddler)$}sort[title]limit[250]]
 SearchResults/Matches: [!is[system]search:title{$(searchTiddler)$}sort[title]limit[250]]
 SystemTags: [tags[]is[system]search:title{$:/temp/NewTagName}sort[]]
 Tags: [tags[]!is[system]search:title{$:/temp/NewTagName}sort[]]
+Types: [all[shadows+tiddlers]prefix[$:/language/Docs/Types/]each[group]sort[group-sort]]

--- a/core/wiki/Filters.multids
+++ b/core/wiki/Filters.multids
@@ -1,0 +1,6 @@
+title: $:/core/filters/
+
+SearchResults/AllMatches: [!is[system]search{$(searchTiddler)$}sort[title]limit[250]]
+SearchResults/Matches: [!is[system]search:title{$(searchTiddler)$}sort[title]limit[250]]
+SystemTags: [tags[]is[system]search:title{$:/temp/NewTagName}sort[]]
+Tags: [tags[]!is[system]search:title{$:/temp/NewTagName}sort[]]

--- a/core/wiki/Filters.multids
+++ b/core/wiki/Filters.multids
@@ -6,4 +6,5 @@ SearchResults/AllMatches: [!is[system]search{$(searchTiddler)$}sort[title]limit[
 SearchResults/Matches: [!is[system]search:title{$(searchTiddler)$}sort[title]limit[250]]
 SystemTags: [tags[]is[system]search:title{$:/temp/NewTagName}sort[]]
 Tags: [tags[]!is[system]search:title{$:/temp/NewTagName}sort[]]
-Types: [all[shadows+tiddlers]prefix[$:/language/Docs/Types/]each[group]sort[group-sort]]
+Types: [all[shadows+tiddlers]prefix[$:/language/Docs/Types/]group{!!group}] +[sort[description]]
+Types/GroupSort: [all[shadows+tiddlers]prefix[$:/language/Docs/Types/]each[group]sort[group-sort]]

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -40,12 +40,12 @@ $actions$
 <$reveal state=<<qualify "$:/state/popup/tags-auto-complete">> type="nomatch" text="" default="">
 <div class="tc-block-dropdown">
 <$list filter="[{$:/temp/NewTagName}minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
-<$list filter="[tags[]!is[system]search:title{$:/temp/NewTagName}sort[]]" variable="tag">
+<$list filter="[subfilter{$:/core/filters/Tags}]" variable="tag">
 <<tag-button>>
 </$list></$list>
 <hr>
 <$list filter="[{$:/temp/NewTagName}minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
-<$list filter="[tags[]is[system]search:title{$:/temp/NewTagName}sort[]]" variable="tag">
+<$list filter="[subfilter{$:/core/filters/SystemTags}]" variable="tag">
 <<tag-button>>
 </$list></$list>
 </div>


### PR DESCRIPTION
this PR creates $:/core/filters/... tiddlers that store the filters used in the tag-picker and search results

the tag-picker and the search-results make use of the new `subfilter` operator