### PR TITLE
Fix inverted default HTML-class for items in toc and toc-expandable

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -28,7 +28,7 @@ tags: $:/tags/Macro
 </ol>
 \end
 
-\define toc(tag,sort:"",itemClassFilter:" ")
+\define toc(tag,sort:"",itemClassFilter:"")
 <$macrocall $name="toc-body"  tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> />
 \end
 
@@ -87,7 +87,7 @@ tags: $:/tags/Macro
 <$macrocall $name="toc-linked-expandable-body" tag=<<tag>> sort=<<sort>> itemClassFilter=<<itemClassFilter>> exclude=<<excluded>> path=<<path>>/>
 \end
 
-\define toc-expandable(tag,sort:"",itemClassFilter:" ",exclude,path)
+\define toc-expandable(tag,sort:"",itemClassFilter:"",exclude,path)
 <$vars tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> path={{{ [<__path__>addsuffix[/]addsuffix<__tag__>] }}}>
   <$set name="excluded" filter="""[enlist<__exclude__>] [<__tag__>]""">
     <ol class="tc-toc toc-expandable">


### PR DESCRIPTION
5d36b48 swapped the "emptyValue" and "value" that determine the HTML-class for toc items, but did not change the default values for "itemClassFilter" in "toc" and "toc-expandable" to reflect this.

This gives all toc items the "toc-item-selected" class when not specifying an "itemClassFilter". See, for instance: https://tiddlywiki.com/#Example%20Table%20of%20Contents%3A%20Simple