### PR TITLE
Separate $tw.boot.startup into three functions

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2172,8 +2172,7 @@ $tw.loadTiddlersNode = function() {
 /*
 Startup TiddlyWiki
 */
-$tw.boot.startup = function(options) {
-	options = options || {};
+$tw.boot.initStartup = function(options) {
 	// Get the URL hash and check for safe mode
 	$tw.locationHash = "#";
 	if($tw.browser && !$tw.node) {
@@ -2285,8 +2284,6 @@ $tw.boot.startup = function(options) {
 	$tw.utils.registerFileType("application/x-bibtex","utf8",".bib");
 	$tw.utils.registerFileType("application/epub+zip","base64",".epub");
 	$tw.utils.registerFileType("application/octet-stream","base64",".octet-stream");
-	// Create the wiki store for the app
-	$tw.wiki = new $tw.Wiki();
 	// Install built in tiddler fields modules
 	$tw.Tiddler.fieldModules = $tw.modules.getModulesByTypeAsHashmap("tiddlerfield");
 	// Install the tiddler deserializer modules
@@ -2306,6 +2303,10 @@ $tw.boot.startup = function(options) {
 			return result;
 		}
 	}
+};
+$tw.boot.loadStartup = function(options){
+	// Create the wiki store for the app
+	$tw.wiki = new $tw.Wiki();
 	// Load tiddlers
 	if($tw.boot.tasks.readBrowserTiddlers) {
 		$tw.loadTiddlersBrowser();
@@ -2318,6 +2319,8 @@ $tw.boot.startup = function(options) {
 	}
 	// Give hooks a chance to modify the store
 	$tw.hooks.invokeHook("th-boot-tiddlers-loaded");
+}
+$tw.boot.execStartup = function(options){
 	// Unpack plugin tiddlers
 	$tw.wiki.readPluginInfo();
 	$tw.wiki.registerPluginTiddlers("plugin",$tw.safeMode ? ["$:/core"] : undefined);
@@ -2346,6 +2349,16 @@ $tw.boot.startup = function(options) {
 	$tw.boot.disabledStartupModules = $tw.boot.disabledStartupModules || [];
 	// Repeatedly execute the next eligible task
 	$tw.boot.executeNextStartupTask(options.callback);
+}
+/*
+Startup TiddlyWiki
+*/
+$tw.boot.startup = function(options) {
+	options = options || {};
+	// Get the URL hash and check for safe mode
+	$tw.boot.initStartup(options);
+	$tw.boot.loadStartup(options);
+	$tw.boot.execStartup(options);
 };
 
 /*

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2284,6 +2284,8 @@ $tw.boot.initStartup = function(options) {
 	$tw.utils.registerFileType("application/x-bibtex","utf8",".bib");
 	$tw.utils.registerFileType("application/epub+zip","base64",".epub");
 	$tw.utils.registerFileType("application/octet-stream","base64",".octet-stream");
+	// Create the wiki store for the app
+	$tw.wiki = new $tw.Wiki();
 	// Install built in tiddler fields modules
 	$tw.Tiddler.fieldModules = $tw.modules.getModulesByTypeAsHashmap("tiddlerfield");
 	// Install the tiddler deserializer modules
@@ -2305,8 +2307,7 @@ $tw.boot.initStartup = function(options) {
 	}
 };
 $tw.boot.loadStartup = function(options){
-	// Create the wiki store for the app
-	$tw.wiki = new $tw.Wiki();
+
 	// Load tiddlers
 	if($tw.boot.tasks.readBrowserTiddlers) {
 		$tw.loadTiddlersBrowser();


### PR DESCRIPTION
This PR is a change I have tried several times to work in and everytime there have been various problems with the way I tried to do it. So I've taken another shot at it using a different method. 

Because $tw.boot.startup is called asyncly and nothing depends on it, it is simple to override it when necessary so no other changes need to be made. 

The only change I made is to move the line `$tw.wiki = ...` down a few lines, but this should not change anything as none of the methods refer to $tw.wiki. 