### PR TITLE
Add editor-height button and stamp-button to tiddler types that miss them

### DIFF
--- a/core/ui/EditorToolbar/editor-height.tid
+++ b/core/ui/EditorToolbar/editor-height.tid
@@ -4,7 +4,7 @@ icon: $:/core/images/fixed-height
 custom-icon: yes
 caption: {{$:/language/Buttons/EditorHeight/Caption}}
 description: {{$:/language/Buttons/EditorHeight/Hint}}
-condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] +[first[]]
+condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] [<targetTiddler>get[type]match[application/javascript]] [<targetTiddler>get[type]match[application/json]] [<targetTiddler>get[type]match[application/x-tiddler-dictionary]] +[first[]]
 dropdown: $:/core/ui/EditorToolbar/editor-height-dropdown
 
 <$reveal tag="span" state="$:/config/TextEditor/EditorHeight/Mode" type="match" text="fixed">

--- a/core/ui/EditorToolbar/stamp.tid
+++ b/core/ui/EditorToolbar/stamp.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/stamp
 caption: {{$:/language/Buttons/Stamp/Caption}}
 description: {{$:/language/Buttons/Stamp/Hint}}
-condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] +[first[]]
+condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] [<targetTiddler>get[type]match[application/javascript]] [<targetTiddler>get[type]match[application/json]] [<targetTiddler>get[type]match[application/x-tiddler-dictionary]] +[first[]]
 shortcuts: ((stamp))
 dropdown: $:/core/ui/EditorToolbar/stamp-dropdown
 text:


### PR DESCRIPTION
This PR adds the editor-height and stamp buttons also to tiddlers of type application/javascript, application/json and application/x-tiddler-dictionary