### PR TITLE
Button and Droppable widgets: improve refresh handling for classes

### DIFF
--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -27,33 +27,22 @@ ButtonWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 ButtonWidget.prototype.render = function(parent,nextSibling) {
-	var self = this;
+	var self = this,
+		tag = "button",
+		domNode;
 	// Remember parent
 	this.parentDomNode = parent;
 	// Compute attributes and execute state
 	this.computeAttributes();
 	this.execute();
 	// Create element
-	var tag = "button";
 	if(this.buttonTag && $tw.config.htmlUnsafeElements.indexOf(this.buttonTag) === -1) {
 		tag = this.buttonTag;
 	}
-	var domNode = this.document.createElement(tag);
+	domNode = this.document.createElement(tag);
+	this.domNode = domNode;
 	// Assign classes
-	var classes = this["class"].split(" ") || [],
-		isPoppedUp = (this.popup || this.popupTitle) && this.isPoppedUp();
-	if(this.selectedClass) {
-		if((this.set || this.setTitle) && this.setTo && this.isSelected()) {
-			$tw.utils.pushTop(classes,this.selectedClass.split(" "));
-		}
-		if(isPoppedUp) {
-			$tw.utils.pushTop(classes,this.selectedClass.split(" "));
-		}
-	}
-	if(isPoppedUp) {
-		$tw.utils.pushTop(classes,"tc-popup-handle");
-	}
-	domNode.className = classes.join(" ");
+	this.assignDomNodeClasses();
 	// Assign other attributes
 	if(this.style) {
 		domNode.setAttribute("style",this.style);
@@ -200,7 +189,6 @@ ButtonWidget.prototype.execute = function() {
 	this.setTo = this.getAttribute("setTo");
 	this.popup = this.getAttribute("popup");
 	this.hover = this.getAttribute("hover");
-	this["class"] = this.getAttribute("class","");
 	this["aria-label"] = this.getAttribute("aria-label");
 	this.tooltip = this.getAttribute("tooltip");
 	this.style = this.getAttribute("style");
@@ -219,14 +207,33 @@ ButtonWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
+ButtonWidget.prototype.assignDomNodeClasses = function() {
+	var classes = this.getAttribute("class","").split(" "),
+		isPoppedUp = (this.popup || this.popupTitle) && this.isPoppedUp();
+	if(this.selectedClass) {
+		if((this.set || this.setTitle) && this.setTo && this.isSelected()) {
+			$tw.utils.pushTop(classes,this.selectedClass.split(" "));
+		}
+		if(isPoppedUp) {
+			$tw.utils.pushTop(classes,this.selectedClass.split(" "));
+		}
+	}
+	if(isPoppedUp) {
+		$tw.utils.pushTop(classes,"tc-popup-handle");
+	}
+	this.domNode.className = classes.join(" ");
+}
+
 /*
 Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 */
 ButtonWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.actions || changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes["class"] || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || (this.popupTitle && changedTiddlers[this.popupTitle]) || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle || changedAttributes.disabled) {
+	if(changedAttributes.actions || changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || (this.popupTitle && changedTiddlers[this.popupTitle]) || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle || changedAttributes.disabled) {
 		this.refreshSelf();
 		return true;
+	} else if(changedAttributes["class"]) {
+		this.assignDomNodeClasses();
 	}
 	return this.refreshChildren(changedTiddlers);
 };

--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -192,6 +192,7 @@ ButtonWidget.prototype.execute = function() {
 	this["aria-label"] = this.getAttribute("aria-label");
 	this.tooltip = this.getAttribute("tooltip");
 	this.style = this.getAttribute("style");
+	// Class attribute is handled in assignDomNodeClasses()
 	this.selectedClass = this.getAttribute("selectedClass");
 	this.defaultSetValue = this.getAttribute("default","");
 	this.buttonTag = this.getAttribute("tag");

--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -27,21 +27,21 @@ DroppableWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 DroppableWidget.prototype.render = function(parent,nextSibling) {
-	var self = this;
+	var self = this,
+		tag = this.parseTreeNode.isBlock ? "div" : "span",
+		domNode;
 	// Remember parent
 	this.parentDomNode = parent;
 	// Compute attributes and execute state
 	this.computeAttributes();
 	this.execute();
-	var tag = this.parseTreeNode.isBlock ? "div" : "span";
 	if(this.droppableTag && $tw.config.htmlUnsafeElements.indexOf(this.droppableTag) === -1) {
 		tag = this.droppableTag;
 	}
 	// Create element and assign classes
-	var domNode = this.document.createElement(tag),
-		classes = (this.droppableClass || "").split(" ");
-	classes.push("tc-droppable");
-	domNode.className = classes.join(" ");
+	domNode = this.document.createElement(tag);
+	this.domNode = domNode;
+	this.assignDomNodeClasses();
 	// Add event handlers
 	if(this.droppableEnable) {
 		$tw.utils.addEventListeners(domNode,[
@@ -144,10 +144,15 @@ DroppableWidget.prototype.execute = function() {
 	this.droppableActions = this.getAttribute("actions");
 	this.droppableEffect = this.getAttribute("effect","copy");
 	this.droppableTag = this.getAttribute("tag");
-	this.droppableClass = this.getAttribute("class");
 	this.droppableEnable = (this.getAttribute("enable") || "yes") === "yes";
 	// Make child widgets
 	this.makeChildWidgets();
+};
+
+DroppableWidget.prototype.assignDomNodeClasses = function() {
+	var classes = this.getAttribute("class","").split(" ");
+	classes.push("tc-droppable");
+	this.domNode.className = classes.join(" ");	
 };
 
 /*
@@ -155,9 +160,11 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 DroppableWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes["class"] || changedAttributes.tag || changedAttributes.enable) {
+	if(changedAttributes.tag || changedAttributes.enable) {
 		this.refreshSelf();
 		return true;
+	} else if(changedAttributes["class"]) {
+		this.assignDomNodeClasses();
 	}
 	return this.refreshChildren(changedTiddlers);
 };


### PR DESCRIPTION
This PR improves the refresh handling for the `Button` and `Droppable` widgets so that if the `class` attribute changes, the DOM node classes are updated without calling `refreshSelf()`

This is a performance improvement and especially relevant when using multiple widgets, and allows using dynamic class names (via filtered attributes) to control appearance of contents via CSS.