### PR TITLE
Fix gitlab saver.

### DIFF
--- a/core/modules/savers/gitlab.js
+++ b/core/modules/savers/gitlab.js
@@ -48,12 +48,9 @@ GitLabSaver.prototype.save = function(text,method,callback) {
 	var uri = endpoint + "/projects/" + encodeURIComponent(repo) + "/repository/";
 	// Perform a get request to get the details (inc shas) of files in the same path as our file
 	$tw.utils.httpRequest({
-		url: uri + "tree/" + encodeURIComponent(path.replace(/^\/+|\/$/g, '')),
+		url: uri + "tree/?path=" + encodeURIComponent(path.replace(/^\/+|\/$/g, '')) + "&branch=" + encodeURIComponent(branch.replace(/^\/+|\/$/g, '')),
 		type: "GET",
 		headers: headers,
-		data: {
-			ref: branch
-		},
 		callback: function(err,getResponseDataJson,xhr) {
 			var getResponseData,sha = "";
 			if(err && xhr.status !== 404) {


### PR DESCRIPTION
This fixes the HTTP request sent to gitlab that is meant to see if the
target file already exists. It did not follow the official gitlab v4 api
documentation. That documentation dictates both `path` and `branch` to
be passed via corresponding GET parameters.

Disclaimer: You probably shouldn't merge this as I am sure this is not the right way to construct this URL. It can't really be safe this way, I think. I just didn't want to keep people waiting as other's probably are running into the same issue. Feel free to edit this PR—GitHub tells me that TiddlyWiki maintainers should have the ability to add commits to this PR.