### PR TITLE
Let Colour-Picker be valid HTML

### DIFF
--- a/core/wiki/macros/colour-picker.tid
+++ b/core/wiki/macros/colour-picker.tid
@@ -15,7 +15,7 @@ $(colour-picker-update-recent)$
 
 $actions$
 
-<div style="background-color: $(colour-picker-value)$; width: 100%; height: 100%; border-radius: 50%;"/>
+<span style="display:inline-block; background-color: $(colour-picker-value)$; width: 100%; height: 100%; border-radius: 50%;"/>
 
 </$button>
 \end
@@ -44,7 +44,7 @@ $actions$
 
 ---
 
-<$edit-text tiddler="$:/config/ColourPicker/New" tag="input" default="" placeholder=""/> 
+<$edit-text tiddler="$:/config/ColourPicker/New" tag="input" default="" placeholder=""/>
 <$edit-text tiddler="$:/config/ColourPicker/New" type="color" tag="input"/>
 <$set name="colour-picker-value" value={{$:/config/ColourPicker/New}}>
 <$macrocall $name="colour-picker-inner" actions="""$actions$"""/>


### PR DESCRIPTION
These [divs](https://w3c.github.io/html-reference/div.html) will be wrapped inside of a [p](https://w3c.github.io/html-reference/p.html), but divs are not allowed there (they are not [phrasing content](https://w3c.github.io/html-reference/common-models.html#common.elem.phrasing)). The [a](https://w3c.github.io/html-reference/a.html) does not change this, because it is [transparent](https://w3c.github.io/html-reference/terminology.html#transparent). Therefore let's replace the divs with spans.

(Accidently also pulled that whitespace removed by Geany).

[Example Colour Picker](https://tiddlywiki.com/#colour-picker%20Macro%20(Example%201)) - currently invalid html.
