### PR TITLE
Change input-accept-variant actions shortcut from alt-Enter ...

### DIFF
--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -2,7 +2,7 @@ title: $:/config/shortcuts/
 
 add-field: enter
 advanced-search: ctrl-shift-A
-advanced-search-sidebar: ctrl-Enter
+advanced-search-sidebar: alt-Enter
 cancel-edit-tiddler: escape
 excise: ctrl-E
 sidebar-search: ctrl-shift-F
@@ -13,7 +13,7 @@ heading-4: ctrl-4
 heading-5: ctrl-5
 heading-6: ctrl-6
 input-accept: Enter
-input-accept-variant: Alt-Enter
+input-accept-variant: ctrl-Enter
 input-cancel: Escape
 input-down: Down
 input-tab-left: alt-Left


### PR DESCRIPTION
... to ctrl-Enter and advanced-search-sidebar shortcut from ctrl-Enter to alt-Enter

the ctrl-Key blocks navigation to the AdvancedSearch tiddler