### PR TITLE
Replace the use of deprecated util.print() in the jasmine plugin

### DIFF
--- a/plugins/tiddlywiki/jasmine/files/reporter.js
+++ b/plugins/tiddlywiki/jasmine/files/reporter.js
@@ -1,14 +1,4 @@
 (function() {
-  //
-  // Imports
-  //
-  var util;
-  try {
-    util = require('util')
-  } catch(e) {
-    util = require('sys')
-  }
-
   var jasmineNode = {};
   //
   // Helpers
@@ -17,7 +7,7 @@
 
 
   jasmineNode.TerminalReporter = function(config) {
-    this.print_ = config.print || util.print;
+    this.print_ = config.print || console.log;
     this.color_ = config.color ? this.ANSIColors : this.NoColors;
 
     this.started_ = false;

--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -52,7 +52,7 @@ exports.startup = function() {
 		jasmine.jasmine.TerminalVerboseReporter = reporterExports.jasmineNode.TerminalVerboseReporter;
 		jasmine.jasmine.TerminalReporter = reporterExports.jasmineNode.TerminalReporter;
 		jasmineEnv.addReporter(new jasmine.jasmine.TerminalVerboseReporter({
-			print: require("util").print,
+			print: console.log,
 			color: true,
 			includeStackTrace: true
 		}));


### PR DESCRIPTION
When I run `bin/test.sh` with node.js v12.5.0, I get this error:

```
# If you use Nix, `nix-shell -p nodejs-12_x` lets you easily drop into a shell with node v12.x.
$ bin/test.sh            
Boot log:                                                   
  Startup task: load-modules                                
  Startup task: info after: load-modules before: startup
  Startup task: startup after: load-modules                                                                              
  Startup task: story after: startup                                                                                     
  Startup task: commands platforms: node after: story
Executing command: version                                                                                               
5.1.21-prerelease                                                                                                        
Executing command: rendertiddler $:/core/save/all test.html text/plain
WARNING: Filter modifier has a deprecated regexp operand /JoeBloggs/
WARNING: Filter modifier has a deprecated regexp operand /Jo/    
WARNING: Filter modifier has a deprecated regexp operand /JoeBloggs/
WARNING: Filter modifier has a deprecated regexp operand /Jo/
$:/plugins/tiddlywiki/jasmine/reporter.js:191
      this.print_(stringValue);
           ^

TypeError: this.print_ is not a function
    at jasmineNode.TerminalVerboseReporter.printLine_ ($:/plugins/tiddlywiki/jasmine/reporter.js:191:12)
    at jasmineNode.TerminalVerboseReporter.reportRunnerResults ($:/plugins/tiddlywiki/jasmine/reporter.js:224:14)
    at jasmine.MultiReporter.reportRunnerResults ($:/plugins/tiddlywiki/jasmine/jasmine.js:1789:39)
    at jasmine.Runner.finishCallback ($:/plugins/tiddlywiki/jasmine/jasmine.js:2161:21)
    at jasmine.Queue.onComplete ($:/plugins/tiddlywiki/jasmine/jasmine.js:2145:10)
    at jasmine.Queue.next_ ($:/plugins/tiddlywiki/jasmine/jasmine.js:2107:14)
    at onComplete ($:/plugins/tiddlywiki/jasmine/jasmine.js:2093:18)
    at jasmine.Suite.finish ($:/plugins/tiddlywiki/jasmine/jasmine.js:2479:5)
    at jasmine.Queue.onComplete ($:/plugins/tiddlywiki/jasmine/jasmine.js:2523:10)
    at jasmine.Queue.next_ ($:/plugins/tiddlywiki/jasmine/jasmine.js:2107:14)
```

`util.print()` is [removed in Node.js 12.x](https://nodejs.org/docs/latest-v12.x/api/util.html) and was [deprecated since 0.11.3](https://nodejs.org/docs/latest-v10.x/api/util.html#util_util_print_strings). The recommendation is to use `console.log()` instead.

`console.log()` was [added in 0.1.100](https://nodejs.org/docs/latest-v10.x/api/console.html#console_console_log_data_args
), which is well below the engine version requirement (>=0.8.2) specified in package.json:

When I run `bin/test.sh` with node.js v10.16.0, I get only this warning:

> (node:17017) [DEP0026] DeprecationWarning: util.print is deprecated. Use console.log instead.

so this looks like the only use of currently deprecated feature, at least within the code that's covered by tests.

Note: this is my first (actual) PR to this repo. PR to sign CLA is #4222 