### PR TITLE
Fix #4591: Use text field instead of tags field for $:/config/NewJournal/Tags ...

### DIFF
--- a/core/language/en-GB/NewJournalTags.tid
+++ b/core/language/en-GB/NewJournalTags.tid
@@ -1,2 +1,2 @@
 title: $:/config/NewJournal/Tags
-tags: Journal
+text: Journal

--- a/core/language/en-GB/NewJournalTags.tid
+++ b/core/language/en-GB/NewJournalTags.tid
@@ -1,2 +1,3 @@
 title: $:/config/NewJournal/Tags
-text: Journal
+
+Journal

--- a/core/ui/Actions/new-image.tid
+++ b/core/ui/Actions/new-image.tid
@@ -6,5 +6,5 @@ description: create a new image tiddler
 image/$(imageType)$
 \end
 <$vars imageType={{$:/config/NewImageType}}>
-<$action-sendmessage $message="tm-new-tiddler" type=<<get-type>> tags={{$:/config/NewTiddler/Tags!!tags}}/>
+<$action-sendmessage $message="tm-new-tiddler" type=<<get-type>> tags={{$:/config/NewTiddler/Tags}}/>
 </$vars>

--- a/core/ui/Actions/new-journal.tid
+++ b/core/ui/Actions/new-journal.tid
@@ -2,7 +2,7 @@ title: $:/core/ui/Actions/new-journal
 tags: $:/tags/Actions
 description: create a new journal tiddler
 
-<$vars journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags!!tags}} journalText={{$:/config/NewJournal/Text}}>
+<$vars journalTitleTemplate={{$:/config/NewJournal/Title}} journalTags={{$:/config/NewJournal/Tags}} journalText={{$:/config/NewJournal/Text}}>
 <$wikify name="journalTitle" text="""<$macrocall $name="now" format=<<journalTitleTemplate>>/>""">
 <$reveal type="nomatch" state=<<journalTitle>> text="">
 <$action-sendmessage $message="tm-new-tiddler" title=<<journalTitle>> tags=<<journalTags>> text={{{ [<journalTitle>get[]] }}}/>

--- a/core/ui/Actions/new-tiddler.tid
+++ b/core/ui/Actions/new-tiddler.tid
@@ -2,4 +2,4 @@ title: $:/core/ui/Actions/new-tiddler
 tags: $:/tags/Actions
 description: create a new empty tiddler
 
-<$action-sendmessage $message="tm-new-tiddler" tags={{$:/config/NewTiddler/Tags!!tags}}/>
+<$action-sendmessage $message="tm-new-tiddler" tags={{$:/config/NewTiddler/Tags}}/>

--- a/core/ui/ControlPanel/Basics.tid
+++ b/core/ui/ControlPanel/Basics.tid
@@ -23,8 +23,8 @@ caption: {{$:/language/ControlPanel/Basics/Caption}}
 |<$link to="$:/language/DefaultNewTiddlerTitle"><<lingo NewTiddler/Title/Prompt>></$link> |<$edit-text tiddler="$:/language/DefaultNewTiddlerTitle" default="" tag="input"/> |
 |<$link to="$:/config/NewJournal/Title"><<lingo NewJournal/Title/Prompt>></$link> |<$edit-text tiddler="$:/config/NewJournal/Title" default="" tag="input"/> |
 |<$link to="$:/config/NewJournal/Text"><<lingo NewJournal/Text/Prompt>></$link> |<$edit tiddler="$:/config/NewJournal/Text" tag="textarea" class="tc-edit-texteditor" default=""/> |
-|<$link to="$:/config/NewTiddler/Tags"><<lingo NewTiddler/Tags/Prompt>></$link> |<$list filter="[[$:/config/NewTiddler/Tags]]" template="$:/core/ui/EditTemplate/tags"/> |
-|<$link to="$:/config/NewJournal/Tags"><<lingo NewJournal/Tags/Prompt>></$link> |<$list filter="[[$:/config/NewJournal/Tags]]" template="$:/core/ui/EditTemplate/tags"/> |
+|<$link to="$:/config/NewTiddler/Tags"><<lingo NewTiddler/Tags/Prompt>></$link> |<$edit-text tiddler="$:/config/NewTiddler/Tags" tag="input" default=""/> |
+|<$link to="$:/config/NewJournal/Tags"><<lingo NewJournal/Tags/Prompt>></$link> |<$edit-text tiddler="$:/config/NewJournal/Tags" tag="input" default=""/> |
 |<$link to="$:/config/AutoFocus"><<lingo AutoFocus/Prompt>></$link> |{{$:/snippets/minifocusswitcher}} |
 |<<lingo Language/Prompt>> |{{$:/snippets/minilanguageswitcher}} |
 |<<lingo Tiddlers/Prompt>> |<<show-filter-count "[!is[system]sort[title]]">> |

--- a/core/ui/ViewToolbar/new-here.tid
+++ b/core/ui/ViewToolbar/new-here.tid
@@ -5,7 +5,7 @@ description: {{$:/language/Buttons/NewHere/Hint}}
 
 \whitespace trim
 \define newHereActions()
-<$set name="tags" filter="[<currentTiddler>] [{$:/config/NewTiddler/Tags!!tags}]">
+<$set name="tags" filter="[<currentTiddler>] [{$:/config/NewTiddler/Tags}]">
 <$action-sendmessage $message="tm-new-tiddler" tags=<<tags>>/>
 </$set>
 \end

--- a/core/ui/ViewToolbar/new-journal-here.tid
+++ b/core/ui/ViewToolbar/new-journal-here.tid
@@ -23,7 +23,7 @@ description: {{$:/language/Buttons/NewJournalHere/Hint}}
 </$button>
 \end
 <$set name="journalTitleTemplate" value={{$:/config/NewJournal/Title}}>
-<$set name="journalTags" value={{$:/config/NewJournal/Tags!!tags}}>
+<$set name="journalTags" value={{$:/config/NewJournal/Tags}}>
 <$set name="currentTiddlerTag" value=<<currentTiddler>>>
 <<journalButton>>
 </$set>


### PR DESCRIPTION
... and $:/config/NewTiddler/Tags

The tags input in $:/ControlPanel/ Info/ Basics/ is replaced by simple text input fields