### PR TITLE
Change tag-picker behavior when there is user-input ...

### DIFF
--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -16,7 +16,7 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 $actions$
 </$list>
 </$set>
-<<delete-tag-state-tiddlers>>
+<$action-deletetiddler $tiddler=<<tagSelectionState>>/><$action-setfield $tiddler=<<newTagNameTiddler>> text={{{ [<storeTitle>get[text]] }}}/>
 <$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
 \end
 
@@ -26,7 +26,8 @@ $actions$
 <$set name="currentTiddlerCSSEscaped" value={{{ [<storyTiddler>escapecss[]] }}}>
 <$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>> preventScroll="true"/>
 </$set>
-<<delete-tag-state-tiddlers>>
+<$action-deletetiddler $tiddler=<<tagSelectionState>>/><$action-setfield $tiddler=<<newTagNameTiddler>> text={{{ [<storeTitle>get[text]] }}}/>
+<$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
 $actions$
 <$macrocall $name="tag-pill" tag=<<tag>>/>
 </$button>
@@ -58,7 +59,7 @@ $actions$
 		focusPopup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-edit-texteditor tc-popup-handle" tabindex=<<tabIndex>> 
 		focus={{{ [{$:/config/AutoFocus}match[tags]then[true]] ~[[false]] }}} filterMinLength={{$:/config/Tags/MinLength}} 
 		cancelPopups=<<cancelPopups>> configTiddlerFilter="[[$:/core/macros/tag-picker]]"/>
-</span><$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button><span class="tc-add-tag-button tc-small-gap-left">
+</span><$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button><$reveal state=<<storeTitle>> type="nomatch" text=""><$button class="tc-btn-invisible tc-small-gap tc-btn-dropdown">{{$:/core/images/close-button}}<<delete-tag-state-tiddlers>></$button></$reveal><span class="tc-add-tag-button tc-small-gap-left">
 <$set name="tag" value={{{ [<newTagNameTiddler>get[text]] }}}>
 <$button set=<<newTagNameTiddler>> setTo="" class="">
 <$action-sendmessage $message="tm-add-tag" $param=<<tag>>/>


### PR DESCRIPTION
... in the search field

This PR changes the behavior of the tag-picker slightly when there's user-input to filter the search-dropdown. In that case, after selecting/adding a tag, the dropdown remains filtered by the user-input. An `X` appears beneath the input field that allows resetting the input, <kbd>Escape</kbd> still works the same way. This also fixes the tag-pills not animating when adding them from a filtered dropdown. See the GIF and the Demo for more:

![Peek 2020-11-13 19-39](https://user-images.githubusercontent.com/9407182/99109130-a07b2f00-25e8-11eb-9299-83e51d70dab0.gif)

[tag_picker_1.zip](https://github.com/Jermolene/TiddlyWiki5/files/5538781/tag_picker_1.zip)
