### PR TITLE
Make type input field min-width the highest character length of selectable types

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1385,7 +1385,7 @@ html body.tc-body.tc-single-tiddler-window {
 	display: inline-block;
 }
 
-<<set-type-input-min-width>>
+<<set-type-selector-min-width>>
 
 .tc-edit-tags {
 	border: 1px solid <<colour tiddler-editor-border>>;

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -48,7 +48,7 @@ $else$
 \end
 
 \define set-type-selector-min-width()
-<$list filter="[all[shadows+tiddlers]removeprefix[$:/language/Docs/Types/]length[]] +[nsort[]] +[last[]]" variable="typeLength">
+<$set name="typeLength" value={{{ [all[shadows+tiddlers]prefix[$:/language/Docs/Types/]get[name]length[]maxall[]] }}}>
 
 	.tc-type-selector-dropdown-wrapper {
 		min-width: calc(<<typeLength>>ch + 4em);
@@ -58,7 +58,7 @@ $else$
 		min-width: <<typeLength>>ch;
 	}
 
-</$list>
+</$set>
 \end
 
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -47,6 +47,20 @@ $else$
 </$reveal>
 \end
 
+\define set-type-selector-min-width()
+<$list filter="[all[shadows+tiddlers]removeprefix[$:/language/Docs/Types/]length[]] +[nsort[]] +[last[]]" variable="typeLength">
+
+	.tc-type-selector-dropdown-wrapper {
+		min-width: calc(<<typeLength>>ch + 4em);
+	}
+
+	.tc-type-selector-dropdown-wrapper input.tc-edit-typeeditor {
+		min-width: <<typeLength>>ch;
+	}
+
+</$list>
+\end
+
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock
 
 /*
@@ -1370,6 +1384,8 @@ html body.tc-body.tc-single-tiddler-window {
 .tc-type-selector-dropdown-wrapper {
 	display: inline-block;
 }
+
+<<set-type-input-min-width>>
 
 .tc-edit-tags {
 	border: 1px solid <<colour tiddler-editor-border>>;


### PR DESCRIPTION
Fixes #2986

This PR counts the length of the longest selectable type and adds that length in characters as min-width to the type input field

It was mentioned somewhere (~~I cannot find the source~~ ... see #2986) that the type input field was too narrow. This PR fixes that problem