### PR TITLE
Fix CamelCase issue for TextEditor/Snippet docs

### DIFF
--- a/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_Texteditor_Snippet.tid
+++ b/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_Texteditor_Snippet.tid
@@ -1,9 +1,9 @@
-caption: $:/tags/Texteditor/Snippet
+caption: $:/tags/TextEditor/Snippet
 created: 20180926170345251
 description: marks text snippets
-modified: 20180926171456546
+modified: 20200427175949000
 tags: SystemTags
-title: SystemTag: $:/tags/Texteditor/Snippet
+title: SystemTag: $:/tags/TextEditor/Snippet
 type: text/vnd.tiddlywiki
 
-The [[system tag|SystemTags]] `$:/tags/Texteditor/Snippet` marks text snippets
+The [[system tag|SystemTags]] `$:/tags/TextEditor/Snippet` marks text snippets


### PR DESCRIPTION
Prior to this change, the docs on the site said to use the tag `$:/tags/Texteditor/Snippet` but TiddlyWiki expects it to be `$:/tags/TextEditor/Snippet` (note the casing)