### PR TITLE
Use static prefix for html tiddler rendering

### DIFF
--- a/core/modules/server/routes/get-tiddler-html.js
+++ b/core/modules/server/routes/get-tiddler-html.js
@@ -14,7 +14,7 @@ GET /:title
 
 exports.method = "GET";
 
-exports.path = /^\/([^\/]+)$/;
+exports.path = /^\/static\/([^\/]+)$/;
 
 exports.handler = function(request,response,state) {
 	var title = decodeURIComponent(state.params[0]),


### PR DESCRIPTION
Per https://github.com/Jermolene/TiddlyWiki5/issues/4131 this adds `/static` as the prefix for HTML tiddlers.