### PR TITLE
reducing function calls across board

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -385,9 +385,10 @@ Widget.prototype.previousSibling = function() {
 Render the children of this widget into the DOM
 */
 Widget.prototype.renderChildren = function(parent,nextSibling) {
-	$tw.utils.each(this.children,function(childWidget) {
-		childWidget.render(parent,nextSibling);
-	});
+	var children = this.children;
+	for(var i = 0; i < children.length; i++) {
+		children[i].render(parent,nextSibling);
+	};
 };
 
 /*
@@ -455,11 +456,11 @@ Widget.prototype.refreshSelf = function() {
 Refresh all the children of a widget
 */
 Widget.prototype.refreshChildren = function(changedTiddlers) {
-	var self = this,
+	var children = this.children,
 		refreshed = false;
-	$tw.utils.each(this.children,function(childWidget) {
-		refreshed = childWidget.refresh(changedTiddlers) || refreshed;
-	});
+	for (var i = 0; i < children.length; i++) {
+		refreshed = children[i].refresh(changedTiddlers) || refreshed;
+	}
 	return refreshed;
 };
 


### PR DESCRIPTION
I heard y'all like clock cycles. Between `render`, `renderChildren`, `refresh`, and `refreshChildren`, I believe they account for a substantial  amount of function calls in tiddlywiki. You can witness this using any browser profiler. I at least know for a fact that `refreshChildren` can be called 10,000s of times just for opening or closing a tiddler.

This modification removes two out of four function calls in this tight loop.
`render -> renderChildren -> each -> (anonymous)` to `render -> renderChildren`

If I'm correct about this, then this small adjustment should reduce function calls in Tiddlywiki by about 35%.

I do invite anyone to check my work. It's hard to count function calls.