### PR TITLE
Reduce operator: second optional parameter instead of suffix

### DIFF
--- a/core/modules/filters/reduce.js
+++ b/core/modules/filters/reduce.js
@@ -23,7 +23,7 @@ exports.reduce = function(source,operator,options) {
 	});
 	// Run the filter over each item
 	var filterFn = options.wiki.compileFilter(operator.operand),
-		accumulator = operator.suffix || "";
+		accumulator = operator.operands[1] || "";
 	for(var index=0; index<results.length; index++) {
 		var title = results[index],
 			list = filterFn.call(options.wiki,options.wiki.makeTiddlerIterator([title]),{

--- a/editions/tw5.com/tiddlers/filters/examples/reduce Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/reduce Operator (Examples).tid
@@ -1,5 +1,5 @@
 created: 20201004154413968
-modified: 20201204123859254
+modified: 20201204131137081
 tags: [[Operator Examples]] [[reduce Operator]]
 title: reduce Operator (Examples)
 type: text/vnd.tiddlywiki
@@ -42,7 +42,7 @@ Using `<index>` to act differently on the first item than the rest:
 
 <<.operator-example 3 "[tag[shopping]reduce<join-with-commas>]">>
 
-Empty input, no suffix:
+Empty input, no second parameter:
 
 <<.operator-example 4 "[tag[non-existent]reduce<add-price>]">>
 

--- a/editions/tw5.com/tiddlers/filters/examples/reduce Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/reduce Operator (Examples).tid
@@ -1,5 +1,5 @@
 created: 20201004154413968
-modified: 20201006181831622
+modified: 20201204123859254
 tags: [[Operator Examples]] [[reduce Operator]]
 title: reduce Operator (Examples)
 type: text/vnd.tiddlywiki
@@ -50,12 +50,12 @@ Note how the output contains a single item with no text. This is not "empty outp
 
 <$macrocall $name=".tip" _=<<reduce-tip>> />
 
-Empty input, no suffix, followed by <<.op else>>:
+Empty input, no second parameter, followed by <<.op else>>:
 
 <<.operator-example 5 "[tag[non-existent]reduce<add-price>else[0]]">>
 
-Note how the output still contains a single item with no text: <<.op else>> did not trigger. If you want the value to be 0 when <<.op reduce>> has no items to process, you need to specify 0 as the initial value by passing it as a suffix to <<.op reduce>>.
+Note how the output still contains a single item with no text: <<.op else>> did not trigger. If you want the value to be 0 when <<.op reduce>> has no items to process, you need to specify 0 as the initial value by passing it as a second parameter to <<.op reduce>>.
 
-Empty input, suffix provided:
+Empty input, second parameter provided:
 
-<<.operator-example 6 "[tag[non-existent]reduce:0<add-price>]">>
+<<.operator-example 6 "[tag[non-existent]reduce<add-price>,[0]]">>

--- a/editions/tw5.com/tiddlers/filters/reduce.tid
+++ b/editions/tw5.com/tiddlers/filters/reduce.tid
@@ -1,19 +1,18 @@
 caption: reduce
 created: 20201004154131193
-modified: 20201006174749170
+modified: 20201204123759507
 op-input: a [[selection of titles|Title Selection]] passed as input to the filter
 op-output: the final result of running the subfilter <<.place S>>
-op-parameter: a [[filter expression|Filter Expression]]
+op-parameter: a [[filter expression|Filter Expression]]. Optional second parameter for initial value for accumulator
 op-parameter-name: S
 op-purpose: apply a subfilter to each input title in turn, accumulating a single value
-op-suffix: Initial value for accumulator
 op-suffix-name: V
 tags: [[Filter Operators]]
 title: reduce Operator
 type: text/vnd.tiddlywiki
 
 \define reduce-tip()
-The <<.op reduce>> operator will always produce output, even if its input was empty. If its input is empty, the output of <<.op reduce>> will be the initial value of the accumulator, i.e. the value of the suffix. One result of this fact is that the <<.op else>> operator will never be triggered if it follows a <<.op reduce>>. The "Empty input" examples show what happens when <<.op reduce>> receives no input.
+The <<.op reduce>> operator will always produce output, even if its input was empty. If its input is empty, the output of <<.op reduce>> will be the initial value of the accumulator, i.e. the value of the second parameter. One result of this fact is that the <<.op else>> operator will never be triggered if it follows a <<.op reduce>>. The "Empty input" examples show what happens when <<.op reduce>> receives no input.
 \end
 
 <<.from-version "5.1.23">> The <<.op reduce>> operator runs a subfilter for each input title, passing the result of the previous subfilter run as a variable. The initial value of the accumulator can optionally be specified. It returns the result of the final subfilter run.

--- a/editions/tw5.com/tiddlers/filters/reduce.tid
+++ b/editions/tw5.com/tiddlers/filters/reduce.tid
@@ -1,12 +1,11 @@
 caption: reduce
 created: 20201004154131193
-modified: 20201204123759507
+modified: 20201204130601564
 op-input: a [[selection of titles|Title Selection]] passed as input to the filter
 op-output: the final result of running the subfilter <<.place S>>
 op-parameter: a [[filter expression|Filter Expression]]. Optional second parameter for initial value for accumulator
 op-parameter-name: S
 op-purpose: apply a subfilter to each input title in turn, accumulating a single value
-op-suffix-name: V
 tags: [[Filter Operators]]
 title: reduce Operator
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
Fixes #5190

Replaces the suffix for `reduce[]` with an optional second parameter so that the initial value can also be set via variables.