### PR TITLE
Make Tag-Picker Macro work with every field

### DIFF
--- a/core/ui/ControlPanel/Basics.tid
+++ b/core/ui/ControlPanel/Basics.tid
@@ -26,8 +26,8 @@ caption: {{$:/language/ControlPanel/Basics/Caption}}
 |<$link to="$:/language/DefaultNewTiddlerTitle"><<lingo NewTiddler/Title/Prompt>></$link> |<$edit-text tiddler="$:/language/DefaultNewTiddlerTitle" default="" tag="input"/> |
 |<$link to="$:/config/NewJournal/Title"><<lingo NewJournal/Title/Prompt>></$link> |<$edit-text tiddler="$:/config/NewJournal/Title" default="" tag="input"/> |
 |<$link to="$:/config/NewJournal/Text"><<lingo NewJournal/Text/Prompt>></$link> |<$edit tiddler="$:/config/NewJournal/Text" tag="textarea" class="tc-edit-texteditor" default=""/> |
-|<$link to="$:/config/NewTiddler/Tags"><<lingo NewTiddler/Tags/Prompt>></$link> |<$edit-text tiddler="$:/config/NewTiddler/Tags" tag="input" default=""/> |
-|<$link to="$:/config/NewJournal/Tags"><<lingo NewJournal/Tags/Prompt>></$link> |<$edit-text tiddler="$:/config/NewJournal/Tags" tag="input" default=""/> |
+|<$link to="$:/config/NewTiddler/Tags"><<lingo NewTiddler/Tags/Prompt>></$link> |<$vars currentTiddler="$:/config/NewTiddler/Tags" tagField="text">{{||$:/core/ui/EditTemplate/tags}}</$vars> |
+|<$link to="$:/config/NewJournal/Tags"><<lingo NewJournal/Tags/Prompt>></$link> |<$vars currentTiddler="$:/config/NewJournal/Tags" tagField="text">{{||$:/core/ui/EditTemplate/tags}}</$vars> |
 |<$link to="$:/config/AutoFocus"><<lingo AutoFocus/Prompt>></$link> |{{$:/snippets/minifocusswitcher}} |
 |<<lingo Language/Prompt>> |{{$:/snippets/minilanguageswitcher}} |
 |<<lingo Tiddlers/Prompt>> |<<show-filter-count "[!is[system]sort[title]]">> |

--- a/core/ui/EditTemplate/tags.tid
+++ b/core/ui/EditTemplate/tags.tid
@@ -11,27 +11,33 @@ fill:$(foregroundColor)$;
 color:$(foregroundColor)$;
 \end
 
-\define tag-body-inner(colour,fallbackTarget,colourA,colourB,icon)
+\define tag-body-inner(colour,fallbackTarget,colourA,colourB,icon,tagField:"tags")
 \whitespace trim
 <$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
 <span style=<<tag-styles>> class="tc-tag-label tc-tag-list-item">
 <$transclude tiddler="""$icon$"""/><$view field="title" format="text" />
-<$button message="tm-remove-tag" param={{!!title}} class="tc-btn-invisible tc-remove-tag-button">{{$:/core/images/close-button}}</$button>
+<$button class="tc-btn-invisible tc-remove-tag-button"><$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="-[{!!title}]"/>{{$:/core/images/close-button}}</$button>
 </span>
 </$vars>
 \end
 
