### PR TITLE
Gitea API wants tokens, not HTTP basic auth

### DIFF
--- a/core/modules/savers/gitea.js
+++ b/core/modules/savers/gitea.js
@@ -31,7 +31,7 @@ GiteaSaver.prototype.save = function(text,method,callback) {
 		headers = {
 			"Accept": "application/json",
 			"Content-Type": "application/json;charset=UTF-8",
-			"Authorization": "Basic " + window.btoa(username + ":" + password)
+			"Authorization": "token " + password
 		};
 	// Bail if we don't have everything we need
 	if(!username || !password || !repo || !filename) {


### PR DESCRIPTION
This should fix #4837. Note that I have not been able to test this myself as I don't have a Gitea setup. I've read the Gitea API docs and this *should* be the correct way to pass authentication tokens to Gitea, but someone will need to test this.