### PR TITLE
fix(syncer): restore tiddlerInfo param to saveTiddler

### DIFF
--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -581,6 +581,8 @@ SaveTiddlerTask.prototype.run = function(callback) {
 			};
 			// Invoke the callback
 			callback(null);
+		},{
+			tiddlerInfo: self.tiddlerInfo[task.title]
 		});
 	} else {
 		this.syncer.logger.log(" Not Dispatching 'save' task:",this.title,"tiddler does not exist");


### PR DESCRIPTION
This was added on a159b5baf3ad91d8defc68cbf81c78d01b69c416 and lost in #4373.
Will be a good idea to introduce tests against this kind of changes