### PR TITLE
Add: Eventcatcher widget

### DIFF
--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -60,7 +60,6 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 				});
 				//Add a variable with a popup coordinate string for the selected node
 				variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
-				
 			} else {
 				return false;
 			}
@@ -116,7 +115,7 @@ EventWidget.prototype.refresh = function(changedTiddlers) {
 	if(changedAttributes.type) {
 		this.refreshSelf();
 		return true;
-	} else if(changedAttributes["class"]) {
+	} else if(changedAttributes["class"] || changedAttributes["tag"]) {
 		this.assignDomNodeClasses();
 	}
 	return this.refreshChildren(changedTiddlers);

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -69,12 +69,14 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 			// Add a variable for the modifier key
 			variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
 			// Add a variable for the mouse button
-			if(event.button === 0) {
-				variables["event-mousebutton"] = "left";
-			} else if(event.button === 1) {
-				variables["event-mousebutton"] = "middle";
-			} else if(event.button === 2) {
-				variables["event-mousebutton"] = "right";
+			if("button" in event) {
+				if(event.button === 0) {
+					variables["event-mousebutton"] = "left";
+				} else if(event.button === 1) {
+					variables["event-mousebutton"] = "middle";
+				} else if(event.button === 2) {
+					variables["event-mousebutton"] = "right";
+				}
 			}
 			self.invokeActionString(actions,self,event,variables);
 			event.preventDefault();
@@ -86,7 +88,7 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 	// Insert element
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);
-	this.domNodes.push(domNode);	
+	this.domNodes.push(domNode);
 };
 
 /*

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -1,5 +1,5 @@
 /*\
-title: $:/core/modules/widgets/event.js
+title: $:/core/modules/widgets/eventcatcher.js
 type: application/javascript
 module-type: widget
 
@@ -35,10 +35,13 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	// Create element
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
+	if(this.elementTag && $tw.config.htmlUnsafeElements.indexOf(this.elementTag) === -1) {
+		tag = this.elementTag;
+	}	
 	var domNode = this.document.createElement(tag);
 	// Assign classes
 	var classes = (this["class"] || "").split(" ");
-	classes.push("tc-event");
+	classes.push("tc-eventcatcher");
 	domNode.className = classes.join(" ");
 	// Add our event handler
 	domNode.addEventListener(this.type,function(event) {
@@ -62,6 +65,14 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 		}
 		// Execute our actions with the variables
 		if(actions) {
+			variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
+			if(event.button === 0) {
+				variables["event-mousebutton"] = "left";
+			} else if(event.button === 1) {
+				variables["event-mousebutton"] = "middle";
+			} else if(event.button === 2) {
+				variables["event-mousebutton"] = "right";
+			}
 			self.invokeActionString(actions,self,event,variables);
 			event.preventDefault();
 			event.stopPropagation();
@@ -82,6 +93,8 @@ EventWidget.prototype.execute = function() {
 	var self = this;
 	// Get attributes that require a refresh on change
 	this.type = this.getAttribute("type");
+	this["class"] = this.getAttribute("class");
+	this.elementTag = this.getAttribute("tag");
 	// Make child widgets
 	this.makeChildWidgets();
 };
@@ -91,13 +104,13 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 EventWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.type) {
+	if(changedAttributes.type || changedAttributes["class"]) {
 		this.refreshSelf();
 		return true;
 	}
 	return this.refreshChildren(changedTiddlers);
 };
 
-exports.event = EventWidget;
+exports.eventcatcher = EventWidget;
 
 })();

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -114,10 +114,10 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 EventWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.type) {
+	if(changedAttributes.type  || changedAttributes["tag"]) {
 		this.refreshSelf();
 		return true;
-	} else if(changedAttributes["class"] || changedAttributes["tag"]) {
+	} else if(changedAttributes["class"]) {
 		this.assignDomNodeClasses();
 	}
 	return this.refreshChildren(changedTiddlers);

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -47,6 +47,8 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 		var selector = self.getAttribute("selector"),
 			actions = self.getAttribute("actions"),
 			selectedNode = event.target,
+			selectedNodeRect,
+			catcherNodeRect,
 			variables = {};
 		if(selector) {
 			// Search ancestors for a node that matches the selector
@@ -60,6 +62,22 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 				});
 				//Add a variable with a popup coordinate string for the selected node
 				variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
+				
+				//Add variables for offset of selected node
+				variables["tv-selectednode-posx"] = selectedNode.offsetLeft;
+				variables["tv-selectednode-posy"] = selectedNode.offsetTop;
+				variables["tv-selectednode-width"] = selectedNode.offsetWidth;
+				variables["tv-selectednode-height"] = selectedNode.offsetHeight;				
+
+				//Add variables for event X and Y position relative to selected node
+				selectedNodeRect = selectedNode.getBoundingClientRect();				
+				variables["event-fromselected-posx"] = event.clientX - selectedNodeRect.left;
+				variables["event-fromselected-posy"] = event.clientY - selectedNodeRect.top;
+
+				//Add variables for event X and Y position relative to event catcher node
+				catcherNodeRect = self.domNode.getBoundingClientRect();
+				variables["event-fromcatcher-posx"] = event.clientX - catcherNodeRect.left;
+				variables["event-fromcatcher-posy"] = event.clientY - catcherNodeRect.top;
 			} else {
 				return false;
 			}

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -1,0 +1,103 @@
+/*\
+title: $:/core/modules/widgets/event.js
+type: application/javascript
+module-type: widget
+
+Event handler widget
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var EventWidget = function(parseTreeNode,options) {
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+EventWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+EventWidget.prototype.render = function(parent,nextSibling) {
+	var self = this;
+	// Remember parent
+	this.parentDomNode = parent;
+	// Compute attributes and execute state
+	this.computeAttributes();
+	this.execute();
+	// Create element
+	var tag = this.parseTreeNode.isBlock ? "div" : "span";
+	var domNode = this.document.createElement(tag);
+	// Assign classes
+	var classes = (this["class"] || "").split(" ");
+	classes.push("tc-event");
+	domNode.className = classes.join(" ");
+	// Add our event handler
+	domNode.addEventListener(this.type,function(event) {
+		var selector = self.getAttribute("selector"),
+			actions = self.getAttribute("actions"),
+			selectedNode = event.target,
+			variables = {};
+		if(selector) {
+			// Search ancestors for a node that matches the selector
+			while(!selectedNode.matches(selector) && selectedNode !== domNode) {
+				selectedNode = selectedNode.parentNode;
+			}
+			// If we found one, copy the attributes as variables, otherwise exit
+			if(selectedNode.matches(selector)) {
+				$tw.utils.each(selectedNode.attributes,function(attribute) {
+					variables["dom-" + attribute.name] = attribute.value;
+				});
+			} else {
+				return false;
+			}
+		}
+		// Execute our actions with the variables
+		if(actions) {
+			self.invokeActionString(actions,self,event,variables);
+			event.preventDefault();
+			event.stopPropagation();
+			return true;
+		}
+		return false;
+	},false);
+	// Insert element
+	parent.insertBefore(domNode,nextSibling);
+	this.renderChildren(domNode,null);
+	this.domNodes.push(domNode);
+};
+
+/*
+Compute the internal state of the widget
+*/
+EventWidget.prototype.execute = function() {
+	var self = this;
+	// Get attributes that require a refresh on change
+	this.type = this.getAttribute("type");
+	// Make child widgets
+	this.makeChildWidgets();
+};
+
+/*
+Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+*/
+EventWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if(changedAttributes.type) {
+		this.refreshSelf();
+		return true;
+	}
+	return this.refreshChildren(changedTiddlers);
+};
+
+exports.event = EventWidget;
+
+})();


### PR DESCRIPTION
Fixes #5074

@Jermolene here is a [diff with your original version](https://github.com/saqimtiaz/TiddlyWiki5/compare/ac709ec..eventcatcher)

Changes:
- rename widget to <$eventcatcher>
- added variable for modifer key: `modifier`
- added variable for mouse button clicked: `event-mousebutton`
- added variable for co-ordinate string for popup: `tv-popup-coords`
- allowed updating domNode className without `refreshSelf()`
- allowed optionally specifying domNode tag

Thoughts:
- I don't think we should do anything extra here to accommodate keyboard events. It would add significant complexity and we already have the keyboard widget.
- Do we want to provide the event co-ordinates (`pageX`/`clientX`...) as variables? If so, relative to what? The `eventcatcher` domNode? Raw values will likely not be helpful in actions.  Not knowing how they might be used makes it harder to know what format to provide them in.

