### PR TITLE
Revert "Allow toggling relink in tm-rename-tiddler"

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -609,13 +609,10 @@ NavigatorWidget.prototype.handleUnfoldAllTiddlersEvent = function(event) {
 };
 
 NavigatorWidget.prototype.handleRenameTiddlerEvent = function(event) {
-	var options = {},
-		paramObject = event.paramObject || {},
+	var paramObject = event.paramObject || {},
 		from = paramObject.from || event.tiddlerTitle,
 		to = paramObject.to;
-	options.dontRenameInTags = (paramObject.dontRenameInTags === "true" || paramObject.dontRenameInTags === "yes") ? true : false;
-	options.dontRenameInLists = (paramObject.dontRenameInLists === "true" || paramObject.dontRenameInLists === "yes") ? true : false;
-	this.wiki.renameTiddler(from,to,options);
+	this.wiki.renameTiddler(from,to);
 };
 
 exports.navigator = NavigatorWidget;

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-rename-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-rename-tiddler.tid
@@ -10,27 +10,5 @@ The `tm-rename-tiddler` message renames a tiddler by deleting it and recreating 
 |!Name |!Description |
 |from |Current title of tiddler  |
 |to |New title of tiddler  |
-|dontRenameInTags |<<.from-version "5.1.23">> Optional value "yes" to disable renaming in tags fields of other tiddlers (defaults to "no") |
-|dontRenameInLists |<<.from-version "5.1.23">> Optional value "yes" to disable renaming in list fields of other tiddlers (defaults to "no") |
 
 The rename tiddler message is usually generated with the ButtonWidget and is handled by the NavigatorWidget.
-
-! Examples
-
-To rename a tiddler called Tiddler1 to Tiddler2 and also renaming Tiddler1 in tags and list fields of other tiddlers:
-
-```
-<$action-sendmessage $message="tm-rename-tiddler" from="Tiddler1" to="Tiddler2" />
-```
-
-To rename a tiddler called Tiddler1 to Tiddler2 and not rename Tiddler1 in tags and list fields of other tiddlers:
-
-```
-<$action-sendmessage $message="tm-rename-tiddler" from="Tiddler1" to="Tiddler2" dontRenameInTags="yes" dontRenameInLists="yes"/>
-```
-
-To rename a tiddler called Tiddler1 to Tiddler2 and respect the setting $:/config/RelinkOnRename for whether to rename Tiddler1 in tags and list fields of other tiddlers:
-
-```
-<$action-sendmessage $message="tm-rename-tiddler" from="Tiddler1" to="Tiddler2" dontRenameInTags={{$:/config/RelinkOnRename}} dontRenameInLists={{$:/config/RelinkOnRename}}/>
-```


### PR DESCRIPTION
Reverts Jermolene/TiddlyWiki5#4719

Revised pull request will follow.

I've realized there is a minor issue with the merged pull request. While the code is correct and works as expected, the third example provided will not work.

`<$action-sendmessage $message="tm-rename-tiddler" from=<<fromTitle>> to=<<toTitle>> dontRenameInTags={{$:/config/RelinkOnRename}} dontRenameInLists={{$:/config/RelinkOnRename}}/>`

This wont work as expected since `$:/config/RelinkOnRename` is `yes` when we want to allow renaming, but that corresponds to `dontRenameInTags` and `dontRenameInLists` needing to be the opposite: `no`.

While this isn't necessary for the added functionality, it is a nice to have option that will make life easy for users. I have revised the code and will submit a revised pull request after I have completed my testing.

---

For those curious about the revision, the parameters `renameinTags` and `renameInLists` are replaced with `dontRenameInTags` and `dontRenameInLists` respectively. This avoids users having to think through double negatives, as well as corresponds better to the setting in `$:/config/RelinkOnRename`

Revised code is here:
https://github.com/saqimtiaz/TiddlyWiki5/commit/48511356f0ce3e146080cf229deea73a58eb9b82