### PR TITLE
fix: add tc-tiddlylink-external to markdown links

### DIFF
--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -118,6 +118,7 @@ function convertNodes(remarkableTree, isStartOfInline) {
 				if (currentNode.href[0] !== "#") {
 					// External link
 					var attributes = {
+						class: { type: "string", value: "tc-tiddlylink-external" },
 						href: { type: "string", value: currentNode.href }
 					};
 					if (pluginOpts.linkNewWindow) {


### PR DESCRIPTION
Fix #4861 