### PR TITLE
Handling for titles starting with `+-~=` (#4084)

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -314,13 +314,13 @@ $tw.utils.parseDate = function(value) {
 // Stringify an array of tiddler titles into a list string
 $tw.utils.stringifyList = function(value) {
 	if($tw.utils.isArray(value)) {
-		var result = [];
-		for(var t=0; t<value.length; t++) {
+		var result = new Array(value.length);
+		for(var t=0, l=value.length; t<l; t++) {
 			var entry = value[t] || "";
-			if(entry.indexOf(" ") !== -1) {
-				result.push("[[" + entry + "]]");
+			if(entry.indexOf(" ") !== -1 || "+-~=".indexOf(entry[0]) !== -1) {
+				result[t] = "[[" + entry + "]]";
 			} else {
-				result.push(entry);
+				result[t] = entry;
 			}
 		}
 		return result.join(" ");

--- a/editions/test/tiddlers/tests/test-utils.js
+++ b/editions/test/tiddlers/tests/test-utils.js
@@ -25,6 +25,17 @@ describe("Utility tests", function() {
 		expect(psa(" [[Tidd\u00a0ler8]] two ")).toEqual(["Tidd\u00a0ler8","two"]);
 	});
 
+	it("should handle stringifying a string array", function() {
+		var str = $tw.utils.stringifyList;
+		expect(str([])).toEqual("");
+		expect(str(["Tiddler8"])).toEqual("Tiddler8");
+		expect(str(["Tiddler8  "])).toEqual("[[Tiddler8  ]]");
+		expect(str(["A+B", "A-B", "A=B"])).toEqual("A+B A-B A=B");
+		expect(str(["A B"])).toEqual("[[A B]]");
+		expect(str(["+T", "-T", "~T", "=T", "$T"])).toEqual("[[+T]] [[-T]] [[~T]] [[=T]] $T");
+		expect(str(["A", "", "B"])).toEqual("A  B");
+	});
+
 	it("should handle formatting a date string", function() {
 		var fds = $tw.utils.formatDateString,
 			// nov is month: 10!


### PR DESCRIPTION
* If a user tries to make a tiddler title that starts with `+-~=`, tiddlywiki warns them (but doesn't stop them)
* $tw.utils.stringifyList will wrap tiddlers starting with `+-~=` in brackets
* Changed tw5.com to mention this change.