### PR TITLE
Use CamelCase for Gitea

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -107,8 +107,8 @@ Saving/GitService/GitHub/Caption: ~GitHub Saver
 Saving/GitService/GitHub/Password: Password, OAUTH token, or personal access token (see [[GitHub help page|https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line]] for details)
 Saving/GitService/GitLab/Caption: ~GitLab Saver
 Saving/GitService/GitLab/Password: Personal access token for API (see [[GitLab help page|https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html]] for details)
-Saving/GitService/gitea/Caption: gitea saver
-Saving/GitService/gitea/Password: Personal access token for API (via Gitea’s web interface: `Settings | Applications | Generate New Token`)
+Saving/GitService/Gitea/Caption: Gitea Saver
+Saving/GitService/Gitea/Password: Personal access token for API (via Gitea’s web interface: `Settings | Applications | Generate New Token`)
 Saving/TiddlySpot/Advanced/Heading: Advanced Settings
 Saving/TiddlySpot/BackupDir: Backup Directory
 Saving/TiddlySpot/Backups: Backups

--- a/core/modules/savers/gitea.js
+++ b/core/modules/savers/gitea.js
@@ -21,13 +21,13 @@ var GiteaSaver = function(wiki) {
 
 GiteaSaver.prototype.save = function(text,method,callback) {
 	var self = this,
-		username = this.wiki.getTiddlerText("$:/gitea/Username"),
-		password = $tw.utils.getPassword("gitea"),
-		repo = this.wiki.getTiddlerText("$:/gitea/Repo"),
-		path = this.wiki.getTiddlerText("$:/gitea/Path",""),
-		filename = this.wiki.getTiddlerText("$:/gitea/Filename"),
-		branch = this.wiki.getTiddlerText("$:/gitea/Branch") || "master",
-		endpoint = this.wiki.getTiddlerText("$:/gitea/ServerURL") || "https://gitea",
+		username = this.wiki.getTiddlerText("$:/Gitea/Username"),
+		password = $tw.utils.getPassword("Gitea"),
+		repo = this.wiki.getTiddlerText("$:/Gitea/Repo"),
+		path = this.wiki.getTiddlerText("$:/Gitea/Path",""),
+		filename = this.wiki.getTiddlerText("$:/Gitea/Filename"),
+		branch = this.wiki.getTiddlerText("$:/Gitea/Branch") || "master",
+		endpoint = this.wiki.getTiddlerText("$:/Gitea/ServerURL") || "https://gitea",
 		headers = {
 			"Accept": "application/json",
 			"Content-Type": "application/json;charset=UTF-8",
@@ -82,7 +82,7 @@ GiteaSaver.prototype.save = function(text,method,callback) {
 				headers: headers,
 				callback: function(err,getResponseDataJson,xhr) {
 					if(xhr.status === 404) {
-						callback("Please ensure the branch in the gitea repo exists");
+						callback("Please ensure the branch in the Gitea repo exists");
 					}else{
 						data["branch"] = branch;
 						self.upload(uri + filename, use_put?"PUT":"POST", headers, data, callback);
@@ -114,7 +114,7 @@ GiteaSaver.prototype.upload = function(uri,method,headers,data,callback) {
 Information about this saver
 */
 GiteaSaver.prototype.info = {
-	name: "gitea",
+	name: "Gitea",
 	priority: 2000,
 	capabilities: ["save", "autosave"]
 };

--- a/core/ui/ControlPanel/Saving/gitea.tid
+++ b/core/ui/ControlPanel/Saving/gitea.tid
@@ -1,16 +1,16 @@
-title: $:/core/ui/ControlPanel/Saving/gitea
+title: $:/core/ui/ControlPanel/Saving/Gitea
 tags: $:/tags/ControlPanel/Saving
-caption: {{$:/language/ControlPanel/Saving/GitService/gitea/Caption}}
+caption: {{$:/language/ControlPanel/Saving/GitService/Gitea/Caption}}
 
 \define lingo-base() $:/language/ControlPanel/Saving/GitService/
-\define service-name() ~gitea
+\define service-name() ~Gitea
 
 <<lingo Description>>
 
-|<<lingo UserName>> |<$edit-text tiddler="$:/gitea/Username" default="" tag="input"/> |
-|<<lingo gitea/Password>> |<$password name="gitea"/> |
-|<<lingo Repo>> |<$edit-text tiddler="$:/gitea/Repo" default="" tag="input"/> |
-|<<lingo Branch>> |<$edit-text tiddler="$:/gitea/Branch" default="master" tag="input"/> |
-|<<lingo Path>> |<$edit-text tiddler="$:/gitea/Path" default="" tag="input"/> |
-|<<lingo Filename>> |<$edit-text tiddler="$:/gitea/Filename" default="" tag="input"/> |
-|<<lingo ServerURL>> |<$edit-text tiddler="$:/gitea/ServerURL" default="https://gitea/api/v1" tag="input"/> |
+|<<lingo UserName>> |<$edit-text tiddler="$:/Gitea/Username" default="" tag="input"/> |
+|<<lingo Gitea/Password>> |<$password name="Gitea"/> |
+|<<lingo Repo>> |<$edit-text tiddler="$:/Gitea/Repo" default="" tag="input"/> |
+|<<lingo Branch>> |<$edit-text tiddler="$:/Gitea/Branch" default="master" tag="input"/> |
+|<<lingo Path>> |<$edit-text tiddler="$:/Gitea/Path" default="" tag="input"/> |
+|<<lingo Filename>> |<$edit-text tiddler="$:/Gitea/Filename" default="" tag="input"/> |
+|<<lingo ServerURL>> |<$edit-text tiddler="$:/Gitea/ServerURL" default="https://gitea/api/v1" tag="input"/> |


### PR DESCRIPTION
As @kookma mentioned in https://github.com/Jermolene/TiddlyWiki5/pull/4491 the names should be in CamelCase. I agree and if you @Jermolene agree too, this could be merged, too. else just close it.