### PR TITLE
Removed bad-character warning

### DIFF
--- a/core/language/en-GB/EditTemplate.multids
+++ b/core/language/en-GB/EditTemplate.multids
@@ -21,7 +21,6 @@ Tags/Add/Button/Hint: add tag
 Tags/Add/Placeholder: tag name
 Tags/Dropdown/Caption: tag list
 Tags/Dropdown/Hint: Show tag list
-Title/BadCharacterWarning: Warning: avoid using any of the characters <<bad-chars>> in tiddler titles
 Title/Exists/Prompt: Target tiddler already exists
 Title/Relink/Prompt: Update ''<$text text=<<fromTitle>>/>'' to ''<$text text=<<toTitle>>/>'' in the //tags// and //list// fields of other tiddlers
 Title/References/Prompt: The following references to this tiddler will not be automatically updated:

--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -3,20 +3,6 @@ tags: $:/tags/EditTemplate
 
 <$edit-text field="draft.title" class="tc-titlebar tc-edit-texteditor" focus={{{ [{$:/config/AutoFocus}match[title]then[true]] ~[[false]] }}} tabindex={{$:/config/EditTabIndex}} cancelPopups="yes"/>
 
-<$vars pattern="""[\|\[\]{}]""" bad-chars="""`| [ ] { }`""">
-
-<$list filter="[all[current]regexp:draft.title<pattern>]" variable="listItem">
-
-<div class="tc-message-box">
-
-{{$:/core/images/warning}} {{$:/language/EditTemplate/Title/BadCharacterWarning}}
-
-</div>
-
-</$list>
-
-</$vars>
-
 <$reveal state="!!draft.title" type="nomatch" text={{!!draft.of}} tag="div">
 
 <$list filter="[{!!draft.title}!is[missing]]" variable="listItem">

--- a/languages/ca-ES/EditTemplate.multids
+++ b/languages/ca-ES/EditTemplate.multids
@@ -21,7 +21,6 @@ Tags/Add/Button/Hint: afegeix una etiqueta
 Tags/Add/Placeholder: nom de l'etiqueta
 Tags/Dropdown/Caption: llista d'etiquetes
 Tags/Dropdown/Hint: Mostra la llista d'etiquetes
-Title/BadCharacterWarning: Avís: eviteu qualsevol dels caràcters <<bad-chars>> al títol d'un tiddler
 Title/Exists/Prompt: El tiddler destinació ja existeix
 Title/References/Prompt: Les referències següents cap aquest tiddler no s'actualitzaran automàticament:
 Title/Relink/Prompt: Actualitza ''<$text text=<<fromTitle>>/>'' cap a ''<$text text=<<toTitle>>/>'' a les //etiquetes// i a la //lista// de camps d'altres tiddlers

--- a/languages/da-DK/EditTemplate.multids
+++ b/languages/da-DK/EditTemplate.multids
@@ -16,7 +16,6 @@ Tags/Add/Button: tilføj
 Tags/Add/Placeholder: tagnavn
 Tags/Dropdown/Caption: tagliste
 Tags/Dropdown/Hint: Vis tagliste
-Title/BadCharacterWarning: Advarsel: undgå alle at bruge nogen af disse bogstaver <<bad-chars>> i tiddler titler
 Type/Delete/Caption: slet indholdstype
 Type/Delete/Hint: Slet indholdstype
 Type/Dropdown/Caption: indholdstypeliste

--- a/languages/de-DE/EditTemplate.multids
+++ b/languages/de-DE/EditTemplate.multids
@@ -21,7 +21,6 @@ Tags/Add/Button/Hint: Erzeuge einen neuen Tag
 Tags/Add/Placeholder: Neuer Tag
 Tags/Dropdown/Caption: Tag Liste
 Tags/Dropdown/Hint: Tag Liste anzeigen
-Title/BadCharacterWarning: Warnung: Folgende Zeichen im Titel können zu Problemen führen: <<bad-chars>>
 Title/Exists/Prompt: Tiddler Name existiert bereits
 Title/Relink/Prompt: Ändere ''<$text text=<<fromTitle>>/>'' -> ''<$text text=<<toTitle>>/>'' in //tags// und //list// Feld aller anderen Tiddler
 Type/Dropdown/Caption: Tiddler Typ Liste

--- a/languages/el-GR/EditTemplate.multids
+++ b/languages/el-GR/EditTemplate.multids
@@ -17,7 +17,6 @@ Tags/Add/Button: προσθήκη
 Tags/Add/Placeholder: όνομα ετικέτας
 Tags/Dropdown/Caption: λίστα ετικετών
 Tags/Dropdown/Hint: Εμφανίζει την λίστα ετικετών
