### PR TITLE
default search-results: remove duplicates

### DIFF
--- a/core/language/en-GB/Search.multids
+++ b/core/language/en-GB/Search.multids
@@ -5,7 +5,8 @@ Filter/Caption: Filter
 Filter/Hint: Search via a [[filter expression|https://tiddlywiki.com/static/Filters.html]]
 Filter/Matches: //<small><<resultCount>> matches</small>//
 Matches: //<small><<resultCount>> matches</small>//
-Matches/All: Other matches:
+Matches/All: All matches:
+Matches/Other: Other matches:
 Matches/Title: Title matches:
 Search: Search
 Search/TooShort: Search text too short

--- a/core/language/en-GB/Search.multids
+++ b/core/language/en-GB/Search.multids
@@ -5,7 +5,7 @@ Filter/Caption: Filter
 Filter/Hint: Search via a [[filter expression|https://tiddlywiki.com/static/Filters.html]]
 Filter/Matches: //<small><<resultCount>> matches</small>//
 Matches: //<small><<resultCount>> matches</small>//
-Matches/All: All matches:
+Matches/All: Other matches:
 Matches/Title: Title matches:
 Search: Search
 Search/TooShort: Search text too short

--- a/core/ui/DefaultSearchResultList.tid
+++ b/core/ui/DefaultSearchResultList.tid
@@ -5,11 +5,15 @@ caption: {{$:/language/Search/DefaultResults/Caption}}
 \define searchResultList()
 //<small>{{$:/language/Search/Matches/Title}}</small>//
 
-<$list filter="[!is[system]search:title{$(searchTiddler)$}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+<$set name="titleList" filter="[!is[system]search:title{$(searchTiddler)$}sort[title]]">
+
+<$list filter="[enlist<titleList>limit[250]]" template="$:/core/ui/ListItemTemplate"/>
 
 //<small>{{$:/language/Search/Matches/All}}</small>//
 
-<$list filter="[!is[system]search{$(searchTiddler)$}sort[title]] -[!is[system]search:title{$(searchTiddler)$}] +[limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+<$list filter="[!is[system]search{$(searchTiddler)$}sort[title]] -[enlist<titleList>] +[limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+
+</$set>
 
 \end
 <<searchResultList>>

--- a/core/ui/DefaultSearchResultList.tid
+++ b/core/ui/DefaultSearchResultList.tid
@@ -9,7 +9,7 @@ caption: {{$:/language/Search/DefaultResults/Caption}}
 
 <$list filter="[enlist<titleList>limit[250]]" template="$:/core/ui/ListItemTemplate"/>
 
-//<small>{{$:/language/Search/Matches/All}}</small>//
+//<small>{{$:/language/Search/Matches/Other}}</small>//
 
 <$list filter="[!is[system]search{$(searchTiddler)$}sort[title]] -[enlist<titleList>] +[limit[250]]" template="$:/core/ui/ListItemTemplate"/>
 

--- a/core/ui/DefaultSearchResultList.tid
+++ b/core/ui/DefaultSearchResultList.tid
@@ -9,7 +9,7 @@ caption: {{$:/language/Search/DefaultResults/Caption}}
 
 //<small>{{$:/language/Search/Matches/All}}</small>//
 
-<$list filter="[!is[system]search{$(searchTiddler)$}sort[title]limit[250]]" template="$:/core/ui/ListItemTemplate"/>
+<$list filter="[!is[system]search{$(searchTiddler)$}sort[title]limit[250]] -[!is[system]search:title{$(searchTiddler)$}]" template="$:/core/ui/ListItemTemplate"/>
 
 \end
 <<searchResultList>>

--- a/core/ui/DefaultSearchResultList.tid
+++ b/core/ui/DefaultSearchResultList.tid
@@ -9,7 +9,7 @@ caption: {{$:/language/Search/DefaultResults/Caption}}
 
 //<small>{{$:/language/Search/Matches/All}}</small>//
 
-<$list filter="[!is[system]search{$(searchTiddler)$}sort[title]limit[250]] -[!is[system]search:title{$(searchTiddler)$}]" template="$:/core/ui/ListItemTemplate"/>
+<$list filter="[!is[system]search{$(searchTiddler)$}sort[title]] -[!is[system]search:title{$(searchTiddler)$}] +[limit[250]]" template="$:/core/ui/ListItemTemplate"/>
 
 \end
 <<searchResultList>>


### PR DESCRIPTION
this removes search results from `All` that are already under the first list