### PR TITLE
Fixes issue with #4504 and importvariable copying

### DIFF
--- a/core/modules/widgets/importvariables.js
+++ b/core/modules/widgets/importvariables.js
@@ -61,7 +61,14 @@ ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 					var widget = widgetPointer.makeChildWidget(node);
 					widget.computeAttributes();
 					widget.execute();
-					$tw.utils.extend(widgetPointer.variables,widget.variables);
+					// We SHALLOW copy over all variables
+					// in widget. We can't use
+					// $tw.utils.assign, because that copies
+					// up the prototype chain, which we
+					// don't want.
+					$tw.utils.each(Object.keys(widget.variables), function(key) {
+						widgetPointer.variables[key] = widget.variables[key];
+					});
 				} else {
 					widgetPointer.makeChildWidgets([node]);
 					widgetPointer = widgetPointer.children[0];

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -525,16 +525,13 @@ describe("Widget module", function() {
 	 * this caused no errors, but it would mess up qualify-macros.
 	 * They would find multiple instances of the same transclusion
 	 * variable if a transclusion occured higher up in the widget tree
-	 * than an import variables AND that import variables was importing
+	 * than an importvariables AND that importvariables was importing
 	 * at least ONE variable.
 	 */
 	it("adding imported variables doesn't change qualifyers", function() {
 		var wiki = new $tw.Wiki();
-		function getBodyText() {
-			// This transclude wraps "body", which has an
-			// importvariable widget in it.
-			var text = "{{body}}";
-			var tree = parseText("{{body}}",wiki);
+		function wikiparse(text) {
+			var tree = parseText(text,wiki);
 			var widgetNode = createWidgetNode(tree,wiki);
 			var wrapper = renderWidgetNode(widgetNode);
 			return wrapper.innerHTML;
@@ -543,12 +540,13 @@ describe("Widget module", function() {
 			{title: "body", text: "\\import A\n<<qualify this>>"},
 			{title: "A", text: "\\define unused() ignored"}
 		]);
+		// This transclude wraps "body", which has an
+		// importvariable widget in it.
+		var withA = wikiparse("{{body}}");
+		wiki.addTiddler({title: "A", text: ""});
+		var withoutA = wikiparse("{{body}}");
 		// Importing two different version of "A" shouldn't cause
 		// the <<qualify>> widget to spit out something different.
-		var withA = getBodyText();
-		wiki.addTiddler({title: "A", text: ""});
-		var withoutA = getBodyText();
-
 		expect(withA).toBe(withoutA);
 	});
 });


### PR DESCRIPTION
ImportVariables widget was using $tw.utils.extend to copy the
variables from temporary set widgets into itself. However,
$tw.utils.extend does NOT behave like Object.assign. It not only
copies all self-owned variables over, but also all variables
in that object's prototype chain. This led to some redundant copying,
and a problem where some variables might show up more than once
(like transclusion).

Fixed now. importvariables widget does its own copying, since it
can't rely on $tw.utils.extend to do the right job, and it can't
count on Object.assign to be there.