### PR TITLE
Allow toggling relink in tm-rename-tiddler

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -609,10 +609,13 @@ NavigatorWidget.prototype.handleUnfoldAllTiddlersEvent = function(event) {
 };
 
 NavigatorWidget.prototype.handleRenameTiddlerEvent = function(event) {
-	var paramObject = event.paramObject || {},
+	var options = {},
+		paramObject = event.paramObject || {},
 		from = paramObject.from || event.tiddlerTitle,
 		to = paramObject.to;
-	this.wiki.renameTiddler(from,to);
+	options.dontRenameInTags = (paramObject.dontRenameInTags === "true" || paramObject.dontRenameInTags === "yes") ? true : false;
+	options.dontRenameInLists = (paramObject.dontRenameInLists === "true" || paramObject.dontRenameInLists === "yes") ? true : false;
+	this.wiki.renameTiddler(from,to,options);
 };
 
 exports.navigator = NavigatorWidget;

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-rename-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-rename-tiddler.tid
@@ -10,5 +10,27 @@ The `tm-rename-tiddler` message renames a tiddler by deleting it and recreating 
 |!Name |!Description |
 |from |Current title of tiddler  |
 |to |New title of tiddler  |
+|dontRenameInTags |<<.from-version "5.1.23">> Optional value "yes" to disable renaming in tags fields of other tiddlers (defaults to "no") |
+|dontRenameInLists |<<.from-version "5.1.23">> Optional value "yes" to disable renaming in list fields of other tiddlers (defaults to "no") |
 
 The rename tiddler message is usually generated with the ButtonWidget and is handled by the NavigatorWidget.
+
+! Examples
+
+To rename a tiddler called Tiddler1 to Tiddler2 and also renaming Tiddler1 in tags and list fields of other tiddlers:
+
+```
+<$action-sendmessage $message="tm-rename-tiddler" from="Tiddler1" to="Tiddler2" />
+```
+
+To rename a tiddler called Tiddler1 to Tiddler2 and not rename Tiddler1 in tags and list fields of other tiddlers:
+
+```
+<$action-sendmessage $message="tm-rename-tiddler" from="Tiddler1" to="Tiddler2" dontRenameInTags="yes" dontRenameInLists="yes"/>
+```
+
+To rename a tiddler called Tiddler1 to Tiddler2 and respect the setting $:/config/RelinkOnRename for whether to rename Tiddler1 in tags and list fields of other tiddlers:
+
+```
+<$action-sendmessage $message="tm-rename-tiddler" from="Tiddler1" to="Tiddler2" dontRenameInTags={{$:/config/RelinkOnRename}} dontRenameInLists={{$:/config/RelinkOnRename}}/>
+```


### PR DESCRIPTION
This change allows the user to determine whether the `tm-rename-tiddler` message will trigger renaming in tags and list fields of other tiddlers, while staying backwards compatible.

The current behaviour is that relinking always happens, which is not always desirable.

Two extra parameters are supported in the `tm-rename-tiddler` message, which correspond to options attributes already supported in `wiki.relinkTiddler`:
- [dontRenameInTags](https://github.com/Jermolene/TiddlyWiki5/blob/master/core/modules/wiki-bulkops.js#L50)
- [dontRenameInLists](https://github.com/Jermolene/TiddlyWiki5/blob/master/core/modules/wiki-bulkops.js#L60)

This would be used as follows:
`<$action-sendmessage $message="tm-rename-tiddler" from=<<fromTitle>> to=<<toTitle>> dontRenameInTags="true" dontRenameInLists="true"/>`

or if the user wants the relink behaviour to abide by the $:/config/RelinkOnRename setting:
`<$action-sendmessage $message="tm-rename-tiddler" from=<<fromTitle>> to=<<toTitle>> dontRenameInTags={{$:/config/RelinkOnRename}} dontRenameInLists={{$:/config/RelinkOnRename}}/>`

If there is consensus on this change I will update docs to match.