### PR TITLE
Add elixir to language support list

### DIFF
--- a/plugins/tiddlywiki/highlight/readme.tid
+++ b/plugins/tiddlywiki/highlight/readme.tid
@@ -36,6 +36,7 @@ The plugin includes support for the following languages (referred to as "brushes
 * css
 * diff
 * dockerfile
+* elixir
 * erlang
 * fortran
 * go


### PR DESCRIPTION
It appears that Elixir is already a supported language. This can be found by performing a ctrl-F on the [highlight.pack.js](https://github.com/Jermolene/TiddlyWiki5/blob/8f3da69f818940eb5f517da850fb3766b72c7d7d/plugins/tiddlywiki/highlight/files/highlight.pack.js#L2) file that ships with TiddlyWiki.
