### PR TITLE
make wikify in save-wiki button evaluate on click

### DIFF
--- a/core/ui/PageControls/savewiki.tid
+++ b/core/ui/PageControls/savewiki.tid
@@ -3,10 +3,10 @@ tags: $:/tags/PageControls
 caption: {{$:/core/images/save-button}} {{$:/language/Buttons/SaveWiki/Caption}}
 description: {{$:/language/Buttons/SaveWiki/Hint}}
 
-<$button tooltip={{$:/language/Buttons/SaveWiki/Hint}} aria-label={{$:/language/Buttons/SaveWiki/Caption}} class=<<tv-config-toolbar-class>>>
+<$button tooltip={{$:/language/Buttons/SaveWiki/Hint}} aria-label={{$:/language/Buttons/SaveWiki/Caption}} class=<<tv-config-toolbar-class>> actions="""
 <$wikify name="site-title" text={{$:/config/SaveWikiButton/Filename}}>
 <$action-sendmessage $message="tm-save-wiki" $param={{$:/config/SaveWikiButton/Template}} filename=<<site-title>>/>
-</$wikify>
+</$wikify>""">
 <span class="tc-dirty-indicator">
 <$list filter="[<tv-config-toolbar-icons>match[yes]]">
 {{$:/core/images/save-button}}


### PR DESCRIPTION
this makes the wikify widget evaluate the content of `$:/config/SaveWikiButton/Filename` when the button is clicked

in case there's a `<<now>>` macro used for example