### PR TITLE
Docs for action-confirm widget, widget improvements

### DIFF
--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -10,6 +10,7 @@ ConfirmCancelTiddler: Do you wish to discard changes to the tiddler "<$text text
 ConfirmDeleteTiddler: Do you wish to delete the tiddler "<$text text=<<title>>/>"?
 ConfirmOverwriteTiddler: Do you wish to overwrite the tiddler "<$text text=<<title>>/>"?
 ConfirmEditShadowTiddler: You are about to edit a ShadowTiddler. Any changes will override the default system making future upgrades non-trivial. Are you sure you want to edit "<$text text=<<title>>/>"?
+ConfirmAction: Do you wish to proceed?
 Count: count
 DefaultNewTiddlerTitle: New Tiddler
 Diffs/CountMessage: <<diff-count>> differences

--- a/core/modules/widgets/confirm.js
+++ b/core/modules/widgets/confirm.js
@@ -36,8 +36,8 @@ ConfirmWidget.prototype.render = function(parent,nextSibling) {
 Compute the internal state of the widget
 */
 ConfirmWidget.prototype.execute = function() {
-	this.message = this.getAttribute("$message");
-	this.prompt = (this.getAttribute("$prompt","yes") == "yes" ? true : false);
+	this.message = this.getAttribute("$message",$tw.language.getString("ConfirmAction"));
+	this.prompt = (this.getAttribute("$prompt","yes") == "no" ? false : true);
 	this.makeChildWidgets();
 };
 
@@ -59,7 +59,7 @@ Invoke the action associated with this widget
 ConfirmWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var invokeActions = true,
 		handled = true;
-	if(this.message && this.prompt) {
+	if(this.prompt) {
 		invokeActions = confirm(this.message);
 	}
 	if(invokeActions) {

--- a/editions/tw5.com/tiddlers/widgets/ActionConfirmWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionConfirmWidget.tid
@@ -1,0 +1,40 @@
+caption: action-confirm
+created: 20201115150255011
+modified: 20201115160335288
+tags: Widgets ActionWidgets
+title: ActionConfirmWidget
+type: text/vnd.tiddlywiki
+
+! Introduction
+
+<<.from-version "5.1.23">>The ''action-confirm'' widget is an [[action widget|ActionWidgets]] that prompts the user for confirmation and invokes other action widgets contained within it only if the user confirms. ActionWidgets are used within triggering widgets such as the ButtonWidget.
+
+! Content and Attributes
+
+The ''action-confirm'' widget is invisible. Any content within it is only processed if the user confirms the action, or the confirmation has been disabled by the `$prompt` attribute.
+
+|!Attribute |!Description |
+|$message |Optional message displayed to the user when asking for confirmation.|
+|$prompt |Optional flag, set to "no" to disable the prompt for confirmation. Defaults to "yes" |
+
+! Examples
+
+Here is an example of a button that asks the user for confirmation, before deleting the caption and tags fields of the current tiddler:
+
+<$macrocall $name='wikitext-example-without-html'
+src='<$button>
+<$action-confirm $message="Do you wish to delete the caption and tags?">
+<$action-deletefield caption tags/>
+Delete "caption" and "tags"
+</$action-confirm>
+</$button>'/>
+
+Here is an example of a button that uses the optional `$prompt` attribute to control whether to prompt the user before deleting the text field of the tiddler HelloThere:
+
+<$macrocall $name='wikitext-example-without-html'
+src='<$button>
+<$action-confirm $message="Do you wish to delete the text field?" $prompt={{$:/state/promptUser}}>
+<$action-deletefield $tiddler="HelloThere" $field="text"/>
+</$action-confirm>
+Delete text from ~HelloThere
+</$button>'/>


### PR DESCRIPTION
This PR adds docs for the new `action-confirm` widget, as well as adding a default message for it to display if one is not specified, and improves the logic for disabling the confirmation.