### PR TITLE
add $:/language/DefaultNewTiddlerTags option for predefined tags

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -13,6 +13,7 @@ Basics/Language/Prompt: Hello! Current language:
 Basics/NewJournal/Title/Prompt: Title of new journal tiddlers
 Basics/NewJournal/Text/Prompt: Text for new journal tiddlers
 Basics/NewJournal/Tags/Prompt: Tags for new journal tiddlers
+Basics/NewTiddler/Tags/Prompt: Tags for new tiddlers
 Basics/NewTiddler/Title/Prompt: Title of new tiddlers
 Basics/OverriddenShadowTiddlers/Prompt: Number of overridden shadow tiddlers:
 Basics/ShadowTiddlers/Prompt: Number of shadow tiddlers:

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -556,18 +556,7 @@ NavigatorWidget.prototype.handlePerformImportEvent = function(event) {
 	$tw.utils.each(importData.tiddlers,function(tiddlerFields) {
 		var title = tiddlerFields.title;
 		if(title && importTiddler && importTiddler.fields["selection-" + title] !== "unchecked") {
-			var tiddler;
-			if(moreTags && tiddlerFields.tags) {
-				tiddler = new $tw.Tiddler(tiddlerFields,{
-					tags: tiddlerFields.tags + " " + moreTags
-				});
-			} else if (moreTags) {
-				tiddler = new $tw.Tiddler(tiddlerFields,{
-					tags: moreTags
-				});
-			} else {
-				tiddler = new $tw.Tiddler(tiddlerFields);
-			}
+			var tiddler = new $tw.Tiddler(tiddlerFields);
 			tiddler = $tw.hooks.invokeHook("th-importing-tiddler",tiddler);
 			self.wiki.addTiddler(tiddler);
 			importReport.push("# [[" + tiddlerFields.title + "]]");

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -556,9 +556,18 @@ NavigatorWidget.prototype.handlePerformImportEvent = function(event) {
 	$tw.utils.each(importData.tiddlers,function(tiddlerFields) {
 		var title = tiddlerFields.title;
 		if(title && importTiddler && importTiddler.fields["selection-" + title] !== "unchecked") {
-			var tiddler = new $tw.Tiddler(tiddlerFields,{
-				tags: tiddlerFields.tags + " " + moreTags
-			});
+			var tiddler;
+			if(moreTags && tiddlerFields.tags) {
+				tiddler = new $tw.Tiddler(tiddlerFields,{
+					tags: tiddlerFields.tags + " " + moreTags
+				});
+			} else if (moreTags) {
+				tiddler = new $tw.Tiddler(tiddlerFields,{
+					tags: moreTags
+				});
+			} else {
+				tiddler = new $tw.Tiddler(tiddlerFields);
+			}
 			tiddler = $tw.hooks.invokeHook("th-importing-tiddler",tiddler);
 			self.wiki.addTiddler(tiddler);
 			importReport.push("# [[" + tiddlerFields.title + "]]");

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -549,13 +549,16 @@ NavigatorWidget.prototype.handlePerformImportEvent = function(event) {
 	var self = this,
 		importTiddler = this.wiki.getTiddler(event.param),
 		importData = this.wiki.getTiddlerDataCached(event.param,{tiddlers: {}}),
-		importReport = [];
+		importReport = [],
+	    	moreTags = this.wiki.getTiddlerText("$:/language/DefaultNewTiddlerTags");
 	// Add the tiddlers to the store
 	importReport.push($tw.language.getString("Import/Imported/Hint") + "\n");
 	$tw.utils.each(importData.tiddlers,function(tiddlerFields) {
 		var title = tiddlerFields.title;
 		if(title && importTiddler && importTiddler.fields["selection-" + title] !== "unchecked") {
-			var tiddler = new $tw.Tiddler(tiddlerFields);
+			var tiddler = new $tw.Tiddler(tiddlerFields,{
+				tags: tiddlerFields.tags + " " + moreTags
+			});
 			tiddler = $tw.hooks.invokeHook("th-importing-tiddler",tiddler);
 			self.wiki.addTiddler(tiddler);
 			importReport.push("# [[" + tiddlerFields.title + "]]");

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -549,8 +549,7 @@ NavigatorWidget.prototype.handlePerformImportEvent = function(event) {
 	var self = this,
 		importTiddler = this.wiki.getTiddler(event.param),
 		importData = this.wiki.getTiddlerDataCached(event.param,{tiddlers: {}}),
-		importReport = [],
-	    	moreTags = this.wiki.getTiddlerText("$:/language/DefaultNewTiddlerTags");
+		importReport = [];
 	// Add the tiddlers to the store
 	importReport.push($tw.language.getString("Import/Imported/Hint") + "\n");
 	$tw.utils.each(importData.tiddlers,function(tiddlerFields) {

--- a/core/ui/Actions/new-image.tid
+++ b/core/ui/Actions/new-image.tid
@@ -6,5 +6,5 @@ description: create a new image tiddler
 image/$(imageType)$
 \end
 <$vars imageType={{$:/config/NewImageType}}>
-<$action-sendmessage $message="tm-new-tiddler" type=<<get-type>>/>
+<$action-sendmessage $message="tm-new-tiddler" type=<<get-type>> tags={{$:/config/NewTiddler/Tags}}/>
 </$vars>

--- a/core/ui/Actions/new-image.tid
+++ b/core/ui/Actions/new-image.tid
@@ -6,5 +6,5 @@ description: create a new image tiddler
 image/$(imageType)$
 \end
 <$vars imageType={{$:/config/NewImageType}}>
-<$action-sendmessage $message="tm-new-tiddler" type=<<get-type>> tags={{$:/config/NewTiddler/Tags}}/>
+<$action-sendmessage $message="tm-new-tiddler" type=<<get-type>> tags={{$:/language/DefaultNewTiddlerTags}}/>
 </$vars>

--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -2,13 +2,16 @@ title: $:/core/ui/Actions/new-journal
 tags: $:/tags/Actions
 description: create a new journal tiddler
 
+\define get-tags()
+$(journalTags)$ $(moreTags)$
+\end
 <$vars journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags}} moreTags={{$:/language/DefaultNewTiddlerTags}} journalText={{$:/config/NewJournal/Text}}>
 <$wikify name="journalTitle" text="""<$macrocall $name="now" format=<<journalTitleTemplate>>/>""">
 <$reveal type="nomatch" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags={{{ [enlist<journalTags>] [enlist<moreTags>] }}} text={{{ [<journalTitle>get[]] }}}/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<get-tags>> text={{{ [<journalTitle>get[]] }}}/>
 </$reveal>
 <$reveal type="match" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags={{{ [enlist<journalTags>] [enlist<moreTags>] }}} text=<<journalText>>/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<get-tags>> text=<<journalText>>/>
 </$reveal>
 </$wikify>
 </$vars>

--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -2,16 +2,13 @@ title: $:/core/ui/Actions/new-journal
 tags: $:/tags/Actions
 description: create a new journal tiddler
 
-\define get-tags()
-$(journalTags)$ $(moreTags)$
-\end
 <$vars journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags}} moreTags={{$:/language/DefaultNewTiddlerTags}} journalText={{$:/config/NewJournal/Text}}>
 <$wikify name="journalTitle" text="""<$macrocall $name="now" format=<<journalTitleTemplate>>/>""">
 <$reveal type="nomatch" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<get-tags>> text={{{ [<journalTitle>get[]] }}}/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags={{{ [enlist<journalTags>] [enlist<moreTags>] }}} text={{{ [<journalTitle>get[]] }}}/>
 </$reveal>
 <$reveal type="match" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<journalTags>> text=<<journalText>>/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags={{{ [enlist<journalTags>] [enlist<moreTags>] }}} text=<<journalText>>/>
 </$reveal>
 </$wikify>
 </$vars>

--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -5,7 +5,7 @@ description: create a new journal tiddler
 \define get-tags()
 $(journalTags)$ $(moreTags)$
 \end
-<$vars journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags}} moreTags={{$:/config/NewTiddler/Tags}} journalText={{$:/config/NewJournal/Text}}>
+<$vars journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags}} moreTags={{$:/language/DefaultNewTiddlerTags}} journalText={{$:/config/NewJournal/Text}}>
 <$wikify name="journalTitle" text="""<$macrocall $name="now" format=<<journalTitleTemplate>>/>""">
 <$reveal type="nomatch" state=<<journalTitle>> text="">
 <$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<get-tags>> text={{{ [<journalTitle>get[]] }}}/>

--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -2,10 +2,13 @@ title: $:/core/ui/Actions/new-journal
 tags: $:/tags/Actions
 description: create a new journal tiddler
 
-<$vars journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags}} journalText={{$:/config/NewJournal/Text}}>
+\define get-tags()
+$(journalTags)$ $(moreTags)$
+\end
+<$vars journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags}} moreTags={{$:/config/NewTiddler/Tags}} journalText={{$:/config/NewJournal/Text}}>
 <$wikify name="journalTitle" text="""<$macrocall $name="now" format=<<journalTitleTemplate>>/>""">
 <$reveal type="nomatch" state=<<journalTitle>> text="">
-<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<journalTags>> text={{{ [<journalTitle>get[]] }}}/>
+<$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<get-tags>> text={{{ [<journalTitle>get[]] }}}/>
 </$reveal>
 <$reveal type="match" state=<<journalTitle>> text="">
 <$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<journalTags>> text=<<journalText>>/>

--- a/core/ui/Actions/new-tiddler.tid
+++ b/core/ui/Actions/new-tiddler.tid
@@ -2,4 +2,4 @@ title: $:/core/ui/Actions/new-tiddler
 tags: $:/tags/Actions
 description: create a new empty tiddler
 
-<$action-sendmessage $message="tm-new-tiddler"/>
+<$action-sendmessage $message="tm-new-tiddler" tags={{$:/config/NewTiddler/Tags}}/>

--- a/core/ui/Actions/new-tiddler.tid
+++ b/core/ui/Actions/new-tiddler.tid
@@ -2,4 +2,4 @@ title: $:/core/ui/Actions/new-tiddler
 tags: $:/tags/Actions
 description: create a new empty tiddler
 
-<$action-sendmessage $message="tm-new-tiddler" tags={{$:/config/NewTiddler/Tags}}/>
+<$action-sendmessage $message="tm-new-tiddler" tags={{$:/language/DefaultNewTiddlerTags}}/>

--- a/core/ui/ControlPanel/Basics.tid
+++ b/core/ui/ControlPanel/Basics.tid
@@ -21,6 +21,7 @@ caption: {{$:/language/ControlPanel/Basics/Caption}}
 |<$link to="$:/config/AnimationDuration"><<lingo AnimDuration/Prompt>></$link> |<$edit-text tiddler="$:/config/AnimationDuration" default="" tag="input"/> |
 |<$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link> |<<lingo DefaultTiddlers/TopHint>><br> <$edit tag="textarea" tiddler="$:/DefaultTiddlers" class="tc-edit-texteditor"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
 |<$link to="$:/language/DefaultNewTiddlerTitle"><<lingo NewTiddler/Title/Prompt>></$link> |<$edit-text tiddler="$:/language/DefaultNewTiddlerTitle" default="" tag="input"/> |
+|<$link to="$:/language/DefaultNewTiddlerTags"><<lingo NewTiddler/Tags/Prompt>></$link> |<$edit-text tiddler="$:/language/DefaultNewTiddlerTags" default="" tag="input"/> |
 |<$link to="$:/config/NewJournal/Title"><<lingo NewJournal/Title/Prompt>></$link> |<$edit-text tiddler="$:/config/NewJournal/Title" default="" tag="input"/> |
 |<$link to="$:/config/NewJournal/Text"><<lingo NewJournal/Text/Prompt>></$link> |<$edit tiddler="$:/config/NewJournal/Text" tag="textarea" class="tc-edit-texteditor" default=""/> |
 |<$link to="$:/config/NewJournal/Tags"><<lingo NewJournal/Tags/Prompt>></$link> |<$edit-text tiddler="$:/config/NewJournal/Tags" default="" tag="input"/> |

--- a/core/ui/PageControls/new-image.tid
+++ b/core/ui/PageControls/new-image.tid
@@ -3,7 +3,8 @@ tags: $:/tags/PageControls
 caption: {{$:/core/images/new-image-button}} {{$:/language/Buttons/NewImage/Caption}}
 description: {{$:/language/Buttons/NewImage/Hint}}
 
-<$button tooltip={{$:/language/Buttons/NewImage/Hint}} aria-label={{$:/language/Buttons/NewImage/Caption}} class=<<tv-config-toolbar-class>> actions={{$:/core/ui/Actions/new-image}}>
+<$button tooltip={{$:/language/Buttons/NewImage/Hint}} aria-label={{$:/language/Buttons/NewImage/Caption}} class=<<tv-config-toolbar-class>>>
+{{$:/core/ui/Actions/new-image}}
 <$list filter="[<tv-config-toolbar-icons>match[yes]]">
 {{$:/core/images/new-image-button}}
 </$list>

--- a/core/ui/PageControls/new-journal.tid
+++ b/core/ui/PageControls/new-journal.tid
@@ -4,7 +4,8 @@ caption: {{$:/core/images/new-journal-button}} {{$:/language/Buttons/NewJournal/
 description: {{$:/language/Buttons/NewJournal/Hint}}
 
 \define journalButton()
-<$button tooltip={{$:/language/Buttons/NewJournal/Hint}} aria-label={{$:/language/Buttons/NewJournal/Caption}} class=<<tv-config-toolbar-class>> actions={{$:/core/ui/Actions/new-journal}}>
+<$button tooltip={{$:/language/Buttons/NewJournal/Hint}} aria-label={{$:/language/Buttons/NewJournal/Caption}} class=<<tv-config-toolbar-class>>>
+{{$:/core/ui/Actions/new-journal}}
 <$list filter="[<tv-config-toolbar-icons>match[yes]]">
 {{$:/core/images/new-journal-button}}
 </$list>

--- a/core/ui/PageControls/newtiddler.tid
+++ b/core/ui/PageControls/newtiddler.tid
@@ -3,7 +3,8 @@ tags: $:/tags/PageControls
 caption: {{$:/core/images/new-button}} {{$:/language/Buttons/NewTiddler/Caption}}
 description: {{$:/language/Buttons/NewTiddler/Hint}}
 
-<$button actions={{$:/core/ui/Actions/new-tiddler}} tooltip={{$:/language/Buttons/NewTiddler/Hint}} aria-label={{$:/language/Buttons/NewTiddler/Caption}} class=<<tv-config-toolbar-class>>>
+<$button tooltip={{$:/language/Buttons/NewTiddler/Hint}} aria-label={{$:/language/Buttons/NewTiddler/Caption}} class=<<tv-config-toolbar-class>>>
+{{$:/core/ui/Actions/new-tiddler}}
 <$list filter="[<tv-config-toolbar-icons>match[yes]]">
 {{$:/core/images/new-button}}
 </$list>

--- a/core/ui/ViewToolbar/new-here.tid
+++ b/core/ui/ViewToolbar/new-here.tid
@@ -4,9 +4,14 @@ caption: {{$:/core/images/new-here-button}} {{$:/language/Buttons/NewHere/Captio
 description: {{$:/language/Buttons/NewHere/Hint}}
 
 \whitespace trim
+\define get-tags()
+$(tags)$ $(moreTags)$
+\end
 \define newHereActions()
 <$set name="tags" filter="[<currentTiddler>]">
-<$action-sendmessage $message="tm-new-tiddler" tags=<<tags>>/>
+<$set name="moreTags" value={{$:/config/NewTiddler/Tags}}>
+<$action-sendmessage $message="tm-new-tiddler" tags=<<get-tags>>/>
+</$set>
 </$set>
 \end
 \define newHereButton()

--- a/core/ui/ViewToolbar/new-here.tid
+++ b/core/ui/ViewToolbar/new-here.tid
@@ -9,7 +9,7 @@ $(tags)$ $(moreTags)$
 \end
 \define newHereActions()
 <$set name="tags" filter="[<currentTiddler>]">
-<$set name="moreTags" value={{$:/config/NewTiddler/Tags}}>
+<$set name="moreTags" value={{$:/language/DefaultNewTiddlerTags}}>
 <$action-sendmessage $message="tm-new-tiddler" tags=<<get-tags>>/>
 </$set>
 </$set>

--- a/core/ui/ViewToolbar/new-journal-here.tid
+++ b/core/ui/ViewToolbar/new-journal-here.tid
@@ -5,7 +5,7 @@ description: {{$:/language/Buttons/NewJournalHere/Hint}}
 
 \whitespace trim
 \define journalButtonTags()
-[[$(currentTiddlerTag)$]] $(journalTags)$
+[[$(currentTiddlerTag)$]] $(journalTags)$ $(moreTags)$
 \end
 \define journalButton()
 <$button tooltip={{$:/language/Buttons/NewJournalHere/Hint}} aria-label={{$:/language/Buttons/NewJournalHere/Caption}} class=<<tv-config-toolbar-class>>>
@@ -24,8 +24,10 @@ description: {{$:/language/Buttons/NewJournalHere/Hint}}
 \end
 <$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
 <$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
+<$set name="moreTags" value={{$:/config/NewTiddler/Tags}}>
 <$set name="currentTiddlerTag" value=<<currentTiddler>>>
 <<journalButton>>
+</$set>
 </$set>
 </$set>
 </$set>

--- a/core/ui/ViewToolbar/new-journal-here.tid
+++ b/core/ui/ViewToolbar/new-journal-here.tid
@@ -24,7 +24,7 @@ description: {{$:/language/Buttons/NewJournalHere/Hint}}
 \end
 <$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
 <$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
-<$set name="moreTags" value={{$:/config/NewTiddler/Tags}}>
+<$set name="moreTags" value={{$:/language/DefaultNewTiddlerTags}}>
 <$set name="currentTiddlerTag" value=<<currentTiddler>>>
 <<journalButton>>
 </$set>

--- a/languages/de-DE/ControlPanel.multids
+++ b/languages/de-DE/ControlPanel.multids
@@ -13,6 +13,7 @@ Basics/Language/Prompt: Hallo! Aktuelle Sprache:
 Basics/NewJournal/Title/Prompt: Titel des neuen Journal-Tiddlers:
 Basics/NewJournal/Text/Prompt: Text des neuen Journal-Tiddlers:
 Basics/NewJournal/Tags/Prompt: Tags des neuen Journal-Tiddlers:
+Basics/NewTiddler/Tags/Prompt: Tags des neuen Tiddlers:
 Basics/NewTiddler/Title/Prompt: Titel des neuen Tiddlers:
 Basics/OverriddenShadowTiddlers/Prompt: Anzahl überschriebener Schatten-Tiddler:
 Basics/ShadowTiddlers/Prompt: Anzahl Schatten-Tiddler:

--- a/languages/it-IT/ControlPanel.multids
+++ b/languages/it-IT/ControlPanel.multids
@@ -12,6 +12,7 @@ Basics/DefaultTiddlers/TopHint: Scegli quali frammenti vuoi visualizzare all'avv
 Basics/Language/Prompt: Ciao! Scegli la lingua:
 Basics/NewJournal/Tags/Prompt: Etichette per i nuovi frammenti diario
 Basics/NewJournal/Title/Prompt: Titolo dei nuovi frammenti diario
+Basics/NewTiddler/Tags/Prompt: Etichette per i nuovi frammenti
 Basics/NewTiddler/Title/Prompt: Titolo dei nuovi frammenti
 Basics/OverriddenShadowTiddlers/Prompt: Numero di frammenti nascosti annullati:
 Basics/ShadowTiddlers/Prompt: Numero di frammenti nascosti:

--- a/plugins/tiddlywiki/markdown/new-markdown.tid
+++ b/plugins/tiddlywiki/markdown/new-markdown.tid
@@ -5,7 +5,7 @@ description: {{$:/language/Buttons/NewMarkdown/Hint}}
 list-after: $:/core/ui/Buttons/new-tiddler
 
 <$button tooltip={{$:/language/Buttons/NewMarkdown/Hint}} aria-label={{$:/language/Buttons/NewMarkdown/Caption}} class=<<tv-config-toolbar-class>>>
-<$action-sendmessage $message="tm-new-tiddler" type="text/x-markdown"/>
+<$action-sendmessage $message="tm-new-tiddler" type="text/x-markdown" tags={{$:/language/DefaultNewTiddlerTags}}/>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/plugins/tiddlywiki/markdown/images/new-markdown-button}}
 </$list>


### PR DESCRIPTION
With this PR, one can define additional tags through $:/language/DefaultNewTiddlerTags that are added when tiddlers are created using the new-tiddler button and shortcut and the new-here and new-journal-here buttons