### PR TITLE
Add keyboard shortcut to change the sidebar layout

### DIFF
--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -72,6 +72,7 @@ Shortcuts/Input/Down/Hint: Select the next item
 Shortcuts/Input/Tab-Left/Hint: Select the previous Tab
 Shortcuts/Input/Tab-Right/Hint: Select the next Tab
 Shortcuts/Input/Up/Hint: Select the previous item
+Shortcuts/SidebarLayout/Hint: Change the sidebar layout
 SystemTiddler/Tooltip: This is a system tiddler
 SystemTiddlers/Include/Prompt: Include system tiddlers
 TagManager/Colour/Heading: Colour

--- a/core/ui/KeyboardShortcuts/change-sidebar-layout.tid
+++ b/core/ui/KeyboardShortcuts/change-sidebar-layout.tid
@@ -1,0 +1,8 @@
+title: $:/core/ui/KeyboardShortcuts/change-sidebar-layout
+tags: $:/tags/KeyboardShortcut
+key: ((change-sidebar-layout))
+
+<$list filter="[{$:/themes/tiddlywiki/vanilla/options/sidebarlayout}match[fixed-fluid]]" 
+emptyMessage="""<$action-setfield $tiddler="$:/themes/tiddlywiki/vanilla/options/sidebarlayout" text="fixed-fluid"/>""">
+<$action-setfield $tiddler="$:/themes/tiddlywiki/vanilla/options/sidebarlayout" text="fluid-fixed"/>
+</$list>

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -5,6 +5,7 @@ advanced-search: {{$:/language/Buttons/AdvancedSearch/Hint}}
 advanced-search-sidebar: {{$:/language/Shortcuts/Input/AdvancedSearch/Hint}}
 bold: {{$:/language/Buttons/Bold/Hint}}
 cancel-edit-tiddler: {{$:/language/Buttons/Cancel/Hint}}
+change-sidebar-layout: {{$:/language/Shortcuts/SidebarLayout/Hint}}
 excise: {{$:/language/Buttons/Excise/Hint}}
 heading-1: {{$:/language/Buttons/Heading1/Hint}}
 heading-2: {{$:/language/Buttons/Heading2/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -4,6 +4,7 @@ add-field: enter
 advanced-search: ctrl-shift-A
 advanced-search-sidebar: alt-Enter
 cancel-edit-tiddler: escape
+change-sidebar-layout: shift-alt-Down
 excise: ctrl-E
 sidebar-search: ctrl-shift-F
 heading-1: ctrl-1


### PR DESCRIPTION
This PR adds a keyboard shortcut (shift-alt-Down by default) that changes the sidebar layout from fluid-fixed to fixed-fluid or vice versa