### PR TITLE
Revised: toggling relink in tm-rename-tiddler

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -609,10 +609,13 @@ NavigatorWidget.prototype.handleUnfoldAllTiddlersEvent = function(event) {
 };
 
 NavigatorWidget.prototype.handleRenameTiddlerEvent = function(event) {
-	var paramObject = event.paramObject || {},
+	var options = {},
+		paramObject = event.paramObject || {},
 		from = paramObject.from || event.tiddlerTitle,
 		to = paramObject.to;
-	this.wiki.renameTiddler(from,to);
+	options.dontRenameInTags = (paramObject.renameInTags === "false" || paramObject.renameInTags === "no") ? true : false;
+	options.dontRenameInLists = (paramObject.renameInLists === "false" || paramObject.renameInLists === "no") ? true : false;
+	this.wiki.renameTiddler(from,to,options);
 };
 
 exports.navigator = NavigatorWidget;

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-rename-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-rename-tiddler.tid
@@ -10,5 +10,27 @@ The `tm-rename-tiddler` message renames a tiddler by deleting it and recreating 
 |!Name |!Description |
 |from |Current title of tiddler  |
 |to |New title of tiddler  |
+|renameInTags |<<.from-version "5.1.23">> Optional value "no" to disable renaming in tags fields of other tiddlers (defaults to "yes") |
+|renameInLists |<<.from-version "5.1.23">> Optional value "no" to disable renaming in list fields of other tiddlers (defaults to "yes") |
 
 The rename tiddler message is usually generated with the ButtonWidget and is handled by the NavigatorWidget.
+
+! Examples
+
+To rename a tiddler called Tiddler1 to Tiddler2 and also renaming Tiddler1 in tags and list fields of other tiddlers:
+
+```
+<$action-sendmessage $message="tm-rename-tiddler" from="Tiddler1" to="Tiddler2" />
+```
+
+To rename a tiddler called Tiddler1 to Tiddler2 and not rename Tiddler1 in tags and list fields of other tiddlers:
+
+```
+<$action-sendmessage $message="tm-rename-tiddler" from="Tiddler1" to="Tiddler2" renameInTags="no" renameInLists="no"/>
+```
+
+To rename a tiddler called Tiddler1 to Tiddler2 and respect the setting in the tiddler $:/config/RelinkOnRename for whether to rename Tiddler1 in tags and list fields of other tiddlers:
+
+```
+<$action-sendmessage $message="tm-rename-tiddler" from="Tiddler1" to="Tiddler2" renameInTags={{$:/config/RelinkOnRename}} renameInLists={{$:/config/RelinkOnRename}}/>
+```


### PR DESCRIPTION
This is a revised version of #4719, which I have thoroughly tested.

The parameters `renameInTags` and `renameInLists` replace `dontRenameInTags` and `dontRenameInLists` from the previous PR respectively. This avoids users having to think through double negatives, as well as corresponds better to the setting in `$:/config/RelinkOnRename`

---

Two extra parameters are supported in the `tm-rename-tiddler` message, which inversely correspond to options attributes already supported in `wiki.relinkTiddler`:

- `renameInTags`
- `renameInLists`

This would be used as follows:
`<$action-sendmessage $message="tm-rename-tiddler" from=<<fromTitle>> to=<<toTitle>> renameInTags="no" renameInLists="no"/>`

or if the user wants the relink behaviour to abide by the $:/config/RelinkOnRename setting:
`<$action-sendmessage $message="tm-rename-tiddler" from=<<fromTitle>> to=<<toTitle>> renameInTags={{$:/config/RelinkOnRename}} renameInLists={{$:/config/RelinkOnRename}}/>`

