### PR TITLE
Remove image-buttons from type image/svg+xml and add editor-height and stamp button

### DIFF
--- a/core/ui/EditorToolbar/clear.tid
+++ b/core/ui/EditorToolbar/clear.tid
@@ -3,6 +3,6 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/erase
 caption: {{$:/language/Buttons/Clear/Caption}}
 description: {{$:/language/Buttons/Clear/Hint}}
-condition: [<targetTiddler>is[image]]
+condition: [<targetTiddler>is[image]] -[<targetTiddler>type[image/svg+xml]]
 dropdown: $:/core/ui/EditorToolbar/clear-dropdown
 

--- a/core/ui/EditorToolbar/editor-height.tid
+++ b/core/ui/EditorToolbar/editor-height.tid
@@ -4,7 +4,7 @@ icon: $:/core/images/fixed-height
 custom-icon: yes
 caption: {{$:/language/Buttons/EditorHeight/Caption}}
 description: {{$:/language/Buttons/EditorHeight/Hint}}
-condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] [<targetTiddler>get[type]match[application/javascript]] [<targetTiddler>get[type]match[application/json]] [<targetTiddler>get[type]match[application/x-tiddler-dictionary]] +[first[]]
+condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] [<targetTiddler>get[type]match[application/javascript]] [<targetTiddler>get[type]match[application/json]] [<targetTiddler>get[type]match[application/x-tiddler-dictionary]] [<targetTiddler>get[type]match[image/svg+xml]] +[first[]]
 dropdown: $:/core/ui/EditorToolbar/editor-height-dropdown
 
 <$reveal tag="span" state="$:/config/TextEditor/EditorHeight/Mode" type="match" text="fixed">

--- a/core/ui/EditorToolbar/line-width.tid
+++ b/core/ui/EditorToolbar/line-width.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/line-width
 caption: {{$:/language/Buttons/LineWidth/Caption}}
 description: {{$:/language/Buttons/LineWidth/Hint}}
-condition: [<targetTiddler>is[image]]
+condition: [<targetTiddler>is[image]] -[<targetTiddler>type[image/svg+xml]]
 dropdown: $:/core/ui/EditorToolbar/line-width-dropdown
 
 <$text text={{$:/config/BitmapEditor/LineWidth}}/>

--- a/core/ui/EditorToolbar/opacity.tid
+++ b/core/ui/EditorToolbar/opacity.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/opacity
 caption: {{$:/language/Buttons/Opacity/Caption}}
 description: {{$:/language/Buttons/Opacity/Hint}}
-condition: [<targetTiddler>is[image]]
+condition: [<targetTiddler>is[image]] -[<targetTiddler>type[image/svg+xml]]
 dropdown: $:/core/ui/EditorToolbar/opacity-dropdown
 
 <$text text={{$:/config/BitmapEditor/Opacity}}/>

--- a/core/ui/EditorToolbar/paint.tid
+++ b/core/ui/EditorToolbar/paint.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/paint
 caption: {{$:/language/Buttons/Paint/Caption}}
 description: {{$:/language/Buttons/Paint/Hint}}
-condition: [<targetTiddler>is[image]]
+condition: [<targetTiddler>is[image]] -[<targetTiddler>type[image/svg+xml]]
 dropdown: $:/core/ui/EditorToolbar/paint-dropdown
 
 \define toolbar-paint()

--- a/core/ui/EditorToolbar/rotate-left.tid
+++ b/core/ui/EditorToolbar/rotate-left.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/rotate-left
 caption: {{$:/language/Buttons/RotateLeft/Caption}}
 description: {{$:/language/Buttons/RotateLeft/Hint}}
-condition: [<targetTiddler>is[image]]
+condition: [<targetTiddler>is[image]] -[<targetTiddler>type[image/svg+xml]]
 
 <$action-sendmessage
 	$message="tm-edit-bitmap-operation"

--- a/core/ui/EditorToolbar/size.tid
+++ b/core/ui/EditorToolbar/size.tid
@@ -3,6 +3,6 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/size
 caption: {{$:/language/Buttons/Size/Caption}}
 description: {{$:/language/Buttons/Size/Hint}}
-condition: [<targetTiddler>is[image]]
+condition: [<targetTiddler>is[image]] -[<targetTiddler>type[image/svg+xml]]
 dropdown: $:/core/ui/EditorToolbar/size-dropdown
 

--- a/core/ui/EditorToolbar/stamp.tid
+++ b/core/ui/EditorToolbar/stamp.tid
@@ -3,7 +3,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/stamp
 caption: {{$:/language/Buttons/Stamp/Caption}}
 description: {{$:/language/Buttons/Stamp/Hint}}
-condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] [<targetTiddler>get[type]match[application/javascript]] [<targetTiddler>get[type]match[application/json]] [<targetTiddler>get[type]match[application/x-tiddler-dictionary]] +[first[]]
+condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] [<targetTiddler>get[type]match[application/javascript]] [<targetTiddler>get[type]match[application/json]] [<targetTiddler>get[type]match[application/x-tiddler-dictionary]] [<targetTiddler>get[type]match[image/svg+xml]] +[first[]]
 shortcuts: ((stamp))
 dropdown: $:/core/ui/EditorToolbar/stamp-dropdown
 text:


### PR DESCRIPTION
This PR removes the (useless) image-buttons from tiddlers with type `image/svg+xml` and adds the editor-height and stamp Buttons