### PR TITLE
Git saver : bypass cache to avoid 409 errors.

### DIFF
--- a/core/modules/savers/github.js
+++ b/core/modules/savers/github.js
@@ -31,7 +31,8 @@ GitHubSaver.prototype.save = function(text,method,callback) {
 		headers = {
 			"Accept": "application/vnd.github.v3+json",
 			"Content-Type": "application/json;charset=UTF-8",
-			"Authorization": "Basic " + window.btoa(username + ":" + password)
+			"Authorization": "Basic " + window.btoa(username + ":" + password),
+			"If-None-Match": ""
 		};
 	// Bail if we don't have everything we need
 	if(!username || !password || !repo || !filename) {


### PR DESCRIPTION
Ensure that we always fetch the latest sha bypassing cache.

Fixes #5119 which is caused by the caching of the GET request if a subsequent save is within 60 seconds.

