### PR TITLE
Update CupertinoDark.tid

### DIFF
--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -85,7 +85,7 @@ tiddler-background: <<colour background>>
 tiddler-border: transparent
 tiddler-controls-foreground-hover: <<colour sidebar-controls-foreground-hover>>
 tiddler-controls-foreground-selected: <<colour sidebar-controls-foreground-hover>>
-tiddler-controls-foreground: <<colour sidebar-controls-foreground>>
+tiddler-controls-foreground: #48484A
 tiddler-editor-background: transparent
 tiddler-editor-border-image: 
 tiddler-editor-border: rgba(255, 255, 255, 0.08)


### PR DESCRIPTION
This makes the tiddler-controls color a bit darker than the sidebar-controls color since the tiddler-controls are on a darker background and their color is also used for the editor buttons