### PR TITLE
Fix Comment in Webserver API route tidlers.json

### DIFF
--- a/core/modules/server/routes/get-tiddlers-json.js
+++ b/core/modules/server/routes/get-tiddlers-json.js
@@ -3,7 +3,7 @@ title: $:/core/modules/server/routes/get-tiddlers-json.js
 type: application/javascript
 module-type: route
 
-GET /recipes/default/tiddlers/tiddlers.json?filter=<filter>
+GET /recipes/default/tiddlers.json?filter=<filter>
 
 \*/
 (function() {
@@ -22,7 +22,7 @@ exports.handler = function(request,response,state) {
 	var filter = state.queryParameters.filter || DEFAULT_FILTER;
 	if($tw.wiki.getTiddlerText("$:/config/Server/AllowAllExternalFilters") !== "yes") {
 		if($tw.wiki.getTiddlerText("$:/config/Server/ExternalFilters/" + filter) !== "yes") {
-			console.log("Blocked attempt to GET /recipes/default/tiddlers/tiddlers.json with filter: " + filter);
+			console.log("Blocked attempt to GET /recipes/default/tiddlers.json with filter: " + filter);
 			response.writeHead(403);
 			response.end();
 			return;


### PR DESCRIPTION
This commit fixes a mismatch between the comment, the `403` response and the regex used for defining the route in the WebserverAPI for getting tiddlers as `.json`.

The comment referred to `recipes/default/tiddlers.json` and the regex was checking for `recipes/default/tiddlers/tiddlers.json`. The extra `/tiddlers` seemed redundant so I decided to take the regex as the "truth" and remove the `/tiddlers` in the comment and the `403` response.