### PR TITLE
Update static.tiddler.html.tid with tc-static-story-river class

### DIFF
--- a/core/templates/static.tiddler.html.tid
+++ b/core/templates/static.tiddler.html.tid
@@ -22,7 +22,7 @@ title: $:/core/templates/static.tiddler.html
 </head>
 <body class="tc-body">
 `{{$:/StaticBanner||$:/core/templates/html-tiddler}}`
-<section class="tc-story-river">
+<section class="tc-story-river tc-static-story-river">
 `<$view tiddler="$:/core/ui/ViewTemplate" format="htmlwikified"/>`
 </section>
 </body>


### PR DESCRIPTION
This PR adds the `tc-static-story-river` class to the `static.tiddler.html` template which makes rendered tiddlers full-width