### PR TITLE
add kb shortcut to add new field and use qualified states

### DIFF
--- a/core/language/en-GB/EditTemplate.multids
+++ b/core/language/en-GB/EditTemplate.multids
@@ -8,6 +8,7 @@ Field/Remove/Hint: Remove field
 Field/Dropdown/Caption: field list
 Field/Dropdown/Hint: Show field list
 Fields/Add/Button: add
+Fields/Add/Button/Hint: Add the fieldname/-value pair to the tiddler
 Fields/Add/Name/Placeholder: field name
 Fields/Add/Prompt: Add a new field:
 Fields/Add/Value/Placeholder: field value

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -1,6 +1,6 @@
 title: $:/core/ui/EditTemplate
 
-\define actions()
+\define save-tiddler-actions()
 <$action-sendmessage $message="tm-add-tag" $param={{$(newTagNameTiddler)$}}/>
 <$action-deletetiddler $tiddler="$(newTagNameTiddler)$"/>
 <$action-sendmessage $message="tm-add-field" $name={{$(newFieldNameTiddler)$}} $value={{$(newFieldValueTiddler)$}}/>
@@ -16,7 +16,7 @@ tc-tiddler-frame tc-tiddler-edit-frame $(missingTiddlerClass)$ $(shadowTiddlerCl
 <$fieldmangler>
 <$set name="storyTiddler" value=<<currentTiddler>>>
 <$keyboard key="((cancel-edit-tiddler))" message="tm-cancel-tiddler">
-<$keyboard key="((save-tiddler))" actions=<<actions>>>
+<$keyboard key="((save-tiddler))" actions=<<save-tiddler-actions>>>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/EditTemplate]!has[draft.of]]" variable="listItem">
 <$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
 <$transclude tiddler=<<listItem>>/>

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -1,17 +1,18 @@
 title: $:/core/ui/EditTemplate
 
 \define actions()
-<$action-sendmessage $message="tm-add-tag" $param={{$:/temp/NewTagName}}/>
-<$action-deletetiddler $tiddler="$:/temp/NewTagName"/>
-<$action-sendmessage $message="tm-add-field" $name={{$:/temp/newfieldname}} $value={{$:/temp/newfieldvalue}}/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldname"/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldvalue"/>
+<$action-sendmessage $message="tm-add-tag" $param={{$(newTagNameTiddler)$}}/>
+<$action-deletetiddler $tiddler="$(newTagNameTiddler)$"/>
+<$action-sendmessage $message="tm-add-field" $name={{$(newFieldNameTiddler)$}} $value={{$(newFieldValueTiddler)$}}/>
+<$action-deletetiddler $tiddler="$(newFieldNameTiddler)$"/>
+<$action-deletetiddler $tiddler="$(newFieldValueTiddler)$"/>
 <$action-sendmessage $message="tm-save-tiddler"/>
 \end
 \define frame-classes()
 tc-tiddler-frame tc-tiddler-edit-frame $(missingTiddlerClass)$ $(shadowTiddlerClass)$ $(systemTiddlerClass)$
 \end
 <div class=<<frame-classes>> data-tiddler-title=<<currentTiddler>>>
+<$vars newTagNameTiddler=<<qualify "$:/temp/NewTagName">> newFieldNameTiddler=<<qualify "$:/temp/newfieldname">> newFieldValueTiddler=<<qualify "$:/temp/newfieldvalue">>>
 <$fieldmangler>
 <$set name="storyTiddler" value=<<currentTiddler>>>
 <$keyboard key="((cancel-edit-tiddler))" message="tm-cancel-tiddler">
