### PR TITLE
Correct breakpoint for no-box-shadow in snowwhite/base stylesheet

### DIFF
--- a/themes/tiddlywiki/snowwhite/base.tid
+++ b/themes/tiddlywiki/snowwhite/base.tid
@@ -1,6 +1,10 @@
 title: $:/themes/tiddlywiki/snowwhite/base
 tags: [[$:/tags/Stylesheet]]
 
+\define sidebarbreakpoint-minus-one()
+<$text text={{{ [{$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint}removesuffix[px]subtract[1]addsuffix[px]] ~[{$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint}] }}}/>
+\end
+
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline
 
 .tc-sidebar-header {
@@ -17,7 +21,7 @@ tags: [[$:/tags/Stylesheet]]
 	}
 }
 
-@media (max-width: {{$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint}}) {
+@media (max-width: <<sidebarbreakpoint-minus-one>>) {
 	.tc-tiddler-frame {
 		<<box-shadow none>>
 	}


### PR DESCRIPTION
When a tiddlywiki is exactly half-screen on a 1920px screen the sidebar does not yet break but the box-shadows are gone. This PR fixes that