### PR TITLE
Avoid editing the wrong tiddlers when input fields are empty

### DIFF
--- a/core/ui/AdvancedSearch/Shadows.tid
+++ b/core/ui/AdvancedSearch/Shadows.tid
@@ -11,7 +11,7 @@ first-search-filter: [all[shadows]search<userInput>sort[title]limit[250]] -[[$:/
 
 \define input-accept-actions() <$action-navigate $to={{{ [<__tiddler__>get[text]] }}}/>
 
-\define input-accept-variant-actions() <$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/>
+\define input-accept-variant-actions() <$list filter="[<__tiddler__>get[text]minlength[1]]"><$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/></$list>
 
 <<lingo Shadows/Hint>>
 

--- a/core/ui/AdvancedSearch/Standard.tid
+++ b/core/ui/AdvancedSearch/Standard.tid
@@ -11,7 +11,7 @@ caption: {{$:/language/Search/Standard/Caption}}
 
 \define input-accept-actions() <$action-navigate $to={{{ [<__tiddler__>get[text]] }}}/>
 
-\define input-accept-variant-actions() <$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/>
+\define input-accept-variant-actions() <$list filter="[<__tiddler__>get[text]minlength[1]]"><$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/></$list>
 
 <<lingo Standard/Hint>>
 

--- a/core/ui/AdvancedSearch/System.tid
+++ b/core/ui/AdvancedSearch/System.tid
@@ -10,7 +10,7 @@ first-search-filter: [is[system]search<userInput>sort[title]limit[250]] -[[$:/te
 
 \define input-accept-actions() <$action-navigate $to={{{ [<__tiddler__>get[text]] }}}/>
 
-\define input-accept-variant-actions() <$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/>
+\define input-accept-variant-actions() <$list filter="[<__tiddler__>get[text]minlength[1]]"><$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/></$list>
 
 <<lingo System/Hint>>
 

--- a/core/ui/SideBarSegments/search.tid
+++ b/core/ui/SideBarSegments/search.tid
@@ -38,7 +38,7 @@ tags: $:/tags/SideBarSegment
 
 \define input-accept-actions() <$action-navigate $to={{{ [<__tiddler__>get[text]] }}}/>
 
-\define input-accept-variant-actions() <$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/>
+\define input-accept-variant-actions() <$list filter="[<__tiddler__>get[text]minlength[1]]"><$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/></$list>
 
 \define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/search-results/sidebar" tag="$:/tags/SearchResults" beforeafter="$beforeafter$" defaultState={{$:/config/SearchResults/Default}} actions="""<$action-setfield $tiddler="$:/state/search/currentTab" text=<<nextTab>>/>"""/>
 


### PR DESCRIPTION
This PR adds a test if input fields are empty before sending the tm-edit-tiddler message