### PR TITLE
Add server-sent events to core

### DIFF
--- a/core/modules/server/routes/get-status-events.js
+++ b/core/modules/server/routes/get-status-events.js
@@ -1,0 +1,36 @@
+/*\
+title: $:/core/modules/server/routes/get-status-events.js
+type: application/javascript
+module-type: route
+
+Adds the server-sent-events server route at /status/events.
+
+\*/
+(function () {
+
+exports.method = "GET";
+
+exports.path = /^\/status\/events$/
+
+exports.handler = handler;
+
+exports.bodyFormat = "stream";
+
+/**
+ * 
+ * @param {import("http").IncomingMessage} request 
+ * @param {import("http").ServerResponse} response 
+ * @param {ServerState} state 
+ */
+function handler(request, response, state) {
+  
+  if (request.headers.accept && request.headers.accept === 'text/event-stream') {
+    $tw.serverEvents.handleConnection(request, response, state);
+  } else {
+    response.writeHead(404, {});
+    response.write(JSON.stringify(request.headers.accept))
+    response.end();
+  }
+}
+
+})();

--- a/core/modules/server/server-events-global.js
+++ b/core/modules/server/server-events-global.js
@@ -1,0 +1,96 @@
+/*\
+title: $:/core/modules/server/server-events-global.js
+type: application/javascript
+module-type: global
+
+Adds serverEvents to $tw. On the server, its public type is 
+`{ isServer: true, broadcastEvent(event: string, data: string) }`. 
+On the client, it is an EventSource instance. 
+
+\*/
+
+(function () {
+
+/**
+ * @type {ReturnType<handleConnection>[]}
+ */
+var activeConnections = [];
+
+var serverEvents = { handleConnection, activeConnections, broadcastEvent, isServer: true }
+
+/**
+ * @this {typeof serverEvents}
+ * @param {string} type 
+ * @param {string} data 
+ */
+function broadcastEvent(type, data) {
+  if (typeof type !== "string") {
+    throw new Error("type must be a string");
+  }
+  if (typeof data !== "string" || data.indexOf("\n") !== -1) {
+    throw new Error("data must be a single-line string");
+  }
+  this.activeConnections.forEach(function (conn) {
+    conn.sendEvent(type, data);
+  });
+}
+
+/**
+ * 
+ * @this {typeof serverEvents}
+ * @param {import("http").IncomingMessage} request 
+ * @param {import("http").ServerResponse} response 
+ * @param {ServerState} state 
+ */
+function handleConnection(request, response, state) {
+
+  response.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive'
+  });
+
+  response.write("\n", "utf8");
+
+  var connection = { request, response, state, sendEvent };
+
+  this.activeConnections.push(connection);
+
+  request.on("close", (function(self){ return function () {
+    let index = self.activeConnections.indexOf(connection);
+    if (index !== -1) self.activeConnections.splice(index, 1);
+  } })(this));
+
+  /**
+   * @this {typeof connection}
+   * @param {string} type The event type to send
+   * @param {string} data The data to send, which must be a string with no newline characters
+   */
+  function sendEvent(type, data) {
+    if (typeof type !== "string") {
+      throw new Error("type must be a string");
+    }
+    if (typeof data !== "string" || data.indexOf("\n") !== -1) {
+      throw new Error("data must be a single-line string");
+    }
+    this.response.write("event: " + type + "\n", "utf8");
+    // this.response.write("id: " + type + "\n", "utf8");
+    // this.response.write("retry: " + type + "\n", "utf8");
+    this.response.write("data: " + data + "\n\n", "utf8");
+
+  }
+
+  return connection;
+
+}
+if ($tw.browser) {
+  let eventsURL = location.protocol + "//" + location.host + location.pathname
+    + (location.pathname.endsWith("/") ? "" : "/")
+    + "status/events";
+  exports.serverEvents = new EventSource(eventsURL, { withCredentials: true });
+} else {
+  exports.serverEvents = serverEvents;
+}
+
+})();
+

--- a/core/modules/server/server-events-global.js
+++ b/core/modules/server/server-events-global.js
@@ -16,7 +16,12 @@ On the client, it is an EventSource instance.
  */
 var activeConnections = [];
 
-var serverEvents = { handleConnection, activeConnections, broadcastEvent, isServer: true }
+var serverEvents = { 
+  handleConnection: handleConnection, 
+  activeConnections: activeConnections, 
+  broadcastEvent: broadcastEvent, 
+  isServer: true 
+}
 
 /**
  * @this {typeof serverEvents}
@@ -57,7 +62,7 @@ function handleConnection(request, response, state) {
   this.activeConnections.push(connection);
 
   request.on("close", (function(self){ return function () {
-    let index = self.activeConnections.indexOf(connection);
+    var index = self.activeConnections.indexOf(connection);
     if (index !== -1) self.activeConnections.splice(index, 1);
   } })(this));
 
@@ -84,7 +89,7 @@ function handleConnection(request, response, state) {
 
 }
 if ($tw.browser) {
-  let eventsURL = location.protocol + "//" + location.host + location.pathname
+  var eventsURL = location.protocol + "//" + location.host + location.pathname
     + (location.pathname.endsWith("/") ? "" : "/")
     + "status/events";
   exports.serverEvents = new EventSource(eventsURL, { withCredentials: true });


### PR DESCRIPTION
This adds a simple API to use server-sent events. It adds `serverEvents` to the $tw global. The mechanism is very simple. It should work fine with Bob and TiddlyServer, as far as I know. I only tested this in vanilla TiddlyWiki. 

On the server, this is a simple object with two functions used to handle connections and messages. I added `isServer: true` so anything wanting to use it can quickly determine which side of the connection they are on. This is what the TypeScript definition would look like for it. 

```ts
interface serverEvents { 
  broadcastEvent(event: string, data: string): void; 
  isServer: true;
  /** called by the server route to handle incoming requests */
  handleConnection(request, response, state): void; 
  /** internal use only */
  activeConnections: any[];
}
```

On the client, it is an instance of EventSource. 

It also adds the route `GET /status/events` to the server to handle connections. Because of get-tiddler-html it is unpredictable to not have a slash in the middle of the path (so I could not use `/events`). This may need to be addressed separately in get-tiddler-html. 