### PR TITLE
Joining an empty list should return an empty list

### DIFF
--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -90,6 +90,9 @@ function makeStringReducingOperator(fnCalc,initialValue) {
 		source(function(tiddler,title) {
 			result.push(title);
 		});
+		if(result.length === 0) {
+			return [];
+		}
 		return [result.reduce(function(accumulator,currentValue) {
 			return fnCalc(accumulator,currentValue,operator.operand || "");
 		},initialValue) || ""];

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -463,7 +463,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("John Paul George Ringo +[split[e]]").join(",")).toBe("John,Paul,G,org,,Ringo");
 		expect(wiki.filterTiddlers("John Paul George Ringo +[join[ ]split[e]join[ee]split[ ]]").join(",")).toBe("John,Paul,Geeorgee,Ringo");
 		// Ensure that join doesn't return null if passed empty list
-		expect(wiki.filterTiddlers("Test +[butlast[]join[ ]]")).toEqual([""]);
+		expect(wiki.filterTiddlers("Test +[butlast[]join[ ]]")).toEqual([]);
 		// Ensure that join correctly handles empty strings in source
 		expect(wiki.filterTiddlers("[[]] Paul +[join[-]]").join(",")).toBe("-Paul");
 		expect(wiki.filterTiddlers("[[ John ]] [[Paul ]] [[ George]] Ringo +[trim[]join[-]]").join(",")).toBe("John-Paul-George-Ringo");


### PR DESCRIPTION
Fixes #4852.

Note that this changes behavior introduced in TiddlyWiki 5.1.22 by https://github.com/Jermolene/TiddlyWiki5/pull/4396. Specifically, #4396 made join return `[""]` (a list containing a single empty string) if passed an empty input list, while this PR makes join return `[]` (an empty list) if passed an empty input list. Before #4396, join would return `[null]` (a list containing a single null) on empty input, which was causing Red Screen of Death errors. While returning `[""]` does stop the crashes, I believe that it's not what users would expect, and users would expect join to return an empty list when given empty input.

I would also like code-style comments: I've written `if(result.length === 0) return [];` as a single line here. Should I instead write this with braces? It seems short enough to merit a one-liner, but some people don't like that.