### PR TITLE
Fix 'if' condition syntax in Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - run: "./bin/test.sh"
   build-prerelease:
     runs-on: ubuntu-latest
-    if: github.ref == "refs/heads/master"
+    if: github.ref == 'refs/heads/master'
     needs: test
     env:
       TW5_BUILD_TIDDLYWIKI: "./tiddlywiki.js"
@@ -45,7 +45,7 @@ jobs:
           TRAVIS_BUILD_NUMBER: ${{ github.run_number }}
   build-tiddlywiki-com:
     runs-on: ubuntu-latest
-    if: github.ref == "refs/heads/tiddlywiki-com"
+    if: github.ref == 'refs/heads/tiddlywiki-com'
     needs: test
     env:
       TW5_BUILD_TIDDLYWIKI: "./node_modules/tiddlywiki/tiddlywiki.js"


### PR DESCRIPTION
#4793 introduced a new GitHub Actions workflow file, and runs are failing with:

> Invalid workflow file
> The workflow is not valid. .github/workflows/ci.yml (Line: 23, Col: 9): Unexpected symbol: '"refs/heads/master"'. Located at position 15 within expression: github.ref == "refs/heads/master",.github/workflows/ci.yml (Line: 48, Col: 9): Unexpected symbol: '"refs/heads/tiddlywiki-com"'. Located at position 15 within expression: github.ref == "refs/heads/tiddlywiki-com"
> https://github.com/Jermolene/TiddlyWiki5/actions/runs/228978450

The reason appears to be that strings in `if` [need to be in single quotes](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#literals), not double quotes. (🤔 I'm not sure why it didn't fail in my repo. Mysterious. -- Edit: because I commented out these `if` conditions in order to test, hah.)