### PR TITLE
Corrected issue with markdowns softbreaks AND whitespace between md markup

### DIFF
--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -225,7 +225,8 @@ function convertNodes(remarkableTree, isStartOfInline) {
 		) {
 			// The Markdown compiler thinks this is just text.
 			// Hand off to the WikiText parser to see if there's more to render
-			if (!pluginOpts.renderWikiText) {
+			// But only if it's configured to, and we have more than whitespace
+			if (!pluginOpts.renderWikiText || accumulatedText.match(/^\s*$/)) {
 				out.push({
 					type: "text",
 					text: accumulatedText

--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -258,7 +258,7 @@ function convertNodes(remarkableTree, isStartOfInline) {
 				// If the original text element started with a space, add it back in
 				if (rs.length > 0
 					&& rs[0].type === "text"
-					&& accumulatedText[0] === " "
+					&& (accumulatedText[0] === " " || accumulatedText[0] === "\n")
 				) {
 					rs[0].text = " " + rs[0].text;
 				}

--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -88,17 +88,28 @@ function convertNodes(remarkableTree, isStartOfInline) {
 
 	for (var i = 0; i < remarkableTree.length; i++) {
 		var currentNode = remarkableTree[i];
-		if (currentNode.type === "paragraph_open") {
+		switch (currentNode.type) {
+		case "paragraph_open":
 			i = wrappedElement("p", i, currentNode.level, "paragraph_close", remarkableTree);
-		} else if (currentNode.type === "heading_open") {
+			break;
+
+		case "heading_open":
 			i = wrappedElement("h" + currentNode.hLevel, i, currentNode.level, "heading_close", remarkableTree);
-		} else if (currentNode.type === "bullet_list_open") {
+			break;
+
+		case "bullet_list_open":
 			i = wrappedElement("ul", i, currentNode.level, "bullet_list_close", remarkableTree);
-		} else if (currentNode.type == 'ordered_list_open') {
+			break;
+
+		case "ordered_list_open":
 			i = wrappedElement('ol', i, currentNode.level,'ordered_list_close', remarkableTree);
-		} else if (currentNode.type === "list_item_open") {
+			break;
+
+		case "list_item_open":
 			i = wrappedElement("li", i, currentNode.level, "list_item_close", remarkableTree);
-		} else if (currentNode.type === "link_open") {
+			break;
+
+		case "link_open":
 			var j = findTagWithType(remarkableTree, i + 1, "link_close", currentNode.level);
 
 			if (currentNode.href[0] !== "#") {
@@ -126,16 +137,17 @@ function convertNodes(remarkableTree, isStartOfInline) {
 				});
 			}
 			i = j;
-		} else if (currentNode.type.substr(currentNode.type.length - 5) === "_open") {
-			var tagName = currentNode.type.substr(0, currentNode.type.length - 5);
-			i = wrappedElement(tagName, i, currentNode.level, tagName + "_close", remarkableTree);
-		} else if (currentNode.type === "code") {
+			break;
+
+		case "code":
 			out.push({
 				type: "element",
 				tag: currentNode.block ? "pre" : "code",
 				children: [{ type: "text", text: currentNode.content }]
 			});
-		} else if (currentNode.type === "fence") {
+			break;
+
+		case "fence":
 			out.push({
 				type: "codeblock",
 				attributes: {
@@ -143,7 +155,9 @@ function convertNodes(remarkableTree, isStartOfInline) {
 					code: { type: "string", value: currentNode.content }
 				}
 			});
-		} else if (currentNode.type === "image") {
+			break;
+
+		case "image":
 			out.push({
 				type: "image",
 				attributes: {
@@ -151,7 +165,9 @@ function convertNodes(remarkableTree, isStartOfInline) {
 					source: { type: "string", value: currentNode.src }
 				}
 			});
-		} else if (currentNode.type === "softbreak") {
+			break;
+
+		case "softbreak":
 			if (remarkableOpts.breaks) {
 				out.push({
 					type: "element",
@@ -160,27 +176,43 @@ function convertNodes(remarkableTree, isStartOfInline) {
 			} else {
 				accumulatedText = accumulatedText + '\n';
 			}
-		} else if (currentNode.type === "hardbreak") {
+			break;
+
+		case "hardbreak":
 			out.push({
 				type: "element",
 				tag: "br",
 			});
-		} else if (currentNode.type == 'hr') {
+			break;
+
+		case "hr":
 			out.push({
 				type: 'element',
 				tag: 'hr',
 			});
-		} else if (currentNode.type === "inline") {
+			break;
+
+		case "inline":
 			out = out.concat(convertNodes(currentNode.children, true));
-		} else if (currentNode.type === "text") {
+			break;
+
+		case "text":
 			// We need to merge this text block with the upcoming text block and parse it all together.
 			accumulatedText = accumulatedText + currentNode.content;
-		} else {
-			console.error("Unknown node type: " + currentNode.type, currentNode);
-			out.push({
-				type: "text",
-				text: currentNode.content
-			});
+			break;
+
+		default:
+			if (currentNode.type.substr(currentNode.type.length - 5) === "_open") {
+				var tagName = currentNode.type.substr(0, currentNode.type.length - 5);
+				i = wrappedElement(tagName, i, currentNode.level, tagName + "_close", remarkableTree);
+			} else {
+				console.error("Unknown node type: " + currentNode.type, currentNode);
+				out.push({
+					type: "text",
+					text: currentNode.content
+				});
+			}
+			break;
 		}
 		// We test to see if we process the block now, or if there's
 		// more to accumulate first.


### PR DESCRIPTION
I was resolving an issue for someone using Relink-markdown when we realized any kind of multi-line wikiSyntax is broken when using markdown. It's because wrapper isn't respecting the $:/config/markdown/breaks setting. It was effectively always "true". So...

```markdown
These lines
should be merged after rendering if breaks==false
but they weren't
```
Also, fixed wrapper so it handles hardbreaks now, which is the proper way to force `<br>` when breaks==false. That's when you put 2 spaces at the end of the line.

Warning, this will change existing rendering somewhat, since markdown is currently rendering everyone's stuff wrong.