### PR TITLE
fix titlebar line-height for chrome

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1053,7 +1053,7 @@ button.tc-btn-invisible.tc-remove-tag-button {
 .tc-titlebar {
 	font-weight: 300;
 	font-size: 2.35em;
-	line-height: 1.3em;
+	line-height: 1.35em;
 	color: <<colour tiddler-title-foreground>>;
 	margin: 0;
 }


### PR DESCRIPTION
Increasing the line-height from initial PR wasn't big enough. 
This fixes: #5104 

@saqimtiaz can you check it with Chrome _and_ different browser ZOOM settings. I did test it with FF latest and Edge latest windows 10. I could recreate the problem with Edge. 