### PR TITLE
Update and rename MacOSDark.tid to CupertinoDark.tid

### DIFF
--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -1,7 +1,7 @@
 title: $:/palettes/CupertinoDark
 tags: $:/tags/palette
 name: Cupertino Dark
-description: A Cupertino-inspired dark palette
+description: A macOS inspired dark palette
 type: application/x-tiddler-dictionary
 
 alert-background: <<colour background>>

--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -1,6 +1,7 @@
-title: $:/palettes/MacOSDark
+title: $:/palettes/CupertinoDark
 tags: $:/tags/palette
-description: A MacOS inspired dark palette
+name: Cupertino Dark
+description: A Cupertino-inspired dark palette
 
 alert-background: <<colour background>>
 alert-border: <<colour very-muted-foreground>>

--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -2,6 +2,7 @@ title: $:/palettes/CupertinoDark
 tags: $:/tags/palette
 name: Cupertino Dark
 description: A Cupertino-inspired dark palette
+type: application/x-tiddler-dictionary
 
 alert-background: <<colour background>>
 alert-border: <<colour very-muted-foreground>>

--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -1,5 +1,5 @@
 title: $:/palettes/CupertinoDark
-tags: $:/tags/palette
+tags: $:/tags/Palette
 name: Cupertino Dark
 description: A macOS inspired dark palette
 type: application/x-tiddler-dictionary


### PR DESCRIPTION
This PR renames the MacOSDark palette to Cupertino dark and changes its description to `A Cupertino-inspired dark palette`