### PR TITLE
Document the TW receiver saver

### DIFF
--- a/editions/tw5.com/tiddlers/saving/Saving on a PHP Server.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on a PHP Server.tid
@@ -3,7 +3,7 @@ created: 20140111091844267
 delivery: DIY
 description: DIY script you can install on your own server
 method: save
-modified: 20171115171431733
+modified: 20200612234718365
 tags: Saving PHP
 title: Saving on a PHP Server
 type: text/vnd.tiddlywiki
@@ -45,3 +45,5 @@ php_value post_max_size 6M
 !!! Note about possible error message
 
 If you get an error message regarding `split()`, you may need to change references  to `split` in ''store.php'' to function `explode` .
+
+This code hasn't been updated in several years. If you have difficulty with it, consider using [[TW Receiver|Saving with TW Receiver]] instead.

--- a/editions/tw5.com/tiddlers/saving/Saving with TW Receiver.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving with TW Receiver.tid
@@ -1,0 +1,15 @@
+caption: TW Receiver
+created: 20200612233356021
+delivery: DIY
+description: DIY script you can install on your own server
+method: save
+modified: 20200612234312631
+tags: Saving PHP
+title: Saving with TW Receiver
+type: text/vnd.tiddlywiki
+
+TW Receiver is a ~TiddlyWiki plugin and PHP script used for saving to a PHP based server.
+
+It's features include simple automated backups,  stale Instance Overwrite Protection,  challenge digest authentication (enhanced security), and data integrity signing (enhanced security).
+
+* Visit [[TW-Receiver|https://github.com/sendwheel/tw-receiver]] for more information, plugin, and code.


### PR DESCRIPTION
Recently, users on reddit were having trouble with the PHP saver (store.php), and frustrated by not getting it to work. The store.php script has not been updated for years, and is likely to break out of the box thanks to changes in PHP.  

The TW receiver plugin and scripts have been well received and have security enhancements. Yet it is not listed as a saver.

This update documents TW-receiver and lightly suggests it as an alternative at the bottom of the PHP saver documentation.