### PR TITLE
shortcut in sidebar search: navigate to advanced search

### DIFF
--- a/core/ui/SideBarSegments/search.tid
+++ b/core/ui/SideBarSegments/search.tid
@@ -1,16 +1,22 @@
 title: $:/core/ui/SideBarSegments/search
 tags: $:/tags/SideBarSegment
 
+\define advanced-search-actions()
+<$action-setfield $tiddler="$:/temp/advancedsearch" text={{$:/temp/search}}/>
+<$action-setfield $tiddler="$:/temp/search" text=""/>
+<$action-navigate $to="$:/AdvancedSearch"/>
+\end
+
 <div class="tc-sidebar-lists tc-sidebar-search">
 
 <$set name="searchTiddler" value="$:/temp/search">
 <div class="tc-search">
+<$keyboard key="((advanced-search))" actions=<<advanced-search-actions>>>
 <$edit-text tiddler="$:/temp/search" type="search" tag="input" focus={{$:/config/Search/AutoFocus}} focusPopup=<<qualify "$:/state/popup/search-dropdown">> class="tc-popup-handle"/>
+</$keyboard>
 <$reveal state="$:/temp/search" type="nomatch" text="">
 <$button tooltip={{$:/language/Buttons/AdvancedSearch/Hint}} aria-label={{$:/language/Buttons/AdvancedSearch/Caption}} class="tc-btn-invisible">
-<$action-setfield $tiddler="$:/temp/advancedsearch" text={{$:/temp/search}}/>
-<$action-setfield $tiddler="$:/temp/search" text=""/>
-<$action-navigate $to="$:/AdvancedSearch"/>
+<<advanced-search-actions>>
 {{$:/core/images/advanced-search-button}}
 </$button>
 <$button class="tc-btn-invisible">

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -1,6 +1,6 @@
 title: $:/config/ShortcutInfo/
 
-advanced-search: {{$:/language/Buttons/AdvancedSearch/Hint}} - <kbd>{{$:/config/shortcuts/advanced-search}}</kbd>
+advanced-search: {{$:/language/Buttons/AdvancedSearch/Hint}}
 bold: {{$:/language/Buttons/Bold/Hint}}
 cancel-edit-tiddler: {{$:/language/Buttons/Cancel/Hint}}
 excise: {{$:/language/Buttons/Excise/Hint}}

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -1,6 +1,6 @@
 title: $:/config/ShortcutInfo/
 
-advanced-search: {{$:/language/Buttons/AdvancedSearch/Hint}}
+advanced-search: {{$:/language/Buttons/AdvancedSearch/Hint}} - <kbd>{{$:/config/shortcuts/advanced-search}}</kbd>
 bold: {{$:/language/Buttons/Bold/Hint}}
 cancel-edit-tiddler: {{$:/language/Buttons/Cancel/Hint}}
 excise: {{$:/language/Buttons/Excise/Hint}}

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -1,5 +1,6 @@
 title: $:/config/ShortcutInfo/
 
+advanced-search: {{$:/language/Buttons/AdvancedSearch/Hint}}
 bold: {{$:/language/Buttons/Bold/Hint}}
 cancel-edit-tiddler: {{$:/language/Buttons/Cancel/Hint}}
 excise: {{$:/language/Buttons/Excise/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -1,5 +1,6 @@
 title: $:/config/shortcuts/
 
+advanced-search: enter
 cancel-edit-tiddler: escape
 excise: ctrl-E
 sidebar-search: ctrl-shift-F

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -1,6 +1,6 @@
 title: $:/config/shortcuts/
 
-advanced-search: enter
+advanced-search: ctrl-enter
 cancel-edit-tiddler: escape
 excise: ctrl-E
 sidebar-search: ctrl-shift-F


### PR DESCRIPTION
this PR adds a keyboard shortcut (configurable, enter by default) in the sidebar search field to navigate to the advanced search