### PR TITLE
Fix "has" filter to properly interpret an empty list field

### DIFF
--- a/core/modules/filters/has.js
+++ b/core/modules/filters/has.js
@@ -52,7 +52,7 @@ exports.has = function(source,operator,options) {
 	else {
 		if(invert) {
 			source(function(tiddler,title) {
-				if(!tiddler || !$tw.utils.hop(tiddler.fields,operator.operand) || (tiddler.fields[operator.operand] === "")) {
+				if(!tiddler || !$tw.utils.hop(tiddler.fields,operator.operand) || (tiddler.fields[operator.operand] === "") || (tiddler.fields[operator.operand].length === 0)) {
 					results.push(title);
 				}
 			});


### PR DESCRIPTION
For a tiddler x with an empty "list" field the filter currently returns no result for the following: 
`[[x]!has[list]] `
whereas the expected result would be x

This is because the filter checks if the field is equal to an empty string, whereas the list field is represented by an empty array.
I am not set up to run the tests at this time, so welcome anyone that can do so and perhaps add some additional tests.