### PR TITLE
add a tree-compact macro to the existing tree macro fixes #4260

### DIFF
--- a/core/wiki/macros/tree.tid
+++ b/core/wiki/macros/tree.tid
@@ -5,6 +5,12 @@ tags: $:/tags/Macro
 <$link to=<<__full-title__>>><$text text=<<__chunk__>>/></$link>
 \end
 
+\define branch-link(full-title,chunk,separator:"/")
+<$set name="short-title" value={{{ [<__chunk__>removesuffix<__separator__>] }}}>
+<$list filter="[<__full-title__>is[missing]]"><$text text=<<short-title>> /></$list><$list filter="[<__full-title__>!is[missing]]"><$link to=<<__full-title__>> ><<short-title>></$link></$list>
+</$set>
+\end
+
 \define leaf-node(prefix,chunk)
 <li>
 <$list filter="[<__prefix__>addsuffix<__chunk__>is[shadow]] [<__prefix__>addsuffix<__chunk__>is[tiddler]]" variable="full-title">
@@ -36,6 +42,28 @@ tags: $:/tags/Macro
 </li>
 \end
 
+\define branch-node-compact(prefix,chunk,separator: "/")
+<li>
+<$set name="full-title" value={{{ [<__prefix__>addsuffix<__chunk__>removesuffix<__separator__>] }}}>
+<$set name="reveal-state" value={{{ [[$:/state/tree/]addsuffix<__prefix__>addsuffix<__chunk__>] }}}>
+<$reveal type="nomatch" stateTitle=<<reveal-state>> text="show" >
+<$button setTitle=<<reveal-state>> setTo="show" class="tc-btn-invisible">
+{{$:/core/images/folder}}
+</$button> <$macrocall $name="branch-link" full-title=<<full-title>> chunk=<<chunk>> separator=<<__separator__>> />
+</$reveal>
+<$reveal type="match" stateTitle=<<reveal-state>> text="show" >
+<$button setTitle=<<reveal-state>> setTo="hide" class="tc-btn-invisible">
+{{$:/core/images/folder}}
+</$button> <$macrocall $name="branch-link" full-title=<<full-title>> chunk=<<chunk>> separator=<<__separator__>> />
+</$reveal>
+<span>(<$count filter="[all[shadows+tiddlers]removeprefix<__prefix__>removeprefix<__chunk__>] -[<__prefix__>addsuffix<__chunk__>]"/>)</span>
+<$reveal type="match" stateTitle=<<reveal-state>> text="show" >
+<$macrocall $name="tree-node-compact" prefix={{{ [<__prefix__>addsuffix<__chunk__>] }}} separator=<<__separator__>> />
+</$reveal>
+</$set></$set>
+</li>
+\end
+
 \define tree-node(prefix,separator: "/")
 <ol>
 <$list filter="[all[shadows+tiddlers]removeprefix<__prefix__>splitbefore<__separator__>sort[]!suffix<__separator__>]" variable="chunk">
@@ -47,11 +75,47 @@ tags: $:/tags/Macro
 </ol>
 \end
 
+\define tree-node-compact(prefix,separator: "/")
+<ol>
+<$list filter="[all[shadows+tiddlers]removeprefix<__prefix__>splitbefore<__separator__>sort[]]" variable="chunk">
+<$list filter="[<chunk>suffix<__separator__>]">
+<$macrocall $name="branch-node-compact" prefix=<<__prefix__>> chunk=<<chunk>> separator=<<__separator__>> />
+</$list>
+<$list filter="[<chunk>!suffix<__separator__>]">
+<$set name="branch-test" value={{{ [<__prefix__>addsuffix<chunk>addsuffix<__separator__>] }}}>
+<$list filter="[all[tiddlers+shadows]prefix<branch-test>count[]match[0]]"><$macrocall $name="leaf-node" prefix=<<__prefix__>> chunk=<<chunk>> separator=<<__separator__>> /></$list>
+</$set>
+</$list>
+</$list>
+</ol>
+\end
+
 \define tree(prefix: "$:/",separator: "/")
 <div class="tc-tree">
 <span><$text text=<<__prefix__>>/></span>
 <div>
 <$macrocall $name="tree-node" prefix=<<__prefix__>> separator=<<__separator__>>/>
