### PR TITLE
fields edittemplate: use qualified newfieldname ...

### DIFF
--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -11,15 +11,13 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 \end
 
 \define new-field()
-<$vars name={{$:/temp/newfieldname}}>
+<$vars name={{{ [{$(newFieldNameTiddler)$}] }}}>
 <$reveal type="nomatch" text="" default=<<name>>>
 <$button>
-<$action-sendmessage $message="tm-add-field"
-$name=<<name>>
-$value={{$:/temp/newfieldvalue}}/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldname"/>
-<$action-deletetiddler $tiddler="$:/temp/newfieldvalue"/>
+<$action-sendmessage $message="tm-add-field" $name=<<name>> $value={{{ [{$(newFieldValueTiddler)$}] }}}/>
 <<lingo Fields/Add/Button>>
+<$action-deletetiddler $tiddler="$(newFieldValueTiddler)$"/>
+<$action-deletetiddler $tiddler="$(newFieldNameTiddler)$">/>
 </$button>
 </$reveal>
 <$reveal type="match" text="" default=<<name>>>
@@ -54,13 +52,14 @@ $value={{$:/temp/newfieldvalue}}/>
 </table>
 </div>
 
+<$vars newFieldNameTiddler=<<qualify "$:/temp/newfieldname">> newFieldValueTiddler=<<qualify "$:/temp/newfieldvalue">>>
 <$fieldmangler>
 <div class="tc-edit-field-add">
 <em class="tc-edit">
 <<lingo Fields/Add/Prompt>>
 </em>
 <span class="tc-edit-field-add-name">
-<$edit-text tiddler="$:/temp/newfieldname" tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Name/Placeholder}} focusPopup=<<qualify "$:/state/popup/field-dropdown">> class="tc-edit-texteditor tc-popup-handle" tabindex={{$:/config/EditTabIndex}}/>
+<$edit-text tiddler=<<newFieldNameTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Name/Placeholder}} focusPopup=<<qualify "$:/state/popup/field-dropdown">> class="tc-edit-texteditor tc-popup-handle" tabindex={{$:/config/EditTabIndex}}/>
 </span>
 <$button popup=<<qualify "$:/state/popup/field-dropdown">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Field/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Field/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button>
 <$reveal state=<<qualify "$:/state/popup/field-dropdown">> type="nomatch" text="" default="">
@@ -88,10 +87,12 @@ $value={{$:/temp/newfieldvalue}}/>
 </div>
 </$reveal>
 <span class="tc-edit-field-add-value">
-<$edit-text tiddler="$:/temp/newfieldvalue" tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor" tabindex={{$:/config/EditTabIndex}}/>
+<$edit-text tiddler=<<newFieldValueTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor" tabindex={{$:/config/EditTabIndex}}/>
 </span>
 <span class="tc-edit-field-add-button">
 <$macrocall $name="new-field"/>
 </span>
 </div>
 </$fieldmangler>
+</$vars>
+

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -28,6 +28,48 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 </$vars>
 \end
 
