### PR TITLE
add the possibility to dynamically exclude tiddlers from being delive…

### DIFF
--- a/core/modules/server/routes/get-tiddlers-json.js
+++ b/core/modules/server/routes/get-tiddlers-json.js
@@ -28,6 +28,7 @@ exports.handler = function(request,response,state) {
 			return;
 		}
 	}
+	filter = filter + "-[subfilter{$:/config/Server/GlobalExclusionFilter}]";
 	var excludeFields = (state.queryParameters.exclude || "text").split(","),
 		titles = state.wiki.filterTiddlers(filter);
 	response.writeHead(200, {"Content-Type": "application/json"});


### PR DESCRIPTION
…red out (e.g. temporarily reduce size by kind of 'hiding' stuff to the browser). one can also add the filter '-[subfilter{$:/config/Server/GlobalExclusionFilter}]' to the root-tiddler to get a synchronous behavior