### PR TITLE
add "preventScroll" option to tm-focus-selector message

### DIFF
--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -44,7 +44,13 @@ exports.startup = function() {
 			console.log("Error in selector: ",selector)
 		}
 		if(element && element.focus) {
-			element.focus();
+			if(event.paramObject.delayed === "yes" || event.paramObject.delayed === "true") {
+				setTimeout(function() {
+					element.focus();
+				},$tw.utils.getAnimationDuration());
+			} else {
+				element.focus();
+			}
 		}
 	});
 	// Install the scroller

--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -44,13 +44,7 @@ exports.startup = function() {
 			console.log("Error in selector: ",selector)
 		}
 		if(element && element.focus) {
-			if(event.paramObject.delayed === "yes" || event.paramObject.delayed === "true") {
-				setTimeout(function() {
-					element.focus();
-				},$tw.utils.getAnimationDuration());
-			} else {
-				element.focus();
-			}
+			element.focus(event.paramObject);
 		}
 	});
 	// Install the scroller

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-focus-selector.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-focus-selector.tid
@@ -9,4 +9,4 @@ The `tm-focus-selector` message sets the focus to the DOM element identified by 
 
 |!Name |!Description |
 |param |Selector identifying the DOM element to be focussed  |
-
+|paramObject |Optional hashmap of additional parameters passed to the `focus` command |

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-focus-selector.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-focus-selector.tid
@@ -10,3 +10,5 @@ The `tm-focus-selector` message sets the focus to the DOM element identified by 
 |!Name |!Description |
 |param |Selector identifying the DOM element to be focussed  |
 |paramObject |Optional hashmap of additional parameters passed to the `focus` command |
+
+<<.tip """preventScroll="true" prevents the browser from scrolling to the focused element""">>


### PR DESCRIPTION
this delays the focussing for the time of the animation duration if delayed="yes" or delayed="true"

this is useful when navigating the story river up and down with keyboard shortcuts and the shortcuts focus the title input if a navigated tiddler is in edit mode -> navigation doesn't jump but stays smooth