### PR TITLE
Update filters for single file to match changes to syncFilter

### DIFF
--- a/core/templates/external-js/save-all-external-js.tid
+++ b/core/templates/external-js/save-all-external-js.tid
@@ -2,6 +2,6 @@ title: $:/core/save/all-external-js
 
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 \define saveTiddlerFilter()
-[is[tiddler]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/core]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
+[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
 {{$:/core/templates/tiddlywiki5-external-js.html}}

--- a/core/templates/save-all.tid
+++ b/core/templates/save-all.tid
@@ -2,6 +2,6 @@ title: $:/core/save/all
 
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 \define saveTiddlerFilter()
-[is[tiddler]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
+[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
 {{$:/core/templates/tiddlywiki5.html}}

--- a/core/wiki/config/SaverFilter.tid
+++ b/core/wiki/config/SaverFilter.tid
@@ -1,3 +1,3 @@
 title: $:/config/SaverFilter
 
-[all[]] -[[$:/HistoryList]] -[[$:/StoryList]] -[[$:/Import]] -[[$:/isEncrypted]] -[[$:/UploadName]] -[prefix[$:/state/]] -[prefix[$:/temp/]]
+[all[]] -[prefix[$:/HistoryList]] -[prefix[$:/StoryList]] -[status[pending]plugin-type[import]] -[[$:/isEncrypted]] -[[$:/UploadName]] -[prefix[$:/state/]] -[prefix[$:/temp/]]

--- a/plugins/tiddlywiki/tiddlyweb/save-offline.tid
+++ b/plugins/tiddlywiki/tiddlyweb/save-offline.tid
@@ -2,6 +2,6 @@ title: $:/plugins/tiddlywiki/tiddlyweb/save/offline
 
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 \define saveTiddlerFilter()
-[is[tiddler]] -[[$:/boot/boot.css]] -[[$:/HistoryList]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] -[[$:/plugins/tiddlywiki/filesystem]] -[[$:/plugins/tiddlywiki/tiddlyweb]] -[prefix[$:/temp/]] +[sort[title]] $(publishFilter)$
+[is[tiddler]] -[[$:/boot/boot.css]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] -[[$:/plugins/tiddlywiki/filesystem]] -[[$:/plugins/tiddlywiki/tiddlyweb]] -[prefix[$:/temp/]] +[sort[title]] $(publishFilter)$
 \end
 {{$:/core/templates/tiddlywiki5.html}}


### PR DESCRIPTION
This PR updates the saving for the single file version to match the changes to the syncFilter in #4906

Namely:

- use the filter `-[prefix[$:/HistoryList]]` to allow excluding multiple history lists
- exclude tiddlers that match the filter `[status[pending]plugin-type[import]]` to ensure that any tiddlers with an import payload are not saved. This resolves #4772 and #4773 

@pmario  and @Jermolene  please review.