### PR TITLE
Fix #4826 - Keyboard-driven-inputs clashes with customized search results.

### DIFF
--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -67,8 +67,8 @@ Shortcuts/Input/Accept/Hint: Accept the selected item
 Shortcuts/Input/AcceptVariant/Hint: Accept the selected item (variant)
 Shortcuts/Input/Cancel/Hint: Clear the input field
 Shortcuts/Input/Down/Hint: Select the next item
-Shortcuts/Input/Tab-Left/Hint: Select the next Tab
-Shortcuts/Input/Tab-Right/Hint: Select the previous Tab
+Shortcuts/Input/Tab-Left/Hint: Select the previous Tab
+Shortcuts/Input/Tab-Right/Hint: Select the next Tab
 Shortcuts/Input/Up/Hint: Select the previous item
 SystemTiddler/Tooltip: This is a system tiddler
 SystemTiddlers/Include/Prompt: Include system tiddlers

--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -67,6 +67,8 @@ Shortcuts/Input/Accept/Hint: Accept the selected item
 Shortcuts/Input/AcceptVariant/Hint: Accept the selected item (variant)
 Shortcuts/Input/Cancel/Hint: Clear the input field
 Shortcuts/Input/Down/Hint: Select the next item
+Shortcuts/Input/Tab-Left/Hint: Select the next Tab
+Shortcuts/Input/Tab-Right/Hint: Select the previous Tab
 Shortcuts/Input/Up/Hint: Select the previous item
 SystemTiddler/Tooltip: This is a system tiddler
 SystemTiddlers/Include/Prompt: Include system tiddlers

--- a/core/ui/DefaultSearchResultList.tid
+++ b/core/ui/DefaultSearchResultList.tid
@@ -1,22 +1,28 @@
 title: $:/core/ui/DefaultSearchResultList
 tags: $:/tags/SearchResults
 caption: {{$:/language/Search/DefaultResults/Caption}}
+first-search-filter: [!is[system]search:title<userInput>sort[title]limit[250]]
+second-search-filter: [!is[system]search<userInput>sort[title]limit[250]]
 
 \define searchResultList()
 //<small>{{$:/language/Search/Matches/Title}}</small>//
 
-<$list filter="[!is[system]search:title{$(searchTiddler)$}sort[title]limit[250]]">
+<$list filter="[<userInput>minlength[1]]" variable="ignore">
+<$list filter={{{ [<configTiddler>get[first-search-filter]] }}}>
 <span class={{{[<currentTiddler>addsuffix[-primaryList]] -[<searchListState>get[text]] +[then[]else[tc-list-item-selected]] }}}>
 <$transclude tiddler="$:/core/ui/ListItemTemplate"/>
 </span>
 </$list>
+</$list>
 
 //<small>{{$:/language/Search/Matches/All}}</small>//
 
-<$list filter="[!is[system]search{$(searchTiddler)$}sort[title]limit[250]]">
+<$list filter="[<userInput>minlength[1]]" variable="ignore">
+<$list filter={{{ [<configTiddler>get[second-search-filter]] }}}>
 <span class={{{[<currentTiddler>addsuffix[-secondaryList]] -[<searchListState>get[text]] +[then[]else[tc-list-item-selected]] }}}>
 <$transclude tiddler="$:/core/ui/ListItemTemplate"/>
 </span>
+</$list>
 </$list>
 
 \end

