### PR TITLE
Add change event listener range widget for IE10/11

### DIFF
--- a/core/modules/widgets/range.js
+++ b/core/modules/widgets/range.js
@@ -49,7 +49,8 @@ RangeWidget.prototype.render = function(parent,nextSibling) {
 	this.inputDomNode.value = this.getValue();
 	// Add a click event handler
 	$tw.utils.addEventListeners(this.inputDomNode,[
-		{name: "input", handlerObject: this, handlerMethod: "handleInputEvent"}
+		{name: "input", handlerObject: this, handlerMethod: "handleInputEvent"},
+		{name: "change", handlerObject: this, handlerMethod: "handleInputEvent"}		
 	]);
 	// Insert the label into the DOM and render any children
 	parent.insertBefore(this.inputDomNode,nextSibling);


### PR DESCRIPTION
As detailed in #4519 the range widget currently does not save its value to the state tiddler on IE 10/11 as they do not support the` input` event, but rather the `change` event is fired instead of the input event. This has patch has been tested in IE11 and should work in IE10 as well.

Note that on Chrome and Firefox, the `change` event will fire only once after the user stops dragging the range slider (In addition to the `input` event). However this does not lead to an extra refresh as the `handleInputEvent` method already checks to see if the current value of the slider is different from the saved value before saving to the store.