### PR TITLE
Make AdvancedSearch/Standard, AdvancedSearch/System and AdvancedSearch/Shadows navigatable by keyboard

### DIFF
--- a/core/ui/AdvancedSearch/Shadows.tid
+++ b/core/ui/AdvancedSearch/Shadows.tid
@@ -1,40 +1,53 @@
 title: $:/core/ui/AdvancedSearch/Shadows
 tags: $:/tags/AdvancedSearch
 caption: {{$:/language/Search/Shadows/Caption}}
+first-search-filter: [all[shadows]search<userInput>sort[title]limit[250]] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]]
 
 \define lingo-base() $:/language/Search/
+
 \define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/advanced-search-results" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
-<$linkcatcher to="$:/temp/advancedsearch">
+
+\define cancel-search-actions() <$action-deletetiddler $filter="[[$:/temp/advancedsearch]] [[$:/temp/advancedsearch/input]] [[$:/temp/advancedsearch/selected-item]]" />
+
+\define input-accept-actions() <$action-navigate $to={{{ [<__tiddler__>get[text]] }}}/>
+
+\define input-accept-variant-actions() <$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/>
 
 <<lingo Shadows/Hint>>
 
 <div class="tc-search">
 <$keyboard key="((input-tab-right))" actions=<<set-next-input-tab>>>
 <$keyboard key="((input-tab-left))" actions=<<set-next-input-tab "before">>>
-<$edit-text tiddler="$:/temp/advancedsearch" type="search" tag="input" focus={{$:/config/Search/AutoFocus}}/>
+<$macrocall $name="keyboard-driven-input" tiddler="$:/temp/advancedsearch" storeTitle="$:/temp/advancedsearch/input"
+		refreshTitle="$:/temp/advancedsearch/refresh" selectionStateTitle="$:/temp/advancedsearch/selected-item" type="search"
+		tag="input" focus={{$:/config/Search/AutoFocus}} configTiddlerFilter="[[$:/core/ui/AdvancedSearch/Shadows]]"
+		inputCancelActions=<<cancel-search-actions>> inputAcceptActions=<<input-accept-actions>> 
+		inputAcceptVariantActions=<<input-accept-variant-actions>> />
 </$keyboard>
 </$keyboard>
 <$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
 <$button class="tc-btn-invisible">
-<$action-setfield $tiddler="$:/temp/advancedsearch" $field="text" $value=""/>
+<<cancel-search-actions>>
 {{$:/core/images/close-button}}
 </$button>
 </$reveal>
 </div>
 
-</$linkcatcher>
+<$reveal state="$:/temp/advancedsearch/input" type="nomatch" text="">
 
-<$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
+<$list filter="[{$:/temp/advancedsearch/input}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
 
-<$list filter="[{$:/temp/advancedsearch}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
-
-<$set name="resultCount" value="""<$count filter="[all[shadows]search{$:/temp/advancedsearch}] -[[$:/temp/advancedsearch]]"/>""">
+<$set name="resultCount" value="""<$count filter="[all[shadows]search{$:/temp/advancedsearch/input}] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]]"/>""">
 
 <div class="tc-search-results">
 
 <<lingo Shadows/Matches>>
 
-<$list filter="[all[shadows]search{$:/temp/advancedsearch}sort[title]limit[250]] -[[$:/temp/advancedsearch]]" template="$:/core/ui/ListItemTemplate"/>
+<$list filter="[all[shadows]search{$:/temp/advancedsearch/input}sort[title]limit[250]] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]]">
+<span class={{{[<currentTiddler>addsuffix[-primaryList]] -[[$:/temp/advancedsearch/selected-item]get[text]] +[then[]else[tc-list-item-selected]] }}}>
+<$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+</span>
+</$list>
 
 </div>
 
@@ -44,6 +57,6 @@ caption: {{$:/language/Search/Shadows/Caption}}
 
 </$reveal>
 
-<$reveal state="$:/temp/advancedsearch" type="match" text="">
+<$reveal state="$:/temp/advancedsearch/input" type="match" text="">
 
 </$reveal>

--- a/core/ui/AdvancedSearch/Standard.tid
+++ b/core/ui/AdvancedSearch/Standard.tid
@@ -4,36 +4,49 @@ caption: {{$:/language/Search/Standard/Caption}}
 
 \define lingo-base() $:/language/Search/
 \define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/advanced-search-results" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
