### PR TITLE
Add requirements to build tiddlywiki executable

### DIFF
--- a/bin/nexe-build-all.js
+++ b/bin/nexe-build-all.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const { compile } = require('nexe')
+
+
+console.log('Building Executable for Linux x64')
+compile({
+  input: './tiddlywiki.js',
+  output: 'tiddlywiki',
+  targets: 'linux-x64',
+  resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+}).then(() => {
+  console.log('Building Executable for Linux x32')
+  return compile({
+    input: './tiddlywiki.js',
+    output: 'tiddlywiki',
+    targets: 'linux-x32',
+    resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+  })
+}).then(() => {
+  console.log('Building Executable for OSX x64')
+  return compile({
+    input: './tiddlywiki.js',
+    output: 'tiddlywiki.command',
+    targets: 'mac-x64',
+    resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+  })
+}).then(() => {
+  console.log('Building Executable for Windows x64')
+  return compile({
+    input: './tiddlywiki.js',
+    output: 'tiddlywiki.exe',
+    targets: 'windows-x64',
+    resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+  })
+}).then(() => {
+  console.log('Building Executable for Windows x32')
+  return compile({
+    input: './tiddlywiki.js',
+    output: 'tiddlywiki.exe',
+    targets: 'windows-x32',
+    resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+  })
+}).then(() => {
+  console.log('done')
+}).catch((e) => {console.log('error?', e)})
+

--- a/bin/nexe-build-linux.js
+++ b/bin/nexe-build-linux.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const { compile } = require('nexe')
+
+
+console.log('Building Executable for Linux x64')
+compile({
+  input: './tiddlywiki.js',
+  output: 'tiddlywiki',
+  targets: 'linux-x64',
+  resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+}).then(() => {
+  console.log('done')
+}).catch((e) => {console.log('error?', e)})
+

--- a/bin/nexe-build-linux32.js
+++ b/bin/nexe-build-linux32.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const { compile } = require('nexe')
+
+
+console.log('Building Executable for Linux x32')
+compile({
+  input: './tiddlywiki.js',
+  output: 'tiddlywiki',
+  targets: 'linux-x32',
+  resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+}).then(() => {
+  console.log('done')
+}).catch((e) => {console.log('error?', e)})
+

--- a/bin/nexe-build-osx.js
+++ b/bin/nexe-build-osx.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const { compile } = require('nexe')
+
+
+console.log('Building Executable for OSX x64')
+compile({
+  input: './tiddlywiki.js',
+  output: 'tiddlywiki.command',
+  targets: 'mac-x64',
+  resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+}).then(() => {
+  console.log('done')
+}).catch((e) => {console.log('error?', e)})
+

--- a/bin/nexe-build-win.js
+++ b/bin/nexe-build-win.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const { compile } = require('nexe')
+
+
+console.log('Building Executable for Windows x64')
+compile({
+  input: './tiddlywiki.js',
+  output: 'tiddlywiki.exe',
+  targets: 'windows-x64',
+  resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+}).then(() => {
+  console.log('done')
+}).catch((e) => {console.log('error?', e)})
+

--- a/bin/nexe-build-win32.js
+++ b/bin/nexe-build-win32.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const { compile } = require('nexe')
+
+
+console.log('Building Executable for Windows x32')
+compile({
+  input: './tiddlywiki.js',
+  output: 'tiddlywiki.exe',
+  targets: 'windows-x32',
+  resources: ['./plugins/**/*', './themes/**/*', './editions/**/*', './languages/**/*']
+}).then(() => {
+  console.log('done')
+}).catch((e) => {console.log('error?', e)})
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "wiki"
   ],
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "nexe": "^3.3.7"
+  },
   "bundleDependencies": [],
   "license": "BSD",
   "engines": {


### PR DESCRIPTION
This adds the needed dev dependency and scripts to build a single file executable for tiddlywiki.

All the core editions, languages, plugins and themes are packaged in it and it is used in the same way as using npm to install tiddlywiki but you don't need node or npm to use it.

One thing to note is that it won't be globally available unless you place it somewhere included in your system $PATH

Building executables like this and putting them up as part of each release will probably make it much easier for people to use the node version.