-\define tag-body(colour,palette,icon)
-<$macrocall $name="tag-body-inner" colour="""$colour$""" fallbackTarget={{$palette$##tag-background}} colourA={{$palette$##foreground}} colourB={{$palette$##background}} icon="""$icon$"""/>
+\define tag-body(colour,palette,icon,tagField:"tags")
+<$macrocall $name="tag-body-inner" colour="""$colour$""" fallbackTarget={{$palette$##tag-background}} colourA={{$palette$##foreground}} colourB={{$palette$##background}} icon="""$icon$""" tagField=<<__tagField__>>/>
 \end
 
+\define edit-tags-template(tagField:"tags")
+\whitespace trim
 <div class="tc-edit-tags">
 <$fieldmangler>
-<$list filter="[all[current]tags[]sort[title]]" storyview="pop">
-<$macrocall $name="tag-body" colour={{!!color}} palette={{$:/palette}} icon={{!!icon}}/>
+<$list filter="[list[!!$tagField$]sort[title]]" storyview="pop">
+<$macrocall $name="tag-body" colour={{!!color}} palette={{$:/palette}} icon={{!!icon}} tagField=<<__tagField__>>/>
 </$list>
 <$vars tabIndex={{$:/config/EditTabIndex}} cancelPopups="yes">
-<$macrocall $name="tag-picker"/>
+<$macrocall $name="tag-picker" tagField=<<__tagField__>>/>
 </$vars>
 </$fieldmangler>
 </div>
+\end
+<$set name="saveTiddler" value=<<currentTiddler>>>
+<$macrocall $name="edit-tags-template" tagField=<<tagField>>/>
+</$set>

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -7,12 +7,12 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 
 \define delete-tag-state-tiddlers() <$action-deletetiddler $filter="[<newTagNameTiddler>] [<storeTitle>] [<tagSelectionState>]"/>
 
-\define add-tag-actions(actions)
+\define add-tag-actions(actions,tagField:"tags")
 <$set name="tag" value={{{ [<__tiddler__>get[text]] }}}>
-<$list filter="[<currentTiddler>!tag<tag>]" variable="ignore" emptyMessage="""
-<$action-sendmessage $message="tm-remove-tag" $param=<<tag>>/>
+<$list filter="[<saveTiddler>!contains:$tagField$<tag>!match[]]" variable="ignore" emptyMessage="""
+<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="-[<tag>]"/>
 """>
-<$action-sendmessage $message="tm-add-tag" $param=<<tag>>/>
+<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>]"/>
 $actions$
 </$list>
 </$set>
@@ -20,10 +20,10 @@ $actions$
 <$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
 \end
 
-\define tag-button(actions,selectedClass)
+\define tag-button(actions,selectedClass,tagField:"tags")
 <$button class="tc-btn-invisible $selectedClass$" tag="a" tooltip={{$:/language/EditTemplate/Tags/Add/Button/Hint}}>
-<$action-sendmessage $message="tm-add-tag" $param=<<tag>>/>
-<$set name="currentTiddlerCSSEscaped" value={{{ [<storyTiddler>escapecss[]] }}}>
+<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>]"/>
+<$set name="currentTiddlerCSSEscaped" value={{{ [<saveTiddler>escapecss[]] }}}>
 <$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>> preventScroll="true"/>
 </$set>
 <$action-deletetiddler $tiddler=<<tagSelectionState>>/><$action-setfield $tiddler=<<newTagNameTiddler>> text={{{ [<storeTitle>get[text]] }}}/>
@@ -47,14 +47,14 @@ $actions$
 </$set>
 \end
 
-\define tag-picker-inner(actions)
+\define tag-picker-inner(actions,tagField:"tags")
 \whitespace trim
 <$vars tagSelectionState=<<qualify "$:/state/selected-tag">> storeTitle=<<qualify "$:/temp/NewTagName/input">> refreshTitle=<<qualify "$:/temp/NewTagName/refresh">> nonSystemTagsFilter="[tags[]!is[system]search:title<userInput>sort[]]" systemTagsFilter="[tags[]is[system]search:title<userInput>sort[]]">
 <div class="tc-edit-add-tag">
 <div>
 <span class="tc-add-tag-name tc-small-gap-right">
 <$macrocall $name="keyboard-driven-input" tiddler=<<newTagNameTiddler>> storeTitle=<<storeTitle>> refreshTitle=<<refreshTitle>>
-		selectionStateTitle=<<tagSelectionState>> inputAcceptActions="""<$macrocall $name="add-tag-actions" actions=<<__actions__>>/>"""
+		selectionStateTitle=<<tagSelectionState>> inputAcceptActions="""<$macrocall $name="add-tag-actions" actions=<<__actions__>> tagField=<<__tagField__>>/>"""
 		inputCancelActions=<<clear-tags-actions>> tag="input" placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}}
 		focusPopup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-edit-texteditor tc-popup-handle" tabindex=<<tabIndex>> 
 		focus={{{ [{$:/config/AutoFocus}match[tags]then[true]] ~[[false]] }}} filterMinLength={{$:/config/Tags/MinLength}} 
@@ -62,9 +62,9 @@ $actions$
 </span><$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button><$reveal state=<<storeTitle>> type="nomatch" text=""><$button class="tc-btn-invisible tc-small-gap tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/ClearInput/Hint}} aria-label={{$:/language/EditTemplate/Tags/ClearInput/Caption}}>{{$:/core/images/close-button}}<<delete-tag-state-tiddlers>></$button></$reveal><span class="tc-add-tag-button tc-small-gap-left">
 <$set name="tag" value={{{ [<newTagNameTiddler>get[text]] }}}>
 <$button set=<<newTagNameTiddler>> setTo="" class="">
-<$action-sendmessage $message="tm-add-tag" $param=<<tag>>/>
+<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>]"/>
 $actions$
-<$set name="currentTiddlerCSSEscaped" value={{{ [<currentTiddler>escapecss[]] }}}>
+<$set name="currentTiddlerCSSEscaped" value={{{ [<saveTiddler>escapecss[]] }}}>
 <<delete-tag-state-tiddlers>><$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>>/>
 </$set>
 {{$:/language/EditTemplate/Tags/Add/Button}}
@@ -79,14 +79,14 @@ $actions$
 <$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
 <$list filter=<<nonSystemTagsFilter>> variable="tag">
 <$list filter="[<tag>addsuffix[-primaryList]] -[<tagSelectionState>get[text]]" emptyMessage="""<$macrocall $name="tag-button" actions=<<__actions__>> selectedClass="tc-tag-button-selected"/>""">
-<$macrocall $name="tag-button" actions=<<__actions__>>/>
+<$macrocall $name="tag-button" actions=<<__actions__>> tagField=<<__tagField__>>/>
 </$list>
 </$list></$list>
 <hr>
 <$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="""<div class="tc-search-results">{{$:/language/Search/Search/TooShort}}</div>""" variable="listItem">
 <$list filter=<<systemTagsFilter>> variable="tag">
 <$list filter="[<tag>addsuffix[-secondaryList]] -[<tagSelectionState>get[text]]" emptyMessage="""<$macrocall $name="tag-button" actions=<<__actions__>> selectedClass="tc-tag-button-selected"/>""">
-<$macrocall $name="tag-button" actions=<<__actions__>>/>
+<$macrocall $name="tag-button" actions=<<__actions__>> tagField=<<__tagField__>>/>
 </$list>
 </$list></$list>
 </$set>
@@ -96,11 +96,13 @@ $actions$
 </div>
 </$vars>
 \end
-\define tag-picker(actions)
+\define tag-picker(actions,tagField:"tags")
 \whitespace trim
-<$list filter="[<newTagNameTiddler>match[]]" emptyMessage="""<$macrocall $name="tag-picker-inner" actions=<<__actions__>>/>""">
+<$set name="saveTiddler" value=<<currentTiddler>>>
+<$list filter="[<newTagNameTiddler>match[]]" emptyMessage="""<$macrocall $name="tag-picker-inner" actions=<<__actions__>> tagField=<<__tagField__>>/>""">
 <$set name="newTagNameTiddler" value=<<qualify "$:/temp/NewTagName">>>
-<$macrocall $name="tag-picker-inner" actions=<<__actions__>>/>
+<$macrocall $name="tag-picker-inner" actions=<<__actions__>> tagField=<<__tagField__>>/>
 </$set>
 </$list>
+</$set>
 \end

--- a/editions/tw5.com/tiddlers/macros/tag-picker_Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/tag-picker_Macro.tid
@@ -11,5 +11,7 @@ The <<.def tag-picker>> [[macro|Macros]] generates a combination of a text box a
 
 ;actions
 : Action widgets to be triggered when the pill is clicked. Within the text, the variable ''tag'' contains the title of the selected tag.
+;tagField
+: <<.from-version 5.1.23>> The ''field'' that gets updated with the selected tag. Defaults to ''tags''.
 
 <<.macro-examples "tag-picker">>


### PR DESCRIPTION
This PR makes the `tag-picker` macro and the `tags EditTemplate` work with every field. It also updates the `$:/core/ui/ControlPanel/Basics` tab where we now can select the tags for New Tiddlers and New Journal Tiddlers using the tag-picker macro but populating the text field of the corresponding configuration tiddlers