### PR TITLE
Add whitespace trims to EditToolbar Buttons

### DIFF
--- a/core/ui/EditToolbar/cancel.tid
+++ b/core/ui/EditToolbar/cancel.tid
@@ -3,6 +3,7 @@ tags: $:/tags/EditToolbar
 caption: {{$:/core/images/cancel-button}} {{$:/language/Buttons/Cancel/Caption}}
 description: {{$:/language/Buttons/Cancel/Hint}}
 
+\whitespace trim
 <$button actions=<<cancel-delete-tiddler-actions "cancel">> tooltip={{$:/language/Buttons/Cancel/Hint}} aria-label={{$:/language/Buttons/Cancel/Caption}} class=<<tv-config-toolbar-class>>>
 <$list filter="[<tv-config-toolbar-icons>match[yes]]">
 {{$:/core/images/cancel-button}}

--- a/core/ui/EditToolbar/delete.tid
+++ b/core/ui/EditToolbar/delete.tid
@@ -3,6 +3,7 @@ tags: $:/tags/EditToolbar $:/tags/ViewToolbar
 caption: {{$:/core/images/delete-button}} {{$:/language/Buttons/Delete/Caption}}
 description: {{$:/language/Buttons/Delete/Hint}}
 
+\whitespace trim
 <$button actions=<<cancel-delete-tiddler-actions "delete">> tooltip={{$:/language/Buttons/Delete/Hint}} aria-label={{$:/language/Buttons/Delete/Caption}} class=<<tv-config-toolbar-class>>>
 <$list filter="[<tv-config-toolbar-icons>match[yes]]">
 {{$:/core/images/delete-button}}

--- a/core/ui/EditToolbar/save.tid
+++ b/core/ui/EditToolbar/save.tid
@@ -4,6 +4,7 @@ caption: {{$:/core/images/done-button}} {{$:/language/Buttons/Save/Caption}}
 description: {{$:/language/Buttons/Save/Hint}}
 
 \define save-tiddler-button()
+\whitespace trim
 <$fieldmangler><$button tooltip={{$:/language/Buttons/Save/Hint}} aria-label={{$:/language/Buttons/Save/Caption}} class=<<tv-config-toolbar-class>>>
 <<save-tiddler-actions>>
 <$list filter="[<tv-config-toolbar-icons>match[yes]]">


### PR DESCRIPTION
This PR adds `\whitespace trim` to the three EditToolbar Buttons and fixes the whitespace between them in the current prerelease