### PR TITLE
Make sidebarsegments/search count-matches-button display the count of ALL search results (de-duplicated)

### DIFF
--- a/core/ui/SideBarSegments/search.tid
+++ b/core/ui/SideBarSegments/search.tid
@@ -8,9 +8,9 @@ tags: $:/tags/SideBarSegment
 <$button popup=<<qualify "$:/state/popup/search-dropdown">> class="tc-btn-invisible">
 {{$:/core/images/down-arrow}}
 <$list filter="[{$(searchTiddler)$}minlength{$:/config/Search/MinLength}limit[1]]" variable="listItem">
-<$vars userInput={{{ [<searchTiddler>get[text]] }}} configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}}>
-<$vars primaryListFilter={{{ [<configTiddler>get[first-search-filter]] }}} secondaryListFilter={{{ [<configTiddler>get[second-search-filter]] }}}>
-<$set name="resultCount" value="""<$count filter="[subfilter<primaryListFilter>] =[subfilter<secondaryListFilter>]"/>""">
+<$vars userInput={{{ [<searchTiddler>get[text]] }}} configTiddler={{{ [[$:/state/search/currentTab]!is[missing]get[text]] ~[{$:/config/SearchResults/Default}] }}} replaceRegexp="limit\[\d+\]">
+<$vars primaryListFilter={{{ [<configTiddler>get[first-search-filter]search-replace:g:regexp<replaceRegexp>,[]] }}} secondaryListFilter={{{ [<configTiddler>get[second-search-filter]search-replace:g:regexp<replaceRegexp>,[]] }}}>
+<$set name="resultCount" value="""<$count filter="[subfilter<primaryListFilter>] [subfilter<secondaryListFilter>]"/>""">
 {{$:/language/Search/Matches}}
 </$set>
 </$vars>


### PR DESCRIPTION
This PR makes the count-matches-button of the sidebar search show the count of ALL matches but de-duplicated. Matches the behavior of 5.1.22