### PR TITLE
Extend action-log and subclass it as log widget

### DIFF
--- a/core/modules/widgets/action-log.js
+++ b/core/modules/widgets/action-log.js
@@ -14,24 +14,24 @@ Action widget to log debug messages
 
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
-var ActionLogWidget = function(parseTreeNode,options) {
+var LogWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
 /*
 Inherit from the base widget class
 */
-ActionLogWidget.prototype = new Widget();
+LogWidget.prototype = new Widget();
 
 /*
 Render this widget into the DOM
 */
-ActionLogWidget.prototype.render = function(parent,nextSibling) {
+LogWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 };
 
-ActionLogWidget.prototype.execute = function(){
+LogWidget.prototype.execute = function(){
 	this.message = this.getAttribute("$$message","debug");
 	this.logAll = this.getAttribute("$$all","no") === "yes" ? true : false;
 	this.filter = this.getAttribute("$$filter");
@@ -40,7 +40,7 @@ ActionLogWidget.prototype.execute = function(){
 /*
 Refresh the widget by ensuring our attributes are up to date
 */
-ActionLogWidget.prototype.refresh = function(changedTiddlers) {
+LogWidget.prototype.refresh = function(changedTiddlers) {
 	this.refreshSelf();
 	return true;
 };
@@ -48,16 +48,16 @@ ActionLogWidget.prototype.refresh = function(changedTiddlers) {
 /*
 Invoke the action associated with this widget
 */
-ActionLogWidget.prototype.invokeAction = function(triggeringWidget,event) {
+LogWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	this.log();
 	return true; // Action was invoked
 };
 
-ActionLogWidget.prototype.log = function() {
+LogWidget.prototype.log = function() {
 	var data = {},
 		dataCount,
 		allVars = {},
-		filteredVariables,
+		filteredVars,
 		self = this;
 
 	$tw.utils.each(this.attributes,function(attribute,name) {
@@ -70,8 +70,8 @@ ActionLogWidget.prototype.log = function() {
 		allVars[v] = this.getVariable(v,{defaultValue:""});
 	}	
 	if(this.filter) {
-		filteredVariables = this.wiki.compileFilter(this.filter).call(this.wiki,this.wiki.makeTiddlerIterator(allVars));
-		$tw.utils.each(filteredVariables,function(name) {
+		filteredVars = this.wiki.compileFilter(this.filter).call(this.wiki,this.wiki.makeTiddlerIterator(allVars));
+		$tw.utils.each(filteredVars,function(name) {
 			data[name] = allVars[name];
 		});		
 	}
@@ -89,6 +89,6 @@ ActionLogWidget.prototype.log = function() {
 	console.groupEnd();
 }
 
-exports["action-log"] = ActionLogWidget;
+exports["action-log"] = LogWidget;
 
 })();

--- a/core/modules/widgets/action-log.js
+++ b/core/modules/widgets/action-log.js
@@ -57,8 +57,7 @@ LogWidget.prototype.log = function() {
 	var data = {},
 		dataCount,
 		allVars = {},
-		filteredVars,
-		self = this;
+		filteredVars;
 
 	$tw.utils.each(this.attributes,function(attribute,name) {
 		if(name.substring(0,2) !== "$$") {

--- a/core/modules/widgets/log.js
+++ b/core/modules/widgets/log.js
@@ -1,0 +1,30 @@
+/*\
+title: $:/core/modules/widgets/log.js
+type: application/javascript
+module-type: widget-subclass
+
+Widget to log debug messages
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.baseClass = "action-log";
+
+exports.name = "log";
+
+exports.constructor = function(parseTreeNode,options) {
+	this.initialise(parseTreeNode,options);
+}
+
+exports.prototype = {};
+
+exports.prototype.render = function(event) {
+	Object.getPrototypeOf(Object.getPrototypeOf(this)).render.call(this,event);	
+	Object.getPrototypeOf(Object.getPrototypeOf(this)).log.call(this);
+}
+
+})();


### PR DESCRIPTION
All previous usage patterns of the `<$action-log>` widget have been preserved.

In addition:
- the optional parameter `$$filter` allows using a filter to specify variables to log, in addition to widget attributes. Example: `[prefix[tv-]]`
- the optional parameter `$$message` allows adding a description to the console group. This is helpful when there are multiple `<$action-log>` widgets in use in sequence.
- the optional parameter `$$all` when set to `yes` will log all variables in a collapsed table
- if no widget parameters are used, all variables are logged.

The `<$action-log>` widget has been subclassed as `<$log>` which provides the same features but on render/refresh.

The choice of parameter names using a `$$` prefix is to avoid clashes with `<$action-setfield>` parameters and allowing use cases like Jeremy's, i.e. renaming a `<$action-setfield>` widget to `<$action-log>`

![image](https://user-images.githubusercontent.com/68092/99711163-bdf54080-2aa1-11eb-8dfa-30c32e00a811.png)

PS: I've checked and all modern browsers (including IE 11) support `console.group` and `console.groupCollapsed`.