### PR TITLE
Operator pad[] along with tests and docs

### DIFF
--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -143,4 +143,33 @@ exports["search-replace"] = function(source,operator,options) {
 	return results;
 };
 
+exports.pad = function(source,operator,options) {
+	var results = [],
+		targetLength = operator.operand ? parseInt(operator.operand) : 0,
+		fill = operator.operands[1] || "0";
+
+	source(function(tiddler,title) {
+		if(title && title.length) {
+			if(title.length >= targetLength) {
+				results.push(title);
+			} else {
+				var padString = "",
+					padStringLength = targetLength - title.length;
+				while (padStringLength > padString.length) {
+					padString += fill;					
+				}
+				//make sure we do not exceed the specified length
+				padString = padString.slice(0,padStringLength);
+				if(operator.suffix && (operator.suffix === "suffix")) {
+					title = title + padString;
+				} else {
+					title = padString + title;
+				}
+				results.push(title);
+			}
+		}
+	});
+	return results;
+}
+
 })();

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -777,6 +777,17 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[[Hello There]search-replace::regexp<myregexp>,[]]",anchorWidget).join(",")).toBe("Hllo There");
 		expect(wiki.filterTiddlers("[[Hello There]search-replace:gi[H],[]]",anchorWidget).join(",")).toBe("ello Tere");	
 	});
+	
+	it("should handle the pad operator", function() {
+	expect(wiki.filterTiddlers("[[2]pad[]]").join(",")).toBe("2");
+	expect(wiki.filterTiddlers("[[2]pad[0]]").join(",")).toBe("2");
+	expect(wiki.filterTiddlers("[[2]pad[1]]").join(",")).toBe("2");
+	expect(wiki.filterTiddlers("2 20 +[pad[3]]").join(",")).toBe("002,020");
+	expect(wiki.filterTiddlers("[[2]pad[9]]").join(",")).toBe("000000002");
+	expect(wiki.filterTiddlers("[[2]pad[9],[a]]").join(",")).toBe("aaaaaaaa2");
+	expect(wiki.filterTiddlers("[[12]pad[9],[abc]]").join(",")).toBe("abcabca12");
+	expect(wiki.filterTiddlers("[[12]pad:suffix[9],[abc]]").join(",")).toBe("12abcabca");
+	});
 }
 
 });

--- a/editions/tw5.com/tiddlers/filters/examples/pad Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/pad Operator (Examples).tid
@@ -1,0 +1,13 @@
+created: 20201129174833980
+modified: 20201129180011580
+tags: [[Operator Examples]] [[pad Operator]]
+title: pad Operator (Examples)
+type: text/vnd.tiddlywiki
+
+<<.operator-example 1 """[[2]pad[3]]""">>
+
+<<.operator-example 2 """[[2]pad[3],[a]]""">>
+
+<<.operator-example 3 """[[12]pad[9],[abc]]""">>
+
+<<.operator-example 4 """[[12]pad:suffix[9],[abc]]""">>

--- a/editions/tw5.com/tiddlers/filters/pad Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/pad Operator.tid
@@ -1,0 +1,23 @@
+caption: pad
+created: 20201129174215674
+modified: 20201129175301148
+op-input: a [[selection of titles|Title Selection]]
+op-output: the input titles padded to the specified length
+op-parameter: the <<.op pad>> operator accepts 1 or more parameters, see below for details
+op-purpose: returns each item in the list padded to the specified length
+op-suffix: (optional). Whether to pad by adding a "suffix" or "prefix". Defaults to "prefix".
+tags: [[Filter Operators]] [[String Operators]]
+title: pad Operator
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.23">>
+
+The <<.op pad>> operator requires at least one parameter which specifies the desired length of the input titles. A second optional parameter can be used to specify the string to pad with (defaults to "0").
+
+```
+[pad[<length>],[<padding-string>]]
+```
+* ''length'' : the desired final length of the input titles.
+* ''padding-string'': (optional). The string to use to pad to the desired length. Defaults to "0".
+
+<<.operator-examples "pad">>


### PR DESCRIPTION
Fixes #5137 

This implements a string operator `pad[]` as described in #5137 and includes tests and docs.

The implementation is consistent with the behaviour of the JavaScript String methods padEnd and padStart.

`[[12]pad[5]]` => `00012`

`[[12]pad[4],[-]]` => `--12`

`[[12]pad[9],[abc]]` => `abcabca12`

`[[12]pad:suffix[9],[abc]]` => `12abcabca`