### PR TITLE
Cache result of parsing macro calls which don't use text subsitution

### DIFF
--- a/core/modules/widgets/macrocall.js
+++ b/core/modules/widgets/macrocall.js
@@ -55,9 +55,18 @@ MacroCallWidget.prototype.execute = function() {
 	// Are we rendering to HTML?
 	if(this.renderOutput === "text/html") {
 		// If so we'll return the parsed macro
-		var parser = this.wiki.parseText(this.parseType,text,
-							{parseAsInline: !this.parseTreeNode.isBlock});
-		parseTreeNodes = parser ? parser.tree : [];
+		// Check if we've already cached parsing this macro
+		var parser;
+		if(variableInfo.srcVariable && variableInfo.srcVariable.parser) {
+			parser = variableInfo.srcVariable.parser;
+		} else {
+			parser = this.wiki.parseText(this.parseType,text,
+								{parseAsInline: !this.parseTreeNode.isBlock});
+			if(variableInfo.isCacheable && variableInfo.srcVariable) {
+				// variableInfo.srcVariable.parser = parser;
+			}
+		}
+		var parseTreeNodes = parser ? parser.tree : [];
 		// Wrap the parse tree in a vars widget assigning the parameters to variables named "__paramname__"
 		var attributes = {};
 		$tw.utils.each(variableInfo.params,function(param) {

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -113,7 +113,8 @@ Widget.prototype.getVariableInfo = function(name,options) {
 	// Check for the variable defined in the parent widget (or an ancestor in the prototype chain)
 	if(parentWidget && name in parentWidget.variables) {
 		var variable = parentWidget.variables[name],
-			value = variable.value,
+			originalValue = variable.value,
+			value = originalValue,
 			params = this.resolveVariableParameters(variable.params,actualParams);
 		// Substitute any parameters specified in the definition
 		$tw.utils.each(params,function(param) {
@@ -125,7 +126,9 @@ Widget.prototype.getVariableInfo = function(name,options) {
 		}
 		return {
 			text: value,
-			params: params
+			params: params,
+			srcVariable: variable,
+			isCacheable: originalValue === value
 		};
 	}
 	// If the variable doesn't exist in the parent widget then look for a macro module


### PR DESCRIPTION
After the [recent discussion](https://github.com/Jermolene/TiddlyWiki5/issues/5188#issuecomment-737896712) of the relatively poor performance of macros relative to transclusions, it occurred to me that there is a possible route to caching the results of parsing a macro. The "catch" is that it only kicks in for macros that do NOT use text substitution of parameters or variables (ie `$parameter$` or `$(variable)$`).

Testing it turned out to a challenge because nearly all of the core macros do still use text substitution. The exception is the `tree` macro. I made a test rig of a tiddler that displayed 1000 instances of the tree macro. The optimisation improved the initial render time by 20% which seems worthwhile (especially given the rough and ready benchmark being used).

We need to decide whether this can go into v5.1.23. It's a deep modification, but it doesn't seem especially risky. We already cache parse trees so we know that part of it is safe. I'd be interested in other views.

