### PR TITLE
Correctly add EventListener 'click' for popup-handling in new windows

### DIFF
--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -84,11 +84,8 @@ exports.startup = function() {
 			name: "keydown",
 			handlerObject: $tw.keyboardManager,
 			handlerMethod: "handleKeydownEvent"
-		},{
-			name: "click",
-			handlerObject: $tw.popup,
-			handlerMethod: "handleEvent"
 		}]);
+		srcWindow.document.documentElement.addEventListener("click",$tw.popup,true);
 		srcWindow.haveInitialisedWindow = true;
 	});
 	// Close open windows when unloading main window


### PR DESCRIPTION
This PR changes how the eventListener for the click event in new windows that deletes popups is added. Before it was faulty