### PR TITLE
Cycle operator and refactored toggle operator

### DIFF
--- a/core/modules/filters/x-listops.js
+++ b/core/modules/filters/x-listops.js
@@ -16,11 +16,11 @@ Extended filter operators to manipulate the current list.
     Fetch titles from the current list
     */
     var prepare_results = function (source) {
-		var results = [];
-		source(function (tiddler, title) {
-			results.push(title);
-		});
-		return results;
+    var results = [];
+        source(function (tiddler, title) {
+            results.push(title);
+        });
+        return results;
     };
 
     /*
@@ -194,11 +194,11 @@ Extended filter operators to manipulate the current list.
 			nextOperandIndex;		
 		for(i; i < operands.length; i++) {
 			resultsIndex = results.indexOf(operands[i]);
-			if(resultsIndex != -1) {
+			if(resultsIndex !== -1) {
 				break;
 			}
 		}
-		if(resultsIndex != -1) {
+		if(resultsIndex !== -1) {
 			i++;
 			nextOperandIndex = (i === operands.length ? 0 : i);
 			if(operands.length > 1) {

--- a/core/modules/filters/x-listops.js
+++ b/core/modules/filters/x-listops.js
@@ -16,7 +16,7 @@ Extended filter operators to manipulate the current list.
     Fetch titles from the current list
     */
     var prepare_results = function (source) {
-    var results = [];
+		var results = [];
         source(function (tiddler, title) {
             results.push(title);
         });
@@ -187,26 +187,45 @@ Extended filter operators to manipulate the current list.
         }, []);
         return set;
     };
-	
-	/*
-	Toggles an item in the current list.
-	*/
-	exports.toggle = function(source, operator) {
-		var results = prepare_results(source),
-			index = results.indexOf(operator.operand),
-			pairIndex = (operator.operands[1] ? results.indexOf(operator.operands[1]) : -1);
-		if(index === -1) {
-			results.push(operator.operand);
-			if(pairIndex !== -1) {
-				results.splice(pairIndex,1);
-			}
-		} else {
-			results.splice(index,1);
-			if(operator.operands[1]) {
-				results.push(operator.operands[1]);
+
+	var cycleValueInArray = function(results,operands) {
+		var resultsIndex,
+			i = 0,
+			nextOperandIndex;		
+		for(i; i < operands.length; i++) {
+			resultsIndex = results.indexOf(operands[i]);
+			if(resultsIndex != -1) {
+				break;
 			}
 		}
-		return results;
-	};
+		if(resultsIndex != -1) {
+			i++;
+			nextOperandIndex = (i === operands.length ? 0 : i);
+			if(operands.length > 1) {
+				results.splice(resultsIndex,1,operands[nextOperandIndex]);
+			} else {
+				results.splice(resultsIndex,1,);
+			}
+		} else {
+			results.push(operands[0]);
+		}
+		return results;		
+	}
+
+	/*
+	Toggles an item in the current list.
+	*/	
+	exports.toggle = function(source,operator) {
+		return cycleValueInArray(prepare_results(source),operator.operands);
+	}
+
+	exports.cycle = function(source,operator) {
+		var results = prepare_results(source),
+			operands = $tw.utils.parseStringArray(operator.operand, "true");
+		if(operator.suffix === "reverse") {
+			operands.reverse();
+		}
+		return cycleValueInArray(results,operands);
+	}
 	
 })();

--- a/core/modules/filters/x-listops.js
+++ b/core/modules/filters/x-listops.js
@@ -17,10 +17,10 @@ Extended filter operators to manipulate the current list.
     */
     var prepare_results = function (source) {
 		var results = [];
-        source(function (tiddler, title) {
-            results.push(title);
-        });
-        return results;
+		source(function (tiddler, title) {
+			results.push(title);
+		});
+		return results;
     };
 
     /*
@@ -221,7 +221,7 @@ Extended filter operators to manipulate the current list.
 
 	exports.cycle = function(source,operator) {
 		var results = prepare_results(source),
-			operands = $tw.utils.parseStringArray(operator.operand, "true");
+			operands = (operator.operand.length ? $tw.utils.parseStringArray(operator.operand, "true") : [""]);
 		if(operator.suffix === "reverse") {
 			operands.reverse();
 		}


### PR DESCRIPTION
@Jermolene @kookma @pmario 
This PR refactors `toggle[]` and introduces a new `cycle[]` operator, following the discussion in #5015 

Both use the same underlying code to avoid duplication. 

`cycle[]` accepts one operand which is parsed as a title list.
`toggle[]` accepts unlimited operands, where each operand is a title.

`cycle[]` also accepts the optional suffix `reverse`

Otherwise their behaviour is identical. We could easily limit `toggle[]` to 2 operands if desired, but the extra functionality comes at no cost.

The output of the following is now identical:

`[[...input-list...]cycle[todo soon now done]]`

`[[...input-list...]toggle[todo],[soon],[now],[done]]`

The advantage with `cycle[]` is that we can pass it a text reference or variable from which to derive the list of values to cycle through.

Feedback and thoughts please.
Once we have consensus I will work on documentation.

PS: for some reason the entirety of x-listops.js uses spaces instead of tabs, will fix in a separate PR.