### PR TITLE
Simplify ci-push.sh: end script on any error

### DIFF
--- a/bin/ci-push.sh
+++ b/bin/ci-push.sh
@@ -2,19 +2,14 @@
 
 # Push output back to GitHub
 
+# Exit script immediately if any command fails
+set -e
 
-cd output || exit 1
-
-git config --global user.email "actions@github.com" || exit 1
-
-git config --global user.name "GitHub Actions" || exit 1
-
-git add -A . || exit 1
-
-git commit --message "GitHub build: $GITHUB_RUN_NUMBER of $TW5_BUILD_BRANCH ($(date +'%F %T %Z'))" || exit 1
-
-git remote add deploy "https://$GH_TOKEN@github.com/Jermolene/jermolene.github.io.git" &>/dev/null || exit 1
-
-git push deploy master &>/dev/null || exit 1
-
-cd .. || exit 1
+cd output
+git config --global user.email "actions@github.com"
+git config --global user.name "GitHub Actions"
+git add -A .
+git commit --message "GitHub build: $GITHUB_RUN_NUMBER of $TW5_BUILD_BRANCH ($(date +'%F %T %Z'))"
+git remote add deploy "https://$GH_TOKEN@github.com/Jermolene/jermolene.github.io.git" &>/dev/null
+git push deploy master &>/dev/null
+cd ..


### PR DESCRIPTION
Use the bash `set -e` option to exit the script immediately if any command returns a non-zero error code, so putting `|| exit 1` at the end of each command is not needed.

As a bonus, this lets us get the actual return code from any failures, instead of the return code always being 1 when something goes wrong. Depending on which command failed, the return code might be meaningful and help with debugging the process.