### PR TITLE
Fixed join filter operator to never return null

### DIFF
--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -70,7 +70,7 @@ function makeStringReducingOperator(fnCalc,initialValue) {
 		});
 		return [result.reduce(function(accumulator,currentValue) {
 			return fnCalc(accumulator,currentValue,operator.operand || "");
-		},initialValue)];
+		},initialValue) || ""];
 	};
 }
 

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -453,6 +453,10 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[[John. Paul. George. Ringo.]] +[split[.]trim[]]").join(",")).toBe("John,Paul,George,Ringo,");
 		expect(wiki.filterTiddlers("John Paul George Ringo +[split[e]]").join(",")).toBe("John,Paul,G,org,,Ringo");
 		expect(wiki.filterTiddlers("John Paul George Ringo +[join[ ]split[e]join[ee]split[ ]]").join(",")).toBe("John,Paul,Geeorgee,Ringo");
+		// Ensure that join doesn't return null if passed empty list
+		expect(wiki.filterTiddlers("Test +[butlast[]join[ ]]")).toEqual([""]);
+		// Ensure that join correctly handles empty strings in source
+		expect(wiki.filterTiddlers("[[]] Paul +[join[-]]").join(",")).toBe("-Paul");
 		expect(wiki.filterTiddlers("[[ John ]] [[Paul ]] [[ George]] Ringo +[trim[]join[-]]").join(",")).toBe("John-Paul-George-Ringo");
 	});
 


### PR DESCRIPTION
`[[Test]butlast[]join[ ]prefix[]]` would cause a Red Screen of Death.

This is because the join operator would return null if passed an
empty list. I've put in a small fix to ensure that doesn't happen,
and included a couple tests to catch that and another possible
pitfall.