### PR TITLE
Move wiki-related $tw.boot variables onto $tw.wiki

### DIFF
--- a/boot/bootprefix.js
+++ b/boot/bootprefix.js
@@ -22,7 +22,7 @@ $tw.boot = $tw.boot || Object.create(null);
 ['files', 'wikiInfo', 'wikiPath', 'wikiTiddlersPath'].forEach(function(e){
 	Object.defineProperty($tw.boot, e, { 
 		get: function() { 
-			console.log(new Error("$tw.boot." + e + " has been renamed $tw.wiki." + e).stack);
+			console.log(new Error("$tw.boot." + e + " has been renamed $tw.wiki." + e).stack.split('\n').slice(0,4).join('\n'));
 			return $tw.wiki[e];
 		},
 		set: function(v) { 

--- a/boot/bootprefix.js
+++ b/boot/bootprefix.js
@@ -19,6 +19,18 @@ var _bootprefix = (function($tw) {
 $tw = $tw || Object.create(null);
 $tw.boot = $tw.boot || Object.create(null);
 
+['files', 'wikiInfo', 'wikiPath', 'wikiTiddlersPath'].forEach(function(e){
+	Object.defineProperty($tw.boot, e, { 
+		get: function() { 
+			console.log(new Error("$tw.boot." + e + " has been renamed $tw.wiki." + e).stack);
+			return $tw.wiki[e];
+		},
+		set: function(v) { 
+			$tw.wiki[e] = v;
+		}
+	});
+});
+
 // Detect platforms
 if(!("browser" in $tw)) {
 	$tw.browser = typeof(window) !== "undefined" ? {} : null;

--- a/core/modules/commander.js
+++ b/core/modules/commander.js
@@ -26,7 +26,7 @@ var Commander = function(commandTokens,callback,wiki,streams) {
 	this.callback = callback;
 	this.wiki = wiki;
 	this.streams = streams;
-	this.outputPath = path.resolve($tw.boot.wikiPath,$tw.config.wikiOutputSubDir);
+	this.outputPath = path.resolve($tw.wiki.wikiPath,$tw.config.wikiOutputSubDir);
 };
 
 /*

--- a/core/modules/commander.js
+++ b/core/modules/commander.js
@@ -26,7 +26,7 @@ var Commander = function(commandTokens,callback,wiki,streams) {
 	this.callback = callback;
 	this.wiki = wiki;
 	this.streams = streams;
-	this.outputPath = path.resolve($tw.wiki.wikiPath,$tw.config.wikiOutputSubDir);
+	this.outputPath = path.resolve(this.wiki.wikiPath,$tw.config.wikiOutputSubDir);
 };
 
 /*

--- a/core/modules/commands/build.js
+++ b/core/modules/commands/build.js
@@ -24,7 +24,7 @@ var Command = function(params,commander) {
 
 Command.prototype.execute = function() {
 	// Get the build targets defined in the wiki
-	var buildTargets = $tw.boot.wikiInfo.build;
+	var buildTargets = $tw.wiki.wikiInfo.build;
 	if(!buildTargets) {
 		return "No build targets defined";
 	}

--- a/core/modules/commands/build.js
+++ b/core/modules/commands/build.js
@@ -24,7 +24,7 @@ var Command = function(params,commander) {
 
 Command.prototype.execute = function() {
 	// Get the build targets defined in the wiki
-	var buildTargets = $tw.wiki.wikiInfo.build;
+	var buildTargets = this.commander.wiki.wikiInfo.build;
 	if(!buildTargets) {
 		return "No build targets defined";
 	}

--- a/core/modules/commands/init.js
+++ b/core/modules/commands/init.js
@@ -26,7 +26,7 @@ Command.prototype.execute = function() {
 	var fs = require("fs"),
 		path = require("path");
 	// Check that we don't already have a valid wiki folder
-	if($tw.wiki.wikiTiddlersPath || ($tw.utils.isDirectory($tw.wiki.wikiPath) && !$tw.utils.isDirectoryEmpty($tw.wiki.wikiPath))) {
+	if(this.commander.wiki.wikiTiddlersPath || ($tw.utils.isDirectory(this.commander.wiki.wikiPath) && !$tw.utils.isDirectoryEmpty(this.commander.wiki.wikiPath))) {
 		return "Wiki folder is not empty";
 	}
 	// Loop through each of the specified editions
@@ -39,15 +39,15 @@ Command.prototype.execute = function() {
 			return "Edition '" + editionName + "' not found";
 		}
 		// Copy the edition content
-		var err = $tw.utils.copyDirectory(editionPath,$tw.wiki.wikiPath);
+		var err = $tw.utils.copyDirectory(editionPath,this.commander.wiki.wikiPath);
 		if(!err) {
-			this.commander.streams.output.write("Copied edition '" + editionName + "' to " + $tw.wiki.wikiPath + "\n");
+			this.commander.streams.output.write("Copied edition '" + editionName + "' to " + this.commander.wiki.wikiPath + "\n");
 		} else {
 			return err;
 		}
 	}
 	// Tweak the tiddlywiki.info to remove any included wikis
-	var packagePath = $tw.wiki.wikiPath + "/tiddlywiki.info",
+	var packagePath = this.commander.wiki.wikiPath + "/tiddlywiki.info",
 		packageJson = JSON.parse(fs.readFileSync(packagePath));
 	delete packageJson.includeWikis;
 	fs.writeFileSync(packagePath,JSON.stringify(packageJson,null,$tw.config.preferences.jsonSpaces));

--- a/core/modules/commands/init.js
+++ b/core/modules/commands/init.js
@@ -26,7 +26,7 @@ Command.prototype.execute = function() {
 	var fs = require("fs"),
 		path = require("path");
 	// Check that we don't already have a valid wiki folder
-	if($tw.boot.wikiTiddlersPath || ($tw.utils.isDirectory($tw.boot.wikiPath) && !$tw.utils.isDirectoryEmpty($tw.boot.wikiPath))) {
+	if($tw.wiki.wikiTiddlersPath || ($tw.utils.isDirectory($tw.wiki.wikiPath) && !$tw.utils.isDirectoryEmpty($tw.wiki.wikiPath))) {
 		return "Wiki folder is not empty";
 	}
 	// Loop through each of the specified editions
@@ -39,15 +39,15 @@ Command.prototype.execute = function() {
 			return "Edition '" + editionName + "' not found";
 		}
 		// Copy the edition content
-		var err = $tw.utils.copyDirectory(editionPath,$tw.boot.wikiPath);
+		var err = $tw.utils.copyDirectory(editionPath,$tw.wiki.wikiPath);
 		if(!err) {
-			this.commander.streams.output.write("Copied edition '" + editionName + "' to " + $tw.boot.wikiPath + "\n");
+			this.commander.streams.output.write("Copied edition '" + editionName + "' to " + $tw.wiki.wikiPath + "\n");
 		} else {
 			return err;
 		}
 	}
 	// Tweak the tiddlywiki.info to remove any included wikis
-	var packagePath = $tw.boot.wikiPath + "/tiddlywiki.info",
+	var packagePath = $tw.wiki.wikiPath + "/tiddlywiki.info",
 		packageJson = JSON.parse(fs.readFileSync(packagePath));
 	delete packageJson.includeWikis;
 	fs.writeFileSync(packagePath,JSON.stringify(packageJson,null,$tw.config.preferences.jsonSpaces));

--- a/core/modules/commands/listen.js
+++ b/core/modules/commands/listen.js
@@ -30,8 +30,8 @@ var Command = function(params,commander,callback) {
 
 Command.prototype.execute = function() {
 	var self = this;
-	if(!$tw.wiki.wikiTiddlersPath) {
-		$tw.utils.warning("Warning: Wiki folder '" + $tw.wiki.wikiPath + "' does not exist or is missing a tiddlywiki.info file");
+	if(!this.commander.wiki.wikiTiddlersPath) {
+		$tw.utils.warning("Warning: Wiki folder '" + this.commander.wiki.wikiPath + "' does not exist or is missing a tiddlywiki.info file");
 	}
 	// Set up server
 	this.server = new Server({

--- a/core/modules/commands/listen.js
+++ b/core/modules/commands/listen.js
@@ -30,8 +30,8 @@ var Command = function(params,commander,callback) {
 
 Command.prototype.execute = function() {
 	var self = this;
-	if(!$tw.boot.wikiTiddlersPath) {
-		$tw.utils.warning("Warning: Wiki folder '" + $tw.boot.wikiPath + "' does not exist or is missing a tiddlywiki.info file");
+	if(!$tw.wiki.wikiTiddlersPath) {
+		$tw.utils.warning("Warning: Wiki folder '" + $tw.wiki.wikiPath + "' does not exist or is missing a tiddlywiki.info file");
 	}
 	// Set up server
 	this.server = new Server({

--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -27,8 +27,8 @@ var Command = function(params,commander,callback) {
 };
 
 Command.prototype.execute = function() {
-	if(!$tw.wiki.wikiTiddlersPath) {
-		$tw.utils.warning("Warning: Wiki folder '" + $tw.wiki.wikiPath + "' does not exist or is missing a tiddlywiki.info file");
+	if(!this.commander.wiki.wikiTiddlersPath) {
+		$tw.utils.warning("Warning: Wiki folder '" + this.commander.wiki.wikiPath + "' does not exist or is missing a tiddlywiki.info file");
 	}
 	// Set up server
 	this.server = new Server({

--- a/core/modules/commands/server.js
+++ b/core/modules/commands/server.js
@@ -27,8 +27,8 @@ var Command = function(params,commander,callback) {
 };
 
 Command.prototype.execute = function() {
-	if(!$tw.boot.wikiTiddlersPath) {
-		$tw.utils.warning("Warning: Wiki folder '" + $tw.boot.wikiPath + "' does not exist or is missing a tiddlywiki.info file");
+	if(!$tw.wiki.wikiTiddlersPath) {
+		$tw.utils.warning("Warning: Wiki folder '" + $tw.wiki.wikiPath + "' does not exist or is missing a tiddlywiki.info file");
 	}
 	// Set up server
 	this.server = new Server({

--- a/core/modules/server/authenticators/basic.js
+++ b/core/modules/server/authenticators/basic.js
@@ -31,7 +31,7 @@ BasicAuthenticator.prototype.init = function() {
 	// Read the credentials data
 	this.credentialsFilepath = this.server.get("credentials");
 	if(this.credentialsFilepath) {
-		var resolveCredentialsFilepath = path.resolve($tw.boot.wikiPath,this.credentialsFilepath);
+		var resolveCredentialsFilepath = path.resolve($tw.wiki.wikiPath,this.credentialsFilepath);
 		if(fs.existsSync(resolveCredentialsFilepath) && !fs.statSync(resolveCredentialsFilepath).isDirectory()) {
 			var credentialsText = fs.readFileSync(resolveCredentialsFilepath,"utf8"),
 				credentialsData = $tw.utils.parseCsvStringWithHeader(credentialsText);

--- a/core/modules/server/authenticators/basic.js
+++ b/core/modules/server/authenticators/basic.js
@@ -31,7 +31,7 @@ BasicAuthenticator.prototype.init = function() {
 	// Read the credentials data
 	this.credentialsFilepath = this.server.get("credentials");
 	if(this.credentialsFilepath) {
-		var resolveCredentialsFilepath = path.resolve($tw.wiki.wikiPath,this.credentialsFilepath);
+		var resolveCredentialsFilepath = path.resolve(this.wiki.wikiPath,this.credentialsFilepath);
 		if(fs.existsSync(resolveCredentialsFilepath) && !fs.statSync(resolveCredentialsFilepath).isDirectory()) {
 			var credentialsText = fs.readFileSync(resolveCredentialsFilepath,"utf8"),
 				credentialsData = $tw.utils.parseCsvStringWithHeader(credentialsText);

--- a/core/modules/server/routes/get-file.js
+++ b/core/modules/server/routes/get-file.js
@@ -21,7 +21,7 @@ exports.handler = function(request,response,state) {
 		fs = require("fs"),
 		util = require("util"),
 		suppliedFilename = decodeURIComponent(state.params[0]),
-		filename = path.resolve($tw.wiki.wikiPath,"files",suppliedFilename),
+		filename = path.resolve(state.wiki.wikiPath,"files",suppliedFilename),
 		extension = path.extname(filename);
 	fs.readFile(filename,function(err,content) {
 		var status,content,type = "text/plain";

--- a/core/modules/server/routes/get-file.js
+++ b/core/modules/server/routes/get-file.js
@@ -21,7 +21,7 @@ exports.handler = function(request,response,state) {
 		fs = require("fs"),
 		util = require("util"),
 		suppliedFilename = decodeURIComponent(state.params[0]),
-		filename = path.resolve($tw.boot.wikiPath,"files",suppliedFilename),
+		filename = path.resolve($tw.wiki.wikiPath,"files",suppliedFilename),
 		extension = path.extname(filename);
 	fs.readFile(filename,function(err,content) {
 		var status,content,type = "text/plain";

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -69,8 +69,8 @@ function Server(options) {
 		tlsCertFilepath = this.get("tls-cert");
 	if(tlsCertFilepath && tlsKeyFilepath) {
 		this.listenOptions = {
-			key: fs.readFileSync(path.resolve($tw.boot.wikiPath,tlsKeyFilepath),"utf8"),
-			cert: fs.readFileSync(path.resolve($tw.boot.wikiPath,tlsCertFilepath),"utf8")
+			key: fs.readFileSync(path.resolve($tw.wiki.wikiPath,tlsKeyFilepath),"utf8"),
+			cert: fs.readFileSync(path.resolve($tw.wiki.wikiPath,tlsCertFilepath),"utf8")
 		};
 		this.protocol = "https";
 	}

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -69,8 +69,8 @@ function Server(options) {
 		tlsCertFilepath = this.get("tls-cert");
 	if(tlsCertFilepath && tlsKeyFilepath) {
 		this.listenOptions = {
-			key: fs.readFileSync(path.resolve($tw.wiki.wikiPath,tlsKeyFilepath),"utf8"),
-			cert: fs.readFileSync(path.resolve($tw.wiki.wikiPath,tlsCertFilepath),"utf8")
+			key: fs.readFileSync(path.resolve(this.wiki.wikiPath,tlsKeyFilepath),"utf8"),
+			cert: fs.readFileSync(path.resolve(this.wiki.wikiPath,tlsCertFilepath),"utf8")
 		};
 		this.protocol = "https";
 	}

--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -21,7 +21,7 @@ function FileSystemAdaptor(options) {
 	this.wiki = options.wiki;
 	this.logger = new $tw.utils.Logger("filesystem",{colour: "blue"});
 	// Create the <wiki>/tiddlers folder if it doesn't exist
-	$tw.utils.createDirectory($tw.boot.wikiTiddlersPath);
+	$tw.utils.createDirectory($tw.wiki.wikiTiddlersPath);
 }
 
 FileSystemAdaptor.prototype.name = "filesystem";
@@ -43,22 +43,22 @@ Return a fileInfo object for a tiddler, creating it if necessary:
   type: the type of the tiddler file (NOT the type of the tiddler -- see below)
   hasMetaFile: true if the file also has a companion .meta file
 
-The boot process populates $tw.boot.files for each of the tiddler files that it loads. The type is found by looking up the extension in $tw.config.fileExtensionInfo (eg "application/x-tiddler" for ".tid" files).
+The boot process populates $tw.wiki.files for each of the tiddler files that it loads. The type is found by looking up the extension in $tw.config.fileExtensionInfo (eg "application/x-tiddler" for ".tid" files).
 
-It is the responsibility of the filesystem adaptor to update $tw.boot.files for new files that are created.
+It is the responsibility of the filesystem adaptor to update $tw.wiki.files for new files that are created.
 */
 FileSystemAdaptor.prototype.getTiddlerFileInfo = function(tiddler,callback) {
 	// See if we've already got information about this file
 	var title = tiddler.fields.title,
-		fileInfo = $tw.boot.files[title];
+		fileInfo = $tw.wiki.files[title];
 	if(!fileInfo) {
 		// Otherwise, we'll need to generate it
 		fileInfo = $tw.utils.generateTiddlerFileInfo(tiddler,{
-			directory: $tw.boot.wikiTiddlersPath,
+			directory: $tw.wiki.wikiTiddlersPath,
 			pathFilters: this.wiki.getTiddlerText("$:/config/FileSystemPaths","").split("\n"),
 			wiki: this.wiki
 		});
-		$tw.boot.files[title] = fileInfo;
+		$tw.wiki.files[title] = fileInfo;
 	}
 	callback(null,fileInfo);
 };
@@ -91,7 +91,7 @@ Delete a tiddler and invoke the callback with (err)
 */
 FileSystemAdaptor.prototype.deleteTiddler = function(title,callback,options) {
 	var self = this,
-		fileInfo = $tw.boot.files[title];
+		fileInfo = $tw.wiki.files[title];
 	// Only delete the tiddler if we have writable information for the file
 	if(fileInfo) {
 		// Delete the file

--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -21,7 +21,7 @@ function FileSystemAdaptor(options) {
 	this.wiki = options.wiki;
 	this.logger = new $tw.utils.Logger("filesystem",{colour: "blue"});
 	// Create the <wiki>/tiddlers folder if it doesn't exist
-	$tw.utils.createDirectory($tw.wiki.wikiTiddlersPath);
+	$tw.utils.createDirectory(this.wiki.wikiTiddlersPath);
 }
 
 FileSystemAdaptor.prototype.name = "filesystem";
@@ -43,22 +43,22 @@ Return a fileInfo object for a tiddler, creating it if necessary:
   type: the type of the tiddler file (NOT the type of the tiddler -- see below)
   hasMetaFile: true if the file also has a companion .meta file
 
-The boot process populates $tw.wiki.files for each of the tiddler files that it loads. The type is found by looking up the extension in $tw.config.fileExtensionInfo (eg "application/x-tiddler" for ".tid" files).
+The boot process populates this.wiki.files for each of the tiddler files that it loads. The type is found by looking up the extension in $tw.config.fileExtensionInfo (eg "application/x-tiddler" for ".tid" files).
 
-It is the responsibility of the filesystem adaptor to update $tw.wiki.files for new files that are created.
+It is the responsibility of the filesystem adaptor to update this.wiki.files for new files that are created.
 */
 FileSystemAdaptor.prototype.getTiddlerFileInfo = function(tiddler,callback) {
 	// See if we've already got information about this file
 	var title = tiddler.fields.title,
-		fileInfo = $tw.wiki.files[title];
+		fileInfo = this.wiki.files[title];
 	if(!fileInfo) {
 		// Otherwise, we'll need to generate it
 		fileInfo = $tw.utils.generateTiddlerFileInfo(tiddler,{
-			directory: $tw.wiki.wikiTiddlersPath,
+			directory: this.wiki.wikiTiddlersPath,
 			pathFilters: this.wiki.getTiddlerText("$:/config/FileSystemPaths","").split("\n"),
 			wiki: this.wiki
 		});
-		$tw.wiki.files[title] = fileInfo;
+		this.wiki.files[title] = fileInfo;
 	}
 	callback(null,fileInfo);
 };
@@ -91,7 +91,7 @@ Delete a tiddler and invoke the callback with (err)
 */
 FileSystemAdaptor.prototype.deleteTiddler = function(title,callback,options) {
 	var self = this,
-		fileInfo = $tw.wiki.files[title];
+		fileInfo = this.wiki.files[title];
 	// Only delete the tiddler if we have writable information for the file
 	if(fileInfo) {
 		// Delete the file


### PR DESCRIPTION
This moves the variables `$tw.boot.files`, `$tw.boot.wikiInfo`, `$tw.boot.wikiPath`, `$tw.boot.wikiTiddlersPath` onto `$tw.wiki`.

- Renamed all occurrences using find and replace all for all Javascript files in the repo. 
- Manually find all occurrences of `$tw.wiki` and replace with the appropriate `this.wiki` or `this.commander.wiki` where applicable. 
- Add a getter and setter on $tw.boot for each variable which gets and sets `$tw.wiki` so current code should not be broken. The getter prints a console message with a stack trace. 
- Test by running `bin/build-site.sh` and `bin/test.sh`. No errors were apparent and no access on `$tw.boot` was logged. 

The main advantage of this is that it keeps file system paths and info with the wiki it pertains to and lets wiki specific code immediately access these variables for the wiki being acted on. 

- NoteSelf has no references to `$tw.boot` in the repo, which makes sense since it is browser-oriented.
- @inmysocks Bob has multiple references to `$tw.boot`, but they will still be able to refer to the global `$tw.wiki` via the getters. Bob may benefit from this change as well by being able to reuse code. 
- TiddlyServer is unaffected.
- I don't know of any other server systems.

The objective I am moving toward is a memory efficient version of Node Server, and one that can handle multiple wikis if desired (through a plugin of course). I did some experiments using the code in TiddlyServer, and the result is very promising. I was able to serve multiple Wiki instances through the same server by setting the pathPrefix and wiki for each request, and attaching a file system adaptor and syncer to each Wiki instance. 

In my testing, because tiddlers are immutable, I was able to save additional memory by sharing one instance of the core tiddler among all data folders. Each core tiddler takes 3.5 MB memory in heap for just the text field string. A modified loader, in this case, would make simple work of this as it could cache this string and use it for the text field of every wiki it loads. This saves another 3.5 MB of memory per wiki. 