### PR TITLE
Enable indexers in tag test

### DIFF
--- a/editions/test/tiddlers/tests/test-tags.js
+++ b/editions/test/tiddlers/tests/test-tags.js
@@ -21,7 +21,7 @@ describe("With no indexers", function() {
 });
 
 describe("With all indexers", function() {
-	var wikiOptions = {enableIndexers: []},
+	var wikiOptions = {},
 		wiki = setupWiki();
 	runTests(wiki,wikiOptions);
 });


### PR DESCRIPTION
Setting enableIndexers to an empty array ends up disabling all indexers for the wiki