### PR TITLE
Update core "tabs" macros to use explicitState

### DIFF
--- a/core/ui/AdvancedSearch.tid
+++ b/core/ui/AdvancedSearch.tid
@@ -3,5 +3,5 @@ icon: $:/core/images/advanced-search-button
 color: #bbb
 
 <div class="tc-advanced-search">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/AdvancedSearch]!has[draft.of]]" default="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<currentTab>>/>""" explicitState="$:/state/tab/advanced-search-results"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/AdvancedSearch]!has[draft.of]]" default="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<currentTab>>/>""" explicitState="$:/state/tab--1498284803"/>
 </div>

--- a/core/ui/AdvancedSearch/Filter.tid
+++ b/core/ui/AdvancedSearch/Filter.tid
@@ -3,7 +3,7 @@ tags: $:/tags/AdvancedSearch
 caption: {{$:/language/Search/Filter/Caption}}
 
 \define lingo-base() $:/language/Search/
-\define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/advanced-search-results" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
+\define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab--1498284803" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
 
 \define cancel-search-actions() <$list filter="[{$:/temp/advancedsearch/input}!match{$:/temp/advancedsearch}]" emptyMessage="""<$action-deletetiddler $filter="[[$:/temp/advancedsearch]] [[$:/temp/advancedsearch/input]] [[$:/temp/advancedsearch/selected-item]]" />"""><$action-setfield $tiddler="$:/temp/advancedsearch/input" text={{$:/temp/advancedsearch}}/><$action-setfield $tiddler="$:/temp/advancedsearch/refresh" text="yes"/></$list>
 

--- a/core/ui/AdvancedSearch/Shadows.tid
+++ b/core/ui/AdvancedSearch/Shadows.tid
@@ -5,7 +5,7 @@ first-search-filter: [all[shadows]search<userInput>sort[title]limit[250]] -[[$:/
 
 \define lingo-base() $:/language/Search/
 
-\define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/advanced-search-results" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
+\define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab--1498284803" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
 
 \define cancel-search-actions() <$list filter="[{$:/temp/advancedsearch}!match{$:/temp/advancedsearch/input}]" emptyMessage="""<$action-deletetiddler $filter="[[$:/temp/advancedsearch]] [[$:/temp/advancedsearch/input]] [[$:/temp/advancedsearch/selected-item]]" />"""><$action-setfield $tiddler="$:/temp/advancedsearch/input" text={{$:/temp/advancedsearch}}/><$action-setfield $tiddler="$:/temp/advancedsearch/refresh" text="yes"/></$list><$action-sendmessage $message="tm-focus-selector" $param=""".tc-advanced-search input"""/>
 

--- a/core/ui/AdvancedSearch/Standard.tid
+++ b/core/ui/AdvancedSearch/Standard.tid
@@ -3,7 +3,7 @@ tags: $:/tags/AdvancedSearch
 caption: {{$:/language/Search/Standard/Caption}}
 
 \define lingo-base() $:/language/Search/
-\define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/advanced-search-results" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
+\define set-next-input-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab--1498284803" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
 
 \define next-search-tab(beforeafter:"after") <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/search-results/advancedsearch" tag="$:/tags/SearchResults" beforeafter="$beforeafter$" defaultState={{$:/config/SearchResults/Default}} actions="""<$action-setfield $tiddler="$:/state/advancedsearch/standard/currentTab" text=<<nextTab>>/>"""/>
 

--- a/core/ui/AdvancedSearch/System.tid
+++ b/core/ui/AdvancedSearch/System.tid
@@ -4,7 +4,7 @@ caption: {{$:/language/Search/System/Caption}}
 first-search-filter: [is[system]search<userInput>sort[title]limit[250]] -[[$:/temp/advancedsearch]] -[[$:/temp/advancedsearch/input]] -[[$:/temp/advancedsearch/selected-item]]
 
 \define lingo-base() $:/language/Search/
-\define set-next-input-tab(beforeafter:"after",stateTitle,tag,defaultState,currentTabTiddler) <$macrocall $name="change-input-tab" stateTitle="$:/state/tab/advanced-search-results" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
+\define set-next-input-tab(beforeafter:"after",stateTitle,tag,defaultState,currentTabTiddler) <$macrocall $name="change-input-tab" stateTitle="$:/state/tab--1498284803" tag="$:/tags/AdvancedSearch" beforeafter="$beforeafter$" defaultState="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<nextTab>>/>"""/>
 
 \define cancel-search-actions() <$list filter="[{$:/temp/advancedsearch}!match{$:/temp/advancedsearch/input}]" emptyMessage="""<$action-deletetiddler $filter="[[$:/temp/advancedsearch]] [[$:/temp/advancedsearch/input]] [[$:/temp/advancedsearch/selected-item]]" />"""><$action-setfield $tiddler="$:/temp/advancedsearch/input" text={{$:/temp/advancedsearch}}/><$action-setfield $tiddler="$:/temp/advancedsearch/refresh" text="yes"/></$list><$action-sendmessage $message="tm-focus-selector" $param=""".tc-advanced-search input"""/>
 

--- a/core/ui/ControlPanel.tid
+++ b/core/ui/ControlPanel.tid
@@ -3,5 +3,5 @@ icon: $:/core/images/options-button
 color: #bbb
 
 <div class="tc-control-panel">
-<<tabs "[all[shadows+tiddlers]tag[$:/tags/ControlPanel]!has[draft.of]]" "$:/core/ui/ControlPanel/Info">>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel]!has[draft.of]]" default="$:/core/ui/ControlPanel/Info" explicitState="$:/state/tab/control-panel"/>
 </div>

