### PR TITLE
Droppable widget: Check for DOM node existence before removing class.

### DIFF
--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -75,7 +75,9 @@ DroppableWidget.prototype.leaveDrag = function(event) {
 	// Remove highlighting if we're leaving externally. The hacky second condition is to resolve a problem with Firefox whereby there is an erroneous dragenter event if the node being dragged is within the dropzone
 	if(this.currentlyEntered.length === 0 || (this.currentlyEntered.length === 1 && this.currentlyEntered[0] === $tw.dragInProgress)) {
 		this.currentlyEntered = [];
-		$tw.utils.removeClass(this.domNodes[0],"tc-dragover");
+		if(this.domNodes[0]) {
+			$tw.utils.removeClass(this.domNodes[0],"tc-dragover");
+		}
 	}
 };
 


### PR DESCRIPTION
Can cause issues if dragstart and dragend actions trigger a refresh.