### PR TITLE
Update links to Json Mangler plugin github pages

### DIFF
--- a/editions/tw5.com/tiddlers/community/resources/Json Mangler plugin by Joshua Fontany.tid
+++ b/editions/tw5.com/tiddlers/community/resources/Json Mangler plugin by Joshua Fontany.tid
@@ -7,6 +7,6 @@ Extend tiddlywiki to parse complex ("nested") json data tiddlers.
 
 Json Mangler introduces a new path syntax for indexes of json data tiddlers , and includes many supporting tools, filters, widgets, etc.
 
-Example Wiki: https://joshuafontany.github.io/TW5-JsonManglerPlugin/
+Example Wiki: https://joshuafontany.github.io/TW5-JsonMangler/
 
-Source: https://github.com/joshuafontany/TW5-JsonManglerPlugin
+Source: https://github.com/joshuafontany/TW5-JsonMangler


### PR DESCRIPTION
The plugin's repo appears to have been renamed.