### PR TITLE
Update TaskManagementExampleDraggable.tid

### DIFF
--- a/editions/tw5.com/tiddlers/demonstrations/Tasks/TaskManagementExampleDraggable.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/Tasks/TaskManagementExampleDraggable.tid
@@ -4,7 +4,7 @@ tags: Learning
 title: TaskManagementExample (Draggable)
 type: text/vnd.tiddlywiki
 
-This is a version of the TaskManagementDemo enhanced with the ability to drag and drop the task list to re-order them.
+This is a version of the TaskManagementExample enhanced with the ability to drag and drop the task list to re-order them.
 
 ! Outstanding tasks
 


### PR DESCRIPTION
Corrected the title of the non-draggable task management example tiddler. TaskManagementDemo doesn't exist.