### PR TITLE
Add modifier variable to button actionstring

### DIFF
--- a/core/modules/keyboard.js
+++ b/core/modules/keyboard.js
@@ -284,6 +284,16 @@ KeyboardManager.prototype.checkKeyDescriptors = function(event,keyInfoArray) {
 	return false;
 };
 
+KeyboardManager.prototype.getEventModifierKeyDescriptor = function(event) {
+	return event.ctrlKey && !event.shiftKey && !event.altKey ? "ctrl" : 
+		event.shiftKey && !event.ctrlKey && !event.altKey? "shift" : 
+		event.ctrlKey && event.shiftKey && !event.altKey ? "ctrl-shift" : 
+		event.altKey && !event.shiftKey && !event.ctrlKey ? "alt" : 
+		event.altKey && event.shiftKey && !event.ctrlKey ? "alt-shift" : 
+		event.altKey && event.ctrlKey && !event.shiftKey ? "ctrl-alt" : 
+		event.altKey && event.shiftKey && event.ctrlKey ? "ctrl-alt-shift" : "normal";
+};
+
 KeyboardManager.prototype.getShortcutTiddlerList = function() {
 	return $tw.wiki.getTiddlersWithTag("$:/tags/KeyboardShortcut");
 };

--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -91,13 +91,7 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 			handled = true;
 		}
 		if(self.actions) {
-			var modifierKey = event.ctrlKey && !event.shiftKey && !event.altKey ? "ctrl" : 
-				event.shiftKey && !event.ctrlKey && !event.altKey? "shift" : 
-                		event.ctrlKey && event.shiftKey && !event.altKey ? "ctrl-shift" : 
-				event.altKey && !event.shiftKey && !event.ctrlKey ? "alt" : 
-				event.altKey && event.shiftKey && !event.ctrlKey ? "alt-shift" : 
-				event.altKey && event.ctrlKey && !event.shiftKey ? "ctrl-alt" : 
-				event.altKey && event.shiftKey && event.ctrlKey ? "ctrl-alt-shift" : "normal";
+			var modifierKey = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
 			self.invokeActionString(self.actions,self,event,{modifier: modifierKey});
 		}
 		if(handled) {

--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -91,7 +91,14 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 			handled = true;
 		}
 		if(self.actions) {
-			self.invokeActionString(self.actions,self,event);
+			var modifierKey = event.ctrlKey && !event.shiftKey && !event.altKey ? "ctrl" : 
+				event.shiftKey && !event.ctrlKey && !event.altKey? "shift" : 
+                		event.ctrlKey && event.shiftKey && !event.altKey ? "ctrl-shift" : 
+				event.altKey && !event.shiftKey && !event.ctrlKey ? "alt" : 
+				event.altKey && event.shiftKey && !event.ctrlKey ? "alt-shift" : 
+				event.altKey && event.ctrlKey && !event.shiftKey ? "ctrl-alt" : 
+				event.altKey && event.shiftKey && event.ctrlKey ? "ctrl-alt-shift" : "normal";
+			self.invokeActionString(self.actions,self,event,{modifier: modifierKey});
 		}
 		if(handled) {
 			event.preventDefault();

--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -130,13 +130,7 @@ DroppableWidget.prototype.handleDropEvent  = function(event) {
 
 DroppableWidget.prototype.performActions = function(title,event) {
 	if(this.droppableActions) {
-		var modifierKey = event.ctrlKey && !event.shiftKey && !event.altKey ? "ctrl" : 
-				event.shiftKey && !event.ctrlKey && !event.altKey? "shift" : 
-                		event.ctrlKey && event.shiftKey && !event.altKey ? "ctrl-shift" : 
-				event.altKey && !event.shiftKey && !event.ctrlKey ? "alt" : 
-				event.altKey && event.shiftKey && !event.ctrlKey ? "alt-shift" : 
-				event.altKey && event.ctrlKey && !event.shiftKey ? "ctrl-alt" : 
-				event.altKey && event.shiftKey && event.ctrlKey ? "ctrl-alt-shift" : "normal";
+		var modifierKey = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
 		this.invokeActionString(this.droppableActions,this,event,{actionTiddler: title, modifier: modifierKey});
 	}
 };

--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -130,8 +130,13 @@ DroppableWidget.prototype.handleDropEvent  = function(event) {
 
 DroppableWidget.prototype.performActions = function(title,event) {
 	if(this.droppableActions) {
-		var modifierKey = event.ctrlKey && ! event.shiftKey ? "ctrl" : event.shiftKey && !event.ctrlKey ? "shift" : 
-				event.ctrlKey && event.shiftKey ? "ctrl-shift" : "normal" ;
+		var modifierKey = event.ctrlKey && !event.shiftKey && !event.altKey ? "ctrl" : 
+				event.shiftKey && !event.ctrlKey && !event.altKey? "shift" : 
+                		event.ctrlKey && event.shiftKey && !event.altKey ? "ctrl-shift" : 
+				event.altKey && !event.shiftKey && !event.ctrlKey ? "alt" : 
+				event.altKey && event.shiftKey && !event.ctrlKey ? "alt-shift" : 
+				event.altKey && event.ctrlKey && !event.shiftKey ? "ctrl-alt" : 
+				event.altKey && event.shiftKey && event.ctrlKey ? "ctrl-alt-shift" : "normal";
 		this.invokeActionString(this.droppableActions,this,event,{actionTiddler: title, modifier: modifierKey});
 	}
 };

--- a/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
@@ -24,7 +24,7 @@ The integrated actions are provided as a shortcut for invoking common actions. T
 The content of the `<$button>` widget is displayed within the button.
 
 |!Attribute |!Description |
-|actions |A string containing ActionWidgets to be triggered when the key combination is detected |
+|actions |A string containing ActionWidgets to be triggered when the key combination is detected. <<.from-version "5.1.23">> the <<.def "modifier">> variable lists the modifier keys that are pressed when the action is invoked. The possible modifiers are ''ctrl'', ''ctrl-alt'', ''ctrl-shift'', ''alt'', ''alt-shift'', ''shift'' and ''ctrl-alt-shift'' |
 |to |The title of the tiddler to navigate to |
 |message |The name of the [[widget message|Messages]] to send when the button is clicked |
 |param |The optional parameter to the message |


### PR DESCRIPTION
This PR adds a `modifier` variable to the button actions parameter, which contains the modifier keys pressed when the actions are invoked