### PR TITLE
Tag-picker: focus tag-input after clicking a tag from the dropdown

### DIFF
--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -24,7 +24,7 @@ $actions$
 <$button class="tc-btn-invisible $selectedClass$" tag="a" tooltip={{$:/language/EditTemplate/Tags/Add/Button/Hint}}>
 <$action-sendmessage $message="tm-add-tag" $param=<<tag>>/>
 <$set name="currentTiddlerCSSEscaped" value={{{ [<storyTiddler>escapecss[]] }}}>
-<$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>>/>
+<$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>> preventScroll="true"/>
 </$set>
 <<delete-tag-state-tiddlers>>
 $actions$

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -23,6 +23,9 @@ $actions$
 \define tag-button(actions,selectedClass)
 <$button class="tc-btn-invisible $selectedClass$" tag="a" tooltip={{$:/language/EditTemplate/Tags/Add/Button/Hint}}>
 <$action-sendmessage $message="tm-add-tag" $param=<<tag>>/>
+<$set name="currentTiddlerCSSEscaped" value={{{ [<storyTiddler>escapecss[]] }}}>
+<$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>>/>
+</$set>
 <<delete-tag-state-tiddlers>>
 $actions$
 <$macrocall $name="tag-pill" tag=<<tag>>/>


### PR DESCRIPTION
This PR makes the tag-picker input focus again when clicking a tag to add from the tag-dropdown. This is very convenient when adding more tags by clicking (and not using the keyboard for it)