### PR TITLE
Let chained `>` blockquotes generate valid HTML

### DIFF
--- a/core/modules/parsers/wikiparser/rules/list.js
+++ b/core/modules/parsers/wikiparser/rules/list.js
@@ -60,7 +60,7 @@ var listTypes = {
 	"#": {listTag: "ol", itemTag: "li"},
 	";": {listTag: "dl", itemTag: "dt"},
 	":": {listTag: "dl", itemTag: "dd"},
-	">": {listTag: "blockquote", itemTag: "p"}
+	">": {listTag: "blockquote", itemTag: "div"}
 };
 
 /*

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -130,6 +130,11 @@ blockquote {
 	quotes: "\201C""\201D""\2018""\2019";
 }
 
+blockquote > div {
+	margin-top: 1em;
+	margin-bottom: 1em;
+}
+
 blockquote.tc-big-quote {
 	font-family: Georgia, serif;
 	position: relative;


### PR DESCRIPTION
```
>> text
```

... now creates (prettyprinted) ...

```
<blockquote>
  <div>
    <blockquote>
      <div>text</div>
    </blockquote>
  </div>
</blockquote>
```
... which is valid Html. Before it created ...

```
<blockquote>
  <p>
    <blockquote>
      <p>text</p>
    </blockquote>
  </p>
</blockquote>
```

... which is invalid html. A [blockquote](https://w3c.github.io/html-reference/blockquote.html) is not [phrasing content](https://w3c.github.io/html-reference/common-models.html#common.elem.phrasing) and therefore not allowed inside of a [p](https://w3c.github.io/html-reference/p.html). 