### PR TITLE
Added disabled attribute support to ButtonWidget

### DIFF
--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -67,7 +67,10 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 	// Set the tabindex
 	if(this.tabIndex) {
 		domNode.setAttribute("tabindex",this.tabIndex);
-	}	
+	}
+	if(this.isDisabled === "yes") {
+		domNode.setAttribute("disabled",true);
+	}
 	// Add a click event handler
 	domNode.addEventListener("click",function (event) {
 		var handled = false;
@@ -211,6 +214,7 @@ ButtonWidget.prototype.execute = function() {
 	this.setIndex = this.getAttribute("setIndex");
 	this.popupTitle = this.getAttribute("popupTitle");
 	this.tabIndex = this.getAttribute("tabindex");
+	this.isDisabled = this.getAttribute("disabled","no");
 	// Make child widgets
 	this.makeChildWidgets();
 };
@@ -220,7 +224,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 ButtonWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.actions || changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes["class"] || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || (this.popupTitle && changedTiddlers[this.popupTitle]) || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle) {
+	if(changedAttributes.actions || changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes["class"] || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || (this.popupTitle && changedTiddlers[this.popupTitle]) || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle || changedAttributes.disabled) {
 		this.refreshSelf();
 		return true;
 	}

--- a/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
@@ -45,7 +45,7 @@ The content of the `<$button>` widget is displayed within the button.
 |dragTiddler |An optional tiddler title making the button draggable and identifying the payload tiddler. See DraggableWidget for details |
 |dragFilter |An optional filter making the button draggable and identifying the list of payload tiddlers. See DraggableWidget for details |
 |tabindex |Sets the `tabindex` attribute of the button to the given value |
-|disabled|Optional, disables the button if set to "yes". Defaults to "no"|
+|disabled|<<.from-version "5.1.23">> Optional, disables the button if set to "yes". Defaults to "no"|
 
 ''Note:'' In almost all other cases where a TextReference is used as a widget attribute, it will be placed between curly brackets, to [[transclude|Transclusion in WikiText]] the value currently stored there. However, when we use a TextReference as the value of a button widget's <<.attr set>> attribute, we are referencing //the storage location itself//, rather than the value stored there, so we do ''not'' use curly brackets there. //Example:// we could code a button widget that sets the `caption` field of TiddlerA to be the same as that of TiddlerB as:
 

--- a/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
@@ -1,6 +1,6 @@
 caption: button
 created: 20131024141900000
-modified: 20200131171028279
+modified: 20201108183908170
 tags: Widgets
 title: ButtonWidget
 type: text/vnd.tiddlywiki
@@ -45,6 +45,7 @@ The content of the `<$button>` widget is displayed within the button.
 |dragTiddler |An optional tiddler title making the button draggable and identifying the payload tiddler. See DraggableWidget for details |
 |dragFilter |An optional filter making the button draggable and identifying the list of payload tiddlers. See DraggableWidget for details |
 |tabindex |Sets the `tabindex` attribute of the button to the given value |
+|disabled|Optional, disables the button if set to "yes". Defaults to "no"|
 
 ''Note:'' In almost all other cases where a TextReference is used as a widget attribute, it will be placed between curly brackets, to [[transclude|Transclusion in WikiText]] the value currently stored there. However, when we use a TextReference as the value of a button widget's <<.attr set>> attribute, we are referencing //the storage location itself//, rather than the value stored there, so we do ''not'' use curly brackets there. //Example:// we could code a button widget that sets the `caption` field of TiddlerA to be the same as that of TiddlerB as:
 


### PR DESCRIPTION
Fixes #3390 and I've needed this a few times myself when wanting to validate user input before saving.

Adds a parameter `disabled` to the ButtonWidget which must be set to "yes" to disable the button.