--- a/core/ui/ControlPanel.tid
+++ b/core/ui/ControlPanel.tid
@@ -3,5 +3,5 @@ icon: $:/core/images/options-button
 color: #bbb
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel]!has[draft.of]]" default="$:/core/ui/ControlPanel/Info" explicitState="$:/state/tab/control-panel"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel]!has[draft.of]]" default="$:/core/ui/ControlPanel/Info" explicitState="$:/state/tab-1749438307"/>
 </div>

--- a/core/ui/ControlPanel/Advanced.tid
+++ b/core/ui/ControlPanel/Advanced.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Advanced/Caption}}
 {{$:/language/ControlPanel/Advanced/Hint}}
 
 <div class="tc-control-panel">
-<<tabs "[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Advanced]!has[draft.of]]" "$:/core/ui/ControlPanel/TiddlerFields">>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Advanced]!has[draft.of]]" default="$:/core/ui/ControlPanel/TiddlerFields" explicitState="$:/state/tab/control-panel/info/advanced"/>
 </div>

--- a/core/ui/ControlPanel/Advanced.tid
+++ b/core/ui/ControlPanel/Advanced.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Advanced/Caption}}
 {{$:/language/ControlPanel/Advanced/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Advanced]!has[draft.of]]" default="$:/core/ui/ControlPanel/TiddlerFields" explicitState="$:/state/tab/control-panel/info/advanced"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Advanced]!has[draft.of]]" default="$:/core/ui/ControlPanel/TiddlerFields" explicitState="$:/state/tab--959111941"/>
 </div>

--- a/core/ui/ControlPanel/Appearance.tid
+++ b/core/ui/ControlPanel/Appearance.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Appearance/Caption}}
 {{$:/language/ControlPanel/Appearance/Hint}}
 
 <div class="tc-control-panel">
-<<tabs "[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Appearance]!has[draft.of]]" "$:/core/ui/ControlPanel/Theme">>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Appearance]!has[draft.of]]" default="$:/core/ui/ControlPanel/Theme" explicitState="$:/state/tab/control-panel/appearance"/>
 </div>

--- a/core/ui/ControlPanel/Appearance.tid
+++ b/core/ui/ControlPanel/Appearance.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Appearance/Caption}}
 {{$:/language/ControlPanel/Appearance/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Appearance]!has[draft.of]]" default="$:/core/ui/ControlPanel/Theme" explicitState="$:/state/tab/control-panel/appearance"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Appearance]!has[draft.of]]" default="$:/core/ui/ControlPanel/Theme" explicitState="$:/state/tab--1963855381"/>
 </div>

--- a/core/ui/ControlPanel/Info.tid
+++ b/core/ui/ControlPanel/Info.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Info/Caption}}
 {{$:/language/ControlPanel/Info/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Info]!has[draft.of]]" default="$:/core/ui/ControlPanel/Basics" explicitState="$:/state/tab/control-panel/info"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Info]!has[draft.of]]" default="$:/core/ui/ControlPanel/Basics" explicitState="$:/state/tab--2112689675"/>
 </div>

--- a/core/ui/ControlPanel/Info.tid
+++ b/core/ui/ControlPanel/Info.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Info/Caption}}
 {{$:/language/ControlPanel/Info/Hint}}
 
 <div class="tc-control-panel">
-<<tabs "[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Info]!has[draft.of]]" "$:/core/ui/ControlPanel/Basics">>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Info]!has[draft.of]]" default="$:/core/ui/ControlPanel/Basics" explicitState="$:/state/tab/control-panel/info"/>
 </div>