@@ -25,4 +26,5 @@ tc-tiddler-frame tc-tiddler-edit-frame $(missingTiddlerClass)$ $(shadowTiddlerCl
 </$keyboard>
 </$set>
 </$fieldmangler>
+</$vars>
 </div>

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -107,8 +107,6 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 </table>
 </div>
 
-<$vars newFieldNameTiddler=<<qualify "$:/temp/newfieldname">> newFieldValueTiddler=<<qualify "$:/temp/newfieldvalue">>>
 <$fieldmangler>
 <$macrocall $name="new-field-macro-outer"/>
 </$fieldmangler>
-</$vars>

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -15,14 +15,14 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 \end
 
 \define new-field-actions()
-<$action-sendmessage $message="tm-add-field" $name={{$:/temp/newfieldname}} $value={{$:/temp/newfieldvalue}}/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldname"/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldvalue"/>
+<$action-sendmessage $message="tm-add-field" $name={{$(newFieldNameTiddler)$}} $value={{$(newFieldValueTiddler)$}}/>
+<$action-deletetiddler $tiddler="$(newFieldNameTiddler)$"/>
+<$action-deletetiddler $tiddler="$(newFieldValueTiddler)$"/>
 <$action-sendmessage $message="tm-focus-selector" $param=<<current-tiddler-new-field-selector>>/>
 \end
 
 \define new-field()
-<$vars name={{$:/temp/newfieldname}}>
+<$vars name={{{ [{$(newFieldNameTiddler)$}] }}}>
 <$reveal type="nomatch" text="" default=<<name>>>
 <$button>
 <$macrocall $name="new-field-actions"/>
@@ -35,6 +35,52 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 </$button>
 </$reveal>
 </$vars>
+\end
+
+\define new-field-macro-outer()
+<div class="tc-edit-field-add">
+<em class="tc-edit">
+<<lingo Fields/Add/Prompt>>
+</em>
+<span class="tc-edit-field-add-name">
+<$edit-text tiddler=<<newFieldNameTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Name/Placeholder}} focusPopup=<<qualify "$:/state/popup/field-dropdown">> class="tc-edit-texteditor tc-popup-handle" tabindex={{$:/config/EditTabIndex}}/>
+</span>
+<$button popup=<<qualify "$:/state/popup/field-dropdown">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Field/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Field/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button>
+<$reveal state=<<qualify "$:/state/popup/field-dropdown">> type="nomatch" text="" default="">
+<div class="tc-block-dropdown tc-edit-type-dropdown">
+<$set name="tv-show-missing-links" value="yes">
+<$linkcatcher to="$(newFieldNameTiddler)$">
+<div class="tc-dropdown-item">
+<<lingo Fields/Add/Dropdown/User>>
+</div>
+<$list filter="[!is[shadow]!is[system]fields[]search:title{$(newFieldNameTiddler)$}sort[]] -created -creator -draft.of -draft.title -modified -modifier -tags -text -title -type"  variable="currentField">
+<$link to=<<currentField>>>
+<<currentField>>
+</$link>
+</$list>
+<div class="tc-dropdown-item">
+<<lingo Fields/Add/Dropdown/System>>
+</div>
+<$list filter="[fields[]search:title{$(newFieldNameTiddler)$}sort[]] -[!is[shadow]!is[system]fields[]]" variable="currentField">
+<$link to=<<currentField>>>
+<<currentField>>
+</$link>
+</$list>
+</$linkcatcher>
+</$set>
+</div>
+</$reveal>
+<span class="tc-edit-field-add-value">
+<$set name="currentTiddlerCSSescaped" value={{{ [<currentTiddler>escapecss[]] }}}>
+<$keyboard key="((add-field))" actions=<<new-field-actions>>>
+<$edit-text tiddler=<<newFieldValueTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor" tabindex={{$:/config/EditTabIndex}}/>
+</$keyboard>
+</$set>
+</span>
+<span class="tc-edit-field-add-button">
+<$macrocall $name="new-field"/>
+</span>
+</div>
 \end
 
 <div class="tc-edit-fields">
@@ -61,49 +107,8 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 </table>
 </div>
 
+<$vars newFieldNameTiddler=<<qualify "$:/temp/newfieldname">> newFieldValueTiddler=<<qualify "$:/temp/newfieldvalue">>>
 <$fieldmangler>