-Title/BadCharacterWarning: Προειδοποίηση: αποφύγετε την χρήση των χαρακτήρων <<bad-chars>> στους τίτλους των tiddler
 Title/Exists/Prompt: Το tiddler προορισμού υπάρχει ήδη
 Title/Relink/Prompt: Ενημερώνει το ''<$text text=<<fromTitle>>/>'' σε ''<$text text=<<toTitle>>/>'' στα πεδία //tags// και //list// των υπολοίπων tiddler
 Type/Delete/Caption: Διέγραψε τον τύπο περιεχομένου

--- a/languages/fa-IR/EditTemplate.multids
+++ b/languages/fa-IR/EditTemplate.multids
@@ -18,7 +18,6 @@ Tags/Add/Button: اضافه کن
 Tags/Add/Placeholder: نام برچسب
 Tags/Dropdown/Caption: لیست برچسب
 Tags/Dropdown/Hint: نمایش لیست برچسب
-Title/BadCharacterWarning: اخطار: از استفاده از هر گونه از کاراکترهای <<bad-chars>> در عنوان تیدلرها خودداری کنید
 Title/Exists/Prompt: تیدلر مورد نظر از قبل وجود دارد
 Title/Relink/Prompt: برروز رسانی کنه ''<$text text=<<fromTitle>>/>'' به ''<$text text=<<toTitle>>/>'' در //برچسب// و //لیست// فضای خالی سایر تیدلرها
 Type/Delete/Caption: پاک کردن نوع محتوا

--- a/languages/fr-FR/EditTemplate.multids
+++ b/languages/fr-FR/EditTemplate.multids
@@ -21,7 +21,6 @@ Tags/Add/Button/Hint: ajoute un tag
 Tags/Add/Placeholder: nom du tag
 Tags/Dropdown/Caption: liste des tags
 Tags/Dropdown/Hint: Montre la liste des tags
-Title/BadCharacterWarning: Attention : il est préférable d'éviter l'usage des caractères <<bad-chars>> dans les titres des tiddlers
 Title/Exists/Prompt: Le tiddler cible existe déjà
 Title/Relink/Prompt: Changer ''<$text text=<<fromTitle>>/>'' en ''<$text text=<<toTitle>>/>'' dans les //tags// et les champs //list// des autres tiddlers
 Title/References/Prompt: Les références suivantes à ce tiddler ne seront pas mises à jour automatiquement :

--- a/languages/he-IL/EditTemplate.multids
+++ b/languages/he-IL/EditTemplate.multids
@@ -17,7 +17,6 @@ Tags/Add/Button: הוסף
 Tags/Add/Placeholder: שם התג
 Tags/Dropdown/Caption: רשימת תגים
 Tags/Dropdown/Hint: הראה רשימת תגים
-Title/BadCharacterWarning: אזהרה: הימנע משימוש בסימנים <<bad-chars>> בשמות טידלרים
 Type/Delete/Caption: מחק סוג תוכן
 Type/Delete/Hint: מחק סוג תוכן
 Type/Dropdown/Caption: רשימת סוגי תוכן

--- a/languages/ko-KR/EditTemplate.multids
+++ b/languages/ko-KR/EditTemplate.multids
@@ -17,7 +17,6 @@ Tags/Add/Button: 추가
 Tags/Add/Placeholder: 태그 이름
 Tags/Dropdown/Caption: 태그 목록
 Tags/Dropdown/Hint: 태그 목록을 보여줍니다
-Title/BadCharacterWarning: 경고: 티들러 제목에 문자 <<bad-chars>> 의 사용은 피하십시오
 Type/Delete/Caption: 내용 형식 삭제
 Type/Delete/Hint: 내용 형식을 삭제합니다
 Type/Dropdown/Caption: 내용 형식 목록

--- a/languages/nl-NL/EditTemplate.multids
+++ b/languages/nl-NL/EditTemplate.multids
@@ -20,7 +20,6 @@ Tags/Add/Button/Hint: voeg label toe
 Tags/Add/Placeholder: labelnaam
 Tags/Dropdown/Caption: labellijst
 Tags/Dropdown/Hint: Toon labellijst
-Title/BadCharacterWarning: Waarschuwing: vermijd elk karakter van <<bad-chars>> in tiddler titels
 Title/Exists/Prompt: Doeltiddler bestaat al
 Title/References/Prompt: De volgende referenties naar deze tiddler worden niet automatisch bijgewerkt:
 Title/Relink/Prompt: Werk ''<$text text=<<fromTitle>>/>'' naar ''<$text text=<<toTitle>>/>'' bij in de //label// en //lijst// velden van andere tiddlers