--- a/core/ui/ControlPanel/Modals/AddPlugins.tid
+++ b/core/ui/ControlPanel/Modals/AddPlugins.tid
@@ -148,7 +148,7 @@ $:/state/add-plugin-info/$(connectionTiddler)$/$(assetInfo)$
 
 <$set name="transclusion" value=<<connectionTiddler>>>
 
-<<tabs "[[$:/core/ui/ControlPanel/Plugins/Add/Updates]] [[$:/core/ui/ControlPanel/Plugins/Add/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Add/Themes]] [[$:/core/ui/ControlPanel/Plugins/Add/Languages]]" "$:/core/ui/ControlPanel/Plugins/Add/Plugins">>
+<$macrocall $name="tabs" tabsList="[[$:/core/ui/ControlPanel/Plugins/Add/Updates]] [[$:/core/ui/ControlPanel/Plugins/Add/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Add/Themes]] [[$:/core/ui/ControlPanel/Plugins/Add/Languages]]" default="$:/core/ui/ControlPanel/Plugins/Add/Plugins" explicitState="$:/state/tab/control-panel/plugins/modals/add-plugins"/>
 
 </$set>
 

--- a/core/ui/ControlPanel/Modals/AddPlugins.tid
+++ b/core/ui/ControlPanel/Modals/AddPlugins.tid
@@ -148,7 +148,7 @@ $:/state/add-plugin-info/$(connectionTiddler)$/$(assetInfo)$
 
 <$set name="transclusion" value=<<connectionTiddler>>>
 
-<$macrocall $name="tabs" tabsList="[[$:/core/ui/ControlPanel/Plugins/Add/Updates]] [[$:/core/ui/ControlPanel/Plugins/Add/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Add/Themes]] [[$:/core/ui/ControlPanel/Plugins/Add/Languages]]" default="$:/core/ui/ControlPanel/Plugins/Add/Plugins" explicitState="$:/state/tab/control-panel/plugins/modals/add-plugins"/>
+<$macrocall $name="tabs" tabsList="[[$:/core/ui/ControlPanel/Plugins/Add/Updates]] [[$:/core/ui/ControlPanel/Plugins/Add/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Add/Themes]] [[$:/core/ui/ControlPanel/Plugins/Add/Languages]]" default="$:/core/ui/ControlPanel/Plugins/Add/Plugins" explicitState="$:/state/addplugins/tab-1342078386"/>
 
 </$set>
 

--- a/core/ui/ControlPanel/Plugins.tid
+++ b/core/ui/ControlPanel/Plugins.tid
@@ -16,4 +16,4 @@ caption: {{$:/language/ControlPanel/Plugins/Caption}}
 
 <<lingo Installed/Hint>>
 
-<<tabs "[[$:/core/ui/ControlPanel/Plugins/Installed/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Installed/Themes]] [[$:/core/ui/ControlPanel/Plugins/Installed/Languages]]" "$:/core/ui/ControlPanel/Plugins/Installed/Plugins">>
+<$macrocall $name="tabs" tabsList="[[$:/core/ui/ControlPanel/Plugins/Installed/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Installed/Themes]] [[$:/core/ui/ControlPanel/Plugins/Installed/Languages]]" default="$:/core/ui/ControlPanel/Plugins/Installed/Plugins" explicitState="$:/state/tab/control-panel/plugins"/>

--- a/core/ui/ControlPanel/Plugins.tid
+++ b/core/ui/ControlPanel/Plugins.tid
@@ -16,4 +16,4 @@ caption: {{$:/language/ControlPanel/Plugins/Caption}}
 
 <<lingo Installed/Hint>>
 
-<$macrocall $name="tabs" tabsList="[[$:/core/ui/ControlPanel/Plugins/Installed/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Installed/Themes]] [[$:/core/ui/ControlPanel/Plugins/Installed/Languages]]" default="$:/core/ui/ControlPanel/Plugins/Installed/Plugins" explicitState="$:/state/tab/control-panel/plugins"/>
+<$macrocall $name="tabs" tabsList="[[$:/core/ui/ControlPanel/Plugins/Installed/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Installed/Themes]] [[$:/core/ui/ControlPanel/Plugins/Installed/Languages]]" default="$:/core/ui/ControlPanel/Plugins/Installed/Plugins" explicitState="$:/state/tab--86143343"/>

