### PR TITLE
Reverting changes to stringifyList

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -317,7 +317,7 @@ $tw.utils.stringifyList = function(value) {
 		var result = new Array(value.length);
 		for(var t=0, l=value.length; t<l; t++) {
 			var entry = value[t] || "";
-			if(entry.indexOf(" ") !== -1 || "+-~=".indexOf(entry[0]) !== -1) {
+			if(entry.indexOf(" ") !== -1) {
 				result[t] = "[[" + entry + "]]";
 			} else {
 				result[t] = entry;

--- a/editions/test/tiddlers/tests/test-utils.js
+++ b/editions/test/tiddlers/tests/test-utils.js
@@ -32,8 +32,17 @@ describe("Utility tests", function() {
 		expect(str(["Tiddler8  "])).toEqual("[[Tiddler8  ]]");
 		expect(str(["A+B", "A-B", "A=B"])).toEqual("A+B A-B A=B");
 		expect(str(["A B"])).toEqual("[[A B]]");
-		expect(str(["+T", "-T", "~T", "=T", "$T"])).toEqual("[[+T]] [[-T]] [[~T]] [[=T]] $T");
+		// Starting special characters aren't treated specially,
+		// even though this makes a list incompatible with a filter parser.
+		expect(str(["+T", "-T", "~T", "=T", "$T"])).toEqual("+T -T ~T =T $T");
 		expect(str(["A", "", "B"])).toEqual("A  B");
+	});
+
+	it("stringifyList shouldn't interfere with setting variables to negative numbers", function() {
+		var wiki = new $tw.Wiki();
+		wiki.addTiddler({title: "test", text: "<$set name=X filter='\"-7\"'>{{{ [<X>add[2]] }}}</$set>"});
+		// X shouldn't be wrapped in brackets. If it is, math filters will treat it as zero.
+		expect(wiki.renderTiddler("text/plain","test")).toBe("-5");
 	});
 
 	it("should handle formatting a date string", function() {


### PR DESCRIPTION
I (Flibbles) changed it so that lists generated by stringifyList
would always be compatible with a filter parser, but since lists
are not, and never will be, a subset of filters, there isn't a
point.

More importantly, wrapping negative numbers like "-7" in brackets
would mess up some math stuff.

This relates to issue: #4248