### PR TITLE
Remove outline border from buttons and remove ::-ms-clear cross from inputs

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -84,6 +84,7 @@ html button {
 	color: <<colour button-foreground>>;
 	background: <<colour button-background>>;
 	border-color: <<colour button-border>>;
+	outline: none;
 }
 
 /*
@@ -228,6 +229,10 @@ input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-results-button,
 input[type="search"]::-webkit-search-results-decoration {
 	-webkit-appearance:none;
+}
+
+::-ms-clear {
+	display: none;
 }
 
 .tc-muted {


### PR DESCRIPTION
This PR removes the outline borders from buttons which makes the page feel more like an application than a website (opinionated) and removes the clear-input-cross from inputs in internet explorer using `::-ms-clear { display: none; }`