### PR TITLE
Make sidebarsegments/search-results-count work with all search tabs

### DIFF
--- a/core/ui/SideBarSegments/search.tid
+++ b/core/ui/SideBarSegments/search.tid
@@ -8,11 +8,13 @@ tags: $:/tags/SideBarSegment
 <$button popup=<<qualify "$:/state/popup/search-dropdown">> class="tc-btn-invisible">
 {{$:/core/images/down-arrow}}
 <$list filter="[{$(searchTiddler)$}minlength{$:/config/Search/MinLength}limit[1]]" variable="listItem">
-<$set name="searchTerm" value={{{ [<searchTiddler>get[text]] }}}>
-<$set name="resultCount" value="""<$count filter="[!is[system]search<searchTerm>]"/>""">
+<$vars userInput={{{ [<searchTiddler>get[text]] }}} configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}}>
+<$vars primaryListFilter={{{ [<configTiddler>get[first-search-filter]] }}} secondaryListFilter={{{ [<configTiddler>get[second-search-filter]] }}}>
+<$set name="resultCount" value="""<$count filter="[subfilter<primaryListFilter>] =[subfilter<secondaryListFilter>]"/>""">
 {{$:/language/Search/Matches}}
 </$set>
-</$set>
+</$vars>
+</$vars>
 </$list>
 </$button>
 \end


### PR DESCRIPTION
This PR makes the "matches" button beneath the sidebar search field show the exact number of found entries (duplicates get counted twice). Further it makes it work with any search-tab if there are more and they use the keyboard-driven-input mechanism