### PR TITLE
KeyboardWidget: don't trap keyboard shortcut if actions and message are empty and invokeActions isn't handled

### DIFF
--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -51,7 +51,7 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 				self.invokeActionString(self.actions,self,event);
 			}
 			self.dispatchMessage(event);
-			if(self.actions) {
+			if(self.actions || self.message) {
 				event.preventDefault();
 				event.stopPropagation();
 			}

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -46,12 +46,12 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 	// Add a keyboard event handler
 	domNode.addEventListener("keydown",function (event) {
 		if($tw.keyboardManager.checkKeyDescriptors(event,self.keyInfoArray)) {
-			self.invokeActions(self,event);
+			var handled = self.invokeActions(self,event);
 			if(self.actions) {
 				self.invokeActionString(self.actions,self,event);
 			}
 			self.dispatchMessage(event);
-			if(self.actions || self.message) {
+			if(handled || self.actions || self.message) {
 				event.preventDefault();
 				event.stopPropagation();
 			}

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -51,8 +51,10 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 				self.invokeActionString(self.actions,self,event);
 			}
 			self.dispatchMessage(event);
-			event.preventDefault();
-			event.stopPropagation();
+			if(self.actions) {
+				event.preventDefault();
+				event.stopPropagation();
+			}
 			return true;
 		}
 		return false;


### PR DESCRIPTION
This PR changes the KeyboardWidget so that, if there are no actions, no message and no invokeActions to handle, `event.preventDefault()` and `event.stopPropagation()` aren't called.

This is useful for the keyboard-driven-inputs in the tag-picker, the link-dropdown and the fieldname-input, where no actions are defined for the keyboard-widget that has the (default) keyboard-shortcut <kbd>ctrl-Enter</kbd> and would prevent the tiddler-global `save-tiddler-actions` that should be dispatched on <kbd>ctrl-Enter</kbd>