### PR TITLE
Fix #5162 - tiddler opening position is incorrect, bug in navigator.js

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -128,7 +128,7 @@ NavigatorWidget.prototype.replaceFirstTitleInStory = function(storyList,oldTitle
 
 NavigatorWidget.prototype.addToStory = function(title,fromTitle) {
 	if(this.storyTitle) {
-		this.story.addToStory(title,fromTitle,this.storyTitle,{
+		this.story.addToStory(title,fromTitle,{
 			openLinkFromInsideRiver: this.getAttribute("openLinkFromInsideRiver","top"),
 			openLinkFromOutsideRiver: this.getAttribute("openLinkFromOutsideRiver","top")
 		});


### PR DESCRIPTION
This PR fixes #5162 - the error is that $tw.Story.addToStory accepts only 3 arguments but it was called with 4 where the fourth was the options object and the third was the (unnecessary) storyTitle