### PR TITLE
Fix undefined print_ error

### DIFF
--- a/plugins/tiddlywiki/jasmine/files/reporter.js
+++ b/plugins/tiddlywiki/jasmine/files/reporter.js
@@ -1,14 +1,4 @@
 (function() {
-  //
-  // Imports
-  //
-  var util;
-  try {
-    util = require('util')
-  } catch(e) {
-    util = require('sys')
-  }
-
   var jasmineNode = {};
   //
   // Helpers
@@ -17,7 +7,7 @@
 
 
   jasmineNode.TerminalReporter = function(config) {
-    this.print_ = config.print || util.print;
+    this.print_ = config.print || console.log;
     this.color_ = config.color ? this.ANSIColors : this.NoColors;
 
     this.started_ = false;


### PR DESCRIPTION
On newer versions of Node, I get this error:

```
    TypeError: this.print_ is not a function
```

I believe this is because Node has deprecated util.print in favor of
console.log