### PR TITLE
Add download button/link to binary tiddler warning banners in view and edit mode

### DIFF
--- a/core/modules/parsers/binaryparser.js
+++ b/core/modules/parsers/binaryparser.js
@@ -3,7 +3,7 @@ title: $:/core/modules/parsers/binaryparser.js
 type: application/javascript
 module-type: parser
 
-The video parser parses a video tiddler into an embeddable HTML element
+The binary parser parses a binary tiddler into a warning message and download link
 
 \*/
 (function(){
@@ -13,14 +13,57 @@ The video parser parses a video tiddler into an embeddable HTML element
 "use strict";
 
 var BINARY_WARNING_MESSAGE = "$:/core/ui/BinaryWarning";
+var EXPORT_BUTTON_IMAGE = "$:/core/images/export-button";
 
 var BinaryParser = function(type,text,options) {
-	this.tree = [{
-		type: "transclude",
+	// Transclude the binary data tiddler warning message
+	var warn = {
+		type: "element",
+		tag: "p",
+		children: [{
+			type: "transclude",
+			attributes: {
+				tiddler: {type: "string", value: BINARY_WARNING_MESSAGE}
+			}
+		}]
+	};
+	// Create download link based on binary tiddler title
+	var link = {
+		type: "element",
+		tag: "a",
 		attributes: {
-			tiddler: {type: "string", value: BINARY_WARNING_MESSAGE}
-		}
-	}];
+			title: {type: "indirect", textReference: "!!title"},
+			download: {type: "indirect", textReference: "!!title"}
+		},
+		children: [{
+			type: "transclude",
+			attributes: {
+				tiddler: {type: "string", value: EXPORT_BUTTON_IMAGE}
+			}
+		}]
+	};
+	// Set the link href to external or internal data URI
+	if(options._canonical_uri) {
+		link.attributes.href = {
+			type: "string", 
+			value: options._canonical_uri
+		};
+	} else if(text) {
+		link.attributes.href = {
+			type: "string", 
+			value: "data:" + type + ";base64," + text
+		};
+	}
+	// Combine warning message and download link in a div
+	var element = {
+		type: "element",
+		tag: "div",
+		attributes: {
+			class: {type: "string", value: "tc-binary-warning"}
+		},
+		children: [warn, link]
+	}
+	this.tree = [element];
 };
 
 exports["application/octet-stream"] = BinaryParser;

--- a/core/modules/widgets/edit-binary.js
+++ b/core/modules/widgets/edit-binary.js
@@ -13,6 +13,7 @@ Edit-binary widget; placeholder for editing binary tiddlers
 "use strict";
 
 var BINARY_WARNING_MESSAGE = "$:/core/ui/BinaryWarning";
+var EXPORT_BUTTON_IMAGE = "$:/core/images/export-button";
 
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
@@ -43,13 +44,55 @@ EditBinaryWidget.prototype.render = function(parent,nextSibling) {
 Compute the internal state of the widget
 */
 EditBinaryWidget.prototype.execute = function() {
-	// Construct the child widgets
-	this.makeChildWidgets([{
-		type: "transclude",
+	// Get our parameters
+	var editTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
+	var tiddler = this.wiki.getTiddler(editTitle);
+	var type = tiddler.fields.type;
+	var text = tiddler.fields.text;
+	// Transclude the binary data tiddler warning message
+	var warn = {
+		type: "element",
+		tag: "p",
+		children: [{
+			type: "transclude",
+			attributes: {
+				tiddler: {type: "string", value: BINARY_WARNING_MESSAGE}
+			}
+		}]
+	};
+	// Create download link based on draft tiddler title
+	var link = {
+		type: "element",
+		tag: "a",
 		attributes: {
-			tiddler: {type: "string", value: BINARY_WARNING_MESSAGE}
-		}
-	}]);
+			title: {type: "indirect", textReference: "!!draft.title"},
+			download: {type: "indirect", textReference: "!!draft.title"}
+		},
+		children: [{
+		type: "transclude",
+			attributes: {
+				tiddler: {type: "string", value: EXPORT_BUTTON_IMAGE}
+			}
+		}]
+	};
+	// Set the link href to internal data URI (no external)
+	if(text) {
+		link.attributes.href = {
+			type: "string", 
+			value: "data:" + type + ";base64," + text
+		};
+	}
+	// Combine warning message and download link in a div
+	var element = {
+		type: "element",
+		tag: "div",
+		attributes: {
+			class: {type: "string", value: "tc-binary-warning"}
+		},
+		children: [warn, link]
+	}
+	// Construct the child widgets
+	this.makeChildWidgets([element]);
 };
 
 /*

--- a/core/ui/BinaryWarning.tid
+++ b/core/ui/BinaryWarning.tid
@@ -1,8 +1,4 @@
 title: $:/core/ui/BinaryWarning
 
 \define lingo-base() $:/language/BinaryWarning/
-<div class="tc-binary-warning">
-
 <<lingo Prompt>>
-
-</div>


### PR DESCRIPTION
This PR adds a download link to the existing warning banners shown for tiddlers containing binary data:
![example](https://user-images.githubusercontent.com/26188413/73117499-9d03b200-3f9a-11ea-92ca-be468377a539.png)
It aims to solve https://github.com/Jermolene/TiddlyWiki5/issues/1522 and kind of helps with https://github.com/Jermolene/TiddlyWiki5/issues/781 but does not cover all the described cases. The code was mostly written referencing [$:/core/modules/parsers/imageparser.js](https://github.com/Jermolene/TiddlyWiki5/blob/master/core/modules/parsers/imageparser.js) and some parts of [$:/core/modules/widgets/edit-bitmap.js](https://github.com/Jermolene/TiddlyWiki5/blob/master/core/modules/widgets/edit-bitmap.js) as well as the original versions of the modified files.

It piggybacks off the existing warning banner for binary tiddlers code so that it does not need to check for the presence binary data itself. It uses the existing export button image for the download link to avoid the need for more translations. 

I don't have much experience with TiddlyWiki and open-source in general so I apologise for any trouble caused. I made these changes so that I can embed and access small .zip archives in my own TiddlyWiki conveniently and thought others may find it useful. Thank you for your time and attention.

Warm regards,
Sheng