### PR TITLE
Fix for filterrunprefixes using $tw.wiki

### DIFF
--- a/core/modules/filterrunprefixes/and.js
+++ b/core/modules/filterrunprefixes/and.js
@@ -16,10 +16,10 @@ Equivalent to + filter run prefix.
 /*
 Export our filter prefix function
 */
-exports.and = function(operationSubFunction) {
+exports.and = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		// This replaces all the elements of the array, but keeps the actual array so that references to it are preserved
-		source = widget.wiki.makeTiddlerIterator(results);
+		source = options.wiki.makeTiddlerIterator(results);
 		results.splice(0,results.length);
 		$tw.utils.pushTop(results,operationSubFunction(source,widget));
 	};

--- a/core/modules/filterrunprefixes/and.js
+++ b/core/modules/filterrunprefixes/and.js
@@ -19,7 +19,7 @@ Export our filter prefix function
 exports.and = function(operationSubFunction) {
 	return function(results,source,widget) {
 		// This replaces all the elements of the array, but keeps the actual array so that references to it are preserved
-		source = $tw.wiki.makeTiddlerIterator(results);
+		source = widget.wiki.makeTiddlerIterator(results);
 		results.splice(0,results.length);
 		$tw.utils.pushTop(results,operationSubFunction(source,widget));
 	};

--- a/core/modules/filterrunprefixes/reduce.js
+++ b/core/modules/filterrunprefixes/reduce.js
@@ -12,13 +12,13 @@ module-type: filterrunprefix
 /*
 Export our filter prefix function
 */
-exports.reduce = function(operationSubFunction) {
+exports.reduce = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		if(results.length > 0) {
 			var accumulator = "";
 			for(var index=0; index<results.length; index++) {
 				var title = results[index],
-					list = operationSubFunction($tw.wiki.makeTiddlerIterator([title]),{
+					list = operationSubFunction(options.wiki.makeTiddlerIterator([title]),{
 						getVariable: function(name) {
 							switch(name) {
 								case "currentTiddler":

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -280,20 +280,21 @@ exports.compileFilter = function(filterString) {
 		var filterRunPrefixes = self.getFilterRunPrefixes();
 		// Wrap the operator functions in a wrapper function that depends on the prefix
 		operationFunctions.push((function() {
+			var options = {wiki: self};
 			switch(operation.prefix || "") {
 				case "": // No prefix means that the operation is unioned into the result
-					return filterRunPrefixes["or"](operationSubFunction);
+					return filterRunPrefixes["or"](operationSubFunction, options);
 				case "=": // The results of the operation are pushed into the result without deduplication
-					return filterRunPrefixes["all"](operationSubFunction);
+					return filterRunPrefixes["all"](operationSubFunction, options);
 				case "-": // The results of this operation are removed from the main result
-					return filterRunPrefixes["except"](operationSubFunction);	
+					return filterRunPrefixes["except"](operationSubFunction, options);
 				case "+": // This operation is applied to the main results so far
-					return filterRunPrefixes["and"](operationSubFunction);
+					return filterRunPrefixes["and"](operationSubFunction, options);
 				case "~": // This operation is unioned into the result only if the main result so far is empty
-					return filterRunPrefixes["else"](operationSubFunction);
+					return filterRunPrefixes["else"](operationSubFunction, options);
 				default: 
 					if(operation.namedPrefix && filterRunPrefixes[operation.namedPrefix]) {
-						return filterRunPrefixes[operation.namedPrefix](operationSubFunction);
+						return filterRunPrefixes[operation.namedPrefix](operationSubFunction, options);
 					} else {
 						return function(results,source,widget) {
 							results.splice(0,results.length);
@@ -305,7 +306,6 @@ exports.compileFilter = function(filterString) {
 	});
 	// Return a function that applies the operations to a source iterator of tiddler titles
 	return $tw.perf.measure("filter: " + filterString,function filterFunction(source,widget) {
-		widget = widget || {wiki: self, getVariable: function() { return undefined; }};
 		if(!source) {
 			source = self.each;
 		} else if(typeof source === "object") { // Array or hashmap

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -305,6 +305,7 @@ exports.compileFilter = function(filterString) {
 	});
 	// Return a function that applies the operations to a source iterator of tiddler titles
 	return $tw.perf.measure("filter: " + filterString,function filterFunction(source,widget) {
+		widget = widget || {wiki: self, getVariable: function() { return undefined; }};
 		if(!source) {
 			source = self.each;
 		} else if(typeof source === "object") { // Array or hashmap

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -459,7 +459,7 @@ function runTests(wiki) {
 	it("should handle indirect operands", function() {
 		expect(wiki.filterTiddlers("[prefix{Tiddler8}] +[sort[title]]").join(",")).toBe("Tiddler Three,TiddlerOne");
 		expect(wiki.filterTiddlers("[modifier{Tiddler8!!test-field}] +[sort[title]]").join(",")).toBe("TiddlerOne");
-		var fakeWidget = {getVariable: function() {return "Tiddler Three";}};
+		var fakeWidget = {wiki: wiki, getVariable: function() {return "Tiddler Three";}};
 		expect(wiki.filterTiddlers("[modifier{!!modifier}] +[sort[title]]",fakeWidget).join(",")).toBe("$:/TiddlerTwo,a fourth tiddler,one,Tiddler Three");
 	});
 


### PR DESCRIPTION
Fix for `and` filterrunprefix. It was using $tw.wiki instead of the wiki supplied in its widget, which meant that it was impossible to test any filters in a testing environment using temporary wiki objects.

A simple one line fix, but it did mean touching all the filter tests. Yech, but it's done now.