### PR TITLE
PreferredSaver

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -159,6 +159,7 @@ Settings/NavigationPermalinkviewMode/UpdateAddressBar/Description: Update addres
 Settings/PerformanceInstrumentation/Caption: Performance Instrumentation
 Settings/PerformanceInstrumentation/Hint: Displays performance statistics in the browser developer console. Requires reload to take effect
 Settings/PerformanceInstrumentation/Description: Enable performance instrumentation
+Settings/PreferredSaver/Caption: Preferred Saver
 Settings/ToolbarButtonStyle/Caption: Toolbar Button Style
 Settings/ToolbarButtonStyle/Hint: Choose the style for toolbar buttons:
 Settings/ToolbarButtonStyle/Styles/Borderless: Borderless

--- a/core/modules/filters/savers.js
+++ b/core/modules/filters/savers.js
@@ -1,0 +1,24 @@
+/*\
+title: $:/core/modules/filters/savers.js
+type: application/javascript
+module-type: filteroperator
+
+This Filter operator return savers title
+
+\*/
+;(function () {
+  /*jslint node: true, browser: true */
+  /*global $tw: false */
+  'use strict'
+
+  /*
+  Export our filter function
+  */
+  exports.savers = function (source, operator, options) {
+    var results = []
+    for (var i in $tw.saverHandler.savers) {
+      results.push($tw.saverHandler.savers[i].title)
+    }
+    return results
+  }
+})()

--- a/core/modules/macros/infosaver.js
+++ b/core/modules/macros/infosaver.js
@@ -1,0 +1,30 @@
+/*\
+title: $:/core/modules/macros/infosaver.js
+type: application/javascript
+module-type: macro
+
+Display saver info name
+
+\*/
+
+;(function () {
+  /*jslint node: true, browser: true */
+  /*global $tw: false */
+  'use strict'
+
+  /*
+   * Information about this macro
+   */
+  exports.name = 'infosaver'
+
+  exports.params = [
+    {name: 'tiddler'}
+  ]
+
+  /*
+   * Run the macro
+   */
+  exports.run = function (tiddler) {
+    return $tw.saverHandler.getSaver(tiddler).module.info.name
+  }
+})()

--- a/core/ui/ControlPanel/Saving/General.tid
+++ b/core/ui/ControlPanel/Saving/General.tid
@@ -1,12 +1,13 @@
 title: $:/core/ui/ControlPanel/Saving/General
+modified: 20200528094915385
 tags: $:/tags/ControlPanel/Saving
 caption: {{$:/language/ControlPanel/Saving/General/Caption}}
 list-before:
 
 \define lingo-base() $:/language/ControlPanel/Settings/
 
-\define ipfs-saver()
-<$text text=<<ipfs-info-saver "$(currentTiddler)$">>/>
+\define preferred-saver()
+<$text text=<<infosaver "$(currentTiddler)$">>/>
 \end
 
 {{$:/language/ControlPanel/Saving/General/Hint}}
@@ -15,9 +16,10 @@ list-before:
 
 <$select tiddler="$:/config/PreferredSaver">
 <$list filter="[savers[]]">
-<option value=<<currentTiddler>>><<ipfs-saver>></option>
+<option value=<<currentTiddler>>><<preferred-saver>></option>
 </$list>
 </$select>
+
 !! <$link to="$:/config/AutoSave"><<lingo AutoSave/Caption>></$link>
 
 <<lingo AutoSave/Hint>>

--- a/core/ui/ControlPanel/Saving/General.tid
+++ b/core/ui/ControlPanel/Saving/General.tid
@@ -5,8 +5,19 @@ list-before:
 
 \define lingo-base() $:/language/ControlPanel/Settings/
 
+\define ipfs-saver()
+<$text text=<<ipfs-info-saver "$(currentTiddler)$">>/>
+\end
+
 {{$:/language/ControlPanel/Saving/General/Hint}}
 
+!! <$link to="$:/config/PreferredSaver"><<lingo PreferredSaver/Caption>></$link>
+
+<$select tiddler="$:/config/PreferredSaver">
+<$list filter="[savers[]]">
+<option value=<<currentTiddler>>><<ipfs-saver>></option>
+</$list>
+</$select>
 !! <$link to="$:/config/AutoSave"><<lingo AutoSave/Caption>></$link>
 
 <<lingo AutoSave/Hint>>

--- a/core/wiki/config/PreferredSaver.tid
+++ b/core/wiki/config/PreferredSaver.tid
@@ -1,0 +1,3 @@
+title: $:/config/PreferredSaver
+
+$:/core/modules/savers/download.js


### PR DESCRIPTION
This PR supersed the closed PR https://github.com/Jermolene/TiddlyWiki5/pull/4371

### Motivation
The mechanism is meant to let users change from the UI their preferred saver.
This feature help users to save their wiki when a saver has failed.

### Artifacts
1. core/language/en-GB/ControlPanel.multids
2. core/modules/saver-handler.js
3. core/modules/filters/savers.js
4. core/modules/macros/infosaver.js
5. core/ui/ControlPanel/Saving/General.tid
6. core/wiki/config/PreferredSaver.tid

### Remarks
There is a debate whether or not savers should handle multiple savers sequentially during a save session. I see a blocking point here as a plugin can decide to reload its wiki once saved preventing any further saver processing.