### PR TITLE
Update StaticRiver exporter to use publishFilter

### DIFF
--- a/core/templates/exporters/StaticRiver.tid
+++ b/core/templates/exporters/StaticRiver.tid
@@ -3,6 +3,9 @@ tags: $:/tags/Exporter
 description: {{$:/language/Exporters/StaticRiver}}
 extension: .html
 
+\define saveTiddlerFilter()
+[is[tiddler]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/core]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
+\end
 \define tv-wikilink-template() #$uri_encoded$
 \define tv-config-toolbar-icons() no
 \define tv-config-toolbar-text() no

--- a/core/templates/exporters/StaticRiverContent.tid
+++ b/core/templates/exporters/StaticRiverContent.tid
@@ -1,7 +1,5 @@
 title: $:/core/templates/exporters/StaticRiver/Content
 
-\define renderContent()
-{{{ $(exportFilter)$ ||$:/core/templates/static-tiddler}}}
-\end
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
-<<renderContent>>
+<$set name="saveTiddlerAndShadowsFilter" filter="[subfilter<saveTiddlerFilter>]">
+{{{ [enlist<saveTiddlerAndShadowsFilter> || $:/core/templates/static-tiddler ] }}}


### PR DESCRIPTION
This fixes issues #4445 and #4446, by implementing the `saveTiddlerFilter()` used in the save mechanism. This also allows the use of `publishFilter` in combination with the StaticRiver exporter when used with the render command.