### PR TITLE
Import UI : Fix issue with size of rename button

### DIFF
--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -29,7 +29,7 @@ title: $:/core/ui/ImportListing
 <table class="tc-import-table">
 <tbody>
 <tr>
-<th align="left" style="width:10%">
+<th align="left">
 <$checkbox tiddler="$:/state/import/select-all" field="text" checked="checked" unchecked="unchecked" default="checked" actions=<<select-all-actions>>>
 <<lingo Listing/Select/Caption>>
 </$checkbox>

--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -29,7 +29,7 @@ title: $:/core/ui/ImportListing
 <table class="tc-import-table">
 <tbody>
 <tr>
-<th align="left">
+<th align="left" style="width:10%">
 <$checkbox tiddler="$:/state/import/select-all" field="text" checked="checked" unchecked="unchecked" default="checked" actions=<<select-all-actions>>>
 <<lingo Listing/Select/Caption>>
 </$checkbox>
@@ -49,10 +49,10 @@ title: $:/core/ui/ImportListing
 <td>
 <$reveal type="nomatch" state=<<renameFieldState>> text="yes" tag="div">
 <$reveal type="nomatch" state=<<previewPopupState>> text="yes" tag="div" class="tc-flex">
-<$button class="tc-btn-invisible tc-btn-dropdown tc-flex-grow-1" set=<<previewPopupState>> setTo="yes">
+<$button class="tc-btn-invisible tc-btn-dropdown tc-flex-grow-1 tc-word-break" set=<<previewPopupState>> setTo="yes">
 <span class="tc-small-gap-right">{{$:/core/images/right-arrow}}</span><$text text={{{[subfilter<payloadTitleFilter>]}}}/>
 </$button>
-<$button class="tc-btn-invisible tc-small-gap-left" set=<<renameFieldState>> setTo="yes" tooltip={{{[<lingo-base>addsuffix[Listing/Rename/Tooltip]get[text]]}}}>{{$:/core/images/edit-button}}</$button>
+<$button class="tc-btn-invisible" set=<<renameFieldState>> setTo="yes" tooltip={{{[<lingo-base>addsuffix[Listing/Rename/Tooltip]get[text]]}}}>{{$:/core/images/edit-button}}</$button>
 </$reveal>
 <$reveal type="match" state=<<previewPopupState>> text="yes" tag="div">
 <$button class="tc-btn-invisible tc-btn-dropdown" set=<<previewPopupState>> setTo="no">

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2044,6 +2044,10 @@ html body.tc-body.tc-single-tiddler-window {
 	max-width: unset;
 }
 
+.tc-import-table th:first-of-type {
+	width: 10%;
+}
+
 .tc-import-table th:last-of-type {
 	width: 30%;
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2040,6 +2040,14 @@ html body.tc-body.tc-single-tiddler-window {
 	width: 100%;
 }
 
+.tc-import-table svg.tc-image-edit-button {
+	max-width: unset;
+}
+
+.tc-import-table th:last-of-type {
+	width: 30%;
+}
+
 /*
 ** Alerts
 */
@@ -2831,4 +2839,8 @@ select {
 
 .tc-big-gap-right {
 	margin-right: 1em;
+}
+
+.tc-word-break {
+	word-break: break-all;
 }


### PR DESCRIPTION
Fixes an issue where the rename button size could vary between table rows depending on content flow.

Also optimizes table layout so that there is enough space for the titles when there are long status messages, and that if necessary the titles can break and wrap to the next line.

I would be in favour or re-doing the entire UI for a future release, using DIVs and flexbox, instead of a table, to allow for a more flexible layout.