### PR TITLE
Action widget: confirm

### DIFF
--- a/core/modules/widgets/confirm.js
+++ b/core/modules/widgets/confirm.js
@@ -57,14 +57,15 @@ ConfirmWidget.prototype.refresh = function(changedTiddlers) {
 Invoke the action associated with this widget
 */
 ConfirmWidget.prototype.invokeAction = function(triggeringWidget,event) {
-	var invokeActions = true;
+	var invokeActions = true,
+		handled = true;
 	if(this.message && this.prompt) {
 		invokeActions = confirm(this.message);
 	}
 	if(invokeActions) {
-		this.invokeActions(triggeringWidget,event);
-		return true;
+		handled = this.invokeActions(triggeringWidget,event);
 	}
+	return handled;
 };
 
 ConfirmWidget.prototype.allowActionPropagation = function() {

--- a/core/modules/widgets/confirm.js
+++ b/core/modules/widgets/confirm.js
@@ -1,0 +1,76 @@
+/*\
+
+title: $:/core/modules/widgets/action-confirm.js
+type: application/javascript
+module-type: widget
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var ConfirmWidget = function(parseTreeNode,options) {
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+ConfirmWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+ConfirmWidget.prototype.render = function(parent,nextSibling) {
+	this.computeAttributes();
+	this.execute();
+	this.parentDomNode = parent;
+	this.renderChildren(parent,nextSibling);
+};
+
+/*
+Compute the internal state of the widget
+*/
+ConfirmWidget.prototype.execute = function() {
+	this.message = this.getAttribute("$message");
+	this.prompt = (this.getAttribute("$prompt","yes") == "yes" ? true : false);
+	this.makeChildWidgets();
+};
+
+/*
+Refresh the widget by ensuring our attributes are up to date
+*/
+ConfirmWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if(changedAttributes["$message"]) {
+		this.refreshSelf();
+		return true;
+	}
+	return this.refreshChildren(changedTiddlers);
+};
+
+/*
+Invoke the action associated with this widget
+*/
+ConfirmWidget.prototype.invokeAction = function(triggeringWidget,event) {
+	var invokeActions = true;
+	if(this.message && this.prompt) {
+		invokeActions = confirm(this.message);
+	}
+	if(invokeActions) {
+		this.invokeActions(triggeringWidget,event);
+		return true;
+	}
+};
+
+ConfirmWidget.prototype.allowActionPropagation = function() {
+	return false;
+};
+
+exports["action-confirm"] = ConfirmWidget;
+
+})();

--- a/core/modules/widgets/confirm.js
+++ b/core/modules/widgets/confirm.js
@@ -46,7 +46,7 @@ Refresh the widget by ensuring our attributes are up to date
 */
 ConfirmWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes["$message"]) {
+	if(changedAttributes["$message"] || changedAttributes["$prompt"]) {
 		this.refreshSelf();
 		return true;
 	}


### PR DESCRIPTION
While action widgets are incredibly powerful in TW, there is currently no way to prompt a user for confirmation before invoking them. Such a confirmation is incredibly important for situations which might incur data loss, or are not easily reversible.
 
Examples: custom delete buttons, batch operations.

I would like to use this PR to discuss potential solutions.

The code in this PR is a renamed version of an [action widget I've been using in all of my wikis](https://github.com/saqimtiaz/streams/blob/master/plugins/streams/widgets/action-ifconfirmed.js) to be able to prompt a user for confirmation. All action-widgets that require confirmation are wrapped in the `action-confirm` widget.

Usage example:
```
<$button>go
<$action-confirm $message="Do you want to proceed?">
	<$action-setfield $tiddler="lego" $value="chopper"/>
</$action-confirm>
</$button>
```

It accepts two parameters:
- `$message`: the text to display to the user
- `$prompt`: a flag to be able to disable the confirmation from a state tiddler/variable.

I'm open to alternative implementations or approaches. 