--- a/languages/pt-BR/EditTemplate.multids
+++ b/languages/pt-BR/EditTemplate.multids
@@ -17,7 +17,6 @@ Tags/Add/Button: adicionar
 Tags/Add/Placeholder: nome do assunto
 Tags/Dropdown/Caption: lista de assuntos
 Tags/Dropdown/Hint: Mostrar a lista de assuntos
-Title/BadCharacterWarning: Atenção: Evite utilizar os caracteres <<bad-chars>> no título de tiddlers
 Title/Exists/Prompt: O Tiddler especificado já existe 
 Title/Relink/Prompt: Substituindo ''<$text text=<<fromTitle>>/>'' por ''<$text text=<<toTitle>>/>'' nas //lista//, //tags// e campos de outros tiddlers
 Type/Delete/Caption: apagar formato de arquivo

--- a/languages/pt-PT/EditTemplate.multids
+++ b/languages/pt-PT/EditTemplate.multids
@@ -19,7 +19,6 @@ Tags/Add/Button: adicionar
 Tags/Add/Placeholder: nome da etiqueta
 Tags/Dropdown/Caption: lista de etiquetas
 Tags/Dropdown/Hint: Mostrar a lista de etiquetas
-Title/BadCharacterWarning: Atenção: Evite utilizar os caracteres <<bad-chars>> no título de tiddlers
 Title/Exists/Prompt: Tiddler alvo já existente
 Title/References/Prompt: As seguintes referências a este tiddler não serão automaticamente actualizadas:
 Title/Relink/Prompt: Actualizar ''<$text text=<<fromTitle>>/>'' para ''<$text text=<<toTitle>>/>'' nas //etiquetas// e nos campos //list// de outros tiddlers

--- a/languages/sl-SI/EditTemplate.multids
+++ b/languages/sl-SI/EditTemplate.multids
@@ -17,7 +17,6 @@ Tags/Add/Button: dodaj
 Tags/Add/Placeholder: ime oznake
 Tags/Dropdown/Caption: seznam oznak
 Tags/Dropdown/Hint: Pokaži seznam oznak
-Title/BadCharacterWarning: Opozorilo: izogibajte se uporabi znakov <<bad-chars>> v naslovih tiddler
 Title/Exists/Prompt: Ciljni tiddler že obstaja
 Title/Relink/Prompt: Spremeni iz ''<$text text=<<fromTitle>>/>'' v ''<$text text=<<toTitle>>/>'' v //oznakah// in //seznamskih// poljih ostalih tiddlerjev
 Type/Delete/Caption: izbriši vrsto vsebine

--- a/languages/zh-Hans/EditTemplate.multids
+++ b/languages/zh-Hans/EditTemplate.multids
@@ -21,7 +21,6 @@ Tags/Add/Button/Hint: 添加标签
 Tags/Add/Placeholder: 标签名称
 Tags/Dropdown/Caption: 标签清单
 Tags/Dropdown/Hint: 显示标签清单
-Title/BadCharacterWarning: 请注意，避免在条目名称中使用这些字符：<<bad-chars>>
 Title/Exists/Prompt: 目标条目已经存在
 Title/Relink/Prompt: 将在其他条目的 //tags// 和 //list// 字段中的 ''<$text text=<<fromTitle>>/>'' 改为 ''<$text text=<<toTitle>>/>''
 Title/References/Prompt: 下列对此条目的引用，不会自动更新：

--- a/languages/zh-Hant/EditTemplate.multids
+++ b/languages/zh-Hant/EditTemplate.multids
@@ -21,7 +21,6 @@ Tags/Add/Button/Hint: 新增標籤
 Tags/Add/Placeholder: 標籤名稱
 Tags/Dropdown/Caption: 標籤清單
 Tags/Dropdown/Hint: 顯示標籤清單
-Title/BadCharacterWarning: 請注意，避免在條目名稱中使用這些字元：<<bad-chars>>
 Title/Exists/Prompt: 目標條目已經存在
 Title/Relink/Prompt: 將在其他條目的 //tags// 和 //list// 欄位中的 ''<$text text=<<fromTitle>>/>'' 改為 ''<$text text=<<toTitle>>/>''
 Title/References/Prompt: 下列對此條目的引用，不會自動更新：


### PR DESCRIPTION
@Jermolene, you once said that you wanted to remove the "bad character warning" that shows up if you use brackets (or some such) in a tiddler title. I don't remember the exact context, but it had to do with other problematic titles I tried to add to the warning while I was building Relink.

But in preparation for its removal, I removed that warning in Relink, and someone is pointing out the inconsistency it now has with core. I either should to put that warning back in, or find out if it ever will be removed from core tiddlywiki.

This pull request will remove it and all associated language strings, if that's the direction you want to go. If not, feel free to reject this PR.

-Flibbles