### PR TITLE
Import UI: Colour code rows

### DIFF
--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -46,7 +46,7 @@ title: $:/core/ui/ImportListing
 </th>
 </tr>
 <$list filter="[all[current]plugintiddlers[]sort[title]]" variable="payloadTiddler">
-<tr>
+<tr class={{{[<currentTiddler>has<suppressedField>then[tc-row-disabled]] ~[subfilter<payloadTitleFilter>is[tiddler]then[tc-row-warning]] }}}>
 <td>
 <$checkbox field=<<selectionField>> checked="checked" unchecked="unchecked" default="checked" disabled={{{[<currentTiddler>has<suppressedField>then[yes]else[no]]}}}/>
 </td>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2086,6 +2086,15 @@ html body.tc-body.tc-single-tiddler-window {
 	width: 30%;
 }
 
+.tc-import-table .tc-row-disabled {
+	background: <<colour very-muted-foreground>>10;
+	opacity: 0.8;
+}
+
+.tc-import-table .tc-row-warning {
+	background: <<colour diff-delete-background>>50;
+}
+
 /*
 ** Alerts
 */


### PR DESCRIPTION
This PR adds some color coding to the Import UI to make it easier to:
- identify tiddlers that might overwrite existing content. 
  - updates if the user chooses to rename the tiddler being imported.
- skim over tiddlers that are disabled and cannot be imported

I have taken a minimal route here, adding alpha values to existing palette colours to adjust opacity.

![image](https://user-images.githubusercontent.com/68092/99525308-ec87f400-2999-11eb-857b-4a4435b807ee.png)

Thoughts @Jermolene @kookma @pmario @BurningTreeC ?