### PR TITLE
More Plugins - Button: use primary color

### DIFF
--- a/core/ui/ControlPanel/Plugins/AddPlugins.tid
+++ b/core/ui/ControlPanel/Plugins/AddPlugins.tid
@@ -2,6 +2,6 @@ title: $:/core/ui/ControlPanel/Plugins/AddPlugins
 
 \define lingo-base() $:/language/ControlPanel/Plugins/
 
-<$button message="tm-modal" param="$:/core/ui/ControlPanel/Modals/AddPlugins" tooltip={{$:/language/ControlPanel/Plugins/Add/Hint}} class="tc-btn-big-green tc-more-plugins-btn">
+<$button message="tm-modal" param="$:/core/ui/ControlPanel/Modals/AddPlugins" tooltip={{$:/language/ControlPanel/Plugins/Add/Hint}} class="tc-btn-big-green tc-primary-btn">
 {{$:/core/images/download-button}} <<lingo Add/Caption>>
 </$button>

--- a/core/ui/ControlPanel/Plugins/AddPlugins.tid
+++ b/core/ui/ControlPanel/Plugins/AddPlugins.tid
@@ -2,6 +2,6 @@ title: $:/core/ui/ControlPanel/Plugins/AddPlugins
 
 \define lingo-base() $:/language/ControlPanel/Plugins/
 
-<$button message="tm-modal" param="$:/core/ui/ControlPanel/Modals/AddPlugins" tooltip={{$:/language/ControlPanel/Plugins/Add/Hint}} class="tc-btn-big-green tc-more-plugins-button">
+<$button message="tm-modal" param="$:/core/ui/ControlPanel/Modals/AddPlugins" tooltip={{$:/language/ControlPanel/Plugins/Add/Hint}} class="tc-btn-big-green tc-more-plugins-btn">
 {{$:/core/images/download-button}} <<lingo Add/Caption>>
 </$button>

--- a/core/ui/ControlPanel/Plugins/AddPlugins.tid
+++ b/core/ui/ControlPanel/Plugins/AddPlugins.tid
@@ -2,6 +2,6 @@ title: $:/core/ui/ControlPanel/Plugins/AddPlugins
 
 \define lingo-base() $:/language/ControlPanel/Plugins/
 
-<$button message="tm-modal" param="$:/core/ui/ControlPanel/Modals/AddPlugins" tooltip={{$:/language/ControlPanel/Plugins/Add/Hint}} class="tc-btn-big-green" style="background:blue;">
+<$button message="tm-modal" param="$:/core/ui/ControlPanel/Modals/AddPlugins" tooltip={{$:/language/ControlPanel/Plugins/Add/Hint}} class="tc-btn-big-green tc-more-plugins-button">
 {{$:/core/images/download-button}} <<lingo Add/Caption>>
 </$button>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -524,7 +524,7 @@ html body.tc-body .tc-btn-rounded:hover svg {
 	fill: <<colour download-foreground>>;
 }
 
-.tc-more-plugins-btn {
+.tc-primary-btn {
  	background: <<colour primary>>;
 }
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -524,6 +524,10 @@ html body.tc-body .tc-btn-rounded:hover svg {
 	fill: <<colour download-foreground>>;
 }
 
+.tc-more-plugins-btn {
+ 	background: <<colour primary>>;
+}
+
 .tc-sidebar-lists input {
 	color: <<colour foreground>>;
 }


### PR DESCRIPTION
this PR makes the `More Plugins` button use the primary color through an additional `tc-more-plugins-btn` class