### PR TITLE
Add cacheFileInfo function

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2124,6 +2124,7 @@ $tw.loadTiddlersNode = function() {
 	// Load the tiddlers from the wiki directory
 	if($tw.boot.wikiPath) {
 		$tw.boot.wikiInfo = $tw.loadWikiTiddlers($tw.boot.wikiPath);
+		$tw.utils.cacheFileInfo();
 	}
 };
 

--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -231,6 +231,21 @@ exports.generateTiddlerFileInfo = function(tiddler,options) {
 	return fileInfo;
 };
 
+/**
+ * Save the boot file info to disk.
+ * This allows simple TiddlyWeb access 
+ * without loading a node instance for it.
+ */
+exports.cacheFileInfo = function() {
+	if($tw.boot.files) {
+		fs.writeFileSync(
+			path.join($tw.boot.wikiPath, "fileinfo.json"), 
+			JSON.stringify($tw.boot.files, null, 2), 
+			"utf8"
+		);
+	}
+}
+
 /*
 Generate the filepath for saving a tiddler
 Options include:

--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -57,6 +57,7 @@ FileSystemAdaptor.prototype.getTiddlerFileInfo = function(tiddler,callback) {
 			wiki: this.wiki
 		});
 		$tw.boot.files[title] = fileInfo;
+		$tw.utils.cacheFileInfo();
 	}
 	callback(null,fileInfo);
 };


### PR DESCRIPTION
This function caches `$tw.boot.files` to a JSON file in the data folder, allowing TiddlyWeb compatible servers to modify the data folder more efficiently. If this is not desired by default, `$tw.utils.cacheFileInfo` could be made a no-op function which specific plugins would be allowed to implement if needed for specific data folders. There is no good way to watch `$tw.boot.files` without using a setInterval, which is suboptimal. 