-<div class="tc-edit-field-add">
-<em class="tc-edit">
-<<lingo Fields/Add/Prompt>>
-</em>
-<span class="tc-edit-field-add-name">
-<$edit-text tiddler="$:/temp/newfieldname" tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Name/Placeholder}} focusPopup=<<qualify "$:/state/popup/field-dropdown">> class="tc-edit-texteditor tc-popup-handle" tabindex={{$:/config/EditTabIndex}}/>
-</span>
-<$button popup=<<qualify "$:/state/popup/field-dropdown">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Field/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Field/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button>
-<$reveal state=<<qualify "$:/state/popup/field-dropdown">> type="nomatch" text="" default="">
-<div class="tc-block-dropdown tc-edit-type-dropdown">
-<$set name="tv-show-missing-links" value="yes">
-<$linkcatcher to="$:/temp/newfieldname">
-<div class="tc-dropdown-item">
-<<lingo Fields/Add/Dropdown/User>>
-</div>
-<$list filter="[!is[shadow]!is[system]fields[]search:title{$:/temp/newfieldname}sort[]] -created -creator -draft.of -draft.title -modified -modifier -tags -text -title -type"  variable="currentField">
-<$link to=<<currentField>>>
-<<currentField>>
-</$link>
-</$list>
-<div class="tc-dropdown-item">
-<<lingo Fields/Add/Dropdown/System>>
-</div>
-<$list filter="[fields[]search:title{$:/temp/newfieldname}sort[]] -[!is[shadow]!is[system]fields[]]" variable="currentField">
-<$link to=<<currentField>>>
-<<currentField>>
-</$link>
-</$list>
-</$linkcatcher>
-</$set>
-</div>
-</$reveal>
-<$set name="currentTiddlerCSSescaped" value={{{ [<currentTiddler>escapecss[]] }}}>
-<span class="tc-edit-field-add-value">
-<$keyboard key="((add-field))" actions=<<new-field-actions>>>
-<$edit-text tiddler="$:/temp/newfieldvalue" tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor" tabindex={{$:/config/EditTabIndex}}/>
-</$keyboard>
-</span>
-<span class="tc-edit-field-add-button">
-<$macrocall $name="new-field"/>
-</span>
-</$set>
-</div>
+<$macrocall $name="new-field-macro-outer"/>
 </$fieldmangler>
-
+</$vars>

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -10,15 +10,22 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 [[hide]] -[title{$(config-title)$}]
 \end
 
+\define current-tiddler-new-field-selector()
+[data-tiddler-title="$(currentTiddlerCSSescaped)$"] .tc-edit-field-add-name input
+\end
+
+\define new-field-actions()
+<$action-sendmessage $message="tm-add-field" $name={{$:/temp/newfieldname}} $value={{$:/temp/newfieldvalue}}/>
+<$action-deletetiddler $tiddler="$:/temp/newfieldname"/>
+<$action-deletetiddler $tiddler="$:/temp/newfieldvalue"/>
+<$action-sendmessage $message="tm-focus-selector" $param=<<current-tiddler-new-field-selector>>/>
+\end
+
 \define new-field()
 <$vars name={{$:/temp/newfieldname}}>
 <$reveal type="nomatch" text="" default=<<name>>>
 <$button>
-<$action-sendmessage $message="tm-add-field"
-$name=<<name>>
-$value={{$:/temp/newfieldvalue}}/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldname"/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldvalue"/>
+<$macrocall $name="new-field-actions"/>
 <<lingo Fields/Add/Button>>
 </$button>
 </$reveal>
@@ -88,10 +95,15 @@ $value={{$:/temp/newfieldvalue}}/>
 </div>
 </$reveal>
 <span class="tc-edit-field-add-value">
+<$set name="currentTiddlerCSSescaped" value={{{ [<currentTiddler>escapecss[]] }}}>
+<$keyboard key="((add-field))" actions=<<new-field-actions>>>
 <$edit-text tiddler="$:/temp/newfieldvalue" tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor" tabindex={{$:/config/EditTabIndex}}/>
+</$keyboard>
+</$set>
 </span>
 <span class="tc-edit-field-add-button">
 <$macrocall $name="new-field"/>
 </span>
 </div>
 </$fieldmangler>
+

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -94,16 +94,16 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 </$set>
 </div>
 </$reveal>
-<span class="tc-edit-field-add-value">
 <$set name="currentTiddlerCSSescaped" value={{{ [<currentTiddler>escapecss[]] }}}>
