### PR TITLE
Correct the jsonstringify documentation

### DIFF
--- a/editions/tw5.com/tiddlers/filters/jsonstringify Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/jsonstringify Operator.tid
@@ -15,10 +15,12 @@ The following substitutions are made:
 
 |!Character |!Replacement |
 |`\` |`\\` |
-|`"` |`\\` |
-|`'` |`\\` |
+|`"` |`\\"` |
 |`\r` (carriage return) |`\\r` |
 |`\n` (line feed) |`\\n` |
+|`\x08` (backpsace) |`\\b` |
+|`\x0c` (formfield) |`\\f` |
+|`\t` (tab) |`\\t` |
 |Characters from 0x00 to 0x1f |`\\x##` where ## is two hex digits |
 |Characters from 0x80 to 0xffff |`\\u####` where #### is four hex digits |
 


### PR DESCRIPTION
The jsonstringify substitution table does not list all substitutions, and it listed `'` as being replaced when it's not.  This updates the table based on the code at https://github.com/Jermolene/TiddlyWiki5/blob/master/core/modules/utils/utils.js#L537