### PR TITLE
Fix support for zip files in some environments

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2245,6 +2245,7 @@ $tw.boot.startup = function(options) {
 	$tw.utils.registerFileType("application/json","utf8",".json");
 	$tw.utils.registerFileType("application/pdf","base64",".pdf",{flags:["image"]});
 	$tw.utils.registerFileType("application/zip","base64",".zip");
+	$tw.utils.registerFileType("application/x-zip-compressed","base64",".zip");
 	$tw.utils.registerFileType("image/jpeg","base64",[".jpg",".jpeg"],{flags:["image"]});
 	$tw.utils.registerFileType("image/png","base64",".png",{flags:["image"]});
 	$tw.utils.registerFileType("image/gif","base64",".gif",{flags:["image"]});


### PR DESCRIPTION
In some environments (at least on my own machine), TiddlyWiki detects zip files as type `"application/x-zip-compressed"` instead of `"application/zip"`. This commit adds support for zip files with type `"application/x-zip-compressed"` so that they are encoded in `"base64"` like other zip files with type `"application/zip"`.