### PR TITLE
Fixed bug with default value in lookup operator

### DIFF
--- a/core/modules/filters/lookup.js
+++ b/core/modules/filters/lookup.js
@@ -22,7 +22,7 @@ Export our filter function
 exports.lookup = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
-		results.push(options.wiki.getTiddlerText(operator.operand + title) || options.wiki.getTiddlerText(operator.operand + operator.suffix));
+		results.push(options.wiki.getTiddlerText(operator.operand + title) || operator.suffix);
 	});
 	return results;
 };

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -207,7 +207,7 @@ function runTests(wiki) {
 
 	it("should handle the lookup operator", function() {
 		expect(wiki.filterTiddlers("Six Seventh 8 +[lookup[Tiddler]]").join(",")).toBe("Missing inaction from TiddlerOne,,Tidd");
-		expect(wiki.filterTiddlers("Six Seventh 8 +[lookup:8[Tiddler]]").join(",")).toBe("Missing inaction from TiddlerOne,Tidd,Tidd");
+		expect(wiki.filterTiddlers("Six Seventh 8 +[lookup:8[Tiddler]]").join(",")).toBe("Missing inaction from TiddlerOne,8,Tidd");
 	});
 
 	it("should retrieve shadow tiddlers", function() {


### PR DESCRIPTION
Apparently this bug has been around for a few years. The default value was never used properly.

Fixes #3445