### PR TITLE
Add string operator enlist-input[]

### DIFF
--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -56,12 +56,12 @@ exports.trim = function(source,operator,options) {
 	return result;
 };
 
-// makeStringBinaryOperator(
-// 	function(a) {return [$tw.utils.trim(a)];}
-// );
-
 exports.split = makeStringBinaryOperator(
 	function(a,b) {return ("" + a).split(b);}
+);
+
+exports.titlelist = makeStringBinaryOperator(
+	function(a) {return $tw.utils.parseStringArray("" + a);}
 );
 
 exports.join = makeStringReducingOperator(

--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -60,7 +60,7 @@ exports.split = makeStringBinaryOperator(
 	function(a,b) {return ("" + a).split(b);}
 );
 
-exports.aslist = makeStringBinaryOperator(
+exports["enlist-input"] = makeStringBinaryOperator(
 	function(a) {return $tw.utils.parseStringArray("" + a);}
 );
 

--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -60,7 +60,7 @@ exports.split = makeStringBinaryOperator(
 	function(a,b) {return ("" + a).split(b);}
 );
 
-exports.titlelist = makeStringBinaryOperator(
+exports.aslist = makeStringBinaryOperator(
 	function(a) {return $tw.utils.parseStringArray("" + a);}
 );
 

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -160,6 +160,13 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[enlist[one two three]addsuffix[!]]").join(",")).toBe("one!,two!,three!");
 	});
 	
+	it("should handle the enlist-input operator", function() {
+		expect(wiki.filterTiddlers("[[one two three]enlist-input[]]").join(",")).toBe("one,two,three");
+		expect(wiki.filterTiddlers("[[one two three]] [[four five six]] +[enlist-input[]]").join(",")).toBe("one,two,three,four,five,six");
+		expect(wiki.filterTiddlers("[[one two three]] [[four five six]] [[seven eight]] +[enlist-input[]]").join(",")).toBe("one,two,three,four,five,six,seven,eight");
+		expect(wiki.filterTiddlers("[[]] +[enlist-input[]]").join(",")).toBe("");
+	});
+	
 	it("should handle the then and else operators", function() {
 		expect(wiki.filterTiddlers("[modifier[JoeBloggs]then[Susi]]").join(",")).toBe("Susi");
 		expect(wiki.filterTiddlers("[!modifier[JoeBloggs]then[Susi]]").join(",")).toBe("Susi,Susi,Susi,Susi,Susi,Susi,Susi,Susi");


### PR DESCRIPTION
While [title lists](https://tiddlywiki.com/#Title%20List) are very common in TiddlyWiki, we are missing a filter operator that allows it's input to be parsed as a title list.

For example consider `[{!!parent}get[children]]` where `children` is a field holding a title list. 
Currently this requires two steps to operate on the list of children, first getting `children` and then `enlist<children>`
```
<$vars children={{{ [{!!parent}get[children]] }}}/>
<$list filter="[enlist<children>]">
<!-- do something -->
</$list>
</$vars>
```

With this operator the above would be:

`[{!!parent}get[children]aslist[]]`

I've considered extending `enlist[]` to operate on its input when no operand is present, but that might be confusing for users.

I'm open to better suggestions for a name:
- `parselist[]`
- `tolist[]`
- `titlelist[]`
- ?

See [this table](https://tiddlywiki.com/#Filter%20Operators) for names of existing string operators.