### PR TITLE
Allow setting boot, wiki, and pathPrefix for each request

### DIFF
--- a/core/modules/server/authenticators/basic.js
+++ b/core/modules/server/authenticators/basic.js
@@ -31,7 +31,7 @@ BasicAuthenticator.prototype.init = function() {
 	// Read the credentials data
 	this.credentialsFilepath = this.server.get("credentials");
 	if(this.credentialsFilepath) {
-		var resolveCredentialsFilepath = path.resolve($tw.boot.wikiPath,this.credentialsFilepath);
+		var resolveCredentialsFilepath = path.resolve(this.server.boot.wikiPath,this.credentialsFilepath);
 		if(fs.existsSync(resolveCredentialsFilepath) && !fs.statSync(resolveCredentialsFilepath).isDirectory()) {
 			var credentialsText = fs.readFileSync(resolveCredentialsFilepath,"utf8"),
 				credentialsData = $tw.utils.parseCsvStringWithHeader(credentialsText);

--- a/core/modules/server/routes/get-file.js
+++ b/core/modules/server/routes/get-file.js
@@ -21,7 +21,7 @@ exports.handler = function(request,response,state) {
 		fs = require("fs"),
 		util = require("util"),
 		suppliedFilename = decodeURIComponent(state.params[0]),
-		filename = path.resolve($tw.boot.wikiPath,"files",suppliedFilename),
+		filename = path.resolve(state.boot.wikiPath,"files",suppliedFilename),
 		extension = path.extname(filename);
 	fs.readFile(filename,function(err,content) {
 		var status,content,type = "text/plain";

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -159,11 +159,11 @@ Server.prototype.requestHandler = function(request,response,options) {
 	// Compose the state object
 	var self = this;
 	var state = {};
-	state.wiki = (options?options.wiki:false) || self.wiki;
+	state.wiki = (options ? options.wiki : false) || self.wiki;
 	state.server = self;
 	state.urlInfo = url.parse(request.url);
 	state.queryParameters = querystring.parse(state.urlInfo.query);
-	state.pathPrefix = (options?options.pathPrefix:false) || this.get("path-prefix") || "";
+	state.pathPrefix = (options ? options.pathPrefix : false) || this.get("path-prefix") || "";
 	// Get the principals authorized to access this resource
 	var authorizationType = this.methodMappings[request.method] || "readers";
 	// Check for the CSRF header if this is a write

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -31,6 +31,7 @@ function Server(options) {
 	this.routes = options.routes || [];
 	this.authenticators = options.authenticators || [];
 	this.wiki = options.wiki;
+	this.boot = options.boot || $tw.boot;
 	this.servername = $tw.utils.transliterateToSafeASCII(this.wiki.getTiddlerText("$:/SiteTitle") || "TiddlyWiki5");
 	// Initialise the variables
 	this.variables = $tw.utils.extend({},this.defaultVariables);
@@ -69,8 +70,8 @@ function Server(options) {
 		tlsCertFilepath = this.get("tls-cert");
 	if(tlsCertFilepath && tlsKeyFilepath) {
 		this.listenOptions = {
-			key: fs.readFileSync(path.resolve($tw.boot.wikiPath,tlsKeyFilepath),"utf8"),
-			cert: fs.readFileSync(path.resolve($tw.boot.wikiPath,tlsCertFilepath),"utf8")
+			key: fs.readFileSync(path.resolve(this.boot.wikiPath,tlsKeyFilepath),"utf8"),
+			cert: fs.readFileSync(path.resolve(this.boot.wikiPath,tlsCertFilepath),"utf8")
 		};
 		this.protocol = "https";
 	}
@@ -161,6 +162,7 @@ Server.prototype.requestHandler = function(request,response,options) {
 	var self = this;
 	var state = {};
 	state.wiki = options.wiki || self.wiki;
+	state.boot = options.boot || self.boot;
 	state.server = self;
 	state.urlInfo = url.parse(request.url);
 	state.queryParameters = querystring.parse(state.urlInfo.query);

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -156,15 +156,14 @@ Server.prototype.isAuthorized = function(authorizationType,username) {
 }
 
 Server.prototype.requestHandler = function(request,response,options) {
-	options = options || Object.create(null);
 	// Compose the state object
 	var self = this;
 	var state = {};
-	state.wiki = options.wiki || self.wiki;
+	state.wiki = (options?options.wiki:false) || self.wiki;
 	state.server = self;
 	state.urlInfo = url.parse(request.url);
 	state.queryParameters = querystring.parse(state.urlInfo.query);
-	state.pathPrefix = options.pathPrefix || this.get("path-prefix") || "";
+	state.pathPrefix = (options?options.pathPrefix:false) || this.get("path-prefix") || "";
 	// Get the principals authorized to access this resource
 	var authorizationType = this.methodMappings[request.method] || "readers";
 	// Check for the CSRF header if this is a write

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -156,14 +156,15 @@ Server.prototype.isAuthorized = function(authorizationType,username) {
 }
 
 Server.prototype.requestHandler = function(request,response,options) {
+	options = options || {};
 	// Compose the state object
 	var self = this;
 	var state = {};
-	state.wiki = (options ? options.wiki : false) || self.wiki;
+	state.wiki = options.wiki || self.wiki;
 	state.server = self;
 	state.urlInfo = url.parse(request.url);
 	state.queryParameters = querystring.parse(state.urlInfo.query);
-	state.pathPrefix = (options ? options.pathPrefix : false) || this.get("path-prefix") || "";
+	state.pathPrefix = options.pathPrefix || this.get("path-prefix") || "";
 	// Get the principals authorized to access this resource
 	var authorizationType = this.methodMappings[request.method] || "readers";
 	// Check for the CSRF header if this is a write

--- a/plugins/tiddlywiki/filesystem/filesystemadaptor.js
+++ b/plugins/tiddlywiki/filesystem/filesystemadaptor.js
@@ -19,9 +19,10 @@ var fs = $tw.node ? require("fs") : null,
 function FileSystemAdaptor(options) {
 	var self = this;
 	this.wiki = options.wiki;
+	this.boot = options.boot || $tw.boot;
 	this.logger = new $tw.utils.Logger("filesystem",{colour: "blue"});
 	// Create the <wiki>/tiddlers folder if it doesn't exist
-	$tw.utils.createDirectory($tw.boot.wikiTiddlersPath);
+	$tw.utils.createDirectory(this.boot.wikiTiddlersPath);
 }
 
 FileSystemAdaptor.prototype.name = "filesystem";
@@ -43,22 +44,22 @@ Return a fileInfo object for a tiddler, creating it if necessary:
   type: the type of the tiddler file (NOT the type of the tiddler -- see below)
   hasMetaFile: true if the file also has a companion .meta file
 
-The boot process populates $tw.boot.files for each of the tiddler files that it loads. The type is found by looking up the extension in $tw.config.fileExtensionInfo (eg "application/x-tiddler" for ".tid" files).
+The boot process populates this.boot.files for each of the tiddler files that it loads. The type is found by looking up the extension in $tw.config.fileExtensionInfo (eg "application/x-tiddler" for ".tid" files).
 
-It is the responsibility of the filesystem adaptor to update $tw.boot.files for new files that are created.
+It is the responsibility of the filesystem adaptor to update this.boot.files for new files that are created.
 */
 FileSystemAdaptor.prototype.getTiddlerFileInfo = function(tiddler,callback) {
 	// See if we've already got information about this file
 	var title = tiddler.fields.title,
-		fileInfo = $tw.boot.files[title];
+		fileInfo = this.boot.files[title];
 	if(!fileInfo) {
 		// Otherwise, we'll need to generate it
 		fileInfo = $tw.utils.generateTiddlerFileInfo(tiddler,{
-			directory: $tw.boot.wikiTiddlersPath,
+			directory: this.boot.wikiTiddlersPath,
 			pathFilters: this.wiki.getTiddlerText("$:/config/FileSystemPaths","").split("\n"),
 			wiki: this.wiki
 		});
-		$tw.boot.files[title] = fileInfo;
+		this.boot.files[title] = fileInfo;
 	}
 	callback(null,fileInfo);
 };
@@ -91,7 +92,7 @@ Delete a tiddler and invoke the callback with (err)
 */
 FileSystemAdaptor.prototype.deleteTiddler = function(title,callback,options) {
 	var self = this,
-		fileInfo = $tw.boot.files[title];
+		fileInfo = this.boot.files[title];
 	// Only delete the tiddler if we have writable information for the file
 	if(fileInfo) {
 		// Delete the file


### PR DESCRIPTION
This adds the `pathPrefix` to the state object for each request and adds an options argument to the request handler which sets both `wiki` and `pathPrefix` for each request. The options argument is optional. 