### PR TITLE
fix(syncer): Tiddler should not be a boolean

### DIFF
--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -180,7 +180,8 @@ Syncer.prototype.readTiddlerInfo = function() {
 	var self = this,
 		tiddlers = this.getSyncedTiddlers();
 	$tw.utils.each(tiddlers,function(title) {
-		var tiddler = self.wiki.tiddlerExists(title) && self.wiki.getTiddler(title);
+		if(!self.wiki.tiddlerExists(title)) return;
+		var tiddler = self.wiki.getTiddler(title);
 		self.tiddlerInfo[title] = {
 			revision: self.getTiddlerRevision(title),
 			adaptorInfo: self.syncadaptor && self.syncadaptor.getTiddlerInfo(tiddler),


### PR DESCRIPTION
When a tiddler does not exist, it is skipt from the getting tiddler info.
I opted for this simpler version, but if it is imperative to run this for every tiddler I can come with a  different implementation like this:

```js
var tiddler = self.wiki.tiddlerExists(title) ? self.wiki.getTiddler(title) : new self.Tiddler({title})
```

Right now the code is passing a boolean when the output of the check is false, which is not correct in any way.