### PR TITLE
Sidebar items should use list widget for visibility

### DIFF
--- a/core/ui/PageTemplate/sidebar.tid
+++ b/core/ui/PageTemplate/sidebar.tid
@@ -5,6 +5,9 @@ tags: $:/tags/PageTemplate
 \define config-title()
 $:/config/SideBarSegments/Visibility/$(listItem)$
 \end
+\define list-display-filter(tag, prefix)
+[all[shadows+tiddlers]tag[$tag$]!has[draft.of]] +[addprefix[$prefix$]!field:text[hide]removeprefix[$prefix$]]
+\end 
 
 <$scrollable fallthrough="no" class="tc-sidebar-scrollable">
 
@@ -12,13 +15,9 @@ $:/config/SideBarSegments/Visibility/$(listItem)$
 
 <$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes" animate="yes">
 
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/SideBarSegment]!has[draft.of]]" variable="listItem">
-
-<$reveal type="nomatch" state=<<config-title>> text="hide"  tag="div">
+<$list filter=<<list-display-filter "$:/tags/SideBarSegment" "$:/config/SideBarSegments/Visibility/">> variable="listItem">
 
 <$transclude tiddler=<<listItem>> mode="block"/>
-
-</$reveal>
 
 </$list>
 


### PR DESCRIPTION
The sidebar items should use the list widget for visibility and this filter combines both into one list item. The main purpose of this change is to make it easier to change the look of the page with only CSS.