### PR TITLE
Fix #5108 - vanilla/reset overrides system fonts

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -90,7 +90,7 @@ html button {
 ** Basic element styles
 */
 
-html {
+html, body {
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/fontfamily}};
 	text-rendering: optimizeLegibility; /* Enables kerning and ligatures etc. */
 	-webkit-font-smoothing: antialiased;


### PR DESCRIPTION
This PR fixes #5108 where we've found out that vanilla/reset overrides the fonts in the vanilla/base stylesheet