### PR TITLE
:reduce filter run prefix

### DIFF
--- a/core/modules/filterrunprefixes/reduce.js
+++ b/core/modules/filterrunprefixes/reduce.js
@@ -1,0 +1,49 @@
+/*\
+title: $:/core/modules/filterrunprefixes/reduce.js
+type: application/javascript
+module-type: filterrunprefix
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter prefix function
+*/
+exports.reduce = function(operationSubFunction) {
+	return function(results,source,widget) {
+		if(results.length > 0) {
+			var accumulator = "";
+			for(var index=0; index<results.length; index++) {
+				var title = results[index],
+					list = operationSubFunction($tw.wiki.makeTiddlerIterator([title]),{
+						getVariable: function(name) {
+							switch(name) {
+								case "currentTiddler":
+									return "" + title;
+								case "accumulator":
+									return "" + accumulator;
+								case "index":
+									return "" + index;
+								case "revIndex":
+									return "" +  (results.length - 1 - index);
+								case "length":
+									return "" + results.length;
+								default:
+									return widget.getVariable(name);
+							}
+						}
+					});
+				if(list.length > 0) {
+					accumulator = "" + list[0];
+				}
+			}
+			results.splice(0,results.length);
+			results.push(accumulator);	
+		}
+	}
+};
+
+})();


### PR DESCRIPTION
@Jermolene this adds a filter run prefix equivalent to the `reduce[]` operator. 

`[tag[shopping]] :reduce[get[quantity]add<accumulator>]`

is equivalent to:

```
\define num-items() [get[quantity]add<accumulator>]

[tag[shopping]reduce<num-items>]
```

AND

`[tag[non-existent]] :reduce[get[price]multiply{!!quantity}add<accumulator>] :else[[0]]`

is equivalent to:

```
\define add-price() [get[price]multiply{!!quantity}add<accumulator>]

[tag[non-existent]reduce:0<add-price>]
```

If you want to leave this for after 5.1.23 that is OK for me.