### PR TITLE
Update syncFilter to allow excluding multiple storyLists, historyLists and import tiddlers

### DIFF
--- a/core/wiki/config/SyncFilter.tid
+++ b/core/wiki/config/SyncFilter.tid
@@ -1,3 +1,3 @@
 title: $:/config/SyncFilter
 
-[is[tiddler]] -[[$:/core]] -[[$:/StoryList]] -[[$:/HistoryList]] -[[$:/Import]] -[[$:/isEncrypted]] -[prefix[$:/status/]] -[prefix[$:/state/]] -[prefix[$:/temp/]]
+[is[tiddler]] -[[$:/core]] -[prefix[$:/StoryList]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/isEncrypted]] -[prefix[$:/status/]] -[prefix[$:/state/]] -[prefix[$:/temp/]]


### PR DESCRIPTION
Per this [discussion](https://github.com/Jermolene/TiddlyWiki5/commit/707e9d892635d21e2b0535fcbd2902e599a922b7), this PR updates the syncFilter to allow excluding multiple storyLists and historyLists based on prefixes, as well as excluding multiple tiddlers that might be used as import tiddlers.