### PR TITLE
Modals: add navigator to handle tm-navigate

### DIFF
--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -23,10 +23,7 @@ exports.startup = function() {
 	// Install the modal message mechanism
 	$tw.modal = new $tw.utils.Modal($tw.wiki);
 	$tw.rootWidget.addEventListener("tm-modal",function(event) {
-		var paramObject = (event.paramObject || {});
-		paramObject["tv-story-list"] = paramObject["tv-story-list"] || event.widget.getVariable("tv-story-list");
-		paramObject["tv-history-list"] = paramObject["tv-history-list"] || event.widget.getVariable("tv-history-list");
-		$tw.modal.display(event.param,{variables: paramObject, event: event});
+		$tw.modal.display(event.param,{variables: event.paramObject, event: event});
 	});
 	// Install the notification  mechanism
 	$tw.notifier = new $tw.utils.Notifier($tw.wiki);

--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -23,7 +23,10 @@ exports.startup = function() {
 	// Install the modal message mechanism
 	$tw.modal = new $tw.utils.Modal($tw.wiki);
 	$tw.rootWidget.addEventListener("tm-modal",function(event) {
-		$tw.modal.display(event.param,{variables: event.paramObject, event: event});
+		var paramObject = (event.paramObject || {});
+		paramObject["tv-story-list"] = paramObject["tv-story-list"] || event.widget.getVariable("tv-story-list");
+		paramObject["tv-history-list"] = paramObject["tv-history-list"] || event.widget.getVariable("tv-history-list");
+		$tw.modal.display(event.param,{variables: paramObject, event: event});
 	});
 	// Install the notification  mechanism
 	$tw.notifier = new $tw.utils.Notifier($tw.wiki);

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -13,7 +13,7 @@ Modal message mechanism
 "use strict";
 
 var widget = require("$:/core/modules/widgets/widget.js");
-var nav = require("$:/core/modules/widgets/navigator.js");
+var navigator = require("$:/core/modules/widgets/navigator.js");
 
 var Modal = function(wiki) {
 	this.wiki = wiki;
@@ -99,7 +99,7 @@ Modal.prototype.display = function(title,options) {
 		"isBlock": true,
 		"children": []
 	};
-	var navigatorWidgetNode = new nav.navigator(navigatorTree, {
+	var navigatorWidgetNode = new navigator.navigator(navigatorTree, {
 		wiki: this.wiki,
 		document : this.srcDocument,
 		parentWidget: $tw.rootWidget
@@ -122,7 +122,6 @@ Modal.prototype.display = function(title,options) {
 		variables: variables,
 		importPageMacros: true
 	});
-	headerWidgetNode.children.push(bodyWidgetNode);
 	headerWidgetNode.render(headerTitle,null);
 	// Render the body of the message
 	var bodyWidgetNode = this.wiki.makeTranscludeWidget(title,{
@@ -131,7 +130,6 @@ Modal.prototype.display = function(title,options) {
 		variables: variables,
 		importPageMacros: true
 	});
-	navigatorWidgetNode.children.push(bodyWidgetNode);
 
 	bodyWidgetNode.render(modalBody,null);
 	// Setup the link if present
@@ -174,7 +172,6 @@ Modal.prototype.display = function(title,options) {
 		variables: variables,
 		importPageMacros: true
 	});
-	navigatorWidgetNode.children.push(footerWidgetNode);
 	footerWidgetNode.render(modalFooterButtons,null);
 	// Set up the refresh handler
 	refreshHandler = function(changes) {

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -13,6 +13,7 @@ Modal message mechanism
 "use strict";
 
 var widget = require("$:/core/modules/widgets/widget.js");
+var nav = require("$:/core/modules/widgets/navigator.js");
 
 var Modal = function(wiki) {
 	this.wiki = wiki;
@@ -75,6 +76,31 @@ Modal.prototype.display = function(title,options) {
 	modalFooter.appendChild(modalFooterHelp);
 	modalFooter.appendChild(modalFooterButtons);
 	modalWrapper.appendChild(modalFooter);
+	var navigatorTree = {
+		"type": "navigator",
+		"attributes": {
+			"story": {
+				"name": "story",
+				"type": "string",
+				"value": options.variables["tv-story-list"]
+			},
+			"history": {
+				"name": "history",
+				"type": "string",
+				"value": options.variables["tv-history-list"]
+			}
+		},
+		"tag": "$navigator",
+		"isBlock": true,
+		"children": []
+	};
+
+	var navigatorWidgetNode = new nav.navigator(navigatorTree, {
+		wiki: this.wiki,
+		document : this.srcDocument,
+		parentWidget: $tw.rootWidget
+	});
+	navigatorWidgetNode.render(modalBody,null);
 	// Render the title of the message
 	var headerWidgetNode = this.wiki.makeTranscludeWidget(title,{
 		field: "subtitle",
@@ -86,19 +112,22 @@ Modal.prototype.display = function(title,options) {
 					type: "string",
 					value: title
 		}}}],
-		parentWidget: $tw.rootWidget,
+		parentWidget: navigatorWidgetNode,
 		document: this.srcDocument,
 		variables: variables,
 		importPageMacros: true
 	});
+	headerWidgetNode.children.push(bodyWidgetNode);
 	headerWidgetNode.render(headerTitle,null);
 	// Render the body of the message
 	var bodyWidgetNode = this.wiki.makeTranscludeWidget(title,{
-		parentWidget: $tw.rootWidget,
+		parentWidget: navigatorWidgetNode,
 		document: this.srcDocument,
 		variables: variables,
 		importPageMacros: true
 	});
+	navigatorWidgetNode.children.push(bodyWidgetNode);
+
 	bodyWidgetNode.render(modalBody,null);
 	// Setup the link if present
 	if(options.downloadLink) {
@@ -135,11 +164,12 @@ Modal.prototype.display = function(title,options) {
 						value: $tw.language.getString("Buttons/Close/Caption")
 			}}}
 		]}],
-		parentWidget: $tw.rootWidget,
+		parentWidget: navigatorWidgetNode,
 		document: this.srcDocument,
 		variables: variables,
 		importPageMacros: true
 	});