--- a/core/ui/ControlPanel/Saving.tid
+++ b/core/ui/ControlPanel/Saving.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Saving/Caption}}
 {{$:/language/ControlPanel/Saving/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Saving]!has[draft.of]]" default="$:/core/ui/ControlPanel/Saving/General" explicitState="$:/state/tab/control-panel/saving"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Saving]!has[draft.of]]" default="$:/core/ui/ControlPanel/Saving/General" explicitState="$:/state/tab-2065006209"/>
 </div>

--- a/core/ui/ControlPanel/Saving.tid
+++ b/core/ui/ControlPanel/Saving.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Saving/Caption}}
 {{$:/language/ControlPanel/Saving/Hint}}
 
 <div class="tc-control-panel">
-<<tabs "[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Saving]!has[draft.of]]" "$:/core/ui/ControlPanel/Saving/General">>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Saving]!has[draft.of]]" default="$:/core/ui/ControlPanel/Saving/General" explicitState="$:/state/tab/control-panel/saving"/>
 </div>

--- a/core/ui/ControlPanel/Toolbars.tid
+++ b/core/ui/ControlPanel/Toolbars.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Toolbars/Caption}}
 {{$:/language/ControlPanel/Toolbars/Hint}}
 
 <div class="tc-control-panel">
-<<tabs "[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Toolbars]!has[draft.of]]" "$:/core/ui/ControlPanel/Toolbars/ViewToolbar" "$:/state/tabs/controlpanel/toolbars" "tc-vertical">>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Toolbars]!has[draft.of]]" default="$:/core/ui/ControlPanel/Toolbars/ViewToolbar" class="tc-vertical" explicitState="$:/state/tab/control-panel/appearance/toolbars"/>
 </div>

--- a/core/ui/ControlPanel/Toolbars.tid
+++ b/core/ui/ControlPanel/Toolbars.tid
@@ -5,5 +5,5 @@ caption: {{$:/language/ControlPanel/Toolbars/Caption}}
 {{$:/language/ControlPanel/Toolbars/Hint}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Toolbars]!has[draft.of]]" default="$:/core/ui/ControlPanel/Toolbars/ViewToolbar" class="tc-vertical" explicitState="$:/state/tab/control-panel/appearance/toolbars"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Toolbars]!has[draft.of]]" default="$:/core/ui/ControlPanel/Toolbars/ViewToolbar" class="tc-vertical" explicitState="$:/state/tabs/controlpanel/toolbars-1345989671"/>
 </div>

--- a/core/ui/MoreSideBar/Plugins.tid
+++ b/core/ui/MoreSideBar/Plugins.tid
@@ -5,4 +5,4 @@ caption: {{$:/language/ControlPanel/Plugins/Caption}}
 
 {{$:/language/ControlPanel/Plugins/Installed/Hint}}
 
-<<tabs "[all[shadows+tiddlers]tag[$:/tags/MoreSideBar/Plugins]!has[draft.of]]" "$:/core/ui/MoreSideBar/Plugins/Plugins">>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar/Plugins]!has[draft.of]]" default="$:/core/ui/MoreSideBar/Plugins/Plugins" explicitState="$:/state/tab/sidebar-tabs/more/plugins"/>

--- a/core/ui/MoreSideBar/Plugins.tid
+++ b/core/ui/MoreSideBar/Plugins.tid
@@ -5,4 +5,4 @@ caption: {{$:/language/ControlPanel/Plugins/Caption}}
 
 {{$:/language/ControlPanel/Plugins/Installed/Hint}}
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar/Plugins]!has[draft.of]]" default="$:/core/ui/MoreSideBar/Plugins/Plugins" explicitState="$:/state/tab/sidebar-tabs/more/plugins"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar/Plugins]!has[draft.of]]" default="$:/core/ui/MoreSideBar/Plugins/Plugins" explicitState="$:/state/tab-1163638994"/>

--- a/core/ui/SideBar/More.tid
+++ b/core/ui/SideBar/More.tid
@@ -3,5 +3,5 @@ tags: $:/tags/SideBar
 caption: {{$:/language/SideBar/More/Caption}}
 
 <div class="tc-more-sidebar">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar]!has[draft.of]]" default={{$:/config/DefaultMoreSidebarTab}} state="$:/state/tab/moresidebar" class="tc-vertical tc-sidebar-tabs-more" explicitState="$:/state/tab/sidebar-tabs/more"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar]!has[draft.of]]" default={{$:/config/DefaultMoreSidebarTab}} state="$:/state/tab/moresidebar" class="tc-vertical tc-sidebar-tabs-more" explicitState="$:/state/tab/moresidebar-1850697562"/>
 </div>

