### PR TITLE
popup cancelling - use state reference

### DIFF
--- a/core/modules/utils/dom/popup.js
+++ b/core/modules/utils/dom/popup.js
@@ -158,7 +158,11 @@ Popup.prototype.cancel = function(level) {
 	for(var t=level; t<numPopups; t++) {
 		var popup = this.popups.pop();
 		if(popup.title) {
-			popup.wiki.deleteTiddler(popup.title);
+			if(popup.noStateReference) {
+				popup.wiki.deleteTiddler(popup.title);
+			} else {
+				popup.wiki.deleteTiddler($tw.utils.parseTextReference(popup.title).title);
+			}
 		}
 	}
 	if(this.popups.length === 0) {


### PR DESCRIPTION
in the google group there's a discussion: https://groups.google.com/forum/#!topic/tiddlywiki/_mDDZ1jpMgU

buttons allow setting a state-reference for popups but the popup mechanism doesn't respect that