+	navigatorWidgetNode.children.push(footerWidgetNode);
 	footerWidgetNode.render(modalFooterButtons,null);
 	// Set up the refresh handler
 	refreshHandler = function(changes) {

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -42,9 +42,11 @@ Modal.prototype.display = function(title,options) {
 		return;
 	}
 	// Create the variables
-	var variables = $tw.utils.extend({currentTiddler: title},options.variables),
-		storyList = (options.event && options.event.widget ? options.event.widget.getVariable("tv-story-list") : ""),
-		historyList = (options.event && options.event.widget ? options.event.widget.getVariable("tv-history-list") : "");
+	var variables = $tw.utils.extend({
+			currentTiddler: title,
+			"tv-story-list": (options.event && options.event.widget ? options.event.widget.getVariable("tv-story-list") : ""),
+			"tv-history-list": (options.event && options.event.widget ? options.event.widget.getVariable("tv-history-list") : "")
+		},options.variables);
 
 	// Create the wrapper divs
 	var wrapper = this.srcDocument.createElement("div"),
@@ -85,25 +87,25 @@ Modal.prototype.display = function(title,options) {
 			"story": {
 				"name": "story",
 				"type": "string",
-				"value": storyList
+				"value": variables["tv-story-list"]
 			},
 			"history": {
 				"name": "history",
 				"type": "string",
-				"value": historyList
+				"value": variables["tv-history-list"]
 			}
 		},
 		"tag": "$navigator",
 		"isBlock": true,
 		"children": []
 	};
-
 	var navigatorWidgetNode = new nav.navigator(navigatorTree, {
 		wiki: this.wiki,
 		document : this.srcDocument,
 		parentWidget: $tw.rootWidget
 	});
 	navigatorWidgetNode.render(modalBody,null);
+	
 	// Render the title of the message
 	var headerWidgetNode = this.wiki.makeTranscludeWidget(title,{
 		field: "subtitle",

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -42,7 +42,10 @@ Modal.prototype.display = function(title,options) {
 		return;
 	}
 	// Create the variables
-	var variables = $tw.utils.extend({currentTiddler: title},options.variables);
+	var variables = $tw.utils.extend({currentTiddler: title},options.variables),
+		storyList = (options.event && options.event.widget ? options.event.widget.getVariable("tv-story-list") : ""),
+		historyList = (options.event && options.event.widget ? options.event.widget.getVariable("tv-history-list") : "");
+
 	// Create the wrapper divs
 	var wrapper = this.srcDocument.createElement("div"),
 		modalBackdrop = this.srcDocument.createElement("div"),
@@ -82,12 +85,12 @@ Modal.prototype.display = function(title,options) {
 			"story": {
 				"name": "story",
 				"type": "string",
-				"value": options.variables["tv-story-list"]
+				"value": storyList
 			},
 			"history": {
 				"name": "history",
 				"type": "string",
-				"value": options.variables["tv-history-list"]
+				"value": historyList
 			}
 		},
 		"tag": "$navigator",


### PR DESCRIPTION
Fixes #3560 
Fixes #2188

As discussed in #3560, there was a regression at some point due to which links within modals no longer work. There is no `navigator` widget available to handle the navigate message.

This PR wraps a `navigator` widget around the `transclude` widgets that make up the modal.
This is a cleaned up version of a modification I have been using for a couple of years.

The value for the storylist and historylist are derived from the widget that dispatched the `tm-modal` message. However, users can specify different values for `tv-story-list` and `tv-history-list` in the `tm-modal` message, in which case they take precedence.

This is a common pitfall for both new and experienced users and would be good to resolve. I'm open to exploring a different way of addressing this, if there are any suggestions for a better approach.