### PR TITLE
Travis: Don't run build-* stages for PRs against master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ node_js:
 stages:
   - name: test
   - name: build-prerelease
-    if: branch = "master"
+    if: branch = "master" AND type = push AND fork = false
   - name: build-tiddlywiki-com
-    if: branch = "tiddlywiki-com"
+    if: branch = "tiddlywiki-com" AND type = push AND fork = false
 
 jobs:  
   include:


### PR DESCRIPTION
### Motivation
I noticed there was an attempt to run the build-prerelease stage [in a recent Travis build](https://travis-ci.org/github/Jermolene/TiddlyWiki5/builds/713944999), which was for a PR. (The attempt failed because the necessary token was not available, I believe -- as expected.)

It turns out [the `branch` variable contains the name of the base branch](https://github.com/travis-ci/travis-ci/issues/8767) in the context of Pull Request builds.

### Related question...
I was expecting to see green checkmarks on PRs that were opened after Pull Request builds were enabled on Travis, like this image below, but I don't see them. Could it be that the repo is using [legacy Travis integration](https://travis-ci.community/t/github-status-not-posted-on-commits-on-repositories-using-legacy-service-integration/7798)?  Or something else that needs to be configured? I don't remember having to set anything up separately for those checks to appear when I used Travis in my repos though.

[![](http://cs107e.github.io/assignments/assign0/images/07-pull-request.png)](http://cs107e.github.io/guides/ci/)