### PR TITLE
Remove 2em of whitespace from EditTemplate when there are no visible fields

### DIFF
--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -57,8 +57,7 @@ $value={{{ [<newFieldValueTiddler>get[text]] }}}/>
 \whitespace trim
 
 <div class="tc-edit-fields">
-<$set name="excludeList" filter="[all[tiddlers+shadows]prefix[$:/config/EditTemplateFields/Visibility/]contains:text[hide]removeprefix[$:/config/EditTemplateFields/Visibility/]]">
-<table class={{{ [all[current]fields[]] -[enlist<excludeList>] +[count[]] +[!match[0]] +[then[tc-edit-fields]] ~[[tc-edit-fields tc-edit-fields-small]] }}}>
+<table class={{{ [all[current]fields[]] :filter[lookup[$:/config/EditTemplateFields/Visibility/]!match[hide]] +[count[]!match[0]] +[then[tc-edit-fields]] ~[[tc-edit-fields tc-edit-fields-small]] }}}>
 <tbody>
 <$list filter="[all[current]fields[]] +[sort[title]]" variable="currentField" storyview="pop">
 <$list filter=<<config-filter>> variable="temp">
@@ -81,7 +80,6 @@ $value={{{ [<newFieldValueTiddler>get[text]] }}}/>
 </$list>
 </tbody>
 </table>
-</$set>
 </div>
 
 <$fieldmangler>

--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -57,7 +57,8 @@ $value={{{ [<newFieldValueTiddler>get[text]] }}}/>
 \whitespace trim
 
 <div class="tc-edit-fields">
-<table class="tc-edit-fields">
+<$set name="excludeList" filter="[all[tiddlers+shadows]prefix[$:/config/EditTemplateFields/Visibility/]contains:text[hide]removeprefix[$:/config/EditTemplateFields/Visibility/]]">
+<table class={{{ [all[current]fields[]] -[enlist<excludeList>] +[count[]] +[!match[0]] +[then[tc-edit-fields]] ~[[tc-edit-fields tc-edit-fields-small]] }}}>
 <tbody>
 <$list filter="[all[current]fields[]] +[sort[title]]" variable="currentField" storyview="pop">
 <$list filter=<<config-filter>> variable="temp">
@@ -80,6 +81,7 @@ $value={{{ [<newFieldValueTiddler>get[text]] }}}/>
 </$list>
 </tbody>
 </table>
+</$set>
 </div>
 
 <$fieldmangler>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1421,7 +1421,7 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-edit-fields.tc-edit-fields-small {
-	margin-top: .5em;
+	margin-top: 0;
 	margin-bottom: 0;
 }
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -47,23 +47,6 @@ $else$
 </$reveal>
 \end
 
-\define set-small-fields-table-margin()
-[data-tiddler-title="$(cssEscapedTitle)$"] .tc-edit-fields table {
-	margin-top: 0.5em;
-	margin-bottom: 0;
-}
-\end
-
-\define set-fields-table-margin()
-<$list filter="[list[$:/StoryList]is[draft]]">
-<$vars fieldCount={{{ [<currentTiddler>fields[]] -[[title]] -[[tags]] -[[text]] -[[type]] -[[created]] -[[creator]] -[[modified]] -[[modifier]] -[[draft.of]] -[[draft.title]] +[count[]] }}} cssEscapedTitle={{{ [<currentTiddler>escapecss[]] }}}>
-<$list filter="[<fieldCount>match[0]]">
-<<set-small-fields-table-margin>>
-</$list>
-</$vars>
-</$list>
-\end
-
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock
 
 /*
@@ -1437,8 +1420,9 @@ html body.tc-body.tc-single-tiddler-window {
 	width: 100%;
 }
 
-.tc-edit-fields table {
-	transition: margin-top {{$:/config/AnimationDuration}}ms ease-in-out, margin-bottom {{$:/config/AnimationDuration}} ease-in-out;
+.tc-edit-fields.tc-edit-fields-small {
+	margin-top: .5em;
+	margin-bottom: 0;
 }
 
 .tc-edit-fields table, .tc-edit-fields tr, .tc-edit-fields td {
@@ -1453,8 +1437,6 @@ html body.tc-body.tc-single-tiddler-window {
 .tc-edit-fields > tbody > .tc-edit-field:nth-child(even) {
 	background-color: <<colour tiddler-editor-fields-even>>;
 }
-
-<<set-fields-table-margin>>
 
 .tc-edit-field-name {
 	text-align: right;

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -47,6 +47,23 @@ $else$
 </$reveal>
 \end
 
+\define set-small-fields-table-margin()
+[data-tiddler-title="$(cssEscapedTitle)$"] .tc-edit-fields table {
+	margin-top: 0.5em;
+	margin-bottom: 0;
+}
+\end
+
+\define set-fields-table-margin()
+<$list filter="[list[$:/StoryList]is[draft]]">
+<$vars fieldCount={{{ [<currentTiddler>fields[]] -[[title]] -[[tags]] -[[text]] -[[type]] -[[created]] -[[creator]] -[[modified]] -[[modifier]] -[[draft.of]] -[[draft.title]] +[count[]] }}} cssEscapedTitle={{{ [<currentTiddler>escapecss[]] }}}>
+<$list filter="[<fieldCount>match[0]]">
+<<set-small-fields-table-margin>>
+</$list>
+</$vars>
+</$list>
+\end
+
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock
 
 /*
@@ -1420,6 +1437,9 @@ html body.tc-body.tc-single-tiddler-window {
 	width: 100%;
 }
 
+.tc-edit-fields table {
+	transition: margin-top {{$:/config/AnimationDuration}}ms ease-in-out, margin-bottom {{$:/config/AnimationDuration}} ease-in-out;
+}
 
 .tc-edit-fields table, .tc-edit-fields tr, .tc-edit-fields td {
 	border: none;
@@ -1433,6 +1453,8 @@ html body.tc-body.tc-single-tiddler-window {
 .tc-edit-fields > tbody > .tc-edit-field:nth-child(even) {
 	background-color: <<colour tiddler-editor-fields-even>>;
 }
+
+<<set-fields-table-margin>>
 
 .tc-edit-field-name {
 	text-align: right;


### PR DESCRIPTION
This PR removes the 2em of whitespace between the type input and the fieldname input when there are no fields added

If there are visible fields, the margin-top and margin-bottom of the fields-table are 1em. If there are no fields, the margin-top is 0.5em and the margin-bottom is 0.

This makes the EditTemplate look cleaner.