### PR TITLE
Update link to Git service documentation

### DIFF
--- a/editions/tw5.com/tiddlers/definitions/GitHub.tid
+++ b/editions/tw5.com/tiddlers/definitions/GitHub.tid
@@ -10,4 +10,4 @@ The code and documentation of TiddlyWiki is hosted on GitHub at:
 
 https://github.com/Jermolene/TiddlyWiki5
 
-GitHub also offer a free web hosting service called [[GitHub Pages|https://pages.github.com/]] that can be used directly from the single file configuration. See [[Saving to GitHub]].
+GitHub also offer a free web hosting service called [[GitHub Pages|https://pages.github.com/]] that can be used directly from the single file configuration. See [[Saving to a Git service]].


### PR DESCRIPTION
Link to Git service documentation on the GitHub tid refers to old name of that page.