### PR TITLE
Make buttons look like buttons in CupertinoDark, GruvboxDark and DesertSand palette

### DIFF
--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -10,9 +10,7 @@ alert-highlight: #FFD60A
 alert-muted-foreground: <<colour muted-foreground>>
 background: #282828
 blockquote-bar: <<colour page-background>>
-button-background: #3F638B
-button-foreground: <<colour foreground>>
-button-border: transparent
+button-foreground: <<colour background>>
 code-background: <<colour pre-background>>
 code-border: <<colour pre-border>>
 code-foreground: rgba(255, 255, 255, 0.54)
@@ -53,7 +51,7 @@ pre-border: transparent
 primary: #0A84FF
 select-tag-background: <<colour background>>
 select-tag-foreground: <<colour foreground>>
-sidebar-button-foreground: <<colour foreground>>
+sidebar-button-foreground: <<colour background>>
 sidebar-controls-foreground-hover: #FF9F0A
 sidebar-controls-foreground: #8E8E93
 sidebar-foreground-shadow: transparent

--- a/core/palettes/DesertSand.tid
+++ b/core/palettes/DesertSand.tid
@@ -10,9 +10,7 @@ alert-highlight: #881122
 alert-muted-foreground: #b99e2f
 background: #E9E0C7
 blockquote-bar: <<colour muted-foreground>>
-button-background: #BAB29C
 button-foreground: <<colour foreground>>
-button-border: transparent
 code-background: #F3EDDF
 code-border: #C3BAA1
 code-foreground: #ab3250

--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -11,9 +11,7 @@ alert-highlight: #d79921
 alert-muted-foreground: #504945
 background: #3c3836
 blockquote-bar: <<colour muted-foreground>>
-button-background: #504945
-button-foreground: #fbf1c7
-button-border: transparent
+button-foreground: <<colour page-background>>
 code-background: #504945
 code-border: #504945
 code-foreground: #fb4934
@@ -62,7 +60,7 @@ pre-border: #504945
 primary: #d79921
 select-tag-background: #665c54
 select-tag-foreground: <<colour foreground>>
-sidebar-button-foreground: <<colour foreground>>
+sidebar-button-foreground: <<colour page-background>>
 sidebar-controls-foreground-hover: #7c6f64
 sidebar-controls-foreground: #504945
 sidebar-foreground-shadow: transparent


### PR DESCRIPTION
This PR removes the background-color and border-color from buttons in the CupertinoDark, GruvboxDark and DesertSand palettes so that buttons look like buttons :grin: