### PR TITLE
Add "Gruvbox Dark" color palette

### DIFF
--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -1,0 +1,121 @@
+title: $:/palettes/GruvboxDark
+name: Gruvbox Dark
+description: Retro groove color scheme
+tags: $:/tags/Palette
+type: application/x-tiddler-dictionary
+
+alert-background: #cc241d
+alert-border: #cc241d
+alert-highlight: #d79921
+alert-muted-foreground: #504945
+background: #3c3836
+blockquote-bar: <<colour muted-foreground>>
+button-background: #504945
+button-foreground: #fbf1c7
+button-border: transparent
+code-background: #504945
+code-border: #504945
+code-foreground: #fb4934
+diff-delete-background: #fb4934
+diff-delete-foreground: <<colour foreground>>
+diff-equal-background: 
+diff-equal-foreground: <<colour foreground>>
+diff-insert-background: #b8bb26
+diff-insert-foreground: <<colour foreground>>
+diff-invisible-background: 
+diff-invisible-foreground: <<colour muted-foreground>>
+dirty-indicator: #fb4934
+download-background: #b8bb26
+download-foreground: <<colour background>>
+dragger-background: <<colour foreground>>
+dragger-foreground: <<colour background>>
+dropdown-background: #665c54
+dropdown-border: <<colour background>>
+dropdown-tab-background-selected: #ebdbb2
+dropdown-tab-background: #665c54
+dropzone-background: #98971a
+external-link-background-hover: inherit
+external-link-background-visited: inherit
+external-link-background: inherit
+external-link-foreground-hover: inherit
+external-link-foreground-visited: #d3869b
+external-link-foreground: #8ec07c
+foreground: #fbf1c7
+menubar-background: #504945
+menubar-foreground: <<colour foreground>>
+message-background: #83a598
+message-border: #83a598
+message-foreground: #3c3836
+modal-backdrop: <<colour foreground>>
+modal-background: <<colour background>>
+modal-border: #504945
+modal-footer-background: #3c3836
+modal-footer-border: #3c3836
+modal-header-border: #3c3836
+muted-foreground: #665c54
+notification-background: <<colour primary>>
+notification-border: <<colour primary>>
+page-background: #282828
+pre-background: #504945
+pre-border: #504945
+primary: #d79921
+select-tag-background: #665c54
+select-tag-foreground: <<colour foreground>>
+sidebar-button-foreground: <<colour foreground>>
+sidebar-controls-foreground-hover: #7c6f64
+sidebar-controls-foreground: #504945
+sidebar-foreground-shadow: transparent
+sidebar-foreground: #fbf1c7
+sidebar-muted-foreground-hover: #7c6f64
+sidebar-muted-foreground: #504945
+sidebar-tab-background-selected: #bdae93
+sidebar-tab-background: #3c3836
+sidebar-tab-border-selected: <<colour tab-border-selected>>
+sidebar-tab-border: #bdae93
+sidebar-tab-divider: <<colour page-background>>
+sidebar-tab-foreground-selected: #282828
+sidebar-tab-foreground: <<colour tab-foreground>>
+sidebar-tiddler-link-foreground-hover: #458588
+sidebar-tiddler-link-foreground: #98971a
+site-title-foreground: <<colour tiddler-title-foreground>>
+static-alert-foreground: #B48EAD
+tab-background-selected: #ebdbb2
+tab-background: #665c54
+tab-border-selected: #665c54
+tab-border: #665c54
+tab-divider: #bdae93
+tab-foreground-selected: #282828
+tab-foreground: #ebdbb2
+table-border: #7c6f64
+table-footer-background: #665c54
+table-header-background: #504945
+tag-background: #d3869b
+tag-foreground: #282828
+tiddler-background: <<colour background>>
+tiddler-border: <<colour background>>
+tiddler-controls-foreground-hover: #7c6f64
+tiddler-controls-foreground-selected: #7c6f64
+tiddler-controls-foreground: #665c54
+tiddler-editor-background: #282828
+tiddler-editor-border-image: #282828
+tiddler-editor-border: #282828
+tiddler-editor-fields-even: #504945
+tiddler-editor-fields-odd: #665c45
+tiddler-info-background: #32302f
+tiddler-info-border: #ebdbb2
+tiddler-info-tab-background: #ebdbb2
+tiddler-link-background: <<colour background>>
+tiddler-link-foreground: <<colour primary>>
+tiddler-subtitle-foreground: #7c6f64
+tiddler-title-foreground: #7c6f64
+toolbar-new-button: 
+toolbar-options-button: 
+toolbar-save-button: 
+toolbar-info-button: 
+toolbar-edit-button: 
+toolbar-close-button: 
+toolbar-delete-button: 
+toolbar-cancel-button: 
+toolbar-done-button: 
+untagged-background: #504945
+very-muted-foreground: #32302f

--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -3,7 +3,7 @@ name: Gruvbox Dark
 description: Retro groove color scheme
 tags: $:/tags/Palette
 type: application/x-tiddler-dictionary
-credits: https://github.com/morhetz/gruvbox
+license: https://github.com/morhetz/gruvbox
 
 alert-background: #cc241d
 alert-border: #cc241d

--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -3,6 +3,7 @@ name: Gruvbox Dark
 description: Retro groove color scheme
 tags: $:/tags/Palette
 type: application/x-tiddler-dictionary
+credits: https://github.com/morhetz/gruvbox
 
 alert-background: #cc241d
 alert-border: #cc241d


### PR DESCRIPTION
this adds the "gruvbox dark" color palette (https://github.com/morhetz/gruvbox) which is also available for highlight.js and codemirror