### PR TITLE
EditWidget: Use attributes from parseTreeNode to make child widgets

### DIFF
--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -54,16 +54,7 @@ EditWidget.prototype.execute = function() {
 	// Make the child widgets
 	this.makeChildWidgets([{
 		type: "edit-" + this.editorType,
-		attributes: {
-			tiddler: {type: "string", value: this.editTitle},
-			field: {type: "string", value: this.editField},
-			index: {type: "string", value: this.editIndex},
-			"class": {type: "string", value: this.editClass},
-			"placeholder": {type: "string", value: this.editPlaceholder},
-			"tabindex": {type: "string", value: this.editTabIndex},
-			"focus": {type: "string", value: this.editFocus},
-			"cancelPopups": {type: "string", value: this.editCancelPopups}
-		},
+		attributes: this.parseTreeNode.attributes,
 		children: this.parseTreeNode.children
 	}]);
 };


### PR DESCRIPTION
The `EditWidget` does not support all the attributes that are expected by the `EditTextWidget`, such as `autoHeight`, `minHeight`, `rows`, `tag`, `size`. 

With this PR, we just use the attributes object from the `parseTreeNode` in the call to `makeChildWidgets`, instead of first adding these attributes to the `EditWidget` only to pass them on to the child widgets. 

Since the attributes from the parseTreeNode are used to make child widgets, the refresh methods of the child widgets will be able to handle any attribute changes that require refresh.

This approach also provides a lot more flexibility for plugin writers. If a plugin adds an attribute to EditTextWidget, it will automatically be supported by the EditWidget. Similarly it will make core maintenance easier, if more attributes are added to the EditTextWidget.