--- a/core/ui/SideBar/More.tid
+++ b/core/ui/SideBar/More.tid
@@ -3,5 +3,5 @@ tags: $:/tags/SideBar
 caption: {{$:/language/SideBar/More/Caption}}
 
 <div class="tc-more-sidebar">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar]!has[draft.of]]" default={{$:/config/DefaultMoreSidebarTab}} state="$:/state/tab/moresidebar" class="tc-vertical tc-sidebar-tabs-more" />
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/MoreSideBar]!has[draft.of]]" default={{$:/config/DefaultMoreSidebarTab}} state="$:/state/tab/moresidebar" class="tc-vertical tc-sidebar-tabs-more" explicitState="$:/state/tab/sidebar-tabs/more"/>
 </div>

--- a/core/ui/SideBarSegments/tabs.tid
+++ b/core/ui/SideBarSegments/tabs.tid
@@ -3,6 +3,6 @@ tags: $:/tags/SideBarSegment
 
 <div class="tc-sidebar-lists tc-sidebar-tabs">
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" class="tc-sidebar-tabs-main"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" class="tc-sidebar-tabs-main" explicitState="$:/state/tab/sidebar-tabs"/>
 
 </div>

--- a/core/ui/SideBarSegments/tabs.tid
+++ b/core/ui/SideBarSegments/tabs.tid
@@ -3,6 +3,6 @@ tags: $:/tags/SideBarSegment
 
 <div class="tc-sidebar-lists tc-sidebar-tabs">
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" class="tc-sidebar-tabs-main" explicitState="$:/state/tab/sidebar-tabs"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" class="tc-sidebar-tabs-main" explicitState="$:/state/tab/sidebar--595412856"/>
 
 </div>

--- a/core/ui/TiddlerInfo.tid
+++ b/core/ui/TiddlerInfo.tid
@@ -10,4 +10,4 @@ title: $:/core/ui/TiddlerInfo
 </div>
 </div>
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfo]!has[draft.of]]" default={{$:/config/TiddlerInfo/Default}} explicitState={{{ [[$:/state/tab/tiddler-info/]addsuffix<currentTiddler>] }}}/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfo]!has[draft.of]]" default={{$:/config/TiddlerInfo/Default}}/>

--- a/core/ui/TiddlerInfo.tid
+++ b/core/ui/TiddlerInfo.tid
@@ -10,4 +10,4 @@ title: $:/core/ui/TiddlerInfo
 </div>
 </div>
 
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfo]!has[draft.of]]" default={{$:/config/TiddlerInfo/Default}}/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfo]!has[draft.of]]" default={{$:/config/TiddlerInfo/Default}} explicitState={{{ [[$:/state/tab/tiddler-info/]addsuffix<currentTiddler>] }}}/>

--- a/plugins/tiddlywiki/codemirror/ui/controlpanel/settings.tid
+++ b/plugins/tiddlywiki/codemirror/ui/controlpanel/settings.tid
@@ -3,5 +3,5 @@ tags: $:/tags/ControlPanel
 caption: {{$:/language/ControlPanel/Settings/Caption}}
 
 <div class="tc-control-panel">
-<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/SettingsTab]!has[draft.of]]" default="$:/core/ui/ControlPanel/Settings/TiddlyWiki" explicitState="$:/state/tab/control-panel/settings"/>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/SettingsTab]!has[draft.of]]" default="$:/core/ui/ControlPanel/Settings/TiddlyWiki" explicitState="$:/state/tab--697582678"/>
 </div>

--- a/plugins/tiddlywiki/codemirror/ui/controlpanel/settings.tid
+++ b/plugins/tiddlywiki/codemirror/ui/controlpanel/settings.tid
@@ -3,5 +3,5 @@ tags: $:/tags/ControlPanel
 caption: {{$:/language/ControlPanel/Settings/Caption}}
 
 <div class="tc-control-panel">
-<<tabs "[all[shadows+tiddlers]tag[$:/tags/ControlPanel/SettingsTab]!has[draft.of]]" "$:/core/ui/ControlPanel/Settings/TiddlyWiki">>
+<$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/SettingsTab]!has[draft.of]]" default="$:/core/ui/ControlPanel/Settings/TiddlyWiki" explicitState="$:/state/tab/control-panel/settings"/>
 </div>


### PR DESCRIPTION
All of the core `tabs macros` are updated to use the `explicitState` parameter, except the tabs macro of the `$:/core/ui/Components/plugin-info` tiddler, where I think it doesn't make sense to change it