### PR TITLE
Fix GitLab saver Base64 encoding

### DIFF
--- a/core/modules/savers/gitlab.js
+++ b/core/modules/savers/gitlab.js
@@ -71,8 +71,7 @@ GitLabSaver.prototype.save = function(text,method,callback) {
 			}
 			var data = {
 				commit_message: $tw.language.getRawString("ControlPanel/Saving/GitService/CommitMessage"),
-				content: $tw.utils.base64Encode(text),
-				encoding: "base64",
+				content: text,
 				branch: branch,
 				sha: sha
 			};

--- a/core/modules/savers/gitlab.js
+++ b/core/modules/savers/gitlab.js
@@ -72,6 +72,7 @@ GitLabSaver.prototype.save = function(text,method,callback) {
 			var data = {
 				commit_message: $tw.language.getRawString("ControlPanel/Saving/GitService/CommitMessage"),
 				content: $tw.utils.base64Encode(text),
+				encoding: "base64",
 				branch: branch,
 				sha: sha
 			};


### PR DESCRIPTION
Without this fix, the commit will have a Base64 encoded file instead of HTML.

Because the GitLab API can interpret the request without Base64 encoding, and because the encoded data is larger (meaning more data traffic and time to send over the internet), we should not use Base64 encoding, thus I changed the code to send the data as plain text.

Empty edition without encoding: 2.19MB
Base64 encoded empty edition: 2.91MB