-<$linkcatcher to="$:/temp/advancedsearch">
+
+\define next-search-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/search-results/advancedsearch" tag="$:/tags/SearchResults" beforeafter="$beforeafter$" defaultState={{$:/config/SearchResults/Default}} actions="""<$action-setfield $tiddler="$:/state/advancedsearch/standard/currentTab" text=<<nextTab>>/>"""/>
+
+\define cancel-search-actions() <$action-deletetiddler $filter="[[$:/temp/advancedsearch]] [[$:/temp/advancedsearch/input]] [[$:/temp/advancedsearch/selected-item]]" />
+
+\define input-accept-actions() <$action-navigate $to={{{ [<__tiddler__>get[text]] }}}/>
+
+\define input-accept-variant-actions() <$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/>
 
 <<lingo Standard/Hint>>
 
 <div class="tc-search">
 <$keyboard key="((input-tab-right))" actions=<<set-next-input-tab>>>
 <$keyboard key="((input-tab-left))" actions=<<set-next-input-tab "before">>>
-<$edit-text tiddler="$:/temp/advancedsearch" type="search" tag="input" focus={{$:/config/Search/AutoFocus}}/>
+<$keyboard key="shift-alt-Right" actions=<<next-search-tab>>>
+<$keyboard key="shift-alt-Left" actions=<<next-search-tab "before">>>
+<$macrocall $name="keyboard-driven-input" tiddler="$:/temp/advancedsearch" storeTitle="$:/temp/advancedsearch/input"
+		refreshTitle="$:/temp/advancedsearch/refresh" selectionStateTitle="$:/temp/advancedsearch/selected-item" type="search"
+		tag="input" focus={{$:/config/Search/AutoFocus}} inputCancelActions=<<cancel-search-actions>> 
+		inputAcceptActions=<<input-accept-actions>> inputAcceptVariantActions=<<input-accept-variant-actions>> 
+		 configTiddlerFilter="[[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}]"/>
 </$keyboard>
 </$keyboard>
-<$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
+</$keyboard>
+</$keyboard>
+<$reveal state="$:/temp/advancedsearch/input" type="nomatch" text="">
 <$button class="tc-btn-invisible">
-<$action-setfield $tiddler="$:/temp/advancedsearch" $field="text" $value=""/>
+<<cancel-search-actions>>
 {{$:/core/images/close-button}}
 </$button>
 </$reveal>
 </div>
 
-</$linkcatcher>
-
-<$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
-<$list filter="[{$:/temp/advancedsearch}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
-<$set name="searchTiddler" value="$:/temp/advancedsearch">
+<$reveal state="$:/temp/advancedsearch/input" type="nomatch" text="">
+<$list filter="[{$:/temp/advancedsearch/input}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
+<$vars userInput={{{ [[$:/temp/advancedsearch/input]get[text]] }}} configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}} searchListState="$:/temp/advancedsearch/selected-item">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]butfirst[]limit[1]]" emptyMessage="""
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]">
 <$transclude/>
 </$list>
 """>
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]" default={{$:/config/SearchResults/Default}}/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SearchResults]!has[draft.of]]" default={{$:/config/SearchResults/Default}} actions="""<$action-setfield $tiddler="$:/state/advancedsearch/standard/currentTab" text=<<currentTab>>/>""" explicitState="$:/state/tab/search-results/advancedsearch" />
 </$list>
-</$set>
+</$vars>
 </$list>
 </$reveal>

--- a/core/ui/AdvancedSearch/System.tid
+++ b/core/ui/AdvancedSearch/System.tid
@@ -1,40 +1,52 @@
 title: $:/core/ui/AdvancedSearch/System
 tags: $:/tags/AdvancedSearch
 caption: {{$:/language/Search/System/Caption}}
+first-search-filter: [is[system]search<userInput>sort[title]limit[250]] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]] -[[$:/temp/advancedsearch/selected-item]]
 
 \define lingo-base() $:/language/Search/
 \define set-next-input-tab(beforeafter:"after",stateTitle,tag,defaultState,currentTabTiddler) <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/advanced-search-results" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
-<$linkcatcher to="$:/temp/advancedsearch">
+
+\define cancel-search-actions() <$action-deletetiddler $filter="[[$:/temp/advancedsearch]] [[$:/temp/advancedsearch/input]] [[$:/temp/advancedsearch/selected-item]]" />
+
+\define input-accept-actions() <$action-navigate $to={{{ [<__tiddler__>get[text]] }}}/>
+
+\define input-accept-variant-actions() <$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/>
 
 <<lingo System/Hint>>
 
 <div class="tc-search">
 <$keyboard key="((input-tab-right))" actions=<<set-next-input-tab>>>
 <$keyboard key="((input-tab-left))" actions=<<set-next-input-tab "before">>>
-<$edit-text tiddler="$:/temp/advancedsearch" type="search" tag="input" focus={{$:/config/Search/AutoFocus}}/>
+<$macrocall $name="keyboard-driven-input" tiddler="$:/temp/advancedsearch" storeTitle="$:/temp/advancedsearch/input"
+		refreshTitle="$:/temp/advancedsearch/refresh" selectionStateTitle="$:/temp/advancedsearch/selected-item"
+		type="search" tag="input" focus={{$:/config/Search/AutoFocus}} configTiddlerFilter="[[$:/core/ui/AdvancedSearch/System]]"
+		inputCancelActions=<<cancel-search-actions>> inputAcceptActions=<<input-accept-actions>> 
+		inputAcceptVariantActions=<<input-accept-variant-actions>>/>
 </$keyboard>
 </$keyboard>
 <$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
 <$button class="tc-btn-invisible">
-<$action-setfield $tiddler="$:/temp/advancedsearch" $field="text" $value=""/>
+<<cancel-search-actions>>
 {{$:/core/images/close-button}}
 </$button>
 </$reveal>
 </div>
 
-</$linkcatcher>
+<$reveal state="$:/temp/advancedsearch/input" type="nomatch" text="">
 
-<$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
+<$list filter="[{$:/temp/advancedsearch/input}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
 
-<$list filter="[{$:/temp/advancedsearch}minlength{$:/config/Search/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
-
-<$set name="resultCount" value="""<$count filter="[is[system]search{$:/temp/advancedsearch}] -[[$:/temp/advancedsearch]]"/>""">
+<$set name="resultCount" value="""<$count filter="[is[system]search{$:/temp/advancedsearch/input}] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]] -[[$:/temp/advancedsearch/selected-item]]"/>""">
 
 <div class="tc-search-results">
 
 <<lingo System/Matches>>
 
-<$list filter="[is[system]search{$:/temp/advancedsearch}sort[title]limit[250]] -[[$:/temp/advancedsearch]]" template="$:/core/ui/ListItemTemplate"/>
+<$list filter="[is[system]search{$:/temp/advancedsearch/input}sort[title]limit[250]] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]] -[[$:/temp/advancedsearch/selected-item]]">
+<span class={{{[<currentTiddler>addsuffix[-primaryList]] -[[$:/temp/advancedsearch/selected-item]get[text]] +[then[]else[tc-list-item-selected]] }}}>
+<$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+</span>
+</$list>
 
 </div>
 

--- a/core/ui/SideBarSegments/search.tid
+++ b/core/ui/SideBarSegments/search.tid
@@ -42,7 +42,7 @@ tags: $:/tags/SideBarSegment
 
 \define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/search-results/sidebar" tag="$:/tags/SearchResults" beforeafter="$beforeafter$" defaultState={{$:/config/SearchResults/Default}} actions="""<$action-setfield $tiddler="$:/state/search/currentTab" text=<<nextTab>>/>"""/>
 
-\define advanced-search-actions() <$action-setfield $tiddler="$:/temp/advancedsearch" text={{$:/temp/search/input}}/><<delete-state-tiddlers>><$action-navigate $to="$:/AdvancedSearch"/>
+\define advanced-search-actions() <$action-setfield $tiddler="$:/temp/advancedsearch" text={{$:/temp/search/input}}/><$action-setfield $tiddler="$:/temp/advancedsearch/input" text={{$:/temp/search/input}}/><<delete-state-tiddlers>><$action-navigate $to="$:/AdvancedSearch"/>
 
 <div class="tc-sidebar-lists tc-sidebar-search">
 


### PR DESCRIPTION
This PR makes the AdvancedSearch/System, AdvancedSearch/Standard and AdvancedSearch/Shadows tabs navigatable using Up/Down arrow keys, Enter to navigate to the selected item, alt-Enter to edit the selected item and Escape to clear the input field

I'm trying to make this also possible for the Filter tab but that appears to need a bit more investigation and work