### PR TITLE
Make tags in tags-dropdown change bg-color on hover

### DIFF
--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -38,7 +38,7 @@ $actions$
 </div>
 <div class="tc-block-dropdown-wrapper">
 <$reveal state=<<qualify "$:/state/popup/tags-auto-complete">> type="nomatch" text="" default="">
-<div class="tc-block-dropdown">
+<div class="tc-block-dropdown tc-block-tags-dropdown">
 <$set name="newTagName" value={{{ [<newTagNameTiddler>get[text]] }}}>
 <$list filter="[<newTagName>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
 <$list filter="[tags[]!is[system]search:title<newTagName>sort[]]" variable="tag">

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -658,7 +658,7 @@ button svg.tc-image-button, button .tc-image-button img {
 	vertical-align: baseline;
 }
 
-.tc-block-tags-dropdown > .tc-button-invisible:hover {
+.tc-block-tags-dropdown > .tc-btn-invisible:hover {
 	background-color: <<colour primary>>;
 }
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -658,6 +658,10 @@ button svg.tc-image-button, button .tc-image-button img {
 	vertical-align: baseline;
 }
 
+.tc-block-tags-dropdown > .tc-button-invisible:hover {
+	background-color: <<colour primary>>;
+}
+
 button.tc-tag-label, span.tc-tag-label {
 	display: inline-block;
 	padding: 0.16em 0.7em;


### PR DESCRIPTION
This PR makes the tags in the tags-dropdown (edit-mode) change their background-color to the primary color on hover