### PR TITLE
Add selection-background/foreground to GruvboxDark and Nord palettes

### DIFF
--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -60,6 +60,8 @@ pre-border: #504945
 primary: #d79921
 select-tag-background: #665c54
 select-tag-foreground: <<colour foreground>>
+selection-background: #458588
+selection-foreground: <<colour foreground>>
 sidebar-button-foreground: <<colour page-background>>
 sidebar-controls-foreground-hover: #7c6f64
 sidebar-controls-foreground: #504945

--- a/core/palettes/Nord.tid
+++ b/core/palettes/Nord.tid
@@ -62,8 +62,8 @@ pre-border: #2E3440
 primary: #5E81AC
 select-tag-background: #3b4252
 select-tag-foreground: <<colour foreground>>
-selection-background: #A3BE8C
-selection-foreground: <<colour background>>
+selection-background: <<colour primary>>
+selection-foreground: <<colour foreground>>
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #D8DEE9
 sidebar-controls-foreground: #4C566A

--- a/core/palettes/Nord.tid
+++ b/core/palettes/Nord.tid
@@ -62,6 +62,8 @@ pre-border: #2E3440
 primary: #5E81AC
 select-tag-background: #3b4252
 select-tag-foreground: <<colour foreground>>
+selection-background: #A3BE8C
+selection-foreground: <<colour background>>
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #D8DEE9
 sidebar-controls-foreground: #4C566A

--- a/core/palettes/Nord.tid
+++ b/core/palettes/Nord.tid
@@ -62,7 +62,7 @@ pre-border: #2E3440
 primary: #5E81AC
 select-tag-background: #3b4252
 select-tag-foreground: <<colour foreground>>
-selection-background: <<colour primary>>
+selection-background: #5E81AC
 selection-foreground: <<colour foreground>>
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #D8DEE9

--- a/core/palettes/Nord.tid
+++ b/core/palettes/Nord.tid
@@ -11,9 +11,7 @@ alert-highlight: #B48EAD
 alert-muted-foreground: #4C566A
 background: #3b4252
 blockquote-bar: <<colour muted-foreground>>
-button-background: #4C566A
-button-foreground: #D8DEE9
-button-border: transparent
+button-foreground: <<colour page-background>>
 code-background: #2E3440
 code-border: #2E3440
 code-foreground: #BF616A
@@ -64,7 +62,7 @@ select-tag-background: #3b4252
 select-tag-foreground: <<colour foreground>>
 selection-background: #5E81AC
 selection-foreground: <<colour foreground>>
-sidebar-button-foreground: <<colour foreground>>
+sidebar-button-foreground: <<colour page-background>>
 sidebar-controls-foreground-hover: #D8DEE9
 sidebar-controls-foreground: #4C566A
 sidebar-foreground-shadow: transparent


### PR DESCRIPTION
This PR adds the `selection-background` and `selection-foreground` to the GruvboxDark and Nord palettes