### PR TITLE
Updates for chinese editions

### DIFF
--- a/editions/zh-Hans/tiddlywiki.info
+++ b/editions/zh-Hans/tiddlywiki.info
@@ -1,6 +1,7 @@
 {
 	"description": "Chinese (Simplified) edition",
 	"plugins": [
+		"tiddlywiki/internals"
 	],
 	"themes": [
 		"tiddlywiki/vanilla",
@@ -9,8 +10,7 @@
 		"tiddlywiki/seamless",
 		"tiddlywiki/centralised",
 		"tiddlywiki/tight",
-		"tiddlywiki/readonly",
-		"tiddlywiki/internals"
+		"tiddlywiki/readonly"
 	],
 	"languages": [
 		"zh-Hans"

--- a/editions/zh-Hant/tiddlywiki.info
+++ b/editions/zh-Hant/tiddlywiki.info
@@ -1,6 +1,7 @@
 {
 	"description": "Chinese (Traditional) edition",
 	"plugins": [
+		"tiddlywiki/internals"
 	],
 	"themes": [
 		"tiddlywiki/vanilla",
@@ -9,8 +10,7 @@
 		"tiddlywiki/seamless",
 		"tiddlywiki/centralised",
 		"tiddlywiki/tight",
-		"tiddlywiki/readonly",
-		"tiddlywiki/internals"
+		"tiddlywiki/readonly"
 	],
 	"languages": [
 		"zh-Hant"


### PR DESCRIPTION
Fix wrong configurations in `tiddlywiki.info` for editions `zh-Hant` and `zh-Hans`