### PR TITLE
Git saver: Correctly handle empty path

### DIFF
--- a/core/modules/savers/github.js
+++ b/core/modules/savers/github.js
@@ -34,7 +34,8 @@ GitHubSaver.prototype.save = function(text,method,callback) {
 			"Authorization": "Basic " + window.btoa(username + ":" + password)
 		};
 	// Bail if we don't have everything we need
-	if(!username || !password || !repo || !path || !filename) {
+	// Not checking path, it is initialized below
+	if(!username || !password || !repo || !filename) {
 		return false;
 	}
 	// Make sure the path start and ends with a slash

--- a/core/modules/savers/gitlab.js
+++ b/core/modules/savers/gitlab.js
@@ -34,7 +34,8 @@ GitLabSaver.prototype.save = function(text,method,callback) {
 			"Private-Token": password
 		};
 	// Bail if we don't have everything we need
-	if(!username || !password || !repo || !path || !filename) {
+	// Not checking path, it is initialized below
+	if(!username || !password || !repo || !filename) {
 		return false;
 	}
 	// Make sure the path start and ends with a slash


### PR DESCRIPTION
Skip checking for empty path (which is the default in a new TiddlyWiki and described as optional in the [Git saver documentation](https://tiddlywiki.com/#Saving%20to%20a%20Git%20service)).

The path is already explicitly checked and initialized to "/" if empty.