### PR TITLE
support save into BitBucket "Downloads" section

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -115,6 +115,9 @@ Saving/GitService/GitLab/Caption: ~GitLab Saver
 Saving/GitService/GitLab/Password: Personal access token for API (see [[GitLab help page|https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html]] for details)
 Saving/GitService/Gitea/Caption: Gitea Saver
 Saving/GitService/Gitea/Password: Personal access token for API (via Gitea’s web interface: `Settings | Applications | Generate New Token`)
+Saving/GitService/BitBucket/Caption: BitBucket
+Saving/GitService/BitBucket/Description: These settings are only used when saving to ~BitBucket. The file will be saved as a downloadable artifact and will be available in the "Downloads" section of the repo
+Saving/GitService/BitBucket/Password: Password or ~AppPassword for your ~BitBucket account
 Saving/TiddlySpot/Advanced/Heading: Advanced Settings
 Saving/TiddlySpot/BackupDir: Backup Directory
 Saving/TiddlySpot/ControlPanel: ~TiddlySpot Control Panel

--- a/core/modules/savers/bitbucket.js
+++ b/core/modules/savers/bitbucket.js
@@ -1,0 +1,99 @@
+/*\
+title: $:/core/modules/savers/bitbucket.js
+type: application/javascript
+module-type: saver
+
+Saves wiki by pushing a commit to the BitBucket REST API
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Select the appropriate saver module and set it up
+*/
+var BitBucketSaver = function(wiki) {
+	this.wiki = wiki;
+
+	this._getBitbucketErrorMessage = function(response) {
+	    var errorMessage;
+        if(response) {
+            var errResponseData;
+            try {
+                errResponseData = JSON.parse(response);
+                if (errResponseData.hasOwnProperty("error") && errResponseData.error.hasOwnProperty("message")) {
+                    errorMessage = errResponseData.error.message;
+                }
+            } catch (e) {
+                // ignore
+            }
+        }
+        return errorMessage;
+    }
+};
+
+    BitBucketSaver.prototype.save = function(text,method,callback) {
+	var self = this,
+		username = this.wiki.getTiddlerText("$:/BitBucket/Username"),
+		password = $tw.utils.getPassword("bitbucket"),
+		repo = this.wiki.getTiddlerText("$:/BitBucket/Repo"),
+		filename = this.wiki.getTiddlerText("$:/BitBucket/Filename"),
+		endpoint = this.wiki.getTiddlerText("$:/BitBucket/ServerURL","https://bitbucket.org"),
+		headers = {
+			"Accept": "application/json",
+			"Authorization": "Basic " + window.btoa(username + ":" + password)
+		};
+	// Bail if we don't have everything we need
+	if(!username || !password || !repo || !filename || !endpoint) {
+		return false;
+	}
+    // Compose the base URI
+    var uri = endpoint + "/api/2.0/repositories/" + repo;
+	var data = new FormData();
+	data.append("files", new Blob([text]), filename);
+	$tw.utils.httpRequest({
+		url: uri + "/downloads",
+		type: "POST",
+		headers: headers,
+        data: data,
+        callback: function(err,postResponseDataJson,xhr) {
+            if(err || xhr.status !== 201) {
+                var errorMessage = self._getBitbucketErrorMessage(xhr.response);
+                if(errorMessage) {
+                    return callback(errorMessage);
+                }
+                return callback(err);
+            }
+            callback(null);
+		}
+	});
+	return true;
+};
+
+/*
+Information about this saver
+*/
+BitBucketSaver.prototype.info = {
+	name: "bitbucket",
+	priority: 2000,
+	capabilities: ["save", "autosave"]
+};
+
+/*
+Static method that returns true if this saver is capable of working
+*/
+exports.canSave = function(wiki) {
+	return true;
+};
+
+/*
+Create an instance of this saver
+*/
+exports.create = function(wiki) {
+	return new BitBucketSaver(wiki);
+};
+
+})();

--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -40,7 +40,13 @@ exports.httpRequest = function(options) {
 		f,results;
 	// Massage the data hashmap into a string
 	if(options.data) {
-		if(typeof options.data === "string") { // Already a string
+	    if(options.data instanceof FormData) {
+	        if(hasHeader("Content-Type")) {
+                delete headers["Content-Type"]; // this will be handled automatically by the browser
+            }
+            data = options.data;
+        }
+		else if(typeof options.data === "string") { // Already a string
 			data = options.data;
 		} else { // A hashmap of strings
 			results = [];
@@ -73,7 +79,7 @@ exports.httpRequest = function(options) {
 			request.setRequestHeader(headerTitle,header);
 		});
 	}
-	if(data && !hasHeader("Content-Type")) {
+	if(data && !hasHeader("Content-Type") && !(data instanceof FormData)) {
 		request.setRequestHeader("Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
 	}
 	if(!hasHeader("X-Requested-With")) {

--- a/core/ui/ControlPanel/Saving/BitBucket.tid
+++ b/core/ui/ControlPanel/Saving/BitBucket.tid
@@ -1,0 +1,14 @@
+title: $:/core/ui/ControlPanel/Saving/BitBucket
+tags: $:/tags/ControlPanel/Saving
+caption: {{$:/language/ControlPanel/Saving/GitService/BitBucket/Caption}}
+
+\define lingo-base() $:/language/ControlPanel/Saving/GitService/
+\define service-name() ~BitBucket
+
+<<lingo BitBucket/Description>>
+
+|<<lingo UserName>> |<$edit-text tiddler="$:/BitBucket/Username" default="" tag="input"/> |
+|<<lingo BitBucket/Password>> |<$password name="bitbucket"/> |
+|<<lingo Repo>> |<$edit-text tiddler="$:/BitBucket/Repo" default="" tag="input"/> |
+|<<lingo Filename>> |<$edit-text tiddler="$:/BitBucket/Filename" default="" tag="input"/> |
+|<<lingo ServerURL>> |<$edit-text tiddler="$:/BitBucket/ServerURL" default="https://bitbucket.org" tag="input"/> |


### PR DESCRIPTION
As noted in https://github.com/Jermolene/TiddlyWiki5/pull/3931 BitBucket doesn't support pushing files into the repo through REST API. But what it does support is the upload of files as repository artifacts, and this is what this saver uses to store the wiki.

The file uploaded in this way won't be versioned by git so every time we save it will be overwritten and it won't be possible to see past versions, but it will be stored and be available in the "Downloads" section of the BitBucket repository.