### PR TITLE
Fix server error when saving a new tiddler created by following a tiddler link

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -273,7 +273,9 @@ NavigatorWidget.prototype.makeDraftTiddler = function(targetTitle) {
 	var tiddler = this.wiki.getTiddler(targetTitle);
 	// Save the initial value of the draft tiddler
 	draftTitle = this.generateDraftTitle(targetTitle);
-	var draftTiddler = new $tw.Tiddler(
+	var draftTiddler = new $tw.Tiddler({
+				text: "",
+			},
 			tiddler,
 			{
 				title: draftTitle,

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -327,7 +327,6 @@ NavigatorWidget.prototype.handleSaveTiddlerEvent = function(event) {
 				// If enabled, relink references to renamed tiddler
 				var shouldRelink = this.getAttribute("relinkOnRename","no").toLowerCase().trim() === "yes";
 				if(isRename && shouldRelink && this.wiki.tiddlerExists(draftOf)) {
-console.log("Relinking '" + draftOf + "' to '" + draftTitle + "'");
 					this.wiki.relinkTiddler(draftOf,draftTitle);
 				}
 				// Remove the draft tiddler


### PR DESCRIPTION
### How to repro

1. Set up an empty wiki and start the node server
   ```
   node tiddlywiki.js test --init server                                                                  
   node tiddlywiki.js test --listen
   ```
2. Access the wiki and click the + button to create a new tiddler
3. Edit the content to add a link to a non-existent tiddler
   ```                                                                                                    
   [[Linked Tiddler]]                                                                                     
   ```                                                                                                    
4. Save the new tiddler
5. Click on the tiddler link ("_Linked Tiddler_")
6. Click the edit button of the newly opened tiddler
7. Set the content type to something that's not "text/vnd.tiddlywiki", such as "text/plain". Do _not_ edit the content.
   * This is needed so that the [branch that calls `fs.writeFile` with `tiddler.fields.text` in `saveTiddlerToFile`](https://github.com/Jermolene/TiddlyWiki5/blob/4de95a64c1e367993cfea964093d9ad19758fdd6/core/modules/utils/filesystem.js#L330) gets run, by virtue of [this path that sets `fileInfo.hasMetaFile` to `true`](https://github.com/Jermolene/TiddlyWiki5/blob/4de95a64c1e367993cfea964093d9ad19758fdd6/core/modules/utils/filesystem.js#L239).
8. Save the linked tiddler

### Expected
"Linked Tiddler" gets saved with an empty text

### Actual
* Node < 14: the content of "Linked Tiddler" on disk is the string "undefined".
   ```
   $ cat test/tiddlers/Linked\ Tiddler.txt
   undefined
   ```
* Node >= 14: the server exits with a TypeError
   ```
   internal/fs/utils.js:657
       throw new ERR_INVALID_ARG_TYPE(
       ^
   
   TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer,
   TypedArray, or DataView. Received undefined
       at Object.writeFile (fs.js:1356:5)
       at Object.exports.saveTiddlerToFile ($:/core/modules/utils/filesystem.js:310:6)
       at $:/plugins/tiddlywiki/filesystem/filesystemadaptor.js:76:13
       at FileSystemAdaptor.getTiddlerFileInfo ($:/plugins/tiddlywiki/filesystem/filesystemadaptor.js:63:2)
       at FileSystemAdaptor.saveTiddler ($:/plugins/tiddlywiki/filesystem/filesystemadaptor.js:72:7)
       at SaveTiddlerTask.run ($:/core/modules/syncer.js:570:27)
       at Syncer.processTaskQueue ($:/core/modules/syncer.js:476:9)
       at Function.<anonymous> ($:/core/modules/syncer.js:90:9)
       at $tw.Wiki.exports.dispatchEvent ($:/core/modules/wiki.js:133:13)
       at $:/core/modules/wiki.js:166:10 {
     code: 'ERR_INVALID_ARG_TYPE'
   }
   ```

This change in behavior comes from https://github.com/nodejs/node/commit/fb6df3bfac8ca38a7012eabf0563d7a799ce1acc, which added argument type validation to `fs.writeFile`.

### What this change does
This PR changes `NavigatorWidget.prototype.makeDraftTiddler` so that it initializes the draft tiddler with an empty `"text"` field, just like [NavigatorWidget.prototype.handleNewTiddlerEvent does](https://github.com/Jermolene/TiddlyWiki5/blob/4de95a64c1e367993cfea964093d9ad19758fdd6/core/modules/widgets/navigator.js#L457).