+<span class="tc-edit-field-add-value">
 <$keyboard key="((add-field))" actions=<<new-field-actions>>>
 <$edit-text tiddler="$:/temp/newfieldvalue" tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor" tabindex={{$:/config/EditTabIndex}}/>
 </$keyboard>
-</$set>
 </span>
 <span class="tc-edit-field-add-button">
 <$macrocall $name="new-field"/>
 </span>
+</$set>
 </div>
 </$fieldmangler>
 

--- a/core/ui/EditToolbar/save.tid
+++ b/core/ui/EditToolbar/save.tid
@@ -5,12 +5,7 @@ description: {{$:/language/Buttons/Save/Hint}}
 
 \define save-tiddler-button()
 <$fieldmangler><$button tooltip={{$:/language/Buttons/Save/Hint}} aria-label={{$:/language/Buttons/Save/Caption}} class=<<tv-config-toolbar-class>>>
-<$action-sendmessage $message="tm-add-tag" $param={{$(newTagNameTiddler)$}}/>
-<$action-deletetiddler $tiddler="$(newTagNameTiddler)$"/>
-<$action-sendmessage $message="tm-add-field" $name={{$(newFieldNameTiddler)$}} $value={{$(newFieldValueTiddler)$}}/>
-<$action-deletetiddler $tiddler="$(newFieldNameTiddler)$"/>
-<$action-deletetiddler $tiddler="$(newFieldValueTiddler)$"/>
-<$action-sendmessage $message="tm-save-tiddler"/>
+<<save-tiddler-actions>>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/done-button}}
 </$list>

--- a/core/ui/EditToolbar/save.tid
+++ b/core/ui/EditToolbar/save.tid
@@ -3,12 +3,13 @@ tags: $:/tags/EditToolbar
 caption: {{$:/core/images/done-button}} {{$:/language/Buttons/Save/Caption}}
 description: {{$:/language/Buttons/Save/Hint}}
 
+\define save-tiddler-button()
 <$fieldmangler><$button tooltip={{$:/language/Buttons/Save/Hint}} aria-label={{$:/language/Buttons/Save/Caption}} class=<<tv-config-toolbar-class>>>
-<$action-sendmessage $message="tm-add-tag" $param={{$:/temp/NewTagName}}/>
-<$action-deletetiddler $tiddler="$:/temp/NewTagName"/>
-<$action-sendmessage $message="tm-add-field" $name={{$:/temp/newfieldname}} $value={{$:/temp/newfieldvalue}}/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldname"/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldvalue"/>
+<$action-sendmessage $message="tm-add-tag" $param={{$(newTagNameTiddler)$}}/>
+<$action-deletetiddler $tiddler="$(newTagNameTiddler)$"/>
+<$action-sendmessage $message="tm-add-field" $name={{$(newFieldNameTiddler)$}} $value={{$(newFieldValueTiddler)$}}/>
+<$action-deletetiddler $tiddler="$(newFieldNameTiddler)$"/>
+<$action-deletetiddler $tiddler="$(newFieldValueTiddler)$"/>
 <$action-sendmessage $message="tm-save-tiddler"/>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/core/images/done-button}}
@@ -17,3 +18,5 @@ description: {{$:/language/Buttons/Save/Hint}}
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Save/Caption}}/></span>
 </$list>
 </$button></$fieldmangler>
+\end
+<<save-tiddler-button>>

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -1,5 +1,6 @@
 title: $:/config/ShortcutInfo/
 
+add-field: {{$:/language/EditTemplate/Fields/Add/Button/Hint}}
 bold: {{$:/language/Buttons/Bold/Hint}}
 cancel-edit-tiddler: {{$:/language/Buttons/Cancel/Hint}}
 excise: {{$:/language/Buttons/Excise/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -1,5 +1,6 @@
 title: $:/config/shortcuts/
 
+add-field: enter
 cancel-edit-tiddler: escape
 excise: ctrl-E
 sidebar-search: ctrl-shift-F


### PR DESCRIPTION
this PR add a keyboard shortcut in the `fieldvalue` field of tiddlers (`enter` by default) that adds the fieldname/-value pair to the tiddler and sets focus to the `next fieldname` input

the keyboard shortcut is configurable through the control panel