### PR TITLE
Link widget: Include original event in tm-navigate

### DIFF
--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -158,7 +158,8 @@ LinkWidget.prototype.handleClickEvent = function(event) {
 		metaKey: event.metaKey,
 		ctrlKey: event.ctrlKey,
 		altKey: event.altKey,
-		shiftKey: event.shiftKey
+		shiftKey: event.shiftKey,
+		event: event
 	});
 	if(this.domNodes[0].hasAttribute("href")) {
 		event.preventDefault();


### PR DESCRIPTION
`tm-navigate` messages sent by the `Link` widget do not include the original `event`, whereas [when sent by the Button widget](https://github.com/Jermolene/TiddlyWiki5/blob/master/core/modules/widgets/button.js#L151) they do.

This change is needed to have a consistent way to detect modifier keys used when a link or button is clicked, as well as any other properties of interest from the original event.

This also addresses the inconsistency introduced in #2889, when we added modifier keys to the message instead of including the original `event`, which was the established pattern from the Button widget. The change introduced in #2889 is not retracted in the interest of backwards compatibility.