### PR TITLE
Change input-tab-right and input-tab-left for macOS to ctrl-Right and ctlr-Left

### DIFF
--- a/core/wiki/config/shortcuts/shortcuts-mac.multids
+++ b/core/wiki/config/shortcuts/shortcuts-mac.multids
@@ -1,6 +1,8 @@
 title: $:/config/shortcuts-mac/
 
 bold: meta-B
+input-tab-left: ctrl-Left
+input-tab-right: ctrl-Right
 italic: meta-I
 underline: meta-U
 new-image: ctrl-I


### PR DESCRIPTION
This PR adds <kbd>ctrl-Right</kbd> and <kbd>ctlr-Left</kbd> for the input-tab-right and input-tab-left shortcuts on **macOS**

Edit: fixes #5178