### PR TITLE
make plugin addons indent visually

### DIFF
--- a/core/ui/Components/plugin-info.tid
+++ b/core/ui/Components/plugin-info.tid
@@ -52,7 +52,7 @@ $:/config/Plugins/Disabled/$(currentTiddler)$
 \define plugin-info(type,default-popup-state)
 <$set name="popup-state" value=<<popup-state-macro>>>
 <$reveal type="nomatch" state=<<plugin-disable-title>> text="yes">
-<$link to={{!!title}} class="tc-plugin-info">
+<$link to={{!!title}} class={{{ [tag[$:/tags/Plugins/AddOn]addprefix[tc-plugin-info ]removesuffix{!!title}addsuffix[tc-plugin-addon]] ~[[tc-plugin-info]] }}}>
 <<plugin-table-body type:"$type$" default-popup-state:"""$default-popup-state$""">>
 </$link>
 </$reveal>

--- a/core/ui/Components/plugin-info.tid
+++ b/core/ui/Components/plugin-info.tid
@@ -62,7 +62,7 @@ $:/config/Plugins/Disabled/$(currentTiddler)$
 </$link>
 </$reveal>
 <$reveal type="match" text="yes" state=<<popup-state>> default="""$default-popup-state$""">
-<div class="tc-plugin-info-dropdown">
+<div class={{{ [tag[$:/tags/Plugins/AddOn]addprefix[tc-plugin-info-dropdown ]removesuffix{!!title}addsuffix[tc-plugin-addon]] ~[[tc-plugin-info-dropdown]] }}}>
 <div class="tc-plugin-info-dropdown-body">
 <$list filter="[all[current]] -[[$:/core]]">
 <div style="float:right;">

--- a/plugins/tiddlywiki/codemirror-autocomplete/plugin.info
+++ b/plugins/tiddlywiki/codemirror-autocomplete/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-autocomplete",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror AddOn: Autocompletion",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-closebrackets/plugin.info
+++ b/plugins/tiddlywiki/codemirror-closebrackets/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-closebrackets",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror AddOn: Close Brackets",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-closetag/plugin.info
+++ b/plugins/tiddlywiki/codemirror-closetag/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-closetag",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror AddOn: Auto-Close Tags",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-fullscreen-editing/plugin.info
+++ b/plugins/tiddlywiki/codemirror-fullscreen-editing/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-fullscreen",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror AddOn: Fullscreen Editing",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-keymap-emacs/plugin.info
+++ b/plugins/tiddlywiki/codemirror-keymap-emacs/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-keymap-emacs",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Keymap: Emacs",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-keymap-sublime-text/plugin.info
+++ b/plugins/tiddlywiki/codemirror-keymap-sublime-text/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-keymap-sublime-text",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Keymap: Sublime Text",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-keymap-vim/plugin.info
+++ b/plugins/tiddlywiki/codemirror-keymap-vim/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-keymap-vim",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Keymap: Vim",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-mode-css/plugin.info
+++ b/plugins/tiddlywiki/codemirror-mode-css/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-mode-css",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Mode: CSS Highlighting",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-mode-htmlembedded/plugin.info
+++ b/plugins/tiddlywiki/codemirror-mode-htmlembedded/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-mode-htmlembedded",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Mode: Embedded-HTML Highlighting",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-mode-htmlmixed/plugin.info
+++ b/plugins/tiddlywiki/codemirror-mode-htmlmixed/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-mode-htmlmixed",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Mode: HTML Highlighting",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-mode-javascript/plugin.info
+++ b/plugins/tiddlywiki/codemirror-mode-javascript/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-mode-javascript",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Mode: Javascript Highlighting",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-mode-markdown/plugin.info
+++ b/plugins/tiddlywiki/codemirror-mode-markdown/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-mode-markdown",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Mode: Markdown Highlighting",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-mode-x-tiddlywiki/plugin.info
+++ b/plugins/tiddlywiki/codemirror-mode-x-tiddlywiki/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-mode-x-tiddlywiki",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Mode: Tiddlywiki Classic Highlighting",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-mode-xml/plugin.info
+++ b/plugins/tiddlywiki/codemirror-mode-xml/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-mode-xml",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror Mode: XML Highlighting",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/plugins/tiddlywiki/codemirror-search-replace/plugin.info
+++ b/plugins/tiddlywiki/codemirror-search-replace/plugin.info
@@ -1,5 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/codemirror-search-replace",
+	"tags": "$:/tags/Plugins/AddOn",
 	"description": "CodeMirror AddOn: Search and Replace",
 	"author": "JeremyRuston",
 	"list": "readme"

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2142,7 +2142,7 @@ a.tc-tiddlylink.tc-plugin-info:hover .tc-plugin-info > .tc-plugin-info-chunk > s
 	padding: 1em 1em 1em 1em;
 }
 
-.tc-tab-content .tc-plugin-info.tc-plugin-addon {
+.tc-tab-content .tc-plugin-info.tc-plugin-addon, .tc-tab-content .tc-plugin-info-dropdown.tc-plugin-addon {
 	margin-left: 2em;
 }
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2142,6 +2142,10 @@ a.tc-tiddlylink.tc-plugin-info:hover .tc-plugin-info > .tc-plugin-info-chunk > s
 	padding: 1em 1em 1em 1em;
 }
 
+.tc-tab-content .tc-plugin-info.tc-plugin-addon {
+	margin-left: 2em;
+}
+
 .tc-check-list {
 	line-height: 2em;
 }


### PR DESCRIPTION
this PR makes Addons (plugins tagged `$:/tags/Plugins/AddOn`) indent 2em in the ControlPanel, see the screenshot. It also adds that tag to all CodeMirror addons

![Bildschirmfoto vom 2019-07-15 07-26-42](https://user-images.githubusercontent.com/9407182/61196979-794dde00-a6d2-11e9-959d-300189149052.png)
