### PR TITLE
Fix #4509: Menubar's search dropdown hidden

### DIFF
--- a/plugins/tiddlywiki/menubar/items/sidebar.tid
+++ b/plugins/tiddlywiki/menubar/items/sidebar.tid
@@ -4,8 +4,12 @@ description: Sidebar
 is-dropdown: yes
 tags: $:/tags/MenuBar
 
+<$scrollable fallthrough="none">
+
 <div class="tc-popup-keep tc-menubar-dropdown-sidebar">
 
 <$transclude tiddler="$:/core/ui/SideBarSegments/tabs" mode="inline"/>
 
 </div>
+
+</$scrollable>

--- a/plugins/tiddlywiki/menubar/menu.tid
+++ b/plugins/tiddlywiki/menubar/menu.tid
@@ -44,7 +44,6 @@ tags: $:/tags/PageTemplate
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/MenuBar]!has[draft.of]limit[1]]" variable="listItem">
 <nav class="tc-menubar tc-adjust-top-of-scroll">
-<$scrollable fallthrough="none">
 <div class="tc-menubar-narrow">
 <<menubar-inner narrow>>
 </div>
@@ -65,6 +64,5 @@ tags: $:/tags/PageTemplate
 </$set>
 </$list>
 </$list>
-</$scrollable>
 </nav>
 </$list>


### PR DESCRIPTION
This fixes #4509 where the search dropdown of the menubar plugin is hidden below the story river