### PR TITLE
Rename "references" to "backlinks" in the tiddler info panel

### DIFF
--- a/core/language/en-GB/TiddlerInfo.multids
+++ b/core/language/en-GB/TiddlerInfo.multids
@@ -14,7 +14,7 @@ List/Caption: List
 List/Empty: This tiddler does not have a list
 Listed/Caption: Listed
 Listed/Empty: This tiddler is not listed by any others
-References/Caption: References
+References/Caption: Backlinks
 References/Empty: No tiddlers link to this one
 Tagging/Caption: Tagging
 Tagging/Empty: No tiddlers are tagged with this one

--- a/editions/tw5.com/tiddlers/concepts/InfoPanel.tid
+++ b/editions/tw5.com/tiddlers/concepts/InfoPanel.tid
@@ -1,5 +1,5 @@
 created: 20150917193630604
-modified: 20150917193631731
+modified: 20201129183045031
 tags: Features
 title: InfoPanel
 type: text/vnd.tiddlywiki
@@ -9,7 +9,7 @@ Each tiddler has a panel of additional information. To reveal it, click the <<.i
 The info panel has the following tabs:
 
 * ''Tools'' - This offers buttons for various actions you can perform on the tiddler. The checkbox next to each button lets you promote an action to the tiddler's toolbar - this will affect all of the tiddlers in your wiki
-* ''References'', ''Tagging'', ''List'' and ''Listed'' - These list various kinds of related tiddlers. See [[Using links to navigate between tiddlers]]
+* ''Backlinks'', ''Tagging'', ''List'' and ''Listed'' - These list various kinds of related tiddlers. See [[Using links to navigate between tiddlers]]
 * ''Fields'' - This summarises all of the tiddler's [[fields|TiddlerFields]], except for ''text''
 * ''Advanced'' - This indicates whether the tiddler is a [[shadow|ShadowTiddlers]]. If it is, this also reveals which plugin it comes from and whether it has been overridden by an ordinary tiddler
 

--- a/editions/tw5.com/tiddlers/workingwithtw/Using links to navigate between tiddlers.tid
+++ b/editions/tw5.com/tiddlers/workingwithtw/Using links to navigate between tiddlers.tid
@@ -1,5 +1,5 @@
 created: 20140908093600000
-modified: 20171219170302268
+modified: 20201129183020567
 tags: [[Working with TiddlyWiki]]
 title: Using links to navigate between tiddlers
 type: text/vnd.tiddlywiki
@@ -12,7 +12,7 @@ You can use links (normally displayed as blue text) to navigate from one tiddler
 
 * The ''InfoPanel'' of each tiddler gives you access to four tabs containing additional lists of related tiddlers:
 
-** The ''References'' tab lists all the tiddlers that link //to// the current tiddler.
+** The ''Backlinks'' tab lists all the tiddlers that link //to// the current tiddler.
 
 ** The ''Tagging'' tab lists all the tiddlers that have been tagged with the current tiddler's title.
 


### PR DESCRIPTION
TiddlyWiki 5 has always referred to "backlinks" as "references" in the user interface, despite the underlying filter operator being called "backlinks". It is proposed to switch to calling them "backlinks" for clarity.

I've made this a separate PR so that we can discuss the merits, and also in case we need to adjust any docs in the light of this change