### PR TITLE
Fixed 3 typos in the example in line 88

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
@@ -85,6 +85,6 @@ Filtered attribute values are indicated with triple curly braces around a [[Filt
 This example shows how to add a prefix to a value:
 
 ```
-<$text text={{{ [<currentTiddler>]addPrefix[$:/myprefix/]] }}}>
+<$text text={{{ [<currentTiddler>addprefix[$:/myprefix/]] }}} />
 ```
 


### PR DESCRIPTION
1.     Removed closing square bracket after <currentTiddler>
2.    Changed capital 'P' in addprefix
3.    Added missing slash at the end