+\define new-field-macro-outer()
+<div class="tc-edit-field-add">
+<em class="tc-edit">
+<<lingo Fields/Add/Prompt>>
+</em>
+<span class="tc-edit-field-add-name">
+<$edit-text tiddler=<<newFieldNameTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Name/Placeholder}} focusPopup=<<qualify "$:/state/popup/field-dropdown">> class="tc-edit-texteditor tc-popup-handle" tabindex={{$:/config/EditTabIndex}}/>
+</span>
+<$button popup=<<qualify "$:/state/popup/field-dropdown">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Field/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Field/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button>
+<$reveal state=<<qualify "$:/state/popup/field-dropdown">> type="nomatch" text="" default="">
+<div class="tc-block-dropdown tc-edit-type-dropdown">
+<$set name="tv-show-missing-links" value="yes">
+<$linkcatcher to="$(newFieldNameTiddler)$">
+<div class="tc-dropdown-item">
+<<lingo Fields/Add/Dropdown/User>>
+</div>
+<$list filter="[!is[shadow]!is[system]fields[]search:title{$(newFieldNameTiddler)$}sort[]] -created -creator -draft.of -draft.title -modified -modifier -tags -text -title -type"  variable="currentField">
+<$link to=<<currentField>>>
+<<currentField>>
+</$link>
+</$list>
+<div class="tc-dropdown-item">
+<<lingo Fields/Add/Dropdown/System>>
+</div>
+<$list filter="[fields[]search:title{$(newFieldNameTiddler)$}sort[]] -[!is[shadow]!is[system]fields[]]" variable="currentField">
+<$link to=<<currentField>>>
+<<currentField>>
+</$link>
+</$list>
+</$linkcatcher>
+</$set>
+</div>
+</$reveal>
+<span class="tc-edit-field-add-value">
+<$edit-text tiddler=<<newFieldValueTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor" tabindex={{$:/config/EditTabIndex}}/>
+</span>
+<span class="tc-edit-field-add-button">
+<$macrocall $name="new-field"/>
+</span>
+</div>
+\end
+
 <div class="tc-edit-fields">
 <table class="tc-edit-fields">
 <tbody>
@@ -54,45 +96,6 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 
 <$vars newFieldNameTiddler=<<qualify "$:/temp/newfieldname">> newFieldValueTiddler=<<qualify "$:/temp/newfieldvalue">>>
 <$fieldmangler>
-<div class="tc-edit-field-add">
-<em class="tc-edit">
-<<lingo Fields/Add/Prompt>>
-</em>
-<span class="tc-edit-field-add-name">
-<$edit-text tiddler=<<newFieldNameTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Name/Placeholder}} focusPopup=<<qualify "$:/state/popup/field-dropdown">> class="tc-edit-texteditor tc-popup-handle" tabindex={{$:/config/EditTabIndex}}/>
-</span>
-<$button popup=<<qualify "$:/state/popup/field-dropdown">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Field/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Field/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button>
-<$reveal state=<<qualify "$:/state/popup/field-dropdown">> type="nomatch" text="" default="">
-<div class="tc-block-dropdown tc-edit-type-dropdown">
-<$set name="tv-show-missing-links" value="yes">
-<$linkcatcher to="$:/temp/newfieldname">
-<div class="tc-dropdown-item">
-<<lingo Fields/Add/Dropdown/User>>
-</div>
-<$list filter="[!is[shadow]!is[system]fields[]search:title{$:/temp/newfieldname}sort[]] -created -creator -draft.of -draft.title -modified -modifier -tags -text -title -type"  variable="currentField">
-<$link to=<<currentField>>>
-<<currentField>>
-</$link>
-</$list>
-<div class="tc-dropdown-item">
-<<lingo Fields/Add/Dropdown/System>>
-</div>
-<$list filter="[fields[]search:title{$:/temp/newfieldname}sort[]] -[!is[shadow]!is[system]fields[]]" variable="currentField">
-<$link to=<<currentField>>>
-<<currentField>>
-</$link>
-</$list>
-</$linkcatcher>
-</$set>
-</div>
-</$reveal>
-<span class="tc-edit-field-add-value">
-<$edit-text tiddler=<<newFieldValueTiddler>> tag="input" default="" placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} class="tc-edit-texteditor" tabindex={{$:/config/EditTabIndex}}/>
-</span>
-<span class="tc-edit-field-add-button">
-<$macrocall $name="new-field"/>
-</span>
-</div>
+<$macrocall $name="new-field-macro-outer"/>
 </$fieldmangler>
 </$vars>
-


### PR DESCRIPTION
and newfieldvalue tiddlers

this PR makes the fields EditTemplate use different $:/temp/newfieldname and $:/temp/newfieldvalue tiddlers for each Tiddler, so that the user input isn't reflected in every open tiddler