### PR TITLE
Replace '<<...>>' with a macrocall widget

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/Using Stamp.tid
+++ b/editions/tw5.com/tiddlers/howtos/Using Stamp.tid
@@ -13,8 +13,7 @@ You can insert preconfigured snippets of text to use stamp from toolbar. Click '
 # Type some text as snippet for the tiddler, add a caption for the name as shown in the menu
 # Click the <<.icon $:/core/images/done-button>> ''ok'' button
 
-<<.tip """''Tip:'' You can also create a snippet tiddler using the ''new tiddler'' <<.icon $:/core/images/new-button>> button in the sidebar, and add tag ''~$:/tags/TextEditor/Snippet''""">>
-
+<$macrocall $name=".tip" _="""''Tip:'' You can also create a snippet tiddler using the ''new tiddler'' <<.icon $:/core/images/new-button>> button in the sidebar, and add tag ''~$:/tags/TextEditor/Snippet''""" />
 
 !!<<.from-version "5.1.20">> Adding a prefix and/or suffix to a selection
 


### PR DESCRIPTION
... because there is another macrocall inside.

This was introduced by the commit 'Fix sizes of SVG icons in documentation' (SHA: 9395d7567179c436d0e8ac26fc976d717eae7f50) where this probably slipped through in a regular expression replacement session.

I searched through the codebase and the other replacements of this type are ok.