### PR TITLE
Fixes use of stateTitle instead of state resulting in artifacts during import

### DIFF
--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -1,5 +1,3 @@
-title: $:/core/ui/ImportListing
-
 \define lingo-base() $:/language/Import/
 
 \define messageField()
@@ -41,13 +39,13 @@ $(currentTiddler)$!!popup-$(payloadTiddler)$
 <$checkbox field=<<selectionField>> checked="checked" unchecked="unchecked" default="checked"/>
 </td>
 <td>
-<$reveal type="nomatch" stateTitle=<<previewPopupState>> text="yes" tag="div">
-<$button class="tc-btn-invisible tc-btn-dropdown" setTitle=<<previewPopupState>> setTo="yes">
+<$reveal type="nomatch" state=<<previewPopupState>> text="yes" tag="div">
+<$button class="tc-btn-invisible tc-btn-dropdown" set=<<previewPopupState>> setTo="yes">
 {{$:/core/images/right-arrow}}&nbsp;<$text text=<<payloadTiddler>>/>
 </$button>
 </$reveal>
-<$reveal type="match" stateTitle=<<previewPopupState>> text="yes" tag="div">
-<$button class="tc-btn-invisible tc-btn-dropdown" setTitle=<<previewPopupState>> setTo="no">
+<$reveal type="match" state=<<previewPopupState>> text="yes" tag="div">
+<$button class="tc-btn-invisible tc-btn-dropdown" set=<<previewPopupState>> setTo="no">
 {{$:/core/images/down-arrow}}&nbsp;<$text text=<<payloadTiddler>>/>
 </$button>
 </$reveal>
@@ -58,7 +56,7 @@ $(currentTiddler)$!!popup-$(payloadTiddler)$
 </tr>
 <tr>
 <td colspan="3">
-<$reveal type="match" text="yes" stateTitle=<<previewPopupState>> tag="div">
+<$reveal type="match" text="yes" state=<<previewPopupState>> tag="div">
 <$list filter="[{$:/state/importpreviewtype}has[text]]" variable="listItem" emptyMessage={{$:/core/ui/ImportPreviews/Text}}>
 <$transclude tiddler={{$:/state/importpreviewtype}}/>
 </$list>

--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -1,3 +1,5 @@
+title: $:/core/ui/ImportListing
+
 \define lingo-base() $:/language/Import/
 
 \define messageField()


### PR DESCRIPTION
Fixes #4599 

If during the process of importing a file into TW, you decide to preview the file before hitting Import, it leaves behind a tiddler with name:
$:/Import!!popup-filename for every file previewed.