### PR TITLE
Add Switcher modal

### DIFF
--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -64,7 +64,7 @@ MissingTiddler/Hint: Missing tiddler "<$text text=<<currentTiddler>>/>" -- click
 No: No
 OfficialPluginLibrary: Official ~TiddlyWiki Plugin Library
 OfficialPluginLibrary/Hint: The official ~TiddlyWiki plugin library at tiddlywiki.com. Plugins, themes and language packs are maintained by the core team.
-PageTemplate/Description: the default tiddlywiki layout
+PageTemplate/Description: the default ~TiddlyWiki layout
 PageTemplate/Name: Default ~PageTemplate
 PluginReloadWarning: Please save {{$:/core/ui/Buttons/save-wiki}} and reload {{$:/core/ui/Buttons/refresh}} to allow changes to ~JavaScript plugins to take effect
 RecentChanges/DateFormat: DDth MMM YYYY
@@ -77,10 +77,10 @@ Shortcuts/Input/Tab-Left/Hint: Select the previous Tab
 Shortcuts/Input/Tab-Right/Hint: Select the next Tab
 Shortcuts/Input/Up/Hint: Select the previous item
 Shortcuts/SidebarLayout/Hint: Change the sidebar layout
-Switcher/Subtitle/theme: Switch themes
-Switcher/Subtitle/layout: Switch layouts
-Switcher/Subtitle/language: Switch languages
-Switcher/Subtitle/palette: Switch palettes
+Switcher/Subtitle/theme: Switch Theme
+Switcher/Subtitle/layout: Switch Layout
+Switcher/Subtitle/language: Switch Language
+Switcher/Subtitle/palette: Switch Palette
 SystemTiddler/Tooltip: This is a system tiddler
 SystemTiddlers/Include/Prompt: Include system tiddlers
 TagManager/Colour/Heading: Colour

--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -40,6 +40,7 @@ Error/XMLHttpRequest: XMLHttpRequest error code
 InternalJavaScriptError/Title: Internal JavaScript Error
 InternalJavaScriptError/Hint: Well, this is embarrassing. It is recommended that you restart TiddlyWiki by refreshing your browser
 InvalidFieldName: Illegal characters in field name "<$text text=<<fieldName>>/>". Fields can only contain lowercase letters, digits and the characters underscore (`_`), hyphen (`-`) and period (`.`)
+LayoutSwitcher/Description: Open the layout switcher
 LazyLoadingWarning: <p>Trying to load external content from ''<$text text={{!!_canonical_uri}}/>''</p><p>If this message doesn't disappear, either the tiddler content type doesn't match the type of the external content, or you may be using a browser that doesn't support external content for wikis loaded as standalone files. See https://tiddlywiki.com/#ExternalText</p>
 LoginToTiddlySpace: Login to TiddlySpace
 Manager/Controls/FilterByTag/None: (none)
@@ -63,6 +64,8 @@ MissingTiddler/Hint: Missing tiddler "<$text text=<<currentTiddler>>/>" -- click
 No: No
 OfficialPluginLibrary: Official ~TiddlyWiki Plugin Library
 OfficialPluginLibrary/Hint: The official ~TiddlyWiki plugin library at tiddlywiki.com. Plugins, themes and language packs are maintained by the core team.
+PageTemplate/Description: the default tiddlywiki layout
+PageTemplate/Name: Default ~PageTemplate
 PluginReloadWarning: Please save {{$:/core/ui/Buttons/save-wiki}} and reload {{$:/core/ui/Buttons/refresh}} to allow changes to ~JavaScript plugins to take effect
 RecentChanges/DateFormat: DDth MMM YYYY
 Shortcuts/Input/AdvancedSearch/Hint: Open the ~AdvancedSearch panel from within the sidebar search field
@@ -74,6 +77,10 @@ Shortcuts/Input/Tab-Left/Hint: Select the previous Tab
 Shortcuts/Input/Tab-Right/Hint: Select the next Tab
 Shortcuts/Input/Up/Hint: Select the previous item
 Shortcuts/SidebarLayout/Hint: Change the sidebar layout
