### PR TITLE
Add generateTransclusionFootprint method to widget.js ...

### DIFF
--- a/core/modules/macros/qualify.js
+++ b/core/modules/macros/qualify.js
@@ -19,14 +19,15 @@ Information about this macro
 exports.name = "qualify";
 
 exports.params = [
-	{name: "title"}
+	{name: "title"},
+	{name: "footprint"}
 ];
 
 /*
 Run the macro
 */
-exports.run = function(title) {
-	return title + "-" + this.getStateQualifier();
+exports.run = function(title,footprint) {
+	return title + "-" + this.getStateQualifier(undefined,footprint === "yes");
 };
 
 })();

--- a/core/modules/widgets/qualify.js
+++ b/core/modules/widgets/qualify.js
@@ -40,9 +40,10 @@ QualifyWidget.prototype.execute = function() {
 	// Get our parameters
 	this.qualifyName = this.getAttribute("name");
 	this.qualifyTitle = this.getAttribute("title");
+	this.qualifyTransclusionFootprint = this.getAttribute("footprint") === "yes"
 	// Set context variable
 	if(this.qualifyName) {
-		this.setVariable(this.qualifyName,this.qualifyTitle + "-" + this.getStateQualifier());
+		this.setVariable(this.qualifyName,this.qualifyTitle + "-" + this.getStateQualifier(undefined,this.qualifyTransclusionFootprint));
 	}
 	// Construct the child widgets
 	this.makeChildWidgets();
@@ -53,7 +54,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 QualifyWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.name || changedAttributes.title) {
+	if(changedAttributes.name || changedAttributes.title || changedAttributes.footprint) {
 		this.refreshSelf();
 		return true;
 	} else {

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -232,6 +232,9 @@ Widget.prototype.hasVariable = function(name,value) {
 	return false;
 };
 
+/*
+Find the widget, walking up the widget-tree, that has a different transclusion variable than the current widget
+*/
 Widget.prototype.findParentTransclusionWidget = function() {
 	var node = this;
 	var transclusionVariable = this.getVariable("transclusion");
@@ -241,6 +244,9 @@ Widget.prototype.findParentTransclusionWidget = function() {
 	return node !== this ? node : null;
 };
 
+/*
+Generate the "transclusion-footprint" of the current widget in the widget-tree up to the next widget that changes the transclusion variable
+*/
 Widget.prototype.generateTransclusionFootprint = function() {
 	var parentTransclusionWidget = this.findParentTransclusionWidget(),
 	    node = this,


### PR DESCRIPTION
... and add switches to the `<<qualify>>` macro and the `<$qualify>` widget (for backwards compatibility) that allow to turn the new functionality on through `footprint="yes"` (or a better name)