### PR TITLE
Revert line-height of 3em on tiddler-edit-title

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1191,10 +1191,6 @@ canvas.tc-edit-bitmapeditor  {
 	overflow: hidden; /* https://github.com/Jermolene/TiddlyWiki5/issues/282 */
 }
 
-.tc-tiddler-title.tc-tiddler-edit-title {
-	line-height: 3em;
-}
-
 html body.tc-body.tc-single-tiddler-window {
 	margin: 1em;
 	background: <<colour tiddler-background>>;


### PR DESCRIPTION
When titles are long, recognizable on narrow screens, the line-height of 3em is way too high. So it's better to revert this like it was before