### PR TITLE
Improve parser automatic paragraph generation

### DIFF
--- a/core/modules/parsers/wikiparser/rules/html.js
+++ b/core/modules/parsers/wikiparser/rules/html.js
@@ -58,7 +58,7 @@ exports.parse = function() {
 	if (!tag.isSelfClosing) {
 		var temp = $tw.utils.parseTokenRegExp(
 			this.parser.source, this.parser.pos,
-			/([^\S\n\r]*\r?\n|$)?([^\S\n\r]*\r?\n|$)?/g
+			/([^\S\n\r]*\r?\n)?([^\S\n\r]*\r?\n)?/g
 		);
 		if (typeof(temp.match[1]) !== 'undefined') {
 			if (typeof(temp.match[2]) !== 'undefined') {
@@ -160,7 +160,7 @@ exports.parseTag = function(source,pos,options) {
 	// element will not be wrapped in a p. If there is none, abort and instead
 	// later parse this element during an inline run (it will be wrapped in a p).
 	if(options.requireLineBreak) {
-		token = $tw.utils.parseTokenRegExp(source,pos,/([^\S\n\r]*\r?\n|$)/g);
+		token = $tw.utils.parseTokenRegExp(source,pos,/([^\S\n\r]*\r?\n)/g);
 		if(!token) {
 			return null;
 		}

--- a/core/modules/parsers/wikiparser/rules/html.js
+++ b/core/modules/parsers/wikiparser/rules/html.js
@@ -132,7 +132,7 @@ exports.parseTag = function(source,pos,options) {
 	pos = token.end;
 	// Check for a required line break
 	if(options.requireLineBreak) {
-		token = $tw.utils.parseTokenRegExp(source,pos,/([^\S\n\r]*\r?\n(?:[^\S\n\r]*\r?\n|$))/g);
+		token = $tw.utils.parseTokenRegExp(source,pos,/([^\S\n\r]*\r?\n|$)/g);
 		if(!token) {
 			return null;
 		}

--- a/core/ui/MoreSideBar/Tags.tid
+++ b/core/ui/MoreSideBar/Tags.tid
@@ -18,7 +18,7 @@ caption: {{$:/language/SideBar/Tags/Caption}}
 
 <$list filter={{$:/core/Filters/AllTags!!filter}}>
 
-<$transclude tiddler="$:/core/ui/TagTemplate"></$transclude>
+<$transclude tiddler="$:/core/ui/TagTemplate"/>
 
 </$list>
 

--- a/core/ui/MoreSideBar/Tags.tid
+++ b/core/ui/MoreSideBar/Tags.tid
@@ -18,7 +18,7 @@ caption: {{$:/language/SideBar/Tags/Caption}}
 
 <$list filter={{$:/core/Filters/AllTags!!filter}}>
 
-<$transclude tiddler="$:/core/ui/TagTemplate"/>
+<$transclude tiddler="$:/core/ui/TagTemplate"></$transclude>
 
 </$list>
 

--- a/core/ui/TagTemplate.tid
+++ b/core/ui/TagTemplate.tid
@@ -1,15 +1,14 @@
 title: $:/core/ui/TagTemplate
 
 \whitespace trim
-<span class="tc-tag-list-item">
-<$set name="transclusion" value=<<currentTiddler>>>
+<span class="tc-tag-list-item"><$set name="transclusion" value=<<currentTiddler>>>
 <$macrocall $name="tag-pill-body" tag=<<currentTiddler>> icon={{!!icon}} colour={{!!color}} palette={{$:/palette}} element-tag="""$button""" element-attributes="""popup=<<qualify "$:/state/popup/tag">> dragFilter='[all[current]tagging[]]' tag='span'"""/>
 <$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes" class="tc-drop-down">
 <$set name="tv-show-missing-links" value="yes">
 <$transclude tiddler="$:/core/ui/ListItemTemplate"/>
 </$set>
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/TagDropdown]!has[draft.of]]" variable="listItem"> 
-<$transclude tiddler=<<listItem>>/> 
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/TagDropdown]!has[draft.of]]" variable="listItem">
+<$transclude tiddler=<<listItem>>/>
 </$list>
 <hr>
 <$macrocall $name="list-tagged-draggable" tag=<<currentTiddler>>/>

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -163,7 +163,7 @@ describe("Widget module", function() {
 		var wrapper = renderWidgetNode(widgetNode);
 		describe("should detect the recursion", function() {
 			// Test the rendering
-			expect(wrapper.innerHTML).toBe("<span class=\"tc-error\">Recursive transclusion error in transclude widget</span>\n");
+			expect(wrapper.innerHTML).toBe("<span class=\"tc-error\">Recursive transclusion error in transclude widget</span>");
 		});
 
 	});
@@ -176,7 +176,7 @@ describe("Widget module", function() {
 		// Render the widget node to the DOM
 		var wrapper = renderWidgetNode(widgetNode);
 		// Test the rendering
-		expect(wrapper.innerHTML).toBe("<svg class=\"tv-image-new-button\" height=\"22pt\" viewBox=\"83 81 50 50\" width=\"22pt\"><path d=\"M 101.25 112.5 L 101.25 127.5 C 101.25 127.5 101.25 127.5 101.25 127.5 L 101.25 127.5 C 101.25 129.156855 102.593146 130.5 104.25 130.5 L 111.75 130.5 C 113.406854 130.5 114.75 129.156854 114.75 127.5 L 114.75 112.5 L 129.75 112.5 C 131.406854 112.5 132.75 111.156854 132.75 109.5 L 132.75 102 C 132.75 100.343146 131.406854 99 129.75 99 L 114.75 99 L 114.75 84 C 114.75 82.343146 113.406854 81 111.75 81 L 104.25 81 C 104.25 81 104.25 81 104.25 81 C 102.593146 81 101.25 82.343146 101.25 84 L 101.25 99 L 86.25 99 C 86.25 99 86.25 99 86.25 99 C 84.593146 99 83.25 100.343146 83.25 102 L 83.25 109.5 C 83.25 109.5 83.25 109.5 83.25 109.5 L 83.25 109.5 C 83.25 111.156855 84.593146 112.5 86.25 112.5 Z\"></path></svg>\n");
+		expect(wrapper.innerHTML).toBe("<svg class=\"tv-image-new-button\" height=\"22pt\" viewBox=\"83 81 50 50\" width=\"22pt\"><path d=\"M 101.25 112.5 L 101.25 127.5 C 101.25 127.5 101.25 127.5 101.25 127.5 L 101.25 127.5 C 101.25 129.156855 102.593146 130.5 104.25 130.5 L 111.75 130.5 C 113.406854 130.5 114.75 129.156854 114.75 127.5 L 114.75 112.5 L 129.75 112.5 C 131.406854 112.5 132.75 111.156854 132.75 109.5 L 132.75 102 C 132.75 100.343146 131.406854 99 129.75 99 L 114.75 99 L 114.75 84 C 114.75 82.343146 113.406854 81 111.75 81 L 104.25 81 C 104.25 81 104.25 81 104.25 81 C 102.593146 81 101.25 82.343146 101.25 84 L 101.25 99 L 86.25 99 C 86.25 99 86.25 99 86.25 99 C 84.593146 99 83.25 100.343146 83.25 102 L 83.25 109.5 C 83.25 109.5 83.25 109.5 83.25 109.5 L 83.25 109.5 C 83.25 111.156855 84.593146 112.5 86.25 112.5 Z\"></path></svg>");
 		expect(wrapper.firstChild.namespaceURI).toBe("http://www.w3.org/2000/svg");
 	});
 

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -100,7 +100,7 @@ describe("WikiText parser tests", function() {
 		);
 		expect(parse("<div><div attribute={{TiddlerTitle!!field}}>\n!some heading</div></div>")).toEqual(
 
-			[ { type : 'element', tag : 'p', children : [ { type : 'element', start : 0, attributes : {  }, tag : 'div', end : 5, isBlock : false, children : [ { type : 'element', start : 5, attributes : { attribute : { start : 9, name : 'attribute', type : 'indirect', textReference : 'TiddlerTitle!!field', end : 43 } }, tag : 'div', end : 44, isBlock : false, children : [ { type : 'text', text : '\n!some heading' } ] } ] } ] } ]
+			[ { type : 'element', tag : 'p', children : [ { type : 'element', start : 0, attributes : {  }, tag : 'div', end : 5, isBlock : false, children : [ { type : 'element', start : 5, attributes : { attribute : { start : 9, name : 'attribute', type : 'indirect', textReference : 'TiddlerTitle!!field', end : 43 } }, tag : 'div', end : 44, isBlock : false, children : [ { type : 'text', text : '!some heading' } ] } ] } ] } ]
 
 		);
 	});

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -171,16 +171,19 @@ describe("WikiText parser tests", function() {
 	});
 
 	it("should trim unneeded, but preserve needed whitespace", function() {
+		// autoparagraphed elements / whitespace before end of parsed string
 		expect(parse("...")).toEqual(
 			[ { type : 'element', tag : 'p', children : [ { type : 'text', text : '...' } ] } ]
 		);
 		expect(parse("\r\t ...")).toEqual(parse("..."));
 		expect(parse("...\n\n")).toEqual(parse("..."));
 
+		// inline mode
 		expect(parse("<e>...</e>")).toEqual(
 			[ { "type": "element", "tag": "p", "children": [ { "type": "element", "tag": "e", "isBlock": false, "start": 0, "end": 3, "attributes": {}, "children": [ { "type": "text", "text": "..." } ] } ] } ]
 		);
 
+		// block mode
 		expect(parse("<e>\n\n...</e>")).toEqual(
 			[ { type : 'element', tag : 'e', isBlock : true, start : 0, end : 3, attributes : {}, children : [ { type : 'element', tag : 'p', children : [ { type : 'text', text : '...' } ] } ] } ]
 		);

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -206,6 +206,11 @@ describe("WikiText parser tests", function() {
 		expect(parse("<e>\n... \t\r\n</e>")).toEqual(parse("<e>\n...</e>"));
 		expect(parse("<e>\n...\n\n</e>")).toEqual(parse("<e>\n...</e>"));
 
+		// preserve an indented first line in the element block, children inline mode. Needed for eg. pre´s.
+		expect(parse("<pre>\n    i am indented\n</pre>")).toEqual(
+			[ { "type": "element", "tag": "pre", "isBlock": true, "start": 0, "end": 5, "attributes": {}, "children": [ { "type": "text", "text": "    i am indented" } ] } ]
+		);
+
 		// block mode
 		expect(parse("<e>\n\n...</e>")).toEqual(
 			[ { type : 'element', tag : 'e', isBlock : true, start : 0, end : 3, attributes : {}, children : [ { type : 'element', tag : 'p', children : [ { type : 'text', text : '...' } ] } ] } ]

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -170,6 +170,19 @@ describe("WikiText parser tests", function() {
 		expect(parse("<x>\n\n!block")).toEqual(parse("<x>\n\n!block\n\n</x>"));
 	});
 
+	it("should parse elements in block, children in inline mode", function() {
+		expect(parse("<block>\n</block>")).toEqual(
+			[ { "type": "element", "tag": "block", "isBlock": true, "start": 0, "end": 7, "attributes": {}, "children": [] } ]
+		);
+		expect(parse("<block>\n</block>")).toEqual(parse("<block>\n\n</block>"));
+		expect(parse("<block>\n")).toEqual(parse("<block>\n</block>"));
+
+		expect(parse("<block>\n!inline</block>")).toEqual(
+			[ { "type": "element", "tag": "block", "isBlock": true, "start": 0, "end": 7, "attributes": {}, "children": [ { "type": "text", "text": "!inline" } ] } ]
+		);
+		expect(parse("<block>\n!inline")).toEqual(parse("<block>\n!inline</block>"));
+	});
+
 	it("should trim unneeded, but preserve needed whitespace", function() {
 		// autoparagraphed elements / whitespace before end of parsed string
 		expect(parse("...")).toEqual(

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -176,6 +176,11 @@ describe("WikiText parser tests", function() {
 		);
 		expect(parse("\r\t ...")).toEqual(parse("..."));
 		expect(parse("...\n\n")).toEqual(parse("..."));
+
+		expect(parse("<e>...</e>")).toEqual(
+			[ { "type": "element", "tag": "p", "children": [ { "type": "element", "tag": "e", "isBlock": false, "start": 0, "end": 3, "attributes": {}, "children": [ { "type": "text", "text": "..." } ] } ] } ]
+		);
+
 		expect(parse("<e>\n\n...</e>")).toEqual(
 			[ { type : 'element', tag : 'e', isBlock : true, start : 0, end : 3, attributes : {}, children : [ { type : 'element', tag : 'p', children : [ { type : 'text', text : '...' } ] } ] } ]
 		);

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -189,17 +189,28 @@ describe("WikiText parser tests", function() {
 			[ { type : 'element', tag : 'p', children : [ { type : 'text', text : '...' } ] } ]
 		);
 		expect(parse("\r\t ...")).toEqual(parse("..."));
+		expect(parse("... \t\r\n")).toEqual(parse("..."));
 		expect(parse("...\n\n")).toEqual(parse("..."));
 
 		// inline mode
 		expect(parse("<e>...</e>")).toEqual(
 			[ { "type": "element", "tag": "p", "children": [ { "type": "element", "tag": "e", "isBlock": false, "start": 0, "end": 3, "attributes": {}, "children": [ { "type": "text", "text": "..." } ] } ] } ]
 		);
+		expect(parse("<e>... \t\r\n</e>")).toEqual(parse("<e>...</e>"));
+		expect(parse("<e>...\n\n</e>")).toEqual(parse("<e>...</e>"));
+
+		// element block, children inline mode
+		expect(parse("<e>\n...</e>")).toEqual(
+			[ { "type": "element", "tag": "e", "isBlock": true, "start": 0, "end": 3, "attributes": {}, "children": [ { "type": "text", "text": "..." } ] } ]
+		);
+		expect(parse("<e>\n... \t\r\n</e>")).toEqual(parse("<e>\n...</e>"));
+		expect(parse("<e>\n...\n\n</e>")).toEqual(parse("<e>\n...</e>"));
 
 		// block mode
 		expect(parse("<e>\n\n...</e>")).toEqual(
 			[ { type : 'element', tag : 'e', isBlock : true, start : 0, end : 3, attributes : {}, children : [ { type : 'element', tag : 'p', children : [ { type : 'text', text : '...' } ] } ] } ]
 		);
+		expect(parse("<e>\n\n... \t\r\n</e>")).toEqual(parse("<e>\n\n...</e>"));
 		expect(parse("<e>\n\n...\n\n</e>")).toEqual(parse("<e>\n\n...</e>"));
 	});
 

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -141,6 +141,47 @@ describe("WikiText parser tests", function() {
 
 	});
 
+	it("should parse elements in inline mode", function() {
+		expect(parse("<inline></inline>")).toEqual(
+			[ { type : 'element', tag : 'p', children : [ { type : 'element', tag : 'inline', isBlock : false, start : 0, end : 8, attributes : {}, children : [] } ] } ]
+		);
+		expect(parse("<inline>")).toEqual(parse("<inline></inline>"));
+		expect(parse("<inline/>")).toEqual(
+			[ { type : 'element', tag : 'p', children : [ { type : 'element', tag : 'inline', isSelfClosing : true, isBlock : false, start : 0, end : 9, attributes : {} } ] } ]
+		);
+		expect(parse("<x>!inline</x>")).toEqual(
+			[ { type : 'element', tag : 'p', children : [ { type : 'element', tag : 'x', isBlock : false, start : 0, end : 3, attributes : {}, children : [ { type : 'text', text : '!inline' } ] } ] } ]
+		);
+		expect(parse("<x>!inline")).toEqual(parse("<x>!inline</x>"));
+	});
+
+	it("should parse elements in block mode", function() {
+		expect(parse("<block>\n\n</block>")).toEqual(
+			[ { type : 'element', tag : 'block', isBlock : true, start : 0, end : 7, attributes : {}, children : [] } ]
+		);
+		expect(parse("<block>\n\n")).toEqual(parse("<block>\n\n</block>"));
+		expect(parse("<block/>\n")).toEqual(
+			[ { type : 'element', tag : 'block', isSelfClosing : true, isBlock : true, start : 0, end : 8, attributes : {} } ]
+		);
+
+		expect(parse("<x>\n\n!block\n\n</x>")).toEqual(
+			[ { type : 'element', tag : 'x', isBlock : true, start : 0, end : 3, attributes : {}, children : [ { type : 'element', tag : 'h1', attributes : { 'class' : { type : 'string', value : '' } }, children : [ { type : 'text', text : 'block' } ] } ] } ]
+		);
+		expect(parse("<x>\n\n!block")).toEqual(parse("<x>\n\n!block\n\n</x>"));
+	});
+
+	it("should trim unneeded, but preserve needed whitespace", function() {
+		expect(parse("...")).toEqual(
+			[ { type : 'element', tag : 'p', children : [ { type : 'text', text : '...' } ] } ]
+		);
+		expect(parse("\r\t ...")).toEqual(parse("..."));
+		expect(parse("...\n\n")).toEqual(parse("..."));
+		expect(parse("<e>\n\n...</e>")).toEqual(
+			[ { type : 'element', tag : 'e', isBlock : true, start : 0, end : 3, attributes : {}, children : [ { type : 'element', tag : 'p', children : [ { type : 'text', text : '...' } ] } ] } ]
+		);
+		expect(parse("<e>\n\n...\n\n</e>")).toEqual(parse("<e>\n\n...</e>"));
+	});
+
 });
 
 })();

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -217,6 +217,13 @@ describe("WikiText parser tests", function() {
 		);
 		expect(parse("<e>\n\n... \t\r\n</e>")).toEqual(parse("<e>\n\n...</e>"));
 		expect(parse("<e>\n\n...\n\n</e>")).toEqual(parse("<e>\n\n...</e>"));
+
+		// preserve whitespace between nodes, only trim inside.
+		expect(
+			parse("i <em> like </em> Wikis!")
+		).toEqual(
+			parse("i <em>like</em> Wikis!")
+		);
 	});
 
 });

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -715,6 +715,10 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	fill: <<colour foreground>>;
 }
 
+.tc-page-controls, .tc-sidebar-search, .tc-sidebar-tabs {
+	margin-top: 14px;
+}
+
 .tc-sidebar-header {
 	color: <<colour sidebar-foreground>>;
 	fill: <<colour sidebar-foreground>>;
@@ -744,7 +748,6 @@ button.tc-btn-invisible.tc-remove-tag-button {
 }
 
 .tc-page-controls {
-	margin-top: 14px;
 	font-size: 1.5em;
 }
 


### PR DESCRIPTION
An elegant solution for #3854.

* The first commit changes one (!) regex and with this change all unwanted p´s are gone :-) It also adds a CSS rule in order to fix the resulting padding issues in the sidebar.
* The second commit can be ignored, i replace those changes in the third commit.
* The third commit introduces a (hopefully) smart removal of whitespaces after opening and before closing tags of an element. It contains the most code changes. It is needed because of the new way to interpret newlines after an opening tag.

It´s all done in the parser.

Please see the descriptions in the commit comments and in the source code for further infos.

May be possible that we need to tweak some more CSS rules or a few template tiddlers here and there but so far everything seems to work.

For the records: After these changes we are down from 76 to 66 errors in the W3C html validator. I tested a complete wiki document, removing the storage and core functionality divs, and the styles from the head - otherwise the document is too huge for the validator - and i added a html5 doctype.