+</div>
+</div>
+\end
+
+\define tree-compact(prefix: "$:/",separator: "/")
+<div class="tc-tree">
+<div>
+<$list filter="[<__prefix__>suffix<__separator__>]">
+<ol><li><$set name="short-title" value={{{ [<__prefix__>removesuffix<__separator__>] }}}>
+<$list filter="[<__short-title__>is[missing]]"><span class="tc-reveal"><$text text=<<short-title>>/></span></$list>
+<$list filter="[<__short-title__>!is[missing]]"><span class="tc-reveal"><$link to=<<__short-title__>> ><<short-title>></$link></span></$list>
+<$macrocall $name="tree-node-compact" prefix=<<__prefix__>> chunk="" separator=<<__separator__>>/>
+</$set></li></ol>
+</$list>
+<$list filter="[<__prefix__>!suffix<__separator__>]">
+<ol><li><$set name="start-title" value={{{ [<__prefix__>addsuffix<__separator__>] }}}>
+<$list filter="[<__prefix__>is[missing]]"><span class="tc-reveal"><$text text=<<__prefix__>>/></span></$list>
+<$list filter="[<__prefix__>!is[missing]]"><span class="tc-reveal"><$link to=<<__prefix__>> ><<__prefix__>></$link></span></$list>
+<$macrocall $name="tree-node-compact" prefix=<<start-title>> chunk="" separator=<<__separator__>>/>
+</$set></li></ol>
+</$list>
 </div>
 </div>
 \end

--- a/editions/fr-FR/tiddlers/macros/tree Macro.tid
+++ b/editions/fr-FR/tiddlers/macros/tree Macro.tid
@@ -1,0 +1,23 @@
+caption: tree
+created: 20191001170000000
+modified: 20191001170000000
+fr-title: macro arborescence
+tags: Macros [[Core Macros]]
+title: tree Macro
+type: text/vnd.tiddlywiki
+
+~TiddlyWiki fournit deux [[macros|Macros]] qui affichent une arborescence à partir d'un préfixe et d'un séparateur à l'intérieur des titres
+
+;<<.var tree>>
+: Une arborescence simple qui sépare les //dossiers// des tiddlers.
+;<<.var tree-compact>>
+: La même que ci-dessus, sauf que si un //dossier// est aussi un tiddler, il n'apparaitra qu'une fois dans l'arborescence: Comme un dossier avec un lien vers le tiddler. On ouvre le dossier en cliquant sur l'icône et par sur le titre (qui renvoie vers le tiddler)
+
+!! Paramètres
+
+;prefix
+: Le préfixe à partir duquel on génère l'arborescence, par défaut `$:/`
+;separator
+: Le séparateur entre les différentes parties du titre, par défaut `/`
+
+<<.macro-examples "tree">>

--- a/editions/tw5.com/tiddlers/macros/examples/tree Macro (Examples).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/tree Macro (Examples).tid
@@ -9,3 +9,9 @@ eg="""<<tree prefix:"$:/">>"""/>
 
 <$macrocall $name=".example" n="2"
 eg="""<<tree prefix:"tree-macro-example-" separator:"-">>"""/>
+
+<$macrocall $name=".example" n="3"
+eg="""<<tree-compact prefix:"$:/">>"""/>
+
+<$macrocall $name=".example" n="4"
+eg="""<<tree-compact prefix:"tree-macro-example-" separator:"-">>"""/>

--- a/editions/tw5.com/tiddlers/macros/tree Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/tree Macro.tid
@@ -1,11 +1,16 @@
 caption: tree
 created: 20170628164534981
-modified: 20170628164654430
+modified: 20191001170000000
 tags: Macros [[Core Macros]]
 title: tree Macro
 type: text/vnd.tiddlywiki
 
-The <<.def tree>> [[macro|Macros]] renders an expandable tree view based on a prefix and separator within tiddler titles.
+~TiddlyWiki provides two [[macros|Macros]] that renders a tree view based on a prefix and separator within tiddler titles.
+
+;<<.var tree>>
+: A simple expandable tree
+;<<.var tree-compact>>
+: The same as above except that when a //folder// is also a tiddler, it will appear only once in the tree: As a folder with a link to the tiddler. You expand a folder by clicking on the icon and not on the title (which drives you to the tiddler)
 
 !! Parameters
 


### PR DESCRIPTION
* the tree-compact displays folders that are also tiddler only once,
* we expand tree folders by clicking on the icon since the name will send you to the tiddler
* to accomplish this also added three "hidden" macros : _branch-link_, _branch-node-compact_ and _tree-node-compact_
* also updated **tree Macro** documentation (and added french translation) and tree Macro examples