### PR TITLE
Add meta-S (mac) / ctrl-S shortcuts to save wiki

### DIFF
--- a/core/ui/KeyboardShortcuts/save-wiki.tid
+++ b/core/ui/KeyboardShortcuts/save-wiki.tid
@@ -1,0 +1,7 @@
+title: $:/core/ui/KeyboardShortcuts/save-wiki
+tags: $:/tags/KeyboardShortcut
+key: ((save-wiki))
+
+<$wikify name="site-title" text={{$:/config/SaveWikiButton/Filename}}>
+<$action-sendmessage $message="tm-save-wiki" $param={{$:/config/SaveWikiButton/Template}} filename=<<site-title>>/>
+</$wikify>

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -33,6 +33,7 @@ picture: {{$:/language/Buttons/Picture/Hint}}
 preview: {{$:/language/Buttons/Preview/Hint}}
 quote: {{$:/language/Buttons/Quote/Hint}}
 save-tiddler: {{$:/language/Buttons/Save/Hint}}
+save-wiki: {{$:/language/Buttons/SaveWiki/Hint}}
 sidebar-search: {{$:/language/Buttons/SidebarSearch/Hint}}
 stamp: {{$:/language/Buttons/Stamp/Hint}}
 strikethrough: {{$:/language/Buttons/Strikethrough/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts-mac.multids
+++ b/core/wiki/config/shortcuts/shortcuts-mac.multids
@@ -6,3 +6,4 @@ underline: meta-U
 new-image: ctrl-I
 new-journal: ctrl-J
 new-tiddler: ctrl-N
+save-wiki: meta-S

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -29,6 +29,7 @@ picture: ctrl-shift-I
 preview: alt-P
 quote: ctrl-Q
 save-tiddler: ctrl+enter
+save-wiki: ctrl-S
 stamp: ctrl-S
 strikethrough: ctrl-T
 subscript: ctrl-shift-B


### PR DESCRIPTION
This PR adds a save-wiki keyboard shortcut that's triggered by ctrl-S or meta-S (on mac)