### PR TITLE
Add documentation for shortcuts introduced in 5.1.20

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/KeyboardShortcuts.tid
+++ b/editions/tw5.com/tiddlers/howtos/KeyboardShortcuts.tid
@@ -20,9 +20,13 @@ Keyboard shortcuts are available for common editing operations within the Text E
 
 <<.from-version 5.1.18>> : New ''global'' Keyboard shortcuts:
 
-* Creating a new tiddler (defaults to <kbd>alt-N</kbd> )
-* Creating a new journal (defaults to <kbd>alt-J</kbd> )
-* Creating a new image (defaults to <kbd>alt-I</kbd> )
+|!Action |!Default Shortcut|
+|Creating a new tiddler |<kbd>alt-N</kbd> |
+|Creating a new journal |<kbd>alt-J</kbd> |
+|Creating a new image |<kbd>alt-I</kbd> |
+|Focusing sidebar search |<<.from-version 5.1.20>><kbd>ctrl-shift-F</kbd> |
+|Toggling the sidebar |<<.from-version 5.1.20>><kbd>shift-alt-S</kbd> |
+|Advanced search |<<.from-version 5.1.20>><kbd>ctrl-shift-A</kbd> |
 
 The current shortcuts can be inspected and customised in the "Keyboard Shortcuts" tab of the [[Control Panel|$:/ControlPanel]] {{$:/core/images/options-button}}.
 


### PR DESCRIPTION
I noticed these weren't present on the KeyboardShorcuts tiddler, so I added them.  I figured a tabular format made more sense now that there are two revisions in which new shortcuts were introduced, but I'm open to changing the format up if need be.