### PR TITLE
add override saver

### DIFF
--- a/core/modules/savers/custom.js
+++ b/core/modules/savers/custom.js
@@ -1,9 +1,9 @@
 /*\
-title: $:/core/modules/savers/override.js
+title: $:/core/modules/savers/custom.js
 type: application/javascript
 module-type: saver
 
-Looks for `window.tiddlyWikiOverrides.saver` first on the current window, then
+Looks for `window.$tw.customSaver` first on the current window, then
 on the parent window (of an iframe). If present, the saver must define
 	save: function(text,method,callback) { ... }
 and the saver may define
@@ -17,27 +17,29 @@ and the saver may define
 
 var findSaver = function(window) {
 	try {
-		return window && window.tiddlyWikiOverrides && window.tiddlyWikiOverrides.saver;
+		return window && window.$tw && window.$tw.customSaver;
 	} catch (err) {
-		// Probably an iframe on a different domain than its parent.
-		console.log({ msg: "override saver is disabled", reason: err });
+		// Catching the exception is the most reliable way to detect cross-origin iframe errors.
+		// For example, instead of saying that `window.parent.$tw` is undefined, Firefox will throw
+		//   Uncaught DOMException: Permission denied to access property "$tw" on cross-origin object
+		console.log({ msg: "custom saver is disabled", reason: err });
 		return null;
 	}
 }
 var saver = findSaver(window) || findSaver(window.parent) || {};
 
-var OverrideSaver = function(wiki) {
+var CustomSaver = function(wiki) {
 };
 
-OverrideSaver.prototype.save = function(text,method,callback) {
+CustomSaver.prototype.save = function(text,method,callback) {
 	return saver.save(text, method, callback);
 };
 
 /*
 Information about this saver
 */
-OverrideSaver.prototype.info = {
-	name: "override",
+CustomSaver.prototype.info = {
+	name: "custom",
 	priority: saver.priority || 4000,
 	capabilities: ["save","autosave"]
 };
@@ -53,6 +55,6 @@ exports.canSave = function(wiki) {
 Create an instance of this saver
 */
 exports.create = function(wiki) {
-	return new OverrideSaver(wiki);
+	return new CustomSaver(wiki);
 };
 })();

--- a/core/modules/savers/override.js
+++ b/core/modules/savers/override.js
@@ -1,0 +1,58 @@
+/*\
+title: $:/core/modules/savers/override.js
+type: application/javascript
+module-type: saver
+
+Looks for `window.tiddlyWikiOverrides.saver` first on the current window, then
+on the parent window (of an iframe). If present, the saver must define
+	save: function(text,method,callback) { ... }
+and the saver may define
+	priority: number
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var findSaver = function(window) {
+	try {
+		return window && window.tiddlyWikiOverrides && window.tiddlyWikiOverrides.saver;
+	} catch (err) {
+		// Probably an iframe on a different domain than its parent.
+		console.log({ msg: "override saver is disabled", reason: err });
+		return null;
+	}
+}
+var saver = findSaver(window) || findSaver(window.parent) || {};
+
+var OverrideSaver = function(wiki) {
+};
+
+OverrideSaver.prototype.save = function(text,method,callback) {
+	return saver.save(text, method, callback);
+};
+
+/*
+Information about this saver
+*/
+OverrideSaver.prototype.info = {
+	name: "override",
+	priority: saver.priority || 4000,
+	capabilities: ["save","autosave"]
+};
+
+/*
+Static method that returns true if this saver is capable of working
+*/
+exports.canSave = function(wiki) {
+	return !!(saver.save);
+};
+
+/*
+Create an instance of this saver
+*/
+exports.create = function(wiki) {
+	return new OverrideSaver(wiki);
+};
+})();

--- a/licenses/cla-individual.md
+++ b/licenses/cla-individual.md
@@ -415,3 +415,5 @@ Kamal Habash, @Kamal-Habash, 2020/08/28
 Florian Kohrt, @fkohrt, 2020/09/10
 
 Gerald Liu, @gera2ld, 2020/09/25
+
+Ryan Kramer, @default-kramer, 2020/10/24


### PR DESCRIPTION
This saver allows a "host window" to hook up a custom saver like this:

```
window.tiddlyWikiOverrides = {
    saver: {
        save: function(text, method, callback) {
            console.log("TODO implement me");
            console.log({len: text.length, method, callback});
            return true;
        }
    }
};
```

I have tested this saver in two scenarios.

1. The host window makes an AJAX call to fetch the full HTML of the TiddlyWiki, then it uses `document.write` to replace the entire document (see: https://stackoverflow.com/a/4292640)
2. The host window loads the TiddlyWiki in an iframe. As long as both are served from the same domain, the iframe is able to access `window.parent.tiddlyWikiOverrides.saver`

There might be other scenarios that work too, but I haven't tested any.