### PR TITLE
Fix Entity widget not rendering its content without a refresh

### DIFF
--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -21,14 +21,32 @@ var bumpSequenceNumber = function(object) {
 	}
 };
 
+var TW_Node = function (){
+	throw TypeError("Illegal constructor");
+};
+
+Object.defineProperty(TW_Node.prototype, 'ELEMENT_NODE', {
+	get: function() {
+		return 1;
+	}
+});
+
+Object.defineProperty(TW_Node.prototype, 'TEXT_NODE', {
+	get: function() {
+		return 3;
+	}
+});
+
 var TW_TextNode = function(text) {
 	bumpSequenceNumber(this);
 	this.textContent = text + "";
 };
 
+TW_TextNode.prototype = Object.create(TW_Node.prototype);
+
 Object.defineProperty(TW_TextNode.prototype, "nodeType", {
 	get: function() {
-		return 3;
+		return this.TEXT_NODE;
 	}
 });
 
@@ -48,6 +66,8 @@ var TW_Element = function(tag,namespace) {
 	this._style = {};
 	this.namespaceURI = namespace || "http://www.w3.org/1999/xhtml";
 };
+
+TW_Element.prototype = Object.create(TW_Node.prototype);
 
 Object.defineProperty(TW_Element.prototype, "style", {
 	get: function() {
@@ -69,7 +89,7 @@ Object.defineProperty(TW_Element.prototype, "style", {
 
 Object.defineProperty(TW_Element.prototype, "nodeType", {
 	get: function() {
-		return 1;
+		return this.ELEMENT_NODE;
 	}
 });
 

--- a/core/modules/widgets/entity.js
+++ b/core/modules/widgets/entity.js
@@ -28,6 +28,7 @@ Render this widget into the DOM
 */
 EntityWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
+	this.computeAttributes();
 	this.execute();
 	var entityString = this.getAttribute("entity",this.parseTreeNode.entity || ""),
 		textNode = this.document.createTextNode($tw.utils.entityDecode(entityString));

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -273,6 +273,24 @@ describe("Widget module", function() {
 		expect(wrapper.innerHTML).toBe("<p><a href=\"data:text/vnd.tiddlywiki,Jolly%20Old%20World\">My linky link</a></p>");
 	});
 
+	/* This test reproduces issue #4693. */
+	it("should render the entity widget", function() {
+		var wiki = new $tw.Wiki();
+		// Construct the widget node
+		var text = "\n\n<$entity entity='&nbsp;' />\n\n<$entity entity='&#x2713;' />\n";
+		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
+		// Render the widget node to the DOM
+		var wrapper = renderWidgetNode(widgetNode);
+		// Test the rendering
+		expect(wrapper.innerHTML).toBe(" ✓");
+		// Test the sequence numbers in the DOM
+		expect(wrapper.sequenceNumber).toBe(0);
+		expect(wrapper.children[0].sequenceNumber).toBe(1);
+		expect(wrapper.children[0].nodeType).toBe(wrapper.children[0].TEXT_NODE);
+		expect(wrapper.children[1].sequenceNumber).toBe(2);
+		expect(wrapper.children[1].nodeType).toBe(wrapper.children[1].TEXT_NODE);
+	});
+
 	it("should deal with the list widget", function() {
 		var wiki = new $tw.Wiki();
 		// Add some tiddlers


### PR DESCRIPTION
Fixes #4693

The workaround described in the original issue worked because the entity widget was getting refreshed in step 2 ("click into the sidebar search input") and `EntityWidget.prototype.refresh` calls `this.computeAttributes()`, pulling in attributes from its `parseTreeNode` for the first time.