### PR TITLE
Fix #4910 - "Editor link dropdown is broken in pre-release."

### DIFF
--- a/core/ui/EditorToolbar/link-dropdown.tid
+++ b/core/ui/EditorToolbar/link-dropdown.tid
@@ -37,7 +37,11 @@ title: $:/core/ui/EditorToolbar/link-dropdown
 
 <$linkcatcher actions=<<add-link-actions>> to=<<linkTiddler>>>
 
+<$vars userInput={{{ [<searchTiddler>get[text]] }}} configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}}>
+
 {{$:/core/ui/SearchResults}}
+
+</$vars>
 
 </$linkcatcher>
 

--- a/core/ui/SideBarSegments/search.tid
+++ b/core/ui/SideBarSegments/search.tid
@@ -19,17 +19,17 @@ tags: $:/tags/SideBarSegment
 
 \define search-results-list()
 \whitespace trim
-<$set name="userInput" value={{$(searchTiddler)$}}>
+<$vars userInput={{$(searchTiddler)$}} configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}}>
 <$list filter="[<userInput>minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
 
-<$tiddler tiddler="$(configTiddler)$">
+<$tiddler tiddler=<<configTiddler>>>
 
 {{$:/core/ui/SearchResults}}
 
 </$tiddler>
 
 </$list>
-</$set>
+</$vars>
 \end
 
 \define delete-state-tiddlers() <$action-deletetiddler $filter="[[$:/temp/search]] [<searchTiddler>] [<searchListState>]"/>
@@ -44,17 +44,16 @@ tags: $:/tags/SideBarSegment
 
 <div class="tc-sidebar-lists tc-sidebar-search">
 
-<$vars configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}} searchTiddler="$:/temp/search/input" searchListState=<<qualify "$:/state/search-list/selected-item">>>
-<$vars titleSearchFilter={{{ [<configTiddler>get[first-search-filter]] }}} allSearchFilter={{{ [<configTiddler>get[second-search-filter]] }}}>
+<$vars searchTiddler="$:/temp/search/input" searchListState=<<qualify "$:/state/search-list/selected-item">>>
 <div class="tc-search">
 <$keyboard key="((input-tab-right))" actions=<<set-next-input-tab>>>
 <$keyboard key="((input-tab-left))" actions=<<set-next-input-tab "before">>>
 <$macrocall $name="keyboard-driven-input" tiddler="$:/temp/search" storeTitle=<<searchTiddler>> 
 		selectionStateTitle=<<searchListState>> refreshTitle="$:/temp/search/refresh" type="search" 
 		tag="input" focus={{$:/config/Search/AutoFocus}} focusPopup=<<qualify "$:/state/popup/search-dropdown">> 
-		class="tc-popup-handle" primaryListFilter=<<titleSearchFilter>> secondaryListFilter=<<allSearchFilter>> 
-		filterMinLength={{$:/config/Search/MinLength}} inputCancelActions=<<cancel-search-actions>> 
-		inputAcceptActions=<<input-accept-actions>> inputAcceptVariantActions=<<input-accept-variant-actions>> cancelPopups="yes" />
+		class="tc-popup-handle" filterMinLength={{$:/config/Search/MinLength}} inputCancelActions=<<cancel-search-actions>> 
+		inputAcceptActions=<<input-accept-actions>> inputAcceptVariantActions=<<input-accept-variant-actions>> cancelPopups="yes" 
+		configTiddlerFilter="[[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}]"/>
 </$keyboard>
 </$keyboard>
 <$reveal state=<<searchTiddler>> type="nomatch" text="">
@@ -86,8 +85,6 @@ tags: $:/tags/SideBarSegment
 </$reveal>
 
 </$reveal>
-
-</$vars>
 
 </$vars>
 

--- a/core/wiki/macros/keyboard-driven-input.tid
+++ b/core/wiki/macros/keyboard-driven-input.tid
@@ -24,7 +24,9 @@ $actions$
 \define input-next-actions(afterOrBefore:"after",reverse:"")
 <$list filter="[<__storeTitle__>get[text]minlength<__filterMinLength__>] [<__filterMinLength__>match[0]] +[limit[1]]" variable="ignore">
 <$vars userInput={{{ [<__storeTitle__>get[text]] }}} selectedItem={{{ [<__selectionStateTitle__>get[text]] }}}>
-<$set name="filteredList" filter="[subfilter<__primaryListFilter__>addsuffix[-primaryList]] =[subfilter<__secondaryListFilter__>addsuffix[-secondaryList]]">
+<$set name="configTiddler" value={{{ [subfilter<__configTiddlerFilter__>] }}}>
+<$vars primaryListFilter={{{ [<configTiddler>get[first-search-filter]] }}} secondaryListFilter={{{ [<configTiddler>get[second-search-filter]] }}}>
+<$set name="filteredList" filter="[subfilter<primaryListFilter>addsuffix[-primaryList]] =[subfilter<secondaryListFilter>addsuffix[-secondaryList]]">
 <$set name="nextItem" value={{{ [enlist<filteredList>$afterOrBefore$<selectedItem>] ~[enlist<filteredList>$reverse$nth[1]] }}}>
 <$list filter="[<nextItem>minlength[1]]">
 <$action-setfield $tiddler=<<__selectionStateTitle__>> text=<<nextItem>>/>
