### PR TITLE
Update navigator widget docs

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/NavigatorWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/NavigatorWidget.tid
@@ -18,7 +18,7 @@ The navigator widget displays any contained content, and responds to Messages di
 |history |Name of the tiddler containing the history list to be manipulated |
 |openLinkFromInsideRiver |Determines the location for opening new tiddlers from links within the story river: at the ''top'' or ''bottom'' of the story river, or ''above'' or ''below'' the current tiddler |
 |openLinkFromOutsideRiver|Determines the location for opening new tiddlers from linkes outside the story river: at the ''top'' or ''bottom'' of the story river|
-|relinkOnRename|<<.from-version "5.1.14">> Determines if tags in other tiddlers are renamed if the tiddler title changes|
+|relinkOnRename|<<.from-version "5.1.14">> Determines if tags in other tiddlers are renamed if the tiddler title changes. ''yes'' or ''no''. default: ''no''|
 
 ! Widget Messages
 

--- a/editions/tw5.com/tiddlers/widgets/NavigatorWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/NavigatorWidget.tid
@@ -18,6 +18,7 @@ The navigator widget displays any contained content, and responds to Messages di
 |history |Name of the tiddler containing the history list to be manipulated |
 |openLinkFromInsideRiver |Determines the location for opening new tiddlers from links within the story river: at the ''top'' or ''bottom'' of the story river, or ''above'' or ''below'' the current tiddler |
 |openLinkFromOutsideRiver|Determines the location for opening new tiddlers from linkes outside the story river: at the ''top'' or ''bottom'' of the story river|
+|relinkOnRename|<<.from-version "5.1.14">> Determines if tags in other tiddlers are renamed if the tiddler title changes|
 
 ! Widget Messages
 


### PR DESCRIPTION
relinkOnRename was missing since 5.1.14