### PR TITLE
replace "&times" with close-button in keyboard-shortcuts

### DIFF
--- a/core/ui/ControlPanel/KeyboardShortcuts.tid
+++ b/core/ui/ControlPanel/KeyboardShortcuts.tid
@@ -48,7 +48,7 @@ caption: {{$:/language/ControlPanel/KeyboardShortcuts/Caption}}
 	$field="text"
 	$subfilter="+[remove<shortcut>]"
 />
-&times;
+<small>{{$:/core/images/close-button}}</small>
 </$button>
 <kbd>
 <$macrocall $name="displayshortcuts" $output="text/html" shortcuts=<<shortcut>>/>


### PR DESCRIPTION
this PR replaces the `&times` in the keyboard-shortcuts dropdown with the `$:/core/images/close-button`