### PR TITLE
Compressing $set chains into one $vars

### DIFF
--- a/core/templates/single.tiddler.window.tid
+++ b/core/templates/single.tiddler.window.tid
@@ -6,17 +6,13 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 \end
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 
-<$set name="tv-config-toolbar-icons" value={{$:/config/Toolbar/Icons}}>
-
-<$set name="tv-config-toolbar-text" value={{$:/config/Toolbar/Text}}>
-
-<$set name="tv-config-toolbar-class" value={{$:/config/Toolbar/ButtonClass}}>
-
-<$set name="tv-show-missing-links" value={{$:/config/MissingLinks}}>
-
-<$set name="storyviewTitle" value={{$:/view}}>
-
-<$set name="languageTitle" value={{{ [{$:/language}get[name]] }}}>
+<$vars
+	tv-config-toolbar-icons={{$:/config/Toolbar/Icons}}
+	tv-config-toolbar-text={{$:/config/Toolbar/Text}}
+	tv-config-toolbar-class={{$:/config/Toolbar/ButtonClass}}
+	tv-show-missing-links={{$:/config/MissingLinks}}
+	storyviewTitle={{$:/view}}
+	languageTitle={{{ [{$:/language}get[name]] }}}>
 
 <div class=<<containerClasses>>>
 
@@ -28,14 +24,4 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 
 </div>
 
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
+</$vars>

--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -6,19 +6,14 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 \end
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 
-<$set name="tv-config-toolbar-icons" value={{$:/config/Toolbar/Icons}}>
-
-<$set name="tv-config-toolbar-text" value={{$:/config/Toolbar/Text}}>
-
-<$set name="tv-config-toolbar-class" value={{$:/config/Toolbar/ButtonClass}}>
-
-<$set name="tv-enable-drag-and-drop" value={{$:/config/DragAndDrop/Enable}}>
-
-<$set name="tv-show-missing-links" value={{$:/config/MissingLinks}}>
-
-<$set name="storyviewTitle" value={{$:/view}}>
-
-<$set name="languageTitle" value={{{ [{$:/language}get[name]] }}}>
+<$vars
+	tv-config-toolbar-icons={{$:/config/Toolbar/Icons}}
+	tv-config-toolbar-text={{$:/config/Toolbar/Text}}
+	tv-config-toolbar-class={{$:/config/Toolbar/ButtonClass}}
+	tv-enable-drag-and-drop={{$:/config/DragAndDrop/Enable}}
+	tv-show-missing-links={{$:/config/MissingLinks}}
+	storyviewTitle={{$:/view}}
+	languageTitle={{{ [{$:/language}get[name]] }}}>
 
 <div class=<<containerClasses>>>
 
@@ -38,16 +33,4 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 
 </div>
 
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</$set>
+</$vars>


### PR DESCRIPTION
This change makes the code:

1. Easier to read
2. more concise
3. use less memory
4. run faster, since vars is more lightweight, and this will parse faster.
5. trim 12 whole floors off those flame chart skyscrapers Tiddlywiki has.

I've been using this improvement on my machine a while to no effect, and looking at it, I can't see how it possibly changes runtime.

(Quick note: I noticed that a month ago, you added **tv-enable-drag-and-drop** to _ui/PageTemplate_, but not to _templates/single.tiddler.window.tid_. Was that an oversight? I'm not sure)

ANYWAY

This tiny improvement is just an example of why $vars is amazing. And I'm really making this PR to promote the following addition to $vars:
```javascript
VarsWidget.prototype.getVariableInfo = function(name,options) {
    // $vars is the only widget which looks in itself when fetching a variable
    // rather than looking at its parent or higher
    if ($tw.utils.hop(this.variables, name)) {
        var variable = this.variables[name];
        // It doesn't have to perform any param or macro stuff, since vars
        // only ever contains simple variables.
        return {
            text: variable.value,
            params: []
        };
    } else {
        return Widget.prototype.getVariableInfo.call(this,name,options);
    }
};
```

That's right. We make $vars the one widget which can look into itself when scrounging up variables. Why? For chaining definitions.
```html
<$vars	tiddler={{myvalue}}
		another={{{ [<tiddler>get[field]] }}}
		third={{{ [tag[another]] }}}>
```
Defining variables in a vars chain can depend on ones before it. It's exactly like javascript. Everywhere in the JS code, you see stuff like,
```javascript
vars tiddler=this.getVariable("currentTiddler"),
	value=tiddler.fields.value;
```
It makes perfect sense that $vars would behave this way. Completely intuitive. And now $vars can be used over cumbersome $set chains more often.

But there are even more advantages to this.

### wiki.makeWidget

You know all those times in code when you make dummy widgets just to run code with context? For instance, wiki.makeWidget is this weird complicated thing that might actually make a TON of widgets. At least 2.
```javascript
exports.makeWidget = function(parser,options) {
    options = options || {};
    var widgetNode = {
            type: "widget",
            children: []
        },
        currWidgetNode = widgetNode;
    // Create set variable widgets for each variable
    $tw.utils.each(options.variables,function(value,name) {
        var setVariableWidget = {
            type: "set",
            attributes: {
                name: {type: "string", value: name},
                value: {type: "string", value: value}
            },
            children: []
        };
        currWidgetNode.children = [setVariableWidget];
        currWidgetNode = setVariableWidget;
    });
    // Add in the supplied parse tree nodes
    currWidgetNode.children = parser ? parser.tree : [];
    // Create the widget
    return new widget.widget(widgetNode,{
        wiki: this,
        document: options.document || $tw.fakeDocument,
        parentWidget: options.parentWidget
    });
};
```
...gross

But this becomes WAY simpler if all you have to make is a $vars widget instead of a $widget widget. It can hold everything, and then you attach parser tree to that. And if you want to to run filters from this, you don't have to climb to the bottom of the returned widget's children. _You can use the widget returned by makeWidget._

### importVariablesWidget

I've turned $importvariables into a highly efficient yet monstrously complicated widget. With this modification to vars (and uh... one other one I'll talk about another time), I can turn importvariables back into something other people can understand, _and still retain the efficiency!_

So how about it? The change is small, and I'd accompany some tests along with it to make sure it's not breaking anything.