### PR TITLE
The `!has[tags]` filter didn't work because `tags` field is an array

### DIFF
--- a/core/modules/filters/has.js
+++ b/core/modules/filters/has.js
@@ -52,13 +52,13 @@ exports.has = function(source,operator,options) {
 	else {
 		if(invert) {
 			source(function(tiddler,title) {
-				if(!tiddler || !$tw.utils.hop(tiddler.fields,operator.operand) || (tiddler.fields[operator.operand] === "")) {
+				if(!tiddler || !$tw.utils.hop(tiddler.fields,operator.operand) || (tiddler.fields[operator.operand].length === 0)) {
 					results.push(title);
 				}
 			});
 		} else {
 			source(function(tiddler,title) {
-				if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && !(tiddler.fields[operator.operand] === "" || tiddler.fields[operator.operand].length === 0)) {
+				if(tiddler && $tw.utils.hop(tiddler.fields,operator.operand) && (tiddler.fields[operator.operand].length !== 0)) {
 					results.push(title);
 				}
 			});				

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -315,6 +315,8 @@ function runTests(wiki) {
 	it("should handle the has operator", function() {
 		expect(wiki.filterTiddlers("[has[modified]sort[title]]").join(",")).toBe("$:/TiddlerTwo,Tiddler Three,TiddlerOne");
 		expect(wiki.filterTiddlers("[!has[modified]sort[title]]").join(",")).toBe("$:/ShadowPlugin,a fourth tiddler,filter regexp test,has filter,hasList,one");
+		expect(wiki.filterTiddlers("[has[tags]sort[title]]").join(",")).toBe("$:/TiddlerTwo,Tiddler Three,TiddlerOne");
+		expect(wiki.filterTiddlers("[!has[tags]sort[title]]").join(",")).toBe("$:/ShadowPlugin,a fourth tiddler,filter regexp test,has filter,hasList,one");
 	});
 
 	it("should handle the has:field operator", function() {


### PR DESCRIPTION
The negated `has` filter only considered empty strings, but not empty arrays (such as the `tags` field).

Steps to reproduce:

* Create a New Tiddler without specifying tags
* Use this filter expression in the AdvancedSearch: `[[New Tiddler]!has[tags]]`
* The output of the filter will be empty, which does not correspond to the behaviour described in the documentation:
> those input tiddlers in which field F does not exist or has an empty value

See also: https://groups.google.com/forum/#!topic/tiddlywiki/2HzNb2V-aIo