### PR TITLE
Format filter to create formatted date strings

### DIFF
--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -27,6 +27,7 @@ Error/EditConflict: File changed on server
 Error/Filter: Filter error
 Error/FilterSyntax: Syntax error in filter expression
 Error/IsFilterOperator: Filter Error: Unknown operand for the 'is' filter operator
+Error/FormatFilterOperator: Filter Error: Unknown suffix for the 'format' filter operator
 Error/LoadingPluginLibrary: Error loading plugin library
 Error/NetworkErrorAlert: `<h2>''Network Error''</h2>It looks like the connection to the server has been lost. This may indicate a problem with your network connection. Please attempt to restore network connectivity before continuing.<br><br>''Any unsaved changes will be automatically synchronised when connectivity is restored''.`
 Error/RecursiveTransclusion: Recursive transclusion error in transclude widget

--- a/core/modules/filters/format.js
+++ b/core/modules/filters/format.js
@@ -1,0 +1,46 @@
+/*\
+title: $:/core/modules/filters/format.js
+type: application/javascript
+module-type: filteroperator
+Filter operator for formatting strings
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var formatFilterOperators;
+
+function getFormatFilterOperators() {
+	if(!formatFilterOperators) {
+		formatFilterOperators = {};
+		$tw.modules.applyMethods("formatfilteroperator",formatFilterOperators);
+	}
+	return formatFilterOperators;
+}
+
+/*
+Export our filter function
+*/
+exports.format = function(source,operator,options) {
+	// Dispatch to the correct formatfilteroperator
+	var formatFilterOperators = getFormatFilterOperators();
+	if(operator.suffix) {
+		var formatFilterOperator = formatFilterOperators[operator.suffix];
+		if(formatFilterOperator) {
+			return formatFilterOperator(source,operator.operand,options);
+		} else {
+			return [$tw.language.getString("Error/FormatFilterOperator")];
+		}
+	} else {
+		// Return all unchanged if the suffix is missing
+		var results = [];
+		source(function(tiddler,title) {
+			results.push(title);
+		});
+		return results;
+	}
+};
+
+})();

--- a/core/modules/filters/format/date.js
+++ b/core/modules/filters/format/date.js
@@ -1,0 +1,26 @@
+/*\
+title: $:/core/modules/filters/format/date.js
+type: application/javascript
+module-type: formatfilteroperator
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.date = function(source,operand,options) {
+	var results = [];	
+	source(function(tiddler,title) {
+		var value = $tw.utils.parseDate(title);
+		if(value && $tw.utils.isDate(value) && value.toString() !== "Invalid Date") {
+			results.push($tw.utils.formatDateString(value,operand || "YYYY MM DD 0hh:0mm"));
+		}
+	});	
+	return results;
+};
+
+})();

--- a/core/modules/filters/format/relativedate.js
+++ b/core/modules/filters/format/relativedate.js
@@ -1,0 +1,26 @@
+/*\
+title: $:/core/modules/filters/format/relativedate.js
+type: application/javascript
+module-type: formatfilteroperator
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.relativedate = function(source,operand,options) {
+	var results = [];	
+	source(function(tiddler,title) {
+		var value = $tw.utils.parseDate(title);
+		if(value && $tw.utils.isDate(value) && value.toString() !== "Invalid Date") {
+			results.push($tw.utils.getRelativeDate((new Date()) - (new Date(value))).description);
+		}
+	});	
+	return results;
+};
+
+})();

--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -42,6 +42,21 @@ exports.split = makeStringBinaryOperator(
 	function(a,b) {return ("" + a).split(b);}
 );
 
+exports.asdate = makeStringBinaryOperator(
+	function(a,b,c) {
+		var value = $tw.utils.parseDate(a);
+		if(value && $tw.utils.isDate(value) && value.toString() !== "Invalid Date") {
+			if(c === "relative") {
+				return [$tw.utils.getRelativeDate((new Date()) - (new Date(value))).description];
+			} else {
+				return [$tw.utils.formatDateString(value,b || "YYYY MM DD 0hh:0mm")];
+			}
+		} else {
+			return [];
+		}
+	}
+);
+
 exports.join = makeStringReducingOperator(
 	function(accumulator,value,operand) {
 		if(accumulator === null) {
@@ -56,7 +71,7 @@ function makeStringBinaryOperator(fnCalc) {
 	return function(source,operator,options) {
 		var result = [];
 		source(function(tiddler,title) {
-			Array.prototype.push.apply(result,fnCalc(title,operator.operand || ""));
+			Array.prototype.push.apply(result,fnCalc(title,operator.operand || "",operator.suffix || ""));
 		});
 		return result;
 	};

--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -42,21 +42,6 @@ exports.split = makeStringBinaryOperator(
 	function(a,b) {return ("" + a).split(b);}
 );
 
-exports.asdate = makeStringBinaryOperator(
-	function(a,b,c) {
-		var value = $tw.utils.parseDate(a);
-		if(value && $tw.utils.isDate(value) && value.toString() !== "Invalid Date") {
-			if(c === "relative") {
-				return [$tw.utils.getRelativeDate((new Date()) - (new Date(value))).description];
-			} else {
-				return [$tw.utils.formatDateString(value,b || "YYYY MM DD 0hh:0mm")];
-			}
-		} else {
-			return [];
-		}
-	}
-);
-
 exports.join = makeStringReducingOperator(
 	function(accumulator,value,operand) {
 		if(accumulator === null) {
@@ -71,7 +56,7 @@ function makeStringBinaryOperator(fnCalc) {
 	return function(source,operator,options) {
 		var result = [];
 		source(function(tiddler,title) {
-			Array.prototype.push.apply(result,fnCalc(title,operator.operand || "",operator.suffix || ""));
+			Array.prototype.push.apply(result,fnCalc(title,operator.operand || ""));
 		});
 		return result;
 	};


### PR DESCRIPTION
This PR adds an optimized version of a filter I have been using for some time to allow easy creation of **formatted date strings.** While there are workarounds possible using the `view widget` and wikify, this extends the ability of filters and is often more convenient.

**Operand:** The _operand_ to the filter operator is used as date `format`, consistent with the handling in the `View widget`. If the operand is not specified it defaults to `YYYY MM DD 0hh:0mm` which is again consistent with the view widget.

**Suffix:** If the _suffix_ `relative` is used, the operand (if any) is ignored and the string is formatted as a relative date.

An invalid date string returns no result.

Examples:
`[[20200731]asdate[mmm DD]] -> Jul 31`
`[[20200730]asdate:relative[]] -> 45 hours ago`
`[[20200730]asdate:relative[mmm DD]] -> 45 hours ago`

If there is interest in adding this to the core I can work on docs as well.