--- a/core/ui/SearchResults.tid
+++ b/core/ui/SearchResults.tid
@@ -1,5 +1,3 @@
-title: $:/core/ui/SearchResults
-
 <div class="tc-search-results">
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]butfirst[]limit[1]]" emptyMessage="""
@@ -8,7 +6,7 @@ title: $:/core/ui/SearchResults
 </$list>
 """>
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]" default={{$:/config/SearchResults/Default}}/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]" default={{$:/config/SearchResults/Default}} actions="""<$action-setfield $tiddler="$:/state/search/currentTab" text=<<currentTab>>/>""" />
 
 </$list>
 

--- a/core/ui/SearchResults.tid
+++ b/core/ui/SearchResults.tid
@@ -1,3 +1,5 @@
+title: $:/core/ui/SearchResults
+
 <div class="tc-search-results">
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]butfirst[]limit[1]]" emptyMessage="""
@@ -6,7 +8,7 @@
 </$list>
 """>
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]" default={{$:/config/SearchResults/Default}} actions="""<$action-setfield $tiddler="$:/state/search/currentTab" text=<<currentTab>>/>""" />
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]" default={{$:/config/SearchResults/Default}} actions="""<$action-setfield $tiddler="$:/state/search/currentTab" text=<<currentTab>>/>""" explicitState="$:/state/tab/search-results/sidebar"/>
 
 </$list>
 

--- a/core/ui/SideBarSegments/search.tid
+++ b/core/ui/SideBarSegments/search.tid
@@ -45,12 +45,16 @@ tags: $:/tags/SideBarSegment
 <$vars configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}} searchTiddler="$:/temp/search/input" searchListState=<<qualify "$:/state/search-list/selected-item">>>
 <$vars titleSearchFilter={{{ [<configTiddler>get[first-search-filter]] }}} allSearchFilter={{{ [<configTiddler>get[second-search-filter]] }}}>
 <div class="tc-search">
+<$keyboard key="((input-tabs-right))" actions="""<$macrocall $name="change-input-tab" stateTitle="$:/state/tab/search-results/sidebar" tag="$:/tags/SearchResults" beforeafter="after" defaultState={{$:/config/SearchResults/Default}}/>""">
+<$keyboard key="((input-tabs-left))" actions="""<$macrocall $name="change-input-tab" stateTitle="$:/state/tab/search-results/sidebar" tag="$:/tags/SearchResults" beforeafter="before" defaultState={{$:/config/SearchResults/Default}}/>""">
 <$macrocall $name="keyboard-driven-input" tiddler="$:/temp/search" storeTitle=<<searchTiddler>> 
 		selectionStateTitle=<<searchListState>> refreshTitle="$:/temp/search/refresh" type="search" 
 		tag="input" focus={{$:/config/Search/AutoFocus}} focusPopup=<<qualify "$:/state/popup/search-dropdown">> 
 		class="tc-popup-handle" primaryListFilter=<<titleSearchFilter>> secondaryListFilter=<<allSearchFilter>> 
 		filterMinLength={{$:/config/Search/MinLength}} inputCancelActions=<<cancel-search-actions>> 
 		inputAcceptActions=<<input-accept-actions>> inputAcceptVariantActions=<<input-accept-variant-actions>> cancelPopups="yes" />
+</$keyboard>
+</$keyboard>
 <$reveal state=<<searchTiddler>> type="nomatch" text="">
 <$button tooltip={{$:/language/Buttons/AdvancedSearch/Hint}} aria-label={{$:/language/Buttons/AdvancedSearch/Caption}} class="tc-btn-invisible">
 <$action-setfield $tiddler="$:/temp/advancedsearch" text={{$:/temp/search}}/>

--- a/core/ui/SideBarSegments/search.tid
+++ b/core/ui/SideBarSegments/search.tid
@@ -19,11 +19,17 @@ tags: $:/tags/SideBarSegment
 
 \define search-results-list()
 \whitespace trim
-<$list filter="[{$(searchTiddler)$}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
+<$set name="userInput" value={{$(searchTiddler)$}}>
+<$list filter="[<userInput>minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
+
+<$tiddler tiddler="$(configTiddler)$">
 
 {{$:/core/ui/SearchResults}}
 
+</$tiddler>
+
 </$list>
+</$set>
 \end
 
 \define delete-state-tiddlers() <$action-deletetiddler $filter="[[$:/temp/search]] [<searchTiddler>] [<searchListState>]"/>
@@ -36,7 +42,8 @@ tags: $:/tags/SideBarSegment
 
 <div class="tc-sidebar-lists tc-sidebar-search">
 
-<$vars searchTiddler="$:/temp/search/input" searchListState=<<qualify "$:/state/search-list/selected-item">> titleSearchFilter="[!is[system]search:title<userInput>sort[title]limit[250]]" allSearchFilter="[!is[system]search<userInput>sort[title]limit[250]]">
+<$vars configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}} searchTiddler="$:/temp/search/input" searchListState=<<qualify "$:/state/search-list/selected-item">>>
+<$vars titleSearchFilter={{{ [<configTiddler>get[first-search-filter]] }}} allSearchFilter={{{ [<configTiddler>get[second-search-filter]] }}}>
 <div class="tc-search">
 <$macrocall $name="keyboard-driven-input" tiddler="$:/temp/search" storeTitle=<<searchTiddler>> 
 		selectionStateTitle=<<searchListState>> refreshTitle="$:/temp/search/refresh" type="search" 
@@ -73,6 +80,8 @@ tags: $:/tags/SideBarSegment
 </$reveal>
 
 </$reveal>
+
+</$vars>
 
 </$vars>
 

--- a/core/ui/SideBarSegments/search.tid
+++ b/core/ui/SideBarSegments/search.tid
@@ -40,13 +40,15 @@ tags: $:/tags/SideBarSegment
 
 \define input-accept-variant-actions() <$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/>
 
+\define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/search-results/sidebar" tag="$:/tags/SearchResults" beforeafter="$beforeafter$" defaultState={{$:/config/SearchResults/Default}} actions="""<$action-setfield $tiddler="$:/state/search/currentTab" text=<<nextTab>>/>"""/>
+
 <div class="tc-sidebar-lists tc-sidebar-search">
 
 <$vars configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}} searchTiddler="$:/temp/search/input" searchListState=<<qualify "$:/state/search-list/selected-item">>>
 <$vars titleSearchFilter={{{ [<configTiddler>get[first-search-filter]] }}} allSearchFilter={{{ [<configTiddler>get[second-search-filter]] }}}>
 <div class="tc-search">
-<$keyboard key="((input-tabs-right))" actions="""<$macrocall $name="change-input-tab" stateTitle="$:/state/tab/search-results/sidebar" tag="$:/tags/SearchResults" beforeafter="after" defaultState={{$:/config/SearchResults/Default}}/>""">
-<$keyboard key="((input-tabs-left))" actions="""<$macrocall $name="change-input-tab" stateTitle="$:/state/tab/search-results/sidebar" tag="$:/tags/SearchResults" beforeafter="before" defaultState={{$:/config/SearchResults/Default}}/>""">
+<$keyboard key="((input-tabs-right))" actions=<<set-next-input-tab>>>
+<$keyboard key="((input-tabs-left))" actions=<<set-next-input-tab "before">>>
 <$macrocall $name="keyboard-driven-input" tiddler="$:/temp/search" storeTitle=<<searchTiddler>> 
 		selectionStateTitle=<<searchListState>> refreshTitle="$:/temp/search/refresh" type="search" 
 		tag="input" focus={{$:/config/Search/AutoFocus}} focusPopup=<<qualify "$:/state/popup/search-dropdown">> 

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -15,6 +15,8 @@ input-accept: {{$:/language/Shortcuts/Input/Accept/Hint}}
 input-accept-variant: {{$:/language/Shortcuts/Input/AcceptVariant/Hint}}
 input-cancel: {{$:/language/Shortcuts/Input/Cancel/Hint}}
 input-down: {{$:/language/Shortcuts/Input/Down/Hint}}
+input-tab-left: {{$:/language/Shortcuts/Input/Tab-Left/Hint}}
+input-tab-right: {{$:/language/Shortcuts/Input/Tab-Right/Hint}}
 input-up: {{$:/language/Shortcuts/Input/Up/Hint}}
 italic: {{$:/language/Buttons/Italic/Hint}}
 link: {{$:/language/Buttons/Link/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -15,6 +15,8 @@ input-accept: Enter
 input-accept-variant: Alt-Enter
 input-cancel: Escape
 input-down: Down
+input-tab-left: alt-Left
+input-tab-right: alt-Right
 input-up: Up
 link: ctrl-L
 linkify: alt-shift-L

--- a/core/wiki/macros/keyboard-driven-input.tid
+++ b/core/wiki/macros/keyboard-driven-input.tid
@@ -1,11 +1,12 @@
 title: $:/core/macros/keyboard-driven-input
 tags: $:/tags/Macro
 
-\define change-input-tab(stateTitle,tag,beforeafter,defaultState)
+\define change-input-tab(stateTitle,tag,beforeafter,defaultState,actions)
 <$set name="tabsList" filter="[all[shadows+tiddlers]tag<__tag__>!has[draft.of]]">
 <$vars currentState={{{ [<__stateTitle__>!is[missing]get[text]] ~[<__defaultState__>] }}} firstTab={{{ [enlist<tabsList>nth[1]] }}} lastTab={{{ [enlist<tabsList>last[]] }}}>
 <$set name="nextTab" value={{{ [all[shadows+tiddlers]tag<__tag__>!has[draft.of]$beforeafter$<currentState>] ~[[$beforeafter$]removeprefix[after]suffix[]addprefix<firstTab>] ~[[$beforeafter$]removeprefix[before]suffix[]addprefix<lastTab>] }}}>
 <$action-setfield $tiddler=<<__stateTitle__>> text=<<nextTab>>/>
+$actions$
 </$set>
 </$vars>
 </$set>

--- a/core/wiki/macros/keyboard-driven-input.tid
+++ b/core/wiki/macros/keyboard-driven-input.tid
@@ -1,6 +1,16 @@
 title: $:/core/macros/keyboard-driven-input
 tags: $:/tags/Macro
 
+\define change-input-tab(stateTitle,tag,beforeafter,defaultState)
+<$set name="tabsList" filter="[all[shadows+tiddlers]tag<__tag__>!has[draft.of]]">
+<$vars currentState={{{ [<__stateTitle__>!is[missing]get[text]] ~[<__defaultState__>] }}} firstTab={{{ [enlist<tabsList>nth[1]] }}} lastTab={{{ [enlist<tabsList>last[]] }}}>
+<$set name="nextTab" value={{{ [all[shadows+tiddlers]tag<__tag__>!has[draft.of]$beforeafter$<currentState>] ~[[$beforeafter$]removeprefix[after]suffix[]addprefix<firstTab>] ~[[$beforeafter$]removeprefix[before]suffix[]addprefix<lastTab>] }}}>
+<$action-setfield $tiddler=<<__stateTitle__>> text=<<nextTab>>/>
+</$set>
+</$vars>
+</$set>
+\end
+
 \define keyboard-input-actions()
 <$list filter="[<__index__>match[]]">
 <$action-setfield $tiddler=<<__storeTitle__>> text={{{ [<__tiddler__>get<__field__>] }}}/>

--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -1,11 +1,12 @@
 title: $:/core/macros/tabs
 tags: $:/tags/Macro
 
-\define tabs(tabsList,default,state:"$:/state/tab",class,template,buttonTemplate,retain,actions)
+\define tabs(tabsList,default,state:"$:/state/tab",class,template,buttonTemplate,retain,actions,explicitState)
+<$set name="qualifiedState" value=<<qualify "$state$">>>
+<$set name="tabsState" filter="[<__explicitState__>minlength[1]] ~[<qualifiedState>]">
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
-<$list filter="$tabsList$" variable="currentTab" storyview="pop"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
-$actions$
+<$list filter="$tabsList$" variable="currentTab" storyview="pop"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<tabsState>> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
 <$tiddler tiddler=<<save-currentTiddler>>>
 <$set name="tv-wikilinks" value="no">
 <$transclude tiddler="$buttonTemplate$" mode="inline">
@@ -13,13 +14,13 @@ $actions$
 <$macrocall $name="currentTab" $type="text/plain" $output="text/plain"/>
 </$transclude>
 </$transclude>
-</$set></$tiddler></$button></$tiddler></$set></$list>
+</$set></$tiddler>$actions$</$button></$tiddler></$set></$list>
 </div>
 <div class="tc-tab-divider $class$"/>
 <div class="tc-tab-content $class$">
 <$list filter="$tabsList$" variable="currentTab">
 
-<$reveal type="match" state=<<qualify "$state$">> text=<<currentTab>> default="$default$" retain="""$retain$""">
+<$reveal type="match" state=<<tabsState>> text=<<currentTab>> default="$default$" retain="""$retain$""">
 
 <$transclude tiddler="$template$" mode="block">
 
@@ -32,4 +33,6 @@ $actions$
 </$list>
 </div>
 </div>
+</$set>
+</$set>
 \end

--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -1,10 +1,11 @@
 title: $:/core/macros/tabs
 tags: $:/tags/Macro
 
-\define tabs(tabsList,default,state:"$:/state/tab",class,template,buttonTemplate,retain)
+\define tabs(tabsList,default,state:"$:/state/tab",class,template,buttonTemplate,retain,actions)
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
 <$list filter="$tabsList$" variable="currentTab" storyview="pop"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<qualify "$state$">> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
+$actions$
 <$tiddler tiddler=<<save-currentTiddler>>>
 <$set name="tv-wikilinks" value="no">
 <$transclude tiddler="$buttonTemplate$" mode="inline">


### PR DESCRIPTION
This PR fixes the problem with customized search results and the keyboard-driven-input macro.

There's some documentation needed, that will follow in a second PR