### PR TITLE
Fixing kinda-serious import bug.

### DIFF
--- a/core/modules/widgets/importvariables.js
+++ b/core/modules/widgets/importvariables.js
@@ -71,6 +71,13 @@ ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 					});
 				} else {
 					widgetPointer.makeChildWidgets([node]);
+					// No more regenerating children for
+					// this widget. If it needs to refresh,
+					// it'll do so along with the the whole
+					// importvariable tree.
+					if (widgetPointer != this) {
+						widgetPointer.makeChildWidgets = function(){};
+					}
 					widgetPointer = widgetPointer.children[0];
 				}
 				parseTreeNode = parseTreeNode.children && parseTreeNode.children[0];

--- a/core/modules/widgets/importvariables.js
+++ b/core/modules/widgets/importvariables.js
@@ -38,6 +38,8 @@ Compute the internal state of the widget
 */
 ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 	var widgetPointer = this;
+	// Got to flush all the accumulated variables
+	this.variables = new this.variablesConstructor();
 	// Get our parameters
 	this.filter = this.getAttribute("filter");
 	// Compute the filter
@@ -70,7 +72,7 @@ ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 						widgetPointer.variables[key] = widget.variables[key];
 					});
 				} else {
-					widgetPointer.makeChildWidgets([node]);
+					widgetPointer.children = [widgetPointer.makeChildWidget(node)];
 					// No more regenerating children for
 					// this widget. If it needs to refresh,
 					// it'll do so along with the the whole

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -504,6 +504,20 @@ describe("Widget module", function() {
 		expect(wrapper.innerHTML).toBe("<p>Aval Bval Cval</p>");
 	});
 
+	it("can have more than one macroDef variable imported", function() {
+		var wiki = new $tw.Wiki();
+		wiki.addTiddlers([
+			{title: "ABC", text: "<$set name=A value=A>\n\n<$set name=B value=B>\n\n<$set name=C value=C>\n\ndummy text</$set></$set></$set>"},
+			{title: "D", text: "\\define D() D"}]);
+		// A and B shouldn't chew up C just cause it's a macroDef
+		var text = "\\import ABC D\n<<A>> <<B>> <<C>> <<D>>";
+		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
+		// Render the widget node to the DOM
+		var wrapper = renderWidgetNode(widgetNode);
+		// Test the rendering
+		expect(wrapper.innerHTML).toBe("<p>A B C D</p>");
+	});
+
 	/** Special case. <$importvariables> has different handling if
 	 *  it doesn't end up importing any variables. Make sure it
 	 *  doesn't forget its childrenNodes.


### PR DESCRIPTION
So if you go to tiddlywiki.com and create a new tiddler with the following text:
```
<$set name=A value=A>

<$set name=B value=B>

Break!!!!
</$set></$set>
```
And you give this tiddler the tag `$:/tags/Macro`, the moment you hit save, Tiddlywiki will go straight to hell. (It literally goes away. Poof.)

This is my fault. But I've already got the fix here. My importvariables magic didn't actually support having more than one nonMacroDefinition variable imported.

My fix is strange, but I've added tests, and it's all working.

I'd like to point out again how utterly bizarre imported nonMacroDefinitions are. Look at this:
```
\define A() A content
<$set name=B value="B content"></$set>
```
Both A and B load when this is imported, right?

WRONG!!

The $set widget will be wrapped in a `<p>`, which prevents importing. Only "A" loads. You want:

```
\define A() A content
<$set name=B value="B content">

</$set>
```
Do you want a second nonMacro variable? This is how you do it.
```
\define A() A content
<$set name=B value="B content">

<$set name=C value="C content">

</$set></$set>
```
It has to be _inside_ the first.

Isn't that weird? Isn't that whack jack? The widget nature of $set makes you think it's variable should only be present INSIDE of it, but no. It gets picked up by import.

Also, the fact that I completely broke Tiddlywiki if you use 2 or more of them, and _nobody_ complained, kinda shows that nobody is using them, right?

...

Also, if you remove macros from a $:/tags/Macro tiddler. It wouldn't actually be gone until you refreshed the page. This was another problem I caused. I fixed and tested that too.