### PR TITLE
Fix the class attribute of Droppable widget

### DIFF
--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -39,7 +39,7 @@ DroppableWidget.prototype.render = function(parent,nextSibling) {
 	}
 	// Create element and assign classes
 	var domNode = this.document.createElement(tag),
-		classes = (this["class"] || "").split(" ");
+		classes = (this.droppableClass || "").split(" ");
 	classes.push("tc-droppable");
 	domNode.className = classes.join(" ");
 	// Add event handlers


### PR DESCRIPTION
Even though we passed the `class` attribute, it did not take it into
account. For example try to render this:

```
  <$droppable class="custom-css-class">
    ... content ...
  </$droppable>
```

Before applying this patch:

```
  <span class=" tc-droppable">
    ... content ...
  </span>
```

After applying:

```
  <span class="custom-css-class tc-droppable">
    ... content ...
  </span>
```