### PR TITLE
lower margin-bottom of tiddler-frames on narrow screens

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -877,6 +877,12 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	border: 1px solid <<colour tiddler-border>>;
 }
 
+@media (max-width: {{$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint}}) {
+	.tc-tiddler-frame {
+		margin-bottom: 10px;
+	}
+}
+
 {{$:/themes/tiddlywiki/vanilla/sticky}}
 
 .tc-tiddler-info {


### PR DESCRIPTION
this is a proposal for a lower margin-bottom on narrow screens...

the default 28px take a lot of vertical space on smartphones for example