### PR TITLE
Fix a couple typos in "deprecated feature" warning

### DIFF
--- a/editions/tw5.com/tiddlers/system/Deprecated_-_What_does_it_mean.tid
+++ b/editions/tw5.com/tiddlers/system/Deprecated_-_What_does_it_mean.tid
@@ -7,9 +7,9 @@ First of all: ''Keep calm!''
 
 {{$:/deprecated}}
 
-For ~TiddlyWiki it means, that you should not use this mechanism for new content anymore! ''AND you should update your existing content''!
+For ~TiddlyWiki it means that you should not use this mechanism for new content anymore, ''AND you should update your existing content''!
 
-Deprecated features have a marker. see: [[Custom styles by tag]]
+Deprecated features have a marker. See: [[How to apply custom styles by tag]]
 
 ''Tiddlers tagged `$:/deprecated`''
 

--- a/editions/tw5.com/tiddlers/system/version-macros.tid
+++ b/editions/tw5.com/tiddlers/system/version-macros.tid
@@ -8,8 +8,8 @@ type: text/vnd.tiddlywiki
 <span class="doc-from-version">{{$:/core/images/warning}} New in: $version$</span>
 \end
 
-\define .deprecated-since(version, superseeded:"TODO-Link")
-<$button to="Deprecated - What does it mean" class="doc-deprecated-version tc-btn-invisible">{{$:/core/images/warning}} Deprecated since: $version$ </$button> use [[$superseeded$]] instead!
+\define .deprecated-since(version, superseded:"TODO-Link")
+<$button to="Deprecated - What does it mean" class="doc-deprecated-version tc-btn-invisible">{{$:/core/images/warning}} Deprecated since: $version$ </$button>. Use [[$superseded$]] instead
 \end
 
 <pre><$view field="text"/></pre>


### PR DESCRIPTION
One tiddler had been renamed since the deprecation warning tiddler was created, and there were also a couple of minor punctuation and/or spelling errors.