### PR TITLE
Count transclusions as links (and therefore backlinks) in extractLinks, added test

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -429,6 +429,12 @@ exports.extractLinks = function(parseTreeRoot) {
 						links.push(value);
 					}
 				}
+				if(parseTreeNode.type === "transclude" && parseTreeNode.attributes.tiddler && parseTreeNode.attributes.tiddler.type === "string") {
+					var value = parseTreeNode.attributes.tiddler.value;
+					if(links.indexOf(value) === -1) {
+						links.push(value);
+					}
+				}
 				if(parseTreeNode.children) {
 					checkParseTree(parseTreeNode.children);
 				}

--- a/editions/test/tiddlers/tests/test-backlinks.js
+++ b/editions/test/tiddlers/tests/test-backlinks.js
@@ -127,6 +127,27 @@ describe('Backlinks tests', function() {
 			expect(wiki.filterTiddlers('TestIncoming +[backlinks[]]').join(',')).toBe('');
 		});
 	});
+
+	describe('A tiddler that transcludes a tiddler', function() {
+		var wiki = new $tw.Wiki();
+
+		wiki.addTiddler({
+			title: 'TestTranscluded',
+			text: ''});
+
+		wiki.addTiddler({
+			title: 'TestTranscluder',
+			text: 'A transclusion of {{TestTranscluded}}'});
+
+		it('should be in the backlinks of the transcluded tiddler', function() {
+			expect(wiki.filterTiddlers('TestTranscluded +[backlinks[]]').join(',')).toBe('TestTranscluder');
+		});
+
+		it('should have the transcluded tiddler among its links', function() {
+			expect(wiki.filterTiddlers('TestTranscluder +[links[]]').join(',')).toBe('TestTranscluded');
+		});
+	});
+
 });
 
 })();


### PR DESCRIPTION
I wanted backlinks in my custom ViewTemplate to also reflect transclusions as incoming links, so I changed my wiki.js to do that a while ago. I haven't observed any unwanted behavior after making this change, so I'd like to propose it be added to core tw5. 

This change makes the links and backlinks operators count transclusions as links.

The change passes /bin/test.cmd. I've also added an extra test to amend the spec.