### PR TITLE
Add delete-field keyboard shortcut

### DIFF
--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -73,7 +73,7 @@ $value={{{ [<newFieldValueTiddler>get[text]] }}}/>
 </td>
 <td class="tc-edit-field-remove">
 <$button class="tc-btn-invisible" tooltip={{$:/language/EditTemplate/Field/Remove/Hint}} aria-label={{$:/language/EditTemplate/Field/Remove/Caption}}>
-<$action-deletefield $field=<<currentField>>/>
+<$action-deletefield $field=<<currentField>>/><$set name="currentTiddlerCSSescaped" value={{{ [<currentTiddler>escapecss[]] }}}><$action-sendmessage $message="tm-focus-selector" $param=<<current-tiddler-new-field-selector>>/></$set>
 {{$:/core/images/delete-button}}
 </$button>
 </td>

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -67,7 +67,9 @@ $value={{{ [<newFieldValueTiddler>get[text]] }}}/>
 <td class="tc-edit-field-name">
 <$text text=<<currentField>>/>:</td>
 <td class="tc-edit-field-value">
+<$keyboard key="((delete-field))" actions="""<$action-deletefield $field=<<currentField>>/><$set name="currentTiddlerCSSescaped" value={{{ [<currentTiddler>escapecss[]] }}}><$action-sendmessage $message="tm-focus-selector" $param=<<current-tiddler-new-field-selector>>/></$set>""">
 <$edit-text tiddler=<<currentTiddler>> field=<<currentField>> placeholder={{$:/language/EditTemplate/Fields/Add/Value/Placeholder}} tabindex={{$:/config/EditTabIndex}} cancelPopups="yes"/>
+</$keyboard>
 </td>
 <td class="tc-edit-field-remove">
 <$button class="tc-btn-invisible" tooltip={{$:/language/EditTemplate/Field/Remove/Hint}} aria-label={{$:/language/EditTemplate/Field/Remove/Caption}}>

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -6,6 +6,7 @@ advanced-search-sidebar: {{$:/language/Shortcuts/Input/AdvancedSearch/Hint}}
 bold: {{$:/language/Buttons/Bold/Hint}}
 cancel-edit-tiddler: {{$:/language/Buttons/Cancel/Hint}}
 change-sidebar-layout: {{$:/language/Shortcuts/SidebarLayout/Hint}}
+delete-field: {{$:/language/EditTemplate/Field/Remove/Hint}}
 excise: {{$:/language/Buttons/Excise/Hint}}
 heading-1: {{$:/language/Buttons/Heading1/Hint}}
 heading-2: {{$:/language/Buttons/Heading2/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -5,6 +5,7 @@ advanced-search: ctrl-shift-A
 advanced-search-sidebar: alt-Enter
 cancel-edit-tiddler: escape
 change-sidebar-layout: shift-alt-Down
+delete-field: ctrl-D
 excise: ctrl-E
 sidebar-search: ctrl-shift-F
 heading-1: ctrl-1

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -5,7 +5,7 @@ advanced-search: ctrl-shift-A
 advanced-search-sidebar: alt-Enter
 cancel-edit-tiddler: escape
 change-sidebar-layout: shift-alt-Down
-delete-field: ctrl-D
+delete-field: shift-alt-D
 excise: ctrl-E
 sidebar-search: ctrl-shift-F
 heading-1: ctrl-1


### PR DESCRIPTION
This PR adds a delete-field keyboard-shortcut (<kbd>ctrl-D</kbd> by default) that deletes a currently focused field and sets focus to the fieldname-input