### PR TITLE
Add "meta" to getEventModifierKeyDescriptor

### DIFF
--- a/core/modules/keyboard.js
+++ b/core/modules/keyboard.js
@@ -285,13 +285,17 @@ KeyboardManager.prototype.checkKeyDescriptors = function(event,keyInfoArray) {
 };
 
 KeyboardManager.prototype.getEventModifierKeyDescriptor = function(event) {
-	return event.ctrlKey && !event.shiftKey && !event.altKey ? "ctrl" : 
-		event.shiftKey && !event.ctrlKey && !event.altKey? "shift" : 
-		event.ctrlKey && event.shiftKey && !event.altKey ? "ctrl-shift" : 
-		event.altKey && !event.shiftKey && !event.ctrlKey ? "alt" : 
-		event.altKey && event.shiftKey && !event.ctrlKey ? "alt-shift" : 
-		event.altKey && event.ctrlKey && !event.shiftKey ? "ctrl-alt" : 
-		event.altKey && event.shiftKey && event.ctrlKey ? "ctrl-alt-shift" : "normal";
+	return event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey ? "ctrl" : 
+		event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey ? "shift" : 
+		event.ctrlKey && event.shiftKey && !event.altKey && !event.metaKey ? "ctrl-shift" : 
+		event.altKey && !event.shiftKey && !event.ctrlKey && !event.metaKey ? "alt" : 
+		event.altKey && event.shiftKey && !event.ctrlKey && !event.metaKey ? "alt-shift" : 
+		event.altKey && event.ctrlKey && !event.shiftKey && !event.metaKey ? "ctrl-alt" : 
+		event.altKey && event.shiftKey && event.ctrlKey && !event.metaKey ? "ctrl-alt-shift" : 
+		event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey ? "meta" : 
+		event.metaKey && event.ctrlKey && !event.shiftKey && !event.altKey ? "meta-ctrl" :
+		event.metaKey && event.ctrlKey && event.shiftKey && !event.altKey ? "meta-ctrl-shift" :
+		event.metaKey && event.ctrlKey & event.shiftKey && event.altKey ? "meta-ctrl-alt-shift" : "normal";
 };
 
 KeyboardManager.prototype.getShortcutTiddlerList = function() {

--- a/editions/tw5.com/tiddlers/variables/modifier Variable.tid
+++ b/editions/tw5.com/tiddlers/variables/modifier Variable.tid
@@ -3,16 +3,24 @@ title: modifier Variable
 type: text/vnd.tiddlywiki
 
 Within the ''action'' string of the DroppableWidget, the ''action'' string of the ButtonWidget and the ''action'' string of the LinkCatcherWidget, the <<.def modifier>> [[variable|Variables]] contains the modifier key(s) held during the drag-process.
-The possible keys are ''ctrl'', ''shift'', ''alt'', ''ctrl'' and ''shift'', ''alt'' and ''shift'', ''ctrl'' and ''alt'', ''ctrl'' and ''alt'' and ''shift''
+The possible keys are ''meta'', ''ctrl'', ''shift'', ''alt'', ''meta'' and ''ctrl'', ''meta'' and ''shift'', ''meta'' and ''alt'', ''ctrl'' and ''shift'', ''alt'' and ''shift'', ''ctrl'' and ''alt'', ''ctrl'' and ''alt'' and ''shift'', ''meta'' and ''alt'' and ''shift'', ''meta'' and ''ctrl'' and ''shift'', ''meta'' and ''ctrl'' and ''alt'', ''meta'' and ''ctrl'' and ''alt'' and ''shift''
 
 The variable contains a string that identifies the keys:
 
 |Modifier Key |Variable Content |h
+|meta |meta |
 |ctrl |ctrl |
 |alt |alt |
 |shift |shift |
+|meta+shift |meta-shift |
+|meta+ctrl |meta-ctrl |
+|meta+alt |meta-alt |
 |ctrl+shift |ctrl-shift |
 |alt+shift |alt-shift |
 |ctrl+alt |ctrl-alt |
+|meta+ctrl+shift |meta-ctrl-shift |
+|meta+ctrl+alt |meta-ctrl-alt |
+|meta+alt+shift |meta-alt-shift |
 |ctrl+alt+shift |ctrl-alt-shift |
+|meta+ctrl+alt+shift |meta-ctrl-alt-shift |
 |no modifier (normal click / drag) |normal |


### PR DESCRIPTION
this PR adds the "meta" key to the `getEventModifierKeyDescriptor` method in keyboard.js which makes meta also accessible for the droppable widget

Fixes #4820