### PR TITLE
Fix typo in x-listops.js

### DIFF
--- a/core/modules/filters/x-listops.js
+++ b/core/modules/filters/x-listops.js
@@ -206,7 +206,7 @@ Extended filter operators to manipulate the current list.
 			if(operands.length > 1) {
 				results.splice(resultsIndex,1,operands[nextOperandIndex]);
 			} else {
-				results.splice(resultsIndex,1,);
+				results.splice(resultsIndex,1);
 			}
 		} else {
 			results.push(operands[0]);


### PR DESCRIPTION
Fixes #5170 

Oddly enough my jslint did not catch this.