### PR TITLE
Make test harness exit with a non-zero code when there's test failure

### DIFF
--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -70,8 +70,10 @@ exports.startup = function() {
 	// that is shared between browser and Node.js environments. Browser-specific
 	// and Node-specific modules are loaded next.
 	var jasmineCore = evalInContext("$:/plugins/tiddlywiki/jasmine/jasmine-core/jasmine-core/jasmine.js");
-	// Get the Jasmine instance and configure reporters
+	// The core Jasmine instance
 	var jasmine;
+	// Node.js wrapper for calling `.execute()`
+	var nodeJasmineWrapper;
 	if($tw.browser) {
 		window.jasmineRequire = jasmineCore;
 		$tw.modules.execute("$:/plugins/tiddlywiki/jasmine/jasmine-core/jasmine-core/jasmine-html.js");
@@ -107,7 +109,7 @@ exports.startup = function() {
 		context.process = process;
 
 		var NodeJasmine = evalInContext("$:/plugins/tiddlywiki/jasmine/jasmine/jasmine.js");
-		var nodeJasmineWrapper = new NodeJasmine({jasmineCore: jasmineCore});
+		nodeJasmineWrapper = new NodeJasmine({jasmineCore: jasmineCore});
 		nodeJasmineWrapper.configureDefaultReporter({});
 		jasmine = nodeJasmineWrapper.jasmine;
 	}
@@ -123,7 +125,7 @@ exports.startup = function() {
 	// In a browser environment, jasmine-core/boot.js calls `execute()` for us.
 	// In Node.js, we call it manually.
 	if(!$tw.browser) {
-		env.execute();
+		nodeJasmineWrapper.execute();
 	}
 };
 

--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -92,10 +92,10 @@ exports.startup = function() {
 		// 'jasmine/jasmine.js' references `process.exit`
 		context.process = process;
 
-		var JasmineNode = evalInContext("$:/plugins/tiddlywiki/jasmine/jasmine/jasmine.js");
-		var jasmineRunner = new JasmineNode({jasmineCore: jasmineCore});
-		jasmineRunner.configureDefaultReporter({});
-		jasmine = jasmineRunner.jasmine;
+		var NodeJasmine = evalInContext("$:/plugins/tiddlywiki/jasmine/jasmine/jasmine.js");
+		var nodeJasmineWrapper = new NodeJasmine({jasmineCore: jasmineCore});
+		nodeJasmineWrapper.configureDefaultReporter({});
+		jasmine = nodeJasmineWrapper.jasmine;
 	}
 	// Add Jasmine's DSL to our context
 	var env = jasmine.getEnv();

--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -110,7 +110,6 @@ exports.startup = function() {
 
 		var NodeJasmine = evalInContext("$:/plugins/tiddlywiki/jasmine/jasmine/jasmine.js");
 		nodeJasmineWrapper = new NodeJasmine({jasmineCore: jasmineCore});
-		nodeJasmineWrapper.configureDefaultReporter({});
 		jasmine = nodeJasmineWrapper.jasmine;
 	}
 	// Add Jasmine's DSL to our context

--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -112,7 +112,7 @@ exports.startup = function() {
 		jasmineCore.files = {
 			path: "$:/plugins/tiddlywiki/jasmine/jasmine-core/jasmine-core"
 		};
-		// 'jasmine/jasmine.js' references `process.exit`
+		// 'jasmine/jasmine.js' references `process.exit`, among other properties
 		context.process = process;
 
 		var NodeJasmine = evalInContext("$:/plugins/tiddlywiki/jasmine/jasmine/jasmine.js");

--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -16,6 +16,13 @@ var TEST_TIDDLER_FILTER = "[type[application/javascript]tag[$:/tags/test-spec]]"
 
 /*
 Startup function for running tests
+
+Below, paths like jasmine-core/jasmine.js refer to files in the 'jasmine-core' npm
+package, whose repository is https://github.com/jasmine/jasmine.
+Paths like jasmine/jasmine.js refer to files in the 'jasmine' npm package, whose
+repository is https://github.com/jasmine/jasmine-npm.
+
+They're all locally checked into the `./files` directory.
 */
 exports.startup = function() {
 	// Set up a shared context object.


### PR DESCRIPTION
Fixes the issue demonstrated by #4869

I believe I sowed the seed for this when I upgraded the jasmine plugin to use Jasmine 3.

What the test harness should've been doing is to call [`Jasmine.prototype.execute()`](https://github.com/jasmine/jasmine-npm/blob/v3.4.0/lib/jasmine.js#L235), which sets up completion callbacks, instead of `env.execute()`, which is a code path shared between both browser and node.

[Here's a check run that failed due to an artificially introduced test failure,](https://github.com/ento/TiddlyWiki5/pull/1/checks?check_run_id=1233895566) based on this branch.

### Review requests
- Would there be any issue in letting Jasmine [call `process.exit()`](https://github.com/jasmine/jasmine-npm/blob/v3.4.0/lib/jasmine.js#L218-L221) in a startup module? Could tests depend on a startup module that was scheduled to run _after_ jasmine's startup module?
  - If it can be problematic, overriding `process.exit` with a function that only sets `process.exitCode` could be a workaround, or making jasmine's startup module run last if possible. (or make it an asynchronous startup module?)