### PR TITLE
Change description for Filesystem and TiddlyWeb plugins

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -9,7 +9,7 @@ Adds tiddler filtering methods to the $tw.Wiki object.
 (function(){
 
 /*jslint node: true, browser: true */
-/*global $tw: false */
+/*global $tw, console, exports */
 "use strict";
 
 /*

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -9,7 +9,7 @@ Adds tiddler filtering methods to the $tw.Wiki object.
 (function(){
 
 /*jslint node: true, browser: true */
-/*global $tw, console, exports */
+/*global $tw:false */
 "use strict";
 
 /*
@@ -82,7 +82,7 @@ function parseFilterOperation(operators,filterString,p) {
 				if(rexMatch) {
 					operator.regexp = new RegExp(rexMatch[1], rexMatch[2]);
 // DEPRECATION WARNING
-console.log("\nWARNING: Filter",operator.operator,"has a deprecated regexp operand",operator.regexp);
+console.log("WARNING: Filter",operator.operator,"has a deprecated regexp operand",operator.regexp);
 					nextBracketPos = p + rex.lastIndex - 1;
 				}
 				else {

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -9,7 +9,7 @@ Adds tiddler filtering methods to the $tw.Wiki object.
 (function(){
 
 /*jslint node: true, browser: true */
-/*global $tw:false */
+/*global $tw: false */
 "use strict";
 
 /*

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -82,7 +82,7 @@ function parseFilterOperation(operators,filterString,p) {
 				if(rexMatch) {
 					operator.regexp = new RegExp(rexMatch[1], rexMatch[2]);
 // DEPRECATION WARNING
-console.log("WARNING: Filter",operator.operator,"has a deprecated regexp operand",operator.regexp);
+console.log("\nWARNING: Filter",operator.operator,"has a deprecated regexp operand",operator.regexp);
 					nextBracketPos = p + rex.lastIndex - 1;
 				}
 				else {

--- a/plugins/tiddlywiki/filesystem/plugin.info
+++ b/plugins/tiddlywiki/filesystem/plugin.info
@@ -1,6 +1,6 @@
 {
 	"title": "$:/plugins/tiddlywiki/filesystem",
 	"name": "Filesystem",
-	"description": "Synchronise changes to the local filesystem",
+	"description": "Synchronize changes from the node.js server to the local filesystem",
 	"list": "readme"
 }

--- a/plugins/tiddlywiki/tiddlyweb/plugin.info
+++ b/plugins/tiddlywiki/tiddlyweb/plugin.info
@@ -1,7 +1,7 @@
 {
 	"title": "$:/plugins/tiddlywiki/tiddlyweb",
 	"name": "TiddlyWeb",
-	"description": "Sync changes to TW5 server or TiddlyWeb server",
+	"description": "Sync changes from the browser to TW5 (node.js) or TiddlyWeb server",
 	"list": "readme",
 	"plugin-priority": 10
 }


### PR DESCRIPTION
[Quote from GG](https://groups.google.com/d/msg/tiddlywiki/cHv4bWvZo00/3Aa6kuTFBgAJ)

So this just cost me about 3 hours and I was really lucky to lose only a few changes to tiddlers.

The plugin is described as "Synchronise changes to the local filesystem" so I thought it had something to do with running TW locally as a single file. But it's actually the mechanism that the node server uses to save tiddlers.

The insidious thing is that it only becomes effective the next time the server is restarted - which could be months after you made the change in the settings and have forgotten about it completely. And then you still don't notice anything wrong because the server keeps changes in memory - until you restart it the next time and all changes in between are lost!

I think it would be a good idea at minimum to change the plugin description, or even make it impossible to disable.

----------

This PR should make the dataflow more obvious. 