@@ -39,10 +41,12 @@ $actions$
 </$set>
 </$set>
 </$vars>
+</$set>
+</$vars>
 </$list>
 \end
 
-\define keyboard-driven-input(tiddler,storeTitle,field:"text",index:"",tag:"input",type,focus:"",inputAcceptActions,inputAcceptVariantActions,inputCancelActions,placeholder:"",default:"",class,primaryListFilter,secondaryListFilter,focusPopup,rows,minHeight,tabindex,size,autoHeight,filterMinLength:"0",refreshTitle,selectionStateTitle,cancelPopups:"")
+\define keyboard-driven-input(tiddler,storeTitle,field:"text",index:"",tag:"input",type,focus:"",inputAcceptActions,inputAcceptVariantActions,inputCancelActions,placeholder:"",default:"",class,focusPopup,rows,minHeight,tabindex,size,autoHeight,filterMinLength:"0",refreshTitle,selectionStateTitle,cancelPopups:"",configTiddlerFilter)
 <$keyboard key="((input-accept))" actions=<<__inputAcceptActions__>>>
 <$keyboard key="((input-accept-variant))" actions=<<__inputAcceptVariantActions__>>>
 <$keyboard key="((input-up))" actions=<<input-next-actions "before" "reverse[]">>>

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -38,11 +38,11 @@ $actions$
 <div>
 <span class="tc-add-tag-name">
 <$macrocall $name="keyboard-driven-input" tiddler=<<newTagNameTiddler>> storeTitle=<<storeTitle>> refreshTitle=<<refreshTitle>>
-		selectionStateTitle=<<tagSelectionState>> primaryListFilter=<<nonSystemTagsFilter>> secondaryListFilter=<<systemTagsFilter>> 
-		inputAcceptActions="""<$macrocall $name="add-tag-actions" actions=<<__actions__>>/>""" inputCancelActions=<<clear-tags-actions>> tag="input" 
-		placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}} focusPopup=<<qualify "$:/state/popup/tags-auto-complete">> 
-		class="tc-edit-texteditor tc-popup-handle" tabindex=<<tabIndex>> focus={{{ [{$:/config/AutoFocus}match[tags]then[true]] ~[[false]] }}} 
-		filterMinLength={{$:/config/Tags/MinLength}} cancelPopups=<<cancelPopups>> />
+		selectionStateTitle=<<tagSelectionState>> inputAcceptActions="""<$macrocall $name="add-tag-actions" actions=<<__actions__>>/>"""
+		inputCancelActions=<<clear-tags-actions>> tag="input" placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}}
+		focusPopup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-edit-texteditor tc-popup-handle" tabindex=<<tabIndex>> 
+		focus={{{ [{$:/config/AutoFocus}match[tags]then[true]] ~[[false]] }}} filterMinLength={{$:/config/Tags/MinLength}} 
+		cancelPopups=<<cancelPopups>> configTiddlerFilter="[[$:/core/macros/tag-picker]]"/>
 </span>&nbsp;<$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button>&nbsp;<span class="tc-add-tag-button">
 <$set name="tag" value={{{ [<newTagNameTiddler>get[text]] }}}>
 <$button set=<<newTagNameTiddler>> setTo="" class="">

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -1,5 +1,7 @@
 title: $:/core/macros/tag-picker
 tags: $:/tags/Macro
+first-search-filter: [tags[]!is[system]search:title<userInput>sort[]]
+second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 
 \define delete-tag-state-tiddlers() <$action-deletetiddler $filter="[<newTagNameTiddler>] [<storeTitle>] [<tagSelectionState>]"/>
 

--- a/editions/tw5.com/tiddlers/macros/keyboard-driven-input_Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/keyboard-driven-input_Macro.tid
@@ -9,12 +9,11 @@ To create the input field or textarea, the <<.def keyboard-driven-input>> [[macr
 
 The additional parameters are:
 
-|  |purpose |h
+|parameter  |purpose |h
 |storeTitle |the title of the tiddler that stores the user input |
 |selectionStateTitle |the title of the tiddler that stores the selected entry with a -primaryList or -secondaryList suffix to make it unique |
 |inputAcceptActions |the actions that get processed when the user hits <kbd>{{$:/config/shortcuts/input-accept}}</kbd> |
 |inputAcceptVariantActions |the actions that get processed when the user hits <kbd>{{$:/config/shortcuts/input-accept-variant}}</kbd> |
 |inputCancelActions |the actions that get processed when the user hits <kbd>{{$:/config/shortcuts/input-cancel}}</kbd> |
-|primaryListFilter |a filter that specifies the first item-list |
-|secondaryListFilter |a second filter that specifies a second item-list |
+|configTiddlerFilter |a ''filter'' that specifies the tiddler that stores the first item-filter in its <<.field first-search-filter>> field and the second item-filter in its <<.field second-search-filter>> field |
 


### PR DESCRIPTION
This PR fixes #4910 

The Editor Link-dropdown didn't work anymore because I missed that it also uses the default SearchResultList

Some more adjustments where needed in the `keyboard-driven-input macro` and the `SidebarSegments/search` tiddler, because - if using more search-tabs via $:/tags/SearchResults changing those tabs within the Link-dropdown caused a redraw of the sidebar-search input which caused it to steal focus from the Link-dropdown.

Now the Link-dropdown would also be prepared to be keyboard-driven-input-ready