### PR TITLE
Tag trim operator as a string operator

### DIFF
--- a/editions/tw5.com/tiddlers/filters/trim Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/trim Operator.tid
@@ -1,12 +1,12 @@
 caption: trim
 created: 20190613153740241
-modified: 20190613153820282
+modified: 20201130040553874
 op-purpose: returns each item in the list with whitespace, or a given character string, trimmed from the start and/or end
 op-input: a [[selection of titles|Title Selection]]
 op-parameter: <<.from-version "5.1.23">> a string of characters
 op-parameter-name: S
 op-output: the input titles with <<.place S>>, or whitespace if <<.place S>> is not specified, trimmed from the start and/or end
-tags: [[Filter Operators]]
+tags: [[Filter Operators]] [[String Operators]]
 title: trim Operator
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/filters/trim Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/trim Operator.tid
@@ -1,11 +1,13 @@
 caption: trim
 created: 20190613153740241
-modified: 20201130040553874
+modified: 20201130141111438
 op-purpose: returns each item in the list with whitespace, or a given character string, trimmed from the start and/or end
 op-input: a [[selection of titles|Title Selection]]
 op-parameter: <<.from-version "5.1.23">> a string of characters
 op-parameter-name: S
 op-output: the input titles with <<.place S>>, or whitespace if <<.place S>> is not specified, trimmed from the start and/or end
+op-suffix: `prefix` to trim from the start only, `suffix` to trim from the end only. If omitted (default), trim from both start and end
+op-suffix-name: T
 tags: [[Filter Operators]] [[String Operators]]
 title: trim Operator
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
With the new functionality of the `trim` operator in 5.1.23, it's now a general-purpose string manipulation tool. So it should be given the "String operators" tag so that people see it in the same list as `removeprefix` and `removesuffix`, etc.

**Note:** PR created against master branch rather than tiddlywiki-com branch because without the new 5.1.23 features, I'm not convinced that it needs the "String operators" tag, so this change should go live once 5.1.23 releases, not before. (And besides which, if I created this PR against tiddlywiki-com, it would likely end up causing a merge conflict once the 5.1.23 release happens due to the "tags:" line being so close to the "op-output:" line, which has been modified in master. So since the 5.1.23 release is so close, I decided this PR was better made against master than against tiddlywiki-com).