+Switcher/Subtitle/theme: Switch themes
+Switcher/Subtitle/layout: Switch layouts
+Switcher/Subtitle/language: Switch languages
+Switcher/Subtitle/palette: Switch palettes
 SystemTiddler/Tooltip: This is a system tiddler
 SystemTiddlers/Include/Prompt: Include system tiddlers
 TagManager/Colour/Heading: Colour

--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -26,7 +26,7 @@ exports.startup = function() {
 		$tw.modal.display(event.param,{variables: event.paramObject, event: event});
 	});
 	$tw.rootWidget.addEventListener("tm-show-switcher",function(event) {
-		$tw.modal.display("$:/core/ui/Switcher",{variables: event.paramObject, event: event});
+		$tw.modal.display("$:/core/ui/SwitcherModal",{variables: event.paramObject, event: event});
 	});	
 	// Install the notification  mechanism
 	$tw.notifier = new $tw.utils.Notifier($tw.wiki);

--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -25,6 +25,9 @@ exports.startup = function() {
 	$tw.rootWidget.addEventListener("tm-modal",function(event) {
 		$tw.modal.display(event.param,{variables: event.paramObject, event: event});
 	});
+	$tw.rootWidget.addEventListener("tm-show-switcher",function(event) {
+		$tw.modal.display("$:/core/ui/Switcher",{variables: event.paramObject, event: event});
+	});	
 	// Install the notification  mechanism
 	$tw.notifier = new $tw.utils.Notifier($tw.wiki);
 	$tw.rootWidget.addEventListener("tm-notify",function(event) {

--- a/core/ui/KeyboardShortcuts/switcher.tid
+++ b/core/ui/KeyboardShortcuts/switcher.tid
@@ -1,0 +1,5 @@
+title: $:/core/ui/KeyboardShortcuts/switcher
+tags: $:/tags/KeyboardShortcut
+key: ((layout-switcher))
+
+<$action-sendmessage $message="tm-show-switcher" switch="layout"/>

--- a/core/ui/LayoutSwitcher.tid
+++ b/core/ui/LayoutSwitcher.tid
@@ -1,0 +1,16 @@
+title: $:/snippets/LayoutSwitcher
+tags: $:/tags/ControlPanel/Appearance
+
+<$linkcatcher to="$:/layout">
+<div class="tc-chooser">
+<$list filter="[all[tiddlers+shadows]tag[$:/tags/Layout]] [[$:/core/ui/PageTemplate]] +[sort[name]]">
+<$list filter="[{$:/layout}!has[text]]" variable="ignore" emptyMessage="""
+<$set name="cls" filter="[all[current]field:title{$:/layout}]" value="tc-chooser-item tc-chosen" emptyValue="tc-chooser-item"><div class=<<cls>>><$link to={{!!title}}>''<$transclude field="name"/>'' - <$transclude field="description"/></$link></div>
+</$set>
+""">
+<$set name="cls" filter="[all[current]field:title[$:/core/ui/PageTemplate]]" value="tc-chooser-item tc-chosen" emptyValue="tc-chooser-item"><div class=<<cls>>><$link to={{!!title}}>''<$transclude field="name"/>'' - <$transclude field="description"/></$link></div>
+</$set>
+</$list>
+</$list>
+</div>
+</$linkcatcher>

--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -1,4 +1,6 @@
 title: $:/core/ui/PageTemplate
+name: {{$:/language/PageTemplate/Name}}
+description: {{$:/language/PageTemplate/Description}}
 
 \whitespace trim
 \define containerClasses()

--- a/core/ui/Switcher.tid
+++ b/core/ui/Switcher.tid
@@ -1,5 +1,6 @@
 title: $:/core/ui/Switcher
 subtitle: <$text text={{{[<switch>lookup[$:/language/Switcher/Subtitle/]]}}}/>
+class: tc-modal-centered
 
 <$vars currentTiddler={{{[<switch>lookup[$:/config/SwitcherTargets/]]}}}>
 

--- a/core/ui/Switcher.tid
+++ b/core/ui/Switcher.tid
@@ -2,10 +2,10 @@ title: $:/core/ui/Switcher
 subtitle: <$text text={{{[<switch>lookup[$:/language/Switcher/Subtitle/]]}}}/>
 class: tc-modal-centered
 
-<$vars currentTiddler={{{[<switch>lookup[$:/config/SwitcherTargets/]]}}}>
+<$tiddler tiddler={{{[<switch>lookup[$:/config/SwitcherTargets/]]}}}>
 
 
 <$transclude/>
 
 
-</$vars>
+</$tiddler>

--- a/core/ui/Switcher.tid
+++ b/core/ui/Switcher.tid
@@ -1,0 +1,10 @@
+title: $:/core/ui/Switcher
+subtitle: <$text text={{{[<switch>lookup[$:/language/Switcher/Subtitle/]]}}}/>
+
+<$vars currentTiddler={{{[<switch>lookup[$:/config/SwitcherTargets/]]}}}>
+
+
+<$transclude/>
+
+
+</$vars>

--- a/core/ui/SwitcherModal.tid
+++ b/core/ui/SwitcherModal.tid
@@ -1,4 +1,4 @@
-title: $:/core/ui/Switcher
+title: $:/core/ui/SwitcherModal
 subtitle: <$text text={{{[<switch>lookup[$:/language/Switcher/Subtitle/]]}}}/>
 class: tc-modal-centered
 

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -22,6 +22,7 @@ input-tab-left: {{$:/language/Shortcuts/Input/Tab-Left/Hint}}
 input-tab-right: {{$:/language/Shortcuts/Input/Tab-Right/Hint}}
 input-up: {{$:/language/Shortcuts/Input/Up/Hint}}
 italic: {{$:/language/Buttons/Italic/Hint}}
+layout-switcher: {{$:/language/LayoutSwitcher/Description}}
 link: {{$:/language/Buttons/Link/Hint}}
 linkify: {{$:/language/Buttons/Linkify/Hint}}
 list-bullet: {{$:/language/Buttons/ListBullet/Hint}}

--- a/core/wiki/config/SwitcherTargets.multids
+++ b/core/wiki/config/SwitcherTargets.multids
@@ -1,0 +1,6 @@
+title: $:/config/SwitcherTargets/
+
+layout: $:/snippets/LayoutSwitcher
+language: $:/snippets/languageswitcher
+palette: $:/core/ui/ControlPanel/Palette
+theme: $:/core/ui/ControlPanel/Theme

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -21,6 +21,7 @@ input-down: Down
 input-tab-left: alt-Left
 input-tab-right: alt-Right
 input-up: Up
+layout-switcher: alt-shift-L
 link: ctrl-L
 linkify: alt-shift-L
 list-bullet: ctrl-shift-L

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -21,7 +21,7 @@ input-down: Down
 input-tab-left: alt-Left
 input-tab-right: alt-Right
 input-up: Up
-layout-switcher: alt-shift-L
+layout-switcher: ctrl-shift-L
 link: ctrl-L
 linkify: alt-shift-L
 list-bullet: ctrl-shift-L

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1824,6 +1824,18 @@ html body.tc-body.tc-single-tiddler-window {
 	border-top: 1px solid <<colour modal-footer-border>>;
 }
 
+
+/*
+** Centered modals
+*/
+.tc-modal-centered .tc-modal {
+	width: auto;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%) !important;
+	transition: transform 10ms ease !important;
+}
+
 /*
 ** Notifications
 */

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1833,7 +1833,6 @@ html body.tc-body.tc-single-tiddler-window {
 	top: 50%;
 	left: 50%;
 	transform: translate(-50%, -50%) !important;
-	transition: transform 10ms ease !important;
 }
 
 /*


### PR DESCRIPTION
This is an alternative take on #5003 

`tm-show-switcher` accepts a parameter `switch` which determines which switcher to show. Possible values are "theme", "palette", "language" and "layout".

The keyboard shortcut <kbd>Ctrl+Shift+L</kbd> is configured for the layout switcher.

A quick take on a CSS class for centered modals has been added and used. Our options here are somewhat limited by the JavaScript controlled animations and properties.

[Demo](https://github.com/Jermolene/TiddlyWiki5/files/5579395/switcher-demo.zip)

![image](https://user-images.githubusercontent.com/68092/99899195-abe4ef00-2ca7-11eb-9061-8093e58e854c.png)

