### PR TITLE
Filter operators power[] and log[]

### DIFF
--- a/core/modules/filters/math.js
+++ b/core/modules/filters/math.js
@@ -91,6 +91,20 @@ exports.exponential = makeNumericBinaryOperator(
 	function(a,b) {return Number.prototype.toExponential.call(a,Math.min(Math.max(b,0),100));}
 );
 
+exports.power = makeNumericBinaryOperator(
+	function(a,b) {return Math.pow(a,b);}
+);
+
+exports.log = makeNumericBinaryOperator(
+	function(a,b) {
+		if(b) {
+			return Math.log(a)/Math.log(b);
+		} else {
+			return Math.log(a);
+		}
+	}
+);
+
 exports.sum = makeNumericReducingOperator(
 	function(accumulator,value) {return accumulator + value},
 	0 // Initial value

--- a/editions/tw5.com/tiddlers/filters/examples/log Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/log Operator (Examples).tid
@@ -1,0 +1,14 @@
+created: 20201120041503515
+modified: 20201120042024813
+tags: [[Operator Examples]] [[log Operator]]
+title: log Operator (Examples)
+type: text/vnd.tiddlywiki
+
+Logarithm of `8` with base `2`:
+<<.operator-example 1 "[[8]log[2]]">>
+
+Logarithm of `100` with base `10`:
+<<.operator-example 2 "[[100]log[10]]">>
+
+Natural logarithm of 10 (base `e`), equivalent to `ln(10)` in mathematics:
+<<.operator-example 2 "[[10]log[]]">>

--- a/editions/tw5.com/tiddlers/filters/examples/power Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/power Operator (Examples).tid
@@ -1,0 +1,8 @@
+created: 20201120040913073
+modified: 20201120041513726
+tags: [[Operator Examples]] [[power Operator]]
+title: power Operator (Examples)
+type: text/vnd.tiddlywiki
+
+<<.operator-example 1 "[[3]power[3]]">>
+<<.operator-example 2 "9 +[power[2]]">>

--- a/editions/tw5.com/tiddlers/filters/log Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/log Operator.tid
@@ -1,0 +1,15 @@
+caption: log
+created: 20201120041113537
+modified: 20201120041443518
+op-input: a [[selection of titles|Title Selection]]
+op-output: the logarithm of each input title as numbers, with base <<.place N>> if specified otherwise base `e`
+op-parameter: a number
+op-parameter-name: N
+op-purpose: treating each input title as a number, return its logarithm with base equal to the numeric value of the operand if specified, otherwise base `e`
+tags: [[Filter Operators]] [[Mathematics Operators]] [[Binary Mathematics Operators]]
+title: log Operator
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.23">>
+
+<<.operator-examples "log">>

--- a/editions/tw5.com/tiddlers/filters/power Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/power Operator.tid
@@ -1,0 +1,15 @@
+caption: power
+created: 20201120040720190
+modified: 20201120040852980
+op-input: a [[selection of titles|Title Selection]]
+op-output: the input as numbers, but with each one raised to the power of <<.place N>>
+op-parameter: a number
+op-parameter-name: N
+op-purpose: treating each input title as a number, raise it to the power of the numeric value of the operand
+tags: [[Filter Operators]] [[Mathematics Operators]] [[Binary Mathematics Operators]]
+title: power Operator
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.23">>
+
+<<.operator-examples "power">>


### PR DESCRIPTION
Fixes #4431 

Adds mathematics filter operators for `power[]` and `log[]` as discussed in #4431 