### PR TITLE
Add support for a custom class to modal wrapper

### DIFF
--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -58,6 +58,9 @@ Modal.prototype.display = function(title,options) {
 	this.adjustPageClass();
 	// Add classes
 	$tw.utils.addClass(wrapper,"tc-modal-wrapper");
+	if(tiddler && tiddler.fields && tiddler.fields.class) {
+		$tw.utils.addClass(wrapper,tiddler.fields.class);
+	}
 	$tw.utils.addClass(modalBackdrop,"tc-modal-backdrop");
 	$tw.utils.addClass(modalWrapper,"tc-modal");
 	$tw.utils.addClass(modalHeader,"tc-modal-header");

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -58,7 +58,7 @@ Modal.prototype.display = function(title,options) {
 	this.adjustPageClass();
 	// Add classes
 	$tw.utils.addClass(wrapper,"tc-modal-wrapper");
-	if(tiddler && tiddler.fields && tiddler.fields.class) {
+	if(tiddler.fields && tiddler.fields.class) {
 		$tw.utils.addClass(wrapper,tiddler.fields.class);
 	}
 	$tw.utils.addClass(modalBackdrop,"tc-modal-backdrop");
@@ -107,7 +107,7 @@ Modal.prototype.display = function(title,options) {
 		modalBody.appendChild(modalLink);
 	}
 	// Render the footer of the message
-	if(tiddler && tiddler.fields && tiddler.fields.help) {
+	if(tiddler.fields && tiddler.fields.help) {
 		var link = this.srcDocument.createElement("a");
 		link.setAttribute("href",tiddler.fields.help);
 		link.setAttribute("target","_blank");


### PR DESCRIPTION
As per #4485 add support for a custom class to modal wrapper, by means of a field in the modal tiddler. The class is added to the modal wrapper in addition to the default class, allowing for custom styling via css of any part of the modal.