### PR TITLE
String Modifiers

### DIFF
--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -217,81 +217,86 @@ exports.parseMacroInvocation = function(source,pos) {
 /*
 Look for an HTML attribute definition. Returns null if not found, otherwise returns {type: "attribute", name:, valueType: "string|indirect|macro", value:, start:, end:,}
 */
-exports.parseAttribute = function(source,pos) {
-	var node = {
-		start: pos
-	};
-	// Define our regexps
-	var reAttributeName = /([^\/\s>"'=]+)/g,
-		reUnquotedAttribute = /([^\/\s<>"'=]+)/g,
-		reFilteredValue = /\{\{\{(.+?)\}\}\}/g,
-		reIndirectValue = /\{\{([^\}]+)\}\}/g;
-	// Skip whitespace
-	pos = $tw.utils.skipWhiteSpace(source,pos);
-	// Get the attribute name
-	var name = $tw.utils.parseTokenRegExp(source,pos,reAttributeName);
-	if(!name) {
-		return null;
-	}
-	node.name = name.match[1];
-	pos = name.end;
-	// Skip whitespace
-	pos = $tw.utils.skipWhiteSpace(source,pos);
-	// Look for an equals sign
-	var token = $tw.utils.parseTokenString(source,pos,"=");
-	if(token) {
-		pos = token.end;
+exports.parseAttribute = (function() {
+	// define the regexes outside of the function.
+	var reAttributeName = /([^\/\s>"'=]+)/g;		// myattribute
+	var reUnquotedAttribute = /([^\/\s<>"'=]+)/g;	// myattributevalue
+	var reFilteredValue = /\{\{\{(.+?)\}\}\}/g;		// {{{filter expression}}}
+	var reIndirectValue = /\{\{([^\}]+)\}\}/g;		// {{transclude}}
+	return function(source,pos){
+		// make these locally available, for performance
+		var utils = $tw.utils;
+		var skipWhitespace = utils.skipWhiteSpace;
+		var parseTokenRegExp = utils.parseTokenRegExp;
+		// remember the start position
+		var start = pos;
 		// Skip whitespace
-		pos = $tw.utils.skipWhiteSpace(source,pos);
-		// Look for a string literal
-		var stringLiteral = $tw.utils.parseStringLiteral(source,pos);
-		if(stringLiteral) {
-			pos = stringLiteral.end;
-			node.type = "string";
-			node.value = stringLiteral.value;
-		} else {
+		pos = skipWhitespace(source,pos);
+		// Get the attribute name
+		var name = parseTokenRegExp(source,pos,reAttributeName);
+		if(!name) {
+			return null;
+		}
+		pos = name.end;
+		name = name.match[1];
+		// Skip whitespace
+		pos = skipWhitespace(source,pos);
+		// Look for an equals sign
+		var token = utils.parseTokenString(source,pos,"=");
+		// fill these node attributes depending on the type of the attribute value
+		var typ = "string";
+		var value = "true";
+		var filter;
+		var reference;
+		if(token) {
+			pos = token.end;
+			// Skip whitespace
+			pos = skipWhitespace(source,pos);
+			// Look for a string literal
+			if(token = utils.parseStringLiteral(source,pos)) {
+				pos = token.end;
+				value = token.value;
+			}
 			// Look for a filtered value
-			var filteredValue = $tw.utils.parseTokenRegExp(source,pos,reFilteredValue);
-			if(filteredValue) {
-				pos = filteredValue.end;
-				node.type = "filtered";
-				node.filter = filteredValue.match[1];
-			} else {
-				// Look for an indirect value
-				var indirectValue = $tw.utils.parseTokenRegExp(source,pos,reIndirectValue);
-				if(indirectValue) {
-					pos = indirectValue.end;
-					node.type = "indirect";
-					node.textReference = indirectValue.match[1];
-				} else {
-					// Look for a unquoted value
-					var unquotedValue = $tw.utils.parseTokenRegExp(source,pos,reUnquotedAttribute);
-					if(unquotedValue) {
-						pos = unquotedValue.end;
-						node.type = "string";
-						node.value = unquotedValue.match[1];
-					} else {
-						// Look for a macro invocation value
-						var macroInvocation = $tw.utils.parseMacroInvocation(source,pos);
-						if(macroInvocation) {
-							pos = macroInvocation.end;
-							node.type = "macro";
-							node.value = macroInvocation;
-						} else {
-							node.type = "string";
-							node.value = "true";
-						}
-					}
-				}
+			else if(token = parseTokenRegExp(source,pos,reFilteredValue)) {
+				pos = token.end;
+				typ = "filtered";
+				filter = token.match[1];
+			}
+			// Look for an indirect value
+			else if(token = parseTokenRegExp(source,pos,reIndirectValue)) {
+				pos = token.end;
+				typ = "indirect";
+				reference = token.match[1];
+			}
+			// Look for a unquoted value
+			else if(token = parseTokenRegExp(source,pos,reUnquotedAttribute)) {
+				pos = token.end;
+				value = token.match[1];
+			}
+			// Look for a macro invocation value
+			else if(token = utils.parseMacroInvocation(source,pos)) {
+				pos = token.end;
+				typ = "macro";
+				value = token;
 			}
 		}
-	} else {
-		node.type = "string";
-		node.value = "true";
+		// Construct the node and return it
+		var node = {
+			name: name,
+			type: typ,
+			start: start,
+			end: pos
+		};
+		if (filter !== undefined) {
+			node.filter = filter;
+		} else if (reference !== undefined) {
+			node.textReference = reference;
+		} else {
+			node.value = value;
+		}
+		return node;
 	}
-	// Update the end position
-	node.end = pos;
-	return node;
-};
+})();
 
 })();

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -95,6 +95,27 @@ exports.trim = function(str) {
 };
 
 /*
+Modify the content of a WikiText string literal, based on modifiers. The modifiers must be placed directly before the string literal. They are executed in order. For example dn"..." will dedent and then strip the string. Meaning of the modifiers: d=dedent, s=strip, n=strip linebreaks at start and strip end. This function is currently just called from parseStringLiteral.
+*/
+exports.modifyStringLiteral = function (string, modifiers) {
+	var utils = $tw.utils; var len = modifiers.length;  // performance
+	for (var c = 0; c < len; c++) {
+		switch (modifiers[c]) {
+			case "d": string = utils.dedent(string); break;
+			case "s": string = utils.trim(string); break;
+			case "n": string = utils.trimNewlines(string); break;
+			default: // this will anyway not be called because parseStringLiteral matches for ([snd]{1,2})
+				console.log(
+					"modifyStringLiteral() says: '" + modifiers[c] +
+					"' is not a known modifier for a string literal. Ignoring it."
+				);
+				break;
+		}
+	}
+	return string;
+};
+
+/*
 Convert a string to sentence case (ie capitalise first letter)
 */
 exports.toSentenceCase = function(str) {

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -82,13 +82,29 @@ exports.repeat = function(str,count) {
 	return result;
 };
 
+// Used below in the trim functions
+var whitespaceAtStartRegex = /^\s\s*/;
+var whitespaceAtEndRegex = /\s\s*$/;
+var newlinesAtStartRegex = /^(?:[^\S\n]*\n)+/;
+
 /*
 Trim whitespace from the start and end of a string
 Thanks to Steven Levithan, http://blog.stevenlevithan.com/archives/faster-trim-javascript
 */
 exports.trim = function(str) {
 	if(typeof str === "string") {
-		return str.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
+		return str.replace(whitespaceAtStartRegex, '').replace(whitespaceAtEndRegex, '');
+	} else {
+		return str;
+	}
+};
+
+/*
+Trim newlines from the start and whitespace from the end of a string (for preformatted code where the first non-empty line may be indented)
+*/
+exports.trimNewlines = function(str) {
+	if(typeof str === "string") {
+		return str.replace(newlinesAtStartRegex, '').replace(whitespaceAtEndRegex, '');
 	} else {
 		return str;
 	}
@@ -114,6 +130,57 @@ exports.modifyStringLiteral = function (string, modifiers) {
 	}
 	return string;
 };
+
+/*
+Dedent a string. The first " " or "\t" of the first non-empty line defines the overall used indent character.
+*/
+exports.dedent = (function() {
+	var indentCharRegex = /^(?:([ \t])\s*)?\S/;  // matches the indent character to be used
+	var newlineRegex = /\r?\n/;
+	return function (string) {
+		var lines = string.split(newlineRegex);
+		// calculate the maximum common indent of all lines in the string
+		var indent; {
+			indent = 999999;
+			var indentChar;
+			var regex = indentCharRegex;  // to be changed after the first match
+			var len = lines.length;
+			for (var c = 0; c < len; c++) {
+				var line = lines[c];
+				var match = line.match(regex);
+				if (match) {  // matches only on non-empty lines
+					// done once
+					if (indentChar === undefined) {
+						if (match[1] === undefined) {  // the string is not indented
+							indent = 0;
+							break;
+						}
+						// We found the Indent char, from now on match the indent size
+						indentChar = match[1];
+						regex = new RegExp(
+							"^(" + indentChar + "*)[^" + indentChar + "\\S]*\\S"
+						);
+						match = line.match(regex);
+					}
+					// done on all non-empty lines
+					indent = Math.min(indent, match[1].length);
+					if (indent === 0) {
+						break;
+					}
+				}
+			}
+		}
+		// if indent > 0, dedent and return the string, otherwise return the string unchanged
+		if (indent > 0) {
+			console.info(lines.join("\n"));
+			lines = lines.map(function(line){return line.slice(indent);}).join("\n");
+			console.info(lines);
+			return lines;
+		} else {
+			return string;
+		}
+	};
+})();
 
 /*
 Convert a string to sentence case (ie capitalise first letter)

--- a/editions/tw5.com/tiddlers/concepts/Date Fields.tid
+++ b/editions/tw5.com/tiddlers/concepts/Date Fields.tid
@@ -24,5 +24,6 @@ As an example, the <<.field created>> field of this tiddler has the value <<.val
 
 Dates can be [[converted to other formats|DateFormat]] for display:
 
-<$macrocall $name="wikitext-example-without-html"
-src="""<$view field="created" format="date" template="DDD DDth MMM YYYY"/>""">
+<$macrocall $name="wikitext-example-without-html" src=dn"""
+  <$view field="created" format="date" template="DDD DDth MMM YYYY"/>
+""">

--- a/editions/tw5.com/tiddlers/filters/Mathematics Operators.tid
+++ b/editions/tw5.com/tiddlers/filters/Mathematics Operators.tid
@@ -35,9 +35,11 @@ Operators can be combined:
 
 Complex operations will sometimes need to be split up into separate filters. For example, to compute the average length of the text field of tiddlers tagged "~HelloThere":
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$set name="number-of-tiddlers" value={{{ [tag[HelloThere]count[]] }}}>
-Average length of <$text text=<<number-of-tiddlers>>/> tiddlers tagged <<tag "HelloThere">>: <$text text={{{ [tag[HelloThere]get[text]length[]sum[]divide<number-of-tiddlers>fixed[3]] }}}/>
-</$set>""" />
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$set name="number-of-tiddlers" value={{{ [tag[HelloThere]count[]] }}}>
+    Average length of <$text text=<<number-of-tiddlers>>/> tiddlers tagged <<tag "HelloThere">>:
+    <$text text={{{ [tag[HelloThere]get[text]length[]sum[]divide<number-of-tiddlers>fixed[3]] }}}/>
+  </$set>
+""" />
 
 <<list-links "[tag[Mathematics Operators]]">>

--- a/editions/tw5.com/tiddlers/filters/examples/days.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/days.tid
@@ -5,16 +5,15 @@ type: text/vnd.tiddlywiki
 <<.operator-example 1 "[days[-14]]" "tiddlers modified within the last 14 days">>
 <<.operator-example 2 "[!days:created[-800]]" "tiddlers created more than 800 days ago">>
 The filter can be used to highlight new items in a list. For example:
-<$macrocall
-  $name="wikitext-example-without-html" src=
-"""
-<ul>
-  <$list filter="[tag[ReleaseNotes]!<currentTiddler>!sort[modified]]">
-    <li>
-      <$link><$view field="title"/></$link>
-         <$list filter="[<currentTiddler>days[-180]]"> @@color:red;^^new^^@@</$list>
-         <$list filter="[<currentTiddler>days[-500]!days[-180]]"> @@color:black;^^recent^^@@</$list>
-    </li>
-  </$list>
-</ul>
+
+<$macrocall $name="wikitext-example-without-html" src=dn"""
+  <ul>
+    <$list filter="[tag[ReleaseNotes]!<currentTiddler>!sort[modified]]">
+      <li>
+        <$link><$view field="title"/></$link>
+        <$list filter="[<currentTiddler>days[-180]]"> @@color:red;^^new^^@@</$list>
+        <$list filter="[<currentTiddler>days[-500]!days[-180]]"> @@color:black;^^recent^^@@</$list>
+      </li>
+    </$list>
+  </ul>
 """/>

--- a/editions/tw5.com/tiddlers/filters/examples/regexp.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/regexp.tid
@@ -14,8 +14,8 @@ type: text/vnd.tiddlywiki
 
 The regular expression `[0-9]{2}` matches two consecutive digits. Because it contains square brackets, the way to use it with the <<.op regexp>> operator is via a [[variable|Variables]], as follows:
 
-<$macrocall
-$name="wikitext-example-without-html"
-src="""<$set name="digit-pattern" value="[0-9]{2}">
-<<list-links "[regexp:title<digit-pattern>]">>
-</$set>"""/>
+<$macrocall $name="wikitext-example-without-html" src=dn"""
+  <$set name="digit-pattern" value="[0-9]{2}">
+    <<list-links "[regexp:title<digit-pattern>]">>
+  </$set>
+"""/>

--- a/editions/tw5.com/tiddlers/learning/Introduction to Lists.tid
+++ b/editions/tw5.com/tiddlers/learning/Introduction to Lists.tid
@@ -47,7 +47,9 @@ The syntax for filtered transclusion `{{{...}}}` takes a filter as input and out
 
 The [[list-links|list-links Macro]] macro gives a preformatted list, typically a bullet list, in a more simplified way than by using the ListWidget. Behind the scenes it really is the ListWidget applying a default template to each list item.
 
-<$macrocall $name="wikitext-example-without-html" src="""<<list-links "[tag[HelloThere]]">>"""/>
+<$macrocall $name="wikitext-example-without-html" src=dn"""
+  <<list-links "[tag[HelloThere]]">>
+"""/>
 
 !Other “list related” features
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-copy-to-clipboard.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-copy-to-clipboard.tid
@@ -18,8 +18,9 @@ This message is usually generated with the ButtonWidget. It is handled by the Ti
 
 This example copies the current time to the clipboard:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button message="tm-copy-to-clipboard" param=<<now>>>
-Copy date to clipboard
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button message="tm-copy-to-clipboard" param=<<now>>>
+    Copy date to clipboard
+  </$button>
+'/>
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-full-screen.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-full-screen.tid
@@ -12,17 +12,16 @@ The fullscreen message is used to enter, exit or toggle the "fullscreen" mode of
 
 The fullscreen message is handled by the TiddlyWiki core.
 
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button message="tm-full-screen">
+    Full screen toggle
+  </$button>
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button message="tm-full-screen">
-Full screen toggle
-</$button>
+  <$button message="tm-full-screen" param="enter">
+    Full screen enter
+  </$button>
 
-<$button message="tm-full-screen" param="enter">
-Full screen enter
-</$button>
-
-<$button message="tm-full-screen" param="exit">
-Full screen exit
-</$button>'/>
-
+  <$button message="tm-full-screen" param="exit">
+    Full screen exit
+  </$button>
+'/>

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-modal.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-modal.tid
@@ -18,16 +18,17 @@ The modal message is usually generated with the ButtonWidget. The modal message 
 
 Here is an example of displaying a modal and passing parameters to it:
 
-<$macrocall $name='wikitext-example-without-html'
-src='Your name: <$edit-text tiddler="$:/temp/yourName" tag="input" default="Your name"/>
-
-Your message:
-<$edit-text tiddler="$:/temp/yourMessage" default="Your message"/>
-
-<$button>
-<$action-sendmessage $message="tm-modal" $param="SampleModal" yourName={{$:/temp/yourName}} yourMessage={{$:/temp/yourMessage}}/>
-Click me!
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  Your name: <$edit-text tiddler="$:/temp/yourName" tag="input" default="Your name"/>
+  
+  Your message:
+  <$edit-text tiddler="$:/temp/yourMessage" default="Your message"/>
+  
+  <$button>
+    <$action-sendmessage $message="tm-modal" $param="SampleModal" yourName={{$:/temp/yourName}} yourMessage={{$:/temp/yourMessage}}/>
+    Click me!
+  </$button>
+'/>
 
 <<.tip """<$macrocall $name=".from-version" version="5.1.18"/> if triggered from within a ''new window'', the above examples will be displayed within that window. The <$macrocall $name=".attr" _="rootwindow"/> attribute can be set to ''yes'' or ''true'' to inherit this behavior and to display the Modal within the ''root'' window""">>
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-external-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-external-window.tid
@@ -23,17 +23,28 @@ The `tm-open-external-window` message is usually generated with the ButtonWidget
 
 ''Examples''
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-sendmessage $message="tm-open-external-window" $param="http://tiddlywiki.com" windowName="_tiddlywiki" windowFeatures="height=500, width=900"/>
-Open ~TiddlyWiki - Action
-</$button>
-
-<$button>
-<$action-sendmessage $message="tm-open-external-window" $param="https://developer.mozilla.org/en-US/docs/Web/API/Window/open" windowName="_tiddlywiki" windowFeatures="height=400, width=600"/>
-Open Mozilla Help - Action
-</$button>
-
-<$button message="tm-open-external-window" param="http://tiddlywiki.com" >
-Open ~TiddlyWiki - Button
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-sendmessage
+      $message="tm-open-external-window"
+      $param="http://tiddlywiki.com"
+      windowName="_tiddlywiki"
+      windowFeatures="height=500, width=900"
+    />
+    Open ~TiddlyWiki - Action
+  </$button>
+  
+  <$button>
+    <$action-sendmessage
+      $message="tm-open-external-window"
+      $param="https://developer.mozilla.org/en-US/docs/Web/API/Window/open"
+      windowName="_tiddlywiki"
+      windowFeatures="height=400, width=600"
+    />
+    Open Mozilla Help - Action
+  </$button>
+  
+  <$button message="tm-open-external-window" param="http://tiddlywiki.com" >
+    Open ~TiddlyWiki - Button
+  </$button>
+'/>

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget.tid
@@ -27,5 +27,4 @@ The ''action-createtiddler'' widget is invisible. Any content within it is ignor
 
 ! Examples
 
-<$macrocall $name='wikitext-example-without-html'
-src={{ActionCreateTiddlerWidget Example}}/>
+<$macrocall $name='wikitext-example-without-html' src={{ActionCreateTiddlerWidget Example}}/>

--- a/editions/tw5.com/tiddlers/widgets/ActionDeleteFieldWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionDeleteFieldWidget.tid
@@ -22,24 +22,27 @@ The ''action-deletefield'' widget is invisible. Any content within it is ignored
 
 Here is an example of a button that deletes the caption and tags fields of the current tiddler:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-deletefield caption tags/>
-Delete "caption" and "tags"
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-deletefield caption tags/>
+    Delete "caption" and "tags"
+  </$button>
+'/>
 
 Here is an example of a button that deletes the modified date and tags fields of the tiddler HelloThere:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-deletefield $tiddler="HelloThere" modified tags/>
-Delete "modified" and "tags" from ~HelloThere
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-deletefield $tiddler="HelloThere" modified tags/>
+    Delete "modified" and "tags" from ~HelloThere
+  </$button>
+'/>
 
 Here is an example of a button that uses the optional $field attribute to delete the text field of the tiddler HelloThere:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-deletefield $tiddler="HelloThere" $field="text"/>
-Delete text from ~HelloThere
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-deletefield $tiddler="HelloThere" $field="text"/>
+    Delete text from ~HelloThere
+  </$button>
+'/>

--- a/editions/tw5.com/tiddlers/widgets/ActionDeleteTiddlerWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionDeleteTiddlerWidget.tid
@@ -27,16 +27,18 @@ The ''action-deletetiddler'' widget is invisible. Any content within it is ignor
 
 Here is an example of a button that deletes the tiddler HelloThere:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-deletetiddler $tiddler="HelloThere"/>
-Delete "~HelloThere"
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-deletetiddler $tiddler="HelloThere"/>
+    Delete "~HelloThere"
+  </$button>
+'/>
 
 Here is an example of a button that deletes all tiddlers tagged [[TableOfContents]]:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-deletetiddler $filter="[tag[TableOfContents]]"/>
-Delete tiddlers tagged "~TableOfContents"
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-deletetiddler $filter="[tag[TableOfContents]]"/>
+    Delete tiddlers tagged "~TableOfContents"
+  </$button>
+'/>

--- a/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
@@ -54,74 +54,77 @@ A number of [[extended filter operators|The Extended Listops Filters]] are neces
 
 In this example we shall populate and then clear a list in an ordinary field (myfield) of this tiddler (the default.)
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $field="myfield" $subfilter="efg hlm pqr"/>
-Populate 'myfield'
-</$button>
-<$button>
-<$action-listops $field="myfield" $subfilter="abc xyz"/>
-Append More Items
-</$button>
-<$button>
-<$action-listops $field="myfield" $subfilter="-abc -hlm"/>
-Remove Items
-</$button>
-<$button>
-<$action-listops $field="myfield" $filter="[[]]"/>
-Clear 'myfield'
-</$button>
-
-<$list filter="[list[!!myfield]]">
-
-</$list>"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$button>
+    <$action-listops $field="myfield" $subfilter="efg hlm pqr"/>
+    Populate 'myfield'
+  </$button>
+  <$button>
+    <$action-listops $field="myfield" $subfilter="abc xyz"/>
+    Append More Items
+  </$button>
+  <$button>
+    <$action-listops $field="myfield" $subfilter="-abc -hlm"/>
+    Remove Items
+  </$button>
+  <$button>
+    <$action-listops $field="myfield" $filter="[[]]"/>
+    Clear 'myfield'
+  </$button>
+  
+  <$list filter="[list[!!myfield]]">
+  
+  </$list>
+"""/>
 
 ---
 In this example we shall append and remove items from a list in an ordinary field (myfield) of this tiddler (the default) and sort the resultant list. We shall then remove some of the appended items and sort the resulting list in reverse order.
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $field="myfield" $subfilter="-efg ijk xyz [[this is a title]] +[sort[]]"/>
-Mangle List
-</$button>
-<$button>
-<$action-listops $field="myfield" $subfilter="-xyz -[[this is a title]] +[!sort[]]"/>
-Unmangle List
-</$button>
-
-<$list filter="[list[!!myfield]]">
-
-</$list>"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$button>
+    <$action-listops $field="myfield" $subfilter="-efg ijk xyz [[this is a title]] +[sort[]]"/>
+    Mangle List
+  </$button>
+  <$button>
+    <$action-listops $field="myfield" $subfilter="-xyz -[[this is a title]] +[!sort[]]"/>
+    Unmangle List
+  </$button>
+  
+  <$list filter="[list[!!myfield]]">
+  
+  </$list>
+"""/>
 
 ---
 In this example we shall append a few tags to the 'tags' field of this tiddler (the default.) We shall then remove some of the appended tags. 
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $tags="+[append{Days of the Week!!short}] $:/tag1 $:/tag2 $:/tag3"/>
-Populate 'tags'
-</$button>
-<$button>
-<$action-listops $tags="+[!remove:2{!!tags}]"/>
-Remove Last Two Tags
-</$button>
-<$button>
-<$action-listops $tags="+[!prefix[$:/]]"/>
-Remove System Tags
-</$button>
-<$button>
-<$action-listops $tags="-Mon -Tue"/>
-Remove Mon and Tue
-</$button>
-<$button>
-<$action-listops $tags="+[prefix[$:/]] ActionWidgets Widgets"/>
-Remove User Tags
-</$button>
-<$button>
-<$action-listops $tags="+[[]] ActionWidgets Widgets"/>
-Clear Tags
-</$button>
-
-<$list filter="[list[!!tags]]">
-
-</$list>"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$button>
+    <$action-listops $tags="+[append{Days of the Week!!short}] $:/tag1 $:/tag2 $:/tag3"/>
+    Populate 'tags'
+  </$button>
+  <$button>
+    <$action-listops $tags="+[!remove:2{!!tags}]"/>
+    Remove Last Two Tags
+  </$button>
+  <$button>
+    <$action-listops $tags="+[!prefix[$:/]]"/>
+    Remove System Tags
+  </$button>
+  <$button>
+    <$action-listops $tags="-Mon -Tue"/>
+    Remove Mon and Tue
+  </$button>
+  <$button>
+    <$action-listops $tags="+[prefix[$:/]] ActionWidgets Widgets"/>
+    Remove User Tags
+  </$button>
+  <$button>
+    <$action-listops $tags="+[[]] ActionWidgets Widgets"/>
+    Clear Tags
+  </$button>
+  
+  <$list filter="[list[!!tags]]">
+  
+  </$list>
+"""/>

--- a/editions/tw5.com/tiddlers/widgets/ActionNavigateWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionNavigateWidget.tid
@@ -30,9 +30,10 @@ Note that if navigating to multiple tiddlers at once you should use the same `$s
 
 Here is an example of button that navigates to two different tiddlers at once:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-navigate $to="ButtonWidget"/>
-<$action-navigate $to="ActionWidgets"/>
-Click me!
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-navigate $to="ButtonWidget"/>
+    <$action-navigate $to="ActionWidgets"/>
+    Click me!
+  </$button>
+'/>

--- a/editions/tw5.com/tiddlers/widgets/ActionSendMessageWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionSendMessageWidget.tid
@@ -24,10 +24,15 @@ The ''action-sendmessage'' widget is invisible. Any content within it is ignored
 
 Here is an example of button that displays both a notification and a wizard, and creates a new tiddler with tags and text:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-sendmessage $message="tm-modal" $param="SampleWizard"/>
-<$action-sendmessage $message="tm-notify" $param="SampleNotification"/>
-<$action-sendmessage $message="tm-new-tiddler" title="This is newly created tiddler" tags="OneTag [[Another Tag]]" text=<<now "Today is DDth, MMM YYYY">>/>
-Click me!
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-sendmessage $message="tm-modal" $param="SampleWizard"/>
+    <$action-sendmessage $message="tm-notify" $param="SampleNotification"/>
+    <$action-sendmessage $message="tm-new-tiddler"
+      title="This is newly created tiddler"
+      tags="OneTag [[Another Tag]]"
+      text=<<now "Today is DDth, MMM YYYY">>
+    />
+    Click me!
+  </$button>
+'/>

--- a/editions/tw5.com/tiddlers/widgets/ActionSetFieldWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionSetFieldWidget.tid
@@ -25,44 +25,48 @@ The ''action-setfield'' widget is invisible. Any content within it is ignored.
 
 Here is an example of a pair of buttons that open the control panel directly to specified tabs. They work by using ''action-setfield'' to set the state tiddler for the control panel tabs.
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-setfield $tiddler="$:/state/tab-1749438307" text="$:/core/ui/ControlPanel/Appearance"/>
-<$action-navigate $to="$:/ControlPanel"/>
-Go to Control Panel "Appearance" tab
-</$button>
-
-<$button>
-<$action-setfield $tiddler="$:/state/tab-1749438307" text="$:/core/ui/ControlPanel/Settings"/>
-<$action-navigate $to="$:/ControlPanel"/>
-Go to Control Panel "Settings" tab
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-setfield $tiddler="$:/state/tab-1749438307" text="$:/core/ui/ControlPanel/Appearance"/>
+    <$action-navigate $to="$:/ControlPanel"/>
+    Go to Control Panel "Appearance" tab
+  </$button>
+  
+  <$button>
+    <$action-setfield $tiddler="$:/state/tab-1749438307" text="$:/core/ui/ControlPanel/Settings"/>
+    <$action-navigate $to="$:/ControlPanel"/>
+    Go to Control Panel "Settings" tab
+  </$button>
+'/>
 
 Here is an example of a button that assigns tags and fields to the tiddler HelloThere, and then navigates to it and opens the tiddler info panel on the "Fields" tab:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-setfield $tiddler="HelloThere" tags="NewTag [[Another New Tag]]" color="red"/>
-<$action-setfield $tiddler="$:/state/popup/tiddler-info--1779055697" text="(568,1443,33,39)"/>
-<$action-setfield $tiddler="$:/state/tab--1890574033" text="$:/core/ui/TiddlerInfo/Fields"/>
-<$action-navigate $to="HelloThere"/>
-Modify ~HelloThere
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-setfield $tiddler="HelloThere" tags="NewTag [[Another New Tag]]" color="red"/>
+    <$action-setfield $tiddler="$:/state/popup/tiddler-info--1779055697" text="(568,1443,33,39)"/>
+    <$action-setfield $tiddler="$:/state/tab--1890574033" text="$:/core/ui/TiddlerInfo/Fields"/>
+    <$action-navigate $to="HelloThere"/>
+    Modify ~HelloThere
+  </$button>
+'/>
 
 Here is an example of a button that assigns tags and fields to the tiddler HelloThere, and then initiates editing it:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-setfield $tiddler="HelloThere" tags="MoreTag [[Further More Tags]]" color="green"/>
-<$action-sendmessage $message="tm-edit-tiddler" $param="HelloThere"/>
-Edit ~HelloThere
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-setfield $tiddler="HelloThere" tags="MoreTag [[Further More Tags]]" color="green"/>
+    <$action-sendmessage $message="tm-edit-tiddler" $param="HelloThere"/>
+    Edit ~HelloThere
+  </$button>
+'/>
 
 Here is an example of a button that opens the control panel directly to the "Appearance" tabs:
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$button>
-<$action-setfield $tiddler="$:/state/tab-1749438307" $field="text" $value="$:/core/ui/ControlPanel/Appearance"/>
-<$action-navigate $to="$:/ControlPanel"/>
-Go to Control Panel "Appearance" tab
-</$button>'/>
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$button>
+    <$action-setfield $tiddler="$:/state/tab-1749438307" $field="text" $value="$:/core/ui/ControlPanel/Appearance"/>
+    <$action-navigate $to="$:/ControlPanel"/>
+    Go to Control Panel "Appearance" tab
+  </$button>
+'/>

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
@@ -52,4 +52,8 @@ To use the checkbox widget in index mode set the ''index'' attribute to the inde
 
 The example below creates a checkbox that is checked if the index by the name of this tiddler in the tiddler ExampleData is equal to ''selected'' and unchecked if the index is an empty string. If the index is undefined then it defaults to an empty string, meaning the checkbox will be unchecked if the index is missing.
 
-<$macrocall $name="wikitext-example-without-html" src="""<$checkbox tiddler="ExampleData" index=<<currentTiddler>> checked="selected" unchecked="" default=""> Selected?</$checkbox>"""/>
+<$macrocall $name="wikitext-example-without-html" src=dn"""
+  <$checkbox tiddler="ExampleData" index=<<currentTiddler>> checked="selected" unchecked="" default="">
+    Selected?
+  </$checkbox>
+"""/>

--- a/editions/tw5.com/tiddlers/widgets/CodeblockWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/CodeblockWidget.tid
@@ -29,11 +29,13 @@ The `language` attribute accepts either:
 
 Here is an example embedding the contents of a tiddler as a code block.
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$codeblock code={{$:/editions/tw5.com/macro-examples/say-hi}} />' />
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$codeblock code={{$:/editions/tw5.com/macro-examples/say-hi}} />
+'/>
 
 A codeblock may also specify a language.
 
-<$macrocall $name='wikitext-example-without-html'
-src='<$codeblock code="SELECT * FROM users WHERE deleted = false" language="sql" />' />
+<$macrocall $name='wikitext-example-without-html' src=dn'
+  <$codeblock code="SELECT * FROM users WHERE deleted = false" language="sql" />
+'/>
 

--- a/editions/tw5.com/tiddlers/widgets/DiffTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DiffTextWidget.tid
@@ -53,9 +53,10 @@ The ''cleanup'' attribute determines which optional post-processing should be ap
 
 In this example we compare two texts:
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$edit-text tiddler="SampleTiddlerFirst"/>
-
-<$edit-text tiddler="SampleTiddlerSecond"/>
-
-<$diff-text source={{SampleTiddlerFirst}} dest={{SampleTiddlerSecond}}/>"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$edit-text tiddler="SampleTiddlerFirst"/>
+  
+  <$edit-text tiddler="SampleTiddlerSecond"/>
+  
+  <$diff-text source={{SampleTiddlerFirst}} dest={{SampleTiddlerSecond}}/>
+"""/>

--- a/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
@@ -33,7 +33,9 @@ Using the radio widget in index mode requires the //index// attribute to specify
 
 This example sets the `Tree Frog` index in the tiddler AnimalColours:
 
-<$macrocall $name="wikitext-example-without-html" src="""<$tiddler tiddler="AnimalColours">
-<$radio index="Tree Frog" value="green"> green</$radio>
-<$radio index="Tree Frog" value="brown"> brown</$radio>
-</$tiddler>"""/>
+<$macrocall $name="wikitext-example-without-html" src=dn"""
+  <$tiddler tiddler="AnimalColours">
+    <$radio index="Tree Frog" value="green"> green</$radio>
+    <$radio index="Tree Frog" value="brown"> brown</$radio>
+  </$tiddler>
+"""/>

--- a/editions/tw5.com/tiddlers/widgets/RangeWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RangeWidget.tid
@@ -26,11 +26,15 @@ The content of the `<$range>` widget is ignored.
 
 !! Range -1 to 10
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$range tiddler="$:/_RangeDemo/1" min="-1" max="10" default="1" increment="1"/> {{$:/_RangeDemo/1}}"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$range tiddler="$:/_RangeDemo/1" min="-1" max="10" default="1" increment="1"/>
+  {{$:/_RangeDemo/1}}
+"""/>
 
 !! Range 0 to 1
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$range tiddler="$:/_RangeDemo/2" min="0" max="1" default=".01" increment=".01"/> {{$:/_RangeDemo/2}}"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$range tiddler="$:/_RangeDemo/2" min="0" max="1" default=".01" increment=".01"/>
+  {{$:/_RangeDemo/2}}
+"""/>
 

--- a/editions/tw5.com/tiddlers/widgets/SelectWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SelectWidget.tid
@@ -14,11 +14,13 @@ In multiple selection mode, the list of selected values is bound to the specifie
 
 For example, this select widget displays a list of the tags in this wiki:
 
-<$macrocall $name="wikitext-example-without-html" src="<$select tiddler=<<qualify 'select-demo'>> default='HelloThere'>
-<$list filter='[all[shadows+tiddlers]tags[]sort[title]]'>
-<option value=<<currentTiddler>>><$view field='title'/></option>
-</$list>
-</$select>"/>
+<$macrocall $name="wikitext-example-without-html" src=dn"
+  <$select tiddler=<<qualify 'select-demo'>> default='HelloThere'>
+    <$list filter='[all[shadows+tiddlers]tags[]sort[title]]'>
+      <option value=<<currentTiddler>>><$view field='title'/></option>
+    </$list>
+  </$select>
+"/>
 
 The <$link to=<<qualify "select-demo">>>state tiddler</$link> currently contains:
 
@@ -47,63 +49,73 @@ The content of the `<$select>` widget should be one or more HTML `<option>` or `
 
 This example sets the title of the current wiki [[$:/SiteTitle]] to one of a list of book titles:
 
-<$macrocall $name="wikitext-example-without-html" src="<$select tiddler='$:/SiteTitle' tooltip='Choose a new site title'>
-<option>A Tale of Two Cities</option>
-<option>A New Kind of Science</option>
-<option>The Dice Man</option>
-</$select>"/>
+<$macrocall $name="wikitext-example-without-html" src=dn"
+  <$select tiddler='$:/SiteTitle' tooltip='Choose a new site title'>
+    <option>A Tale of Two Cities</option>
+    <option>A New Kind of Science</option>
+    <option>The Dice Man</option>
+  </$select>
+"/>
 
 !! Value lists
 
 In this example the `value` attribute has been used to specify the text that should be used as the value of the entry instead of the display text.
 
-<$macrocall $name="wikitext-example-without-html" src="<$select tiddler='$:/SiteTitle'>
-<option value='cities'>A Tale of Two Cities</option>
-<option value='science'>A New Kind of Science</option>
-<option value='dice'>The Dice Man</option>
-</$select>"/>
+<$macrocall $name="wikitext-example-without-html" src=dn"
+  <$select tiddler='$:/SiteTitle'>
+    <option value='cities'>A Tale of Two Cities</option>
+    <option value='science'>A New Kind of Science</option>
+    <option value='dice'>The Dice Man</option>
+  </$select>
+"/>
 
 !! Option Groups
 
 Entries in the list can be grouped together with the `<optgroup>` element
 
-<$macrocall $name="wikitext-example-without-html" src="<$select tiddler='$:/SiteTitle'>
-<optgroup label='Fiction'>
-<option value='cities'>A Tale of Two Cities</option>
-<option value='dice'>The Dice Man</option>
-</optgroup>
-<optgroup label='Non-fiction'>
-<option value='science'>A New Kind of Science</option>
-<option value='recursive'>The Recursive Universe</option>
-</optgroup>
-</$select>"/>
+<$macrocall $name="wikitext-example-without-html" src=dn"
+  <$select tiddler='$:/SiteTitle'>
+    <optgroup label='Fiction'>
+      <option value='cities'>A Tale of Two Cities</option>
+      <option value='dice'>The Dice Man</option>
+    </optgroup>
+    <optgroup label='Non-fiction'>
+      <option value='science'>A New Kind of Science</option>
+      <option value='recursive'>The Recursive Universe</option>
+    </optgroup>
+  </$select>
+"/>
 
 !! Generated Lists
 
 The ListWidget can be used to generate the options for a select widget. For example, here we combine a select widget listing all the tiddlers tagged ''TableOfContents'' with a transclusion to display the text of the selected one.
 
-<$macrocall $name="wikitext-example-without-html" src="<$select tiddler='$:/generated-list-demo-state'>
-<$list filter='[tag[TableOfContents]]'>
-<option><$view field='title'/></option>
-</$list>
-</$select>
-<$tiddler tiddler={{$:/generated-list-demo-state}}>
-<$transclude mode='block'/>
-</$tiddler>"/>
+<$macrocall $name="wikitext-example-without-html" src=dn"
+  <$select tiddler='$:/generated-list-demo-state'>
+    <$list filter='[tag[TableOfContents]]'>
+    <option><$view field='title'/></option>
+    </$list>
+  </$select>
+  <$tiddler tiddler={{$:/generated-list-demo-state}}>
+    <$transclude mode='block'/>
+  </$tiddler>
+"/>
 
 !! Nested Lists
 
 This example uses a nested pair of list widgets. The outer one generates the `<optgroup>` elements, and the inner one generates `<option>` elements:
 
-<$macrocall $name="wikitext-example-without-html" src="<$select tiddler='$:/generated-list-demo-nestedstate' field='type' default='text/vnd.tiddlywiki'>
-<$list filter='[all[shadows+tiddlers]prefix[$:/language/Docs/Types/]each[group]sort[group]]'>
-<optgroup label={{!!group}}>
-<$list filter='[all[shadows+tiddlers]prefix[$:/language/Docs/Types/]group{!!group}] +[sort[description]]'>
-<option value={{!!name}}><$view field='description'><$view field='title'/></$view> (<$view field='name'/>)</option>
-</$list>
-</optgroup>
-</$list>
-</$select>"/>
+<$macrocall $name="wikitext-example-without-html" src=dn"
+  <$select tiddler='$:/generated-list-demo-nestedstate' field='type' default='text/vnd.tiddlywiki'>
+    <$list filter='[all[shadows+tiddlers]prefix[$:/language/Docs/Types/]each[group]sort[group]]'>
+      <optgroup label={{!!group}}>
+        <$list filter='[all[shadows+tiddlers]prefix[$:/language/Docs/Types/]group{!!group}] +[sort[description]]'>
+          <option value={{!!name}}><$view field='description'><$view field='title'/></$view> (<$view field='name'/>)</option>
+        </$list>
+      </optgroup>
+    </$list>
+  </$select>
+"/>
 
 !! Multiple Selections
 

--- a/editions/tw5.com/tiddlers/widgets/TextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/TextWidget.tid
@@ -26,7 +26,7 @@ The content of the `<$text>` widget is not used.
 </$vars>
 ' />
 
-<$macrocall $name='wikitext-example-without-html' src='
+<$macrocall $name='wikitext-example-without-html' src=dn'
 The text-test field of this tiddler has a field value: <$text text={{!!text-test}}/>
 
 It displays in its normal WikiText format as: {{!!text-test}}

--- a/editions/tw5.com/tiddlers/widgets/The Extended Listops Filters.tid
+++ b/editions/tw5.com/tiddlers/widgets/The Extended Listops Filters.tid
@@ -23,91 +23,96 @@ A second set of filters are designed to either add or remove from the list, a se
 
 In this example we shall populate the '~DataIndex' index of the tiddler '~MyData' with the names of the days of the week, then clear this list. 
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $filter="[list[Days of the Week]]"/>
-Get days-of-the-week
-</$button> 
-<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $filter="[[]]"/>
-Clear
-</$button>
-
-{{ListopsData}}"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $filter="[list[Days of the Week]]"/>
+    Get days-of-the-week
+  </$button> 
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $filter="[[]]"/>
+    Clear
+  </$button>
+  
+  {{ListopsData}}
+"""/>
 
 ---
 In this example we shall slice the populated list from the 'DaysOfTheWeek' index of the tiddler '~MyData' in order to insert items before and after a marker item (Wednesday) that are first appended to the list.
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="one two +[putbefore:2[Wednesday]]"/>
-Put 2 Items Before Wednesday
-</$button> 
-<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="four five +[putafter:2[Wednesday]] three +[putbefore[Wednesday]]"/>
-Put One Item Before & Two Items After Wednesday
-</$button>
-
-{{ListopsData}}"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="one two +[putbefore:2[Wednesday]]"/>
+    Put 2 Items Before Wednesday
+  </$button> 
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="four five +[putafter:2[Wednesday]] three +[putbefore[Wednesday]]"/>
+    Put One Item Before & Two Items After Wednesday
+  </$button>
+  
+  {{ListopsData}}
+"""/>
 
 ---
 In this example we shall slice the populated list from the 'DaysOfTheWeek' index of the tiddler '~MyData' in order to replace the marker item (Wednesday) with items which are first appended to the list. We shall then move 3 items to the head of the list which have first been appended to the list from referenced fields.
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="[[---o]] [[o---]] +[replace:2{!!marker}]"/>
-Replace '!!marker' with 2 Items
-</$button>
-<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="[{!!item1}] [{!!item2}] [{!!item3}] +[putfirst:3[]]"/>
-Put 3 Items First
-</$button>
-
-{{ListopsData}}"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="[[---o]] [[o---]] +[replace:2{!!marker}]"/>
+    Replace '!!marker' with 2 Items
+  </$button>
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="[{!!item1}] [{!!item2}] [{!!item3}] +[putfirst:3[]]"/>
+    Put 3 Items First
+  </$button>
+  
+  {{ListopsData}}
+"""/>
 
 ---
 In this example we shall slice the populated list from the 'DaysOfTheWeek' index of the tiddler '~MyData' in order to append to the truncated list, items from a referenced field. We shall then remove the first two of the items added.
 
-<$macrocall $name='wikitext-example-without-html'
-src="""|list: |<$view field="list"/> |
-
-<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[allbefore:include[Wednesday]] +[prepend{!!list}]"/>
-Prepend '!!list' to items before 'Wednesday'
-</$button> 
-<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[remove:2{!!list}]"/>
-Remove first two items in '!!list' from current list
-</$button>
-<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[!remove:1{!!list}]"/>
-Remove last item in '!!list' from current list
-</$button>
-
-{{ListopsData}}"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  |list: |<$view field="list"/> |
+  
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[allbefore:include[Wednesday]] +[prepend{!!list}]"/>
+    Prepend '!!list' to items before 'Wednesday'
+  </$button> 
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[remove:2{!!list}]"/>
+    Remove first two items in '!!list' from current list
+  </$button>
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[!remove:1{!!list}]"/>
+    Remove last item in '!!list' from current list
+  </$button>
+  
+  {{ListopsData}}
+"""/>
 
 ---
 In this example we shall populate the list with numbers, then move items one by one from the head to the tail and from the tail to the head (best seen by clicking the lower buttons several times.) 
 
 This example illustrates that the append[] and prepend[] operators do not enforce unique instances of an item and that, with the next run, any duplicates are removed.
 
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $filter="[[]]" $subfilter="+[append:3{!!numbers}]"/>
-Setup some numbers
-</$button>
-<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[!append:6{!!numbers}]"/>
-Append more numbers
-</$button>
-
-<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[putfirst:2[]]"/>
-Move last 2 items to the head
-</$button>
-<$button>
-<$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[putlast[]]"/>
-Move the head to the last item
-</$button>
-
-{{ListopsData}}"""/>
+<$macrocall $name='wikitext-example-without-html' src=dn"""
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $filter="[[]]" $subfilter="+[append:3{!!numbers}]"/>
+    Setup some numbers
+  </$button>
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[!append:6{!!numbers}]"/>
+    Append more numbers
+  </$button>
+  
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[putfirst:2[]]"/>
+    Move last 2 items to the head
+  </$button>
+  <$button>
+    <$action-listops $tiddler="ListopsData" $index="DataIndex" $subfilter="+[putlast[]]"/>
+    Move the head to the last item
+  </$button>
+  
+  {{ListopsData}}
+"""/>


### PR DESCRIPTION
Already mentioned this in my 'improve p generation' PR message, under 9. 

you can now write ...

```
<$macrocall $name="my-macro" src=dn"""

  <my>
    <complex>
      <code>inside of the attribute vale</code>
    </complex>
  </my>
  
"""/>
```

... and it gets dedented and stripped as if you wrote ...

```
<$macrocall $name="my-macro" src="""<my>
  <complex>
    <code>inside of the attribute vale</code>
  </complex>
</my>"""/>
```

(notice the `dn` before the string)

Shall `'''...'''` be an alias for `dn"""..."""`?
