### PR TITLE
Change evalSandboxed to use only one context for all modules

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -510,11 +510,11 @@ var polyfill =[
 	"(function() {",
 	"	if (typeof globalThis === 'object') return;",
 	"	// node.green says this is available since 0.10.48",
-	"	Object.prototype.__defineGetter__('__wow__', function() {",
+	"	Object.prototype.__defineGetter__('__temp__', function() {",
 	"		return this;",
 	"	});",
-	"	__wow__.globalThis = __wow__; // lolwat",
-	"	delete Object.prototype.__wow__;",
+	"	__temp__.globalThis = __temp__;",
+	"	delete Object.prototype.__temp__;",
 	"}());"
 ].join("\n");
 
@@ -545,7 +545,7 @@ $tw.utils.evalGlobal = function(code,context,filename,sandbox,allowGlobals) {
 		"  return exports;\n",
 		"})"
 	].join("\n");
-	// code = "(function(" + contextNames.join(",") + ") {(function(){  \n" + code + "\n;})();\nreturn exports;\n})\n";
+
 	// Compile the code into a function
 	var fn;
 	if($tw.browser) {
@@ -565,18 +565,12 @@ $tw.utils.sandbox = !$tw.browser ? vm.createContext({}) : undefined;
 Run code in a sandbox with only the specified context variables in scope
 */
 $tw.utils.evalSandboxed = $tw.browser ? $tw.utils.evalGlobal : function(code,context,filename,allowGlobals) {
-	return $tw.utils.evalGlobal(code,context,filename,(allowGlobals ? vm.createContext({}) : $tw.utils.sandbox),allowGlobals);
+	return $tw.utils.evalGlobal(
+		code,context,filename,
+		allowGlobals ? vm.createContext({}) : $tw.utils.sandbox,
+		allowGlobals
+	);
 };
-
-// if(!$tw.browser) $tw.utils.evalSandboxed(`
-//   setInterval(function(){
-// 		console.log(globalThis)
-// 		if(Object.keys(globalThis).length){
-// 			console.log(globalThis);
-// 			throw "Global assignment is not allowed within modules on node.";
-// 		}
-// 	}, 1000);
-// `, { setInterval, exports: {}, console }, "$:/boot/boot.js-global-monitor");
 
 /*
 Creates a PasswordPrompt object

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -23,12 +23,7 @@ $tw.utils = $tw.utils || Object.create(null);
 
 /////////////////////////// Standard node.js libraries
 
-/** @type {import{"fs"}} */
-var fs;
-/** @type {import{"path"}} */
-var path;
-/** @type {import{"vm"}} */
-var vm;
+var fs, path, vm;
 if($tw.node) {
 	fs = require("fs");
 	path = require("path");

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -552,7 +552,6 @@ $tw.utils.evalGlobal = function(code,context,filename,sandbox,allowGlobals) {
 		fn = window["eval"](code + "\n\n//# sourceURL=" + filename);
 	} else {
 		if(sandbox){
-			console.log(code);
 			fn = vm.runInContext(code,sandbox,filename)
 		} else {
 			fn = vm.runInThisContext(code,filename);

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -503,26 +503,27 @@ $tw.utils.getTypeEncoding = function(ext) {
 	return typeInfo ? typeInfo.encoding : "utf8";
 };
 
-var polyfill = `
-// this polyfills the globalThis variable
-// using the this variable on a getter 
-// inserted into the prototype of globalThis
-(function() {
-	if (typeof globalThis === 'object') return;
-	// node.green says this is available since 0.10.48
-	Object.prototype.__defineGetter__('__wow__', function() {
-		return this;
-	});
-	__wow__.globalThis = __wow__; // lolwat
-	delete Object.prototype.__wow__;
-}());
-`;
-var globalCheck = `{
-	if(Object.keys(globalThis).length){
-		console.log(Object.keys(globalThis));
-		throw "Global assignment is not allowed within modules on node.";
-	}
-}`;
+var polyfill =[
+	"// this polyfills the globalThis variable",
+	"// using the this variable on a getter ",
+	"// inserted into the prototype of globalThis",
+	"(function() {",
+	"	if (typeof globalThis === 'object') return;",
+	"	// node.green says this is available since 0.10.48",
+	"	Object.prototype.__defineGetter__('__wow__', function() {",
+	"		return this;",
+	"	});",
+	"	__wow__.globalThis = __wow__; // lolwat",
+	"	delete Object.prototype.__wow__;",
+	"}());"
+].join("\n");
+
+var globalCheck =[
+	"	if(Object.keys(globalThis).length){",
+	"		console.log(Object.keys(globalThis));",
+	"		throw \"Global assignment is not allowed within modules on node.\";",
+	"	}"
+].join('\n');
 
 /*
 Run code globally with specified context variables in scope
@@ -536,15 +537,14 @@ $tw.utils.evalGlobal = function(code,context,filename,sandbox,allowGlobals) {
 		contextValues.push(value);
 	});
 	// Add the code prologue and epilogue
-	code = `
-	${!$tw.browser ? polyfill : ""}
-	//Now we run the module and check the output
-	(function(${contextNames.join(",") }) {
-		(function(){${code};})();
-		${(!$tw.browser && sandbox && !allowGlobals) ? globalCheck : ""}
-		return exports;
-	})
-	`
+	code = [
+		(!$tw.browser ? polyfill : ""),
+		"(function(" + contextNames.join(",") + " }) {",
+		"  (function(){" + code + ";})();",
+		(!$tw.browser && sandbox && !allowGlobals) ? globalCheck : "",
+		"  return exports;\n",
+		"})"
+	].join("\n");
 	// code = "(function(" + contextNames.join(",") + ") {(function(){  \n" + code + "\n;})();\nreturn exports;\n})\n";
 	// Compile the code into a function
 	var fn;

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -515,7 +515,21 @@ $tw.utils.evalGlobal = function(code,context,filename,sandbox) {
 		contextValues.push(value);
 	});
 	// Add the code prologue and epilogue
-	code = "(function(" + contextNames.join(",") + ") {(function(){\n" + code + "\n;})();\nreturn exports;\n})\n";
+	// and the sandboxed global check
+	code = `
+	(function(${contextNames.join(",") }) {
+		(function(){${code};})();
+		${(!$tw.browser && sandbox) ? `
+			let globe = typeof global !== "undefined" ? global : this;
+			if(Object.keys(globe).length){
+				console.log(globe);
+				throw "Global assignment is not allowed within server modules.";
+			}
+		` : ""}
+		return exports;
+	})
+	`
+	// code = "(function(" + contextNames.join(",") + ") {(function(){  \n" + code + "\n;})();\nreturn exports;\n})\n";
 	// Compile the code into a function
 	var fn;
 	if($tw.browser) {

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -519,10 +519,10 @@ var polyfill =[
 ].join("\n");
 
 var globalCheck =[
-	"	if(Object.keys(globalThis).length){",
-	"		console.log(Object.keys(globalThis));",
-	"		throw \"Global assignment is not allowed within modules on node.\";",
-	"	}"
+	"  if(Object.keys(globalThis).length){",
+	"    console.log(Object.keys(globalThis));",
+	"    throw \"Global assignment is not allowed within modules on node.\";",
+	"  }"
 ].join('\n');
 
 /*
@@ -540,7 +540,7 @@ $tw.utils.evalGlobal = function(code,context,filename,sandbox,allowGlobals) {
 	code = [
 		(!$tw.browser ? polyfill : ""),
 		"(function(" + contextNames.join(",") + ") {",
-		"  (function(){" + code + ";})();",
+		"  (function(){\n" + code + "\n;})();",
 		(!$tw.browser && sandbox && !allowGlobals) ? globalCheck : "",
 		"  return exports;\n",
 		"})"
@@ -552,6 +552,7 @@ $tw.utils.evalGlobal = function(code,context,filename,sandbox,allowGlobals) {
 		fn = window["eval"](code + "\n\n//# sourceURL=" + filename);
 	} else {
 		if(sandbox){
+			console.log(code);
 			fn = vm.runInContext(code,sandbox,filename)
 		} else {
 			fn = vm.runInThisContext(code,filename);

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -506,7 +506,7 @@ $tw.utils.getTypeEncoding = function(ext) {
 /*
 Run code globally with specified context variables in scope
 */
-$tw.utils.evalGlobal = function(code,context,filename,sandbox, allowGlobals) {
+$tw.utils.evalGlobal = function(code,context,filename,sandbox,allowGlobals) {
 	var contextCopy = $tw.utils.extend(Object.create(null),context);
 	// Get the context variables as a pair of arrays of names and values
 	var contextNames = [], contextValues = [];
@@ -548,8 +548,8 @@ var sandbox = !$tw.browser ? vm.createContext() : undefined;
 /*
 Run code in a sandbox with only the specified context variables in scope
 */
-$tw.utils.evalSandboxed = $tw.browser ? $tw.utils.evalGlobal : function(code,context,filename, allowGlobals) {
-	return $tw.utils.evalGlobal(code, context, filename, allowGlobals ? vm.createContext() : sandbox, allowGlobals);
+$tw.utils.evalSandboxed = $tw.browser ? $tw.utils.evalGlobal : function(code,context,filename,allowGlobals) {
+	return $tw.utils.evalGlobal(code,context,filename,(allowGlobals ? vm.createContext() : sandbox),allowGlobals);
 };
 
 /*

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -539,7 +539,7 @@ $tw.utils.evalGlobal = function(code,context,filename,sandbox,allowGlobals) {
 	// Add the code prologue and epilogue
 	code = [
 		(!$tw.browser ? polyfill : ""),
-		"(function(" + contextNames.join(",") + " }) {",
+		"(function(" + contextNames.join(",") + ") {",
 		"  (function(){" + code + ";})();",
 		(!$tw.browser && sandbox && !allowGlobals) ? globalCheck : "",
 		"  return exports;\n",

--- a/core/modules/startup/css-escape-polyfill.js
+++ b/core/modules/startup/css-escape-polyfill.js
@@ -19,7 +19,7 @@ exports.synchronous = true;
 
 /*! https://mths.be/cssescape v1.5.1 by @mathias | MIT license */
 // https://github.com/umdjs/umd/blob/master/returnExports.js
-exports.startup = function(){ factory(root); };
+exports.startup = factory(root);
 }(typeof global != 'undefined' ? global : this, function(root) {
 
 	if (root.CSS && root.CSS.escape) {

--- a/core/modules/startup/css-escape-polyfill.js
+++ b/core/modules/startup/css-escape-polyfill.js
@@ -19,7 +19,7 @@ exports.synchronous = true;
 
 /*! https://mths.be/cssescape v1.5.1 by @mathias | MIT license */
 // https://github.com/umdjs/umd/blob/master/returnExports.js
-exports.startup = factory(root);
+exports.startup = function() { factory(root) };
 }(typeof global != 'undefined' ? global : this, function(root) {
 
 	if (root.CSS && root.CSS.escape) {

--- a/core/modules/startup/css-escape-polyfill.js
+++ b/core/modules/startup/css-escape-polyfill.js
@@ -19,7 +19,7 @@ exports.synchronous = true;
 
 /*! https://mths.be/cssescape v1.5.1 by @mathias | MIT license */
 // https://github.com/umdjs/umd/blob/master/returnExports.js
-exports.startup = function() { factory(root) };
+exports.startup = function(){ factory(root); };
 }(typeof global != 'undefined' ? global : this, function(root) {
 
 	if (root.CSS && root.CSS.escape) {

--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -59,7 +59,7 @@ exports.startup = function() {
 			}
 			return $tw.modules.execute(moduleTitle,title);
 		};
-		var contextExports = $tw.utils.evalSandboxed(code,context,title);
+		var contextExports = $tw.utils.evalSandboxed(code,context,title,true);
 		// jasmine/jasmine.js assigns directly to `module.exports`: check
 		// for it first.
 		return context.module.exports || contextExports;


### PR DESCRIPTION
This fixes https://github.com/Jermolene/TiddlyWiki5/issues/4618. Modules may still be sandboxed in their own context as before, if required. Jasmine is the only case I ran into. 

These all work.

```sh
node tiddlywiki.js editions/test
node tiddlywiki.js editions/full
node tiddlywiki.js editions/tw5.com-server
```