### PR TITLE
Pass pathFilters as an array

### DIFF
--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -50,16 +50,10 @@ FileSystemAdaptor.prototype.getTiddlerFileInfo = function(tiddler,callback) {
 	var title = tiddler.fields.title,
 		fileInfo = $tw.boot.files[title];
 	if(!fileInfo) {
-		var pathFilters = this.wiki.getTiddlerText("$:/config/FileSystemPaths");
-		if(pathFilters !== null) {
-		    pathFilters = [ pathFilters ];
-		} else {
-		    pathFilters = [];
-		}
 		// Otherwise, we'll need to generate it
 		fileInfo = $tw.utils.generateTiddlerFileInfo(tiddler,{
 			directory: $tw.boot.wikiTiddlersPath,
-			pathFilters: pathFilters,
+			pathFilters: this.wiki.getTiddlerText("$:/config/FileSystemPaths","").split("\n"),
 			wiki: this.wiki
 		});
 		$tw.boot.files[title] = fileInfo;

--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -50,10 +50,16 @@ FileSystemAdaptor.prototype.getTiddlerFileInfo = function(tiddler,callback) {
 	var title = tiddler.fields.title,
 		fileInfo = $tw.boot.files[title];
 	if(!fileInfo) {
+		var pathFilters = this.wiki.getTiddlerText("$:/config/FileSystemPaths");
+		if(pathFilters !== null) {
+		    pathFilters = [ pathFilters ];
+		} else {
+		    pathFilters = [];
+		}
 		// Otherwise, we'll need to generate it
 		fileInfo = $tw.utils.generateTiddlerFileInfo(tiddler,{
 			directory: $tw.boot.wikiTiddlersPath,
-			pathFilters: this.wiki.getTiddlerText("$:/config/FileSystemPaths"),
+			pathFilters: pathFilters,
 			wiki: this.wiki
 		});
 		$tw.boot.files[title] = fileInfo;


### PR DESCRIPTION
Otherwise, when we try to iterate over pathFilters in the filesystem
utils module, we end up iterating over each character in the filter
string, which ends up generating 'Filter error_ Missing [ in filter
expression.tid' as the tiddler's filename

Fixes GH #4173