### PR TITLE
Fix StaticRiver exporter width of static tiddlers

### DIFF
--- a/core/templates/exporters/StaticRiver.tid
+++ b/core/templates/exporters/StaticRiver.tid
@@ -26,7 +26,7 @@ extension: .html
 </head>
 <body class="tc-body">
 {{$:/StaticBanner||$:/core/templates/html-tiddler}}
-<section class="tc-story-river">
+<section class="tc-story-river tc-static-story-river">
 {{$:/core/templates/exporters/StaticRiver/Content||$:/core/templates/html-tiddler}}
 </section>
 </body>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -937,6 +937,11 @@ button.tc-btn-invisible.tc-remove-tag-button {
 
 ">>
 
+	.tc-story-river.tc-static-story-river {
+		margin-right: 0;
+		padding-right: 42px;
+	}
+
 }
 
 @media print {


### PR DESCRIPTION
Fixes #5072

This PR adds a class `tc-static-story-river` to the StaticRiver exporter, removes the right margin and adds a padding of 42px when we're above the sidebarbreakpoint