### PR TITLE
Do not save temp tiddlers in single file

### DIFF
--- a/core/templates/external-js/save-all-external-js.tid
+++ b/core/templates/external-js/save-all-external-js.tid
@@ -2,6 +2,6 @@ title: $:/core/save/all-external-js
 
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 \define saveTiddlerFilter()
-[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
+[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
 {{$:/core/templates/tiddlywiki5-external-js.html}}

--- a/core/templates/save-all.tid
+++ b/core/templates/save-all.tid
@@ -2,6 +2,6 @@ title: $:/core/save/all
 
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 \define saveTiddlerFilter()
-[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
+[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
 {{$:/core/templates/tiddlywiki5.html}}


### PR DESCRIPTION
Fixes #4933
Fixes #4938 

Temp tiddlers should not be saved in single file as they accumulate over time. Furthermore their value as temporary storage to plugin writers is negated by the fact that they are saved in single file but not on node.js.

As the [documentation ](https://tiddlywiki.com/#Naming%20of%20System%20Tiddlers ) suggests, these are temporary tiddlers and should not be saved.