### PR TITLE
Fix alignment of tc-tiddler-edit-title

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1143,6 +1143,10 @@ canvas.tc-edit-bitmapeditor  {
 	overflow: hidden; /* https://github.com/Jermolene/TiddlyWiki5/issues/282 */
 }
 
+.tc-tiddler-title.tc-tiddler-edit-title {
+	line-height: 3em;
+}
+
 html body.tc-body.tc-single-tiddler-window {
 	margin: 1em;
 	background: <<colour tiddler-background>>;


### PR DESCRIPTION
BEFORE:

![Bildschirmfoto vom 2020-10-31 09-01-32](https://user-images.githubusercontent.com/9407182/97774420-e13e6700-1b57-11eb-90ab-fa2d3f328ee3.png)

AFTER:

![Bildschirmfoto vom 2020-10-31 09-02-04](https://user-images.githubusercontent.com/9407182/97774424-ed2a2900-1b57-11eb-919a-3bd667daed5e.png)

