### PR TITLE
Lighter sidebar-controls-foreground for Cupertino Dark Palette

### DIFF
--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -53,7 +53,7 @@ select-tag-background: <<colour background>>
 select-tag-foreground: <<colour foreground>>
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #FF9F0A
-sidebar-controls-foreground: #464646
+sidebar-controls-foreground: #8E8E93
 sidebar-foreground-shadow: transparent
 sidebar-foreground: rgba(255, 255, 255, 0.54)
 sidebar-muted-foreground-hover: rgba(255, 255, 255, 0.54)


### PR DESCRIPTION
This makes the sidebar and tiddler controls better visible