### PR TITLE
Fix authenticated-user-header is case sensitive in header authenticator

### DIFF
--- a/core/modules/server/authenticators/header.js
+++ b/core/modules/server/authenticators/header.js
@@ -14,7 +14,7 @@ Authenticator for trusted header authentication
 
 function HeaderAuthenticator(server) {
 	this.server = server;
-	this.header = server.get("authenticated-user-header");
+	this.header = server.get("authenticated-user-header").toLowerCase();
 }
 
 /*


### PR DESCRIPTION
From RFC 2616 - "Hypertext Transfer Protocol -- HTTP/1.1", Section 4.2, "Message Headers":

Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.