### PR TITLE
Fix AdvancedSearch Standard, System and Shadows up/down behavior

### DIFF
--- a/core/ui/AdvancedSearch/Shadows.tid
+++ b/core/ui/AdvancedSearch/Shadows.tid
@@ -22,7 +22,7 @@ first-search-filter: [all[shadows]search<userInput>sort[title]limit[250]] -[[$:/
 		refreshTitle="$:/temp/advancedsearch/refresh" selectionStateTitle="$:/temp/advancedsearch/selected-item" type="search"
 		tag="input" focus={{$:/config/Search/AutoFocus}} configTiddlerFilter="[[$:/core/ui/AdvancedSearch/Shadows]]"
 		inputCancelActions=<<cancel-search-actions>> inputAcceptActions=<<input-accept-actions>> 
-		inputAcceptVariantActions=<<input-accept-variant-actions>> />
+		inputAcceptVariantActions=<<input-accept-variant-actions>>  filterMinLength={{$:/config/Search/MinLength}}/>
 </$keyboard>
 </$keyboard>
 <$reveal state="$:/temp/advancedsearch" type="nomatch" text="">

--- a/core/ui/AdvancedSearch/Standard.tid
+++ b/core/ui/AdvancedSearch/Standard.tid
@@ -24,7 +24,8 @@ caption: {{$:/language/Search/Standard/Caption}}
 		refreshTitle="$:/temp/advancedsearch/refresh" selectionStateTitle="$:/temp/advancedsearch/selected-item" type="search"
 		tag="input" focus={{$:/config/Search/AutoFocus}} inputCancelActions=<<cancel-search-actions>> 
 		inputAcceptActions=<<input-accept-actions>> inputAcceptVariantActions=<<input-accept-variant-actions>> 
-		 configTiddlerFilter="[[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}]"/>
+		configTiddlerFilter="[[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}]"
+		filterMinLength={{$:/config/Search/MinLength}}/>
 </$keyboard>
 </$keyboard>
 </$keyboard>

--- a/core/ui/AdvancedSearch/System.tid
+++ b/core/ui/AdvancedSearch/System.tid
@@ -21,7 +21,7 @@ first-search-filter: [is[system]search<userInput>sort[title]limit[250]] -[[$:/te
 		refreshTitle="$:/temp/advancedsearch/refresh" selectionStateTitle="$:/temp/advancedsearch/selected-item"
 		type="search" tag="input" focus={{$:/config/Search/AutoFocus}} configTiddlerFilter="[[$:/core/ui/AdvancedSearch/System]]"
 		inputCancelActions=<<cancel-search-actions>> inputAcceptActions=<<input-accept-actions>> 
-		inputAcceptVariantActions=<<input-accept-variant-actions>>/>
+		inputAcceptVariantActions=<<input-accept-variant-actions>> filterMinLength={{$:/config/Search/MinLength}}/>
 </$keyboard>
 </$keyboard>
 <$reveal state="$:/temp/advancedsearch" type="nomatch" text="">

--- a/core/ui/EditorToolbar/link-dropdown.tid
+++ b/core/ui/EditorToolbar/link-dropdown.tid
@@ -25,7 +25,7 @@ title: $:/core/ui/EditorToolbar/link-dropdown
 <$vars linkTiddler=<<searchTiddler>>>
 <$keyboard key="((input-tab-right))" actions=<<set-next-input-tab>>>
 <$keyboard key="((input-tab-left))" actions=<<set-next-input-tab "before">>>
-<$macrocall $name="keyboard-driven-input" tiddler=<<searchTiddler>> storeTitle=<<storeTitle>> 
+<$macrocall $name="keyboard-driven-input" tiddler=<<searchTiddler>> storeTitle=<<storeTitle>> filterMinLength={{$:/config/Search/MinLength}}
 		selectionStateTitle=<<searchListState>> refreshTitle=<<refreshTitle>> type="search" 
 		tag="input" focus="true" class="tc-popup-handle" inputCancelActions=<<cancel-search-actions>> 
 		inputAcceptActions=<<add-link-actions>> placeholder={{$:/language/Search/Search}} default="" 


### PR DESCRIPTION
This fixes the problem that, when pressing up/down in an EMPTY search field, the keyboard-driven-input macro gave some search results