### PR TITLE
add support for video file type webm & ogg theora

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2256,6 +2256,8 @@ $tw.boot.startup = function(options) {
 	$tw.utils.registerFileType("application/font-woff","base64",".woff");
 	$tw.utils.registerFileType("application/x-font-ttf","base64",".woff");
 	$tw.utils.registerFileType("audio/ogg","base64",".ogg");
+	$tw.utils.registerFileType("video/ogg","base64",[".ogm",".ogv",".ogg"]);
+	$tw.utils.registerFileType("video/webm","base64",".webm");
 	$tw.utils.registerFileType("video/mp4","base64",".mp4");
 	$tw.utils.registerFileType("audio/mp3","base64",".mp3");
 	$tw.utils.registerFileType("audio/mp4","base64",[".mp4",".m4a"]);

--- a/core/modules/parsers/videoparser.js
+++ b/core/modules/parsers/videoparser.js
@@ -30,8 +30,9 @@ var VideoParser = function(type,text,options) {
 	this.tree = [element];
 };
 
+exports["video/ogg"] = VideoParser;
+exports["video/webm"] = VideoParser;
 exports["video/mp4"] = VideoParser;
 exports["video/quicktime"] = VideoParser;
 
 })();
-


### PR DESCRIPTION
as discussed in [#2083](https://github.com/Jermolene/TiddlyWiki5/issues/2083#issuecomment-566963210)

added support for file type
- video/webm
- video/ogg
filename extension for Ogg Theora video files based on [this mdn note](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Server_support_for_video)