### PR TITLE
remove &nbsp from tag pill in edit mode

### DIFF
--- a/core/ui/EditTemplate/tags.tid
+++ b/core/ui/EditTemplate/tags.tid
@@ -15,7 +15,7 @@ color:$(foregroundColor)$;
 \whitespace trim
 <$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
 <span style=<<tag-styles>> class="tc-tag-label tc-tag-list-item">
-<$transclude tiddler="""$icon$"""/>&nbsp;<$view field="title" format="text" />
+<$transclude tiddler="""$icon$"""/><$view field="title" format="text" />
 <$button message="tm-remove-tag" param={{!!title}} class="tc-btn-invisible tc-remove-tag-button">{{$:/core/images/close-button}}</$button>
 </span>
 </$vars>

--- a/core/wiki/macros/tag.tid
+++ b/core/wiki/macros/tag.tid
@@ -10,7 +10,7 @@ color:$(foregroundColor)$;
 \define tag-pill-inner(tag,icon,colour,fallbackTarget,colourA,colourB,element-tag,element-attributes,actions)
 <$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
 <$element-tag$ $element-attributes$ class="tc-tag-label tc-btn-invisible" style=<<tag-pill-styles>>>
-$actions$<$transclude tiddler="""$icon$"""/> <$view tiddler=<<__tag__>> field="title" format="text" />
+$actions$<$transclude tiddler="""$icon$"""/><$view tiddler=<<__tag__>> field="title" format="text" />
 </$element-tag$>
 </$vars>
 \end

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -672,6 +672,8 @@ button.tc-untagged-label {
 .tc-tag-label svg, .tc-tag-label img {
 	height: 1em;
 	width: 1em;
+	margin-right: 3px; 
+	margin-bottom: 1px;
 	vertical-align: text-bottom;
 }
 


### PR DESCRIPTION
PR: fix missing space between edittemplate tags #3585 introduced an unbreakable space ...

The `&nbsp` isn't needed and **causes problems**, if users copy&paste the tag text, because the "new" tag in the text input field now contains an space in front of the tag. This space invalidates the tag, so it doesn't function anymore. 

see [comment in GG](https://groups.google.com/d/msg/tiddlywiki/RQEyqPQIZSM/uaU7lgJJAAAJ) .. I also had a problem like this some time ago, which costed me several hours of debugging.