### PR TITLE
use a linked list for filter runs.

### DIFF
--- a/core/modules/filterrunprefixes/all.js
+++ b/core/modules/filterrunprefixes/all.js
@@ -18,7 +18,7 @@ Export our filter prefix function
 */
 exports.all = function(operationSubFunction) {
 	return function(results,source,widget) {
-		Array.prototype.push.apply(results,operationSubFunction(source,widget));
+		results.push.apply(results, operationSubFunction(source,widget));
 	};
 };
 

--- a/core/modules/filterrunprefixes/and.js
+++ b/core/modules/filterrunprefixes/and.js
@@ -19,9 +19,9 @@ Export our filter prefix function
 exports.and = function(operationSubFunction) {
 	return function(results,source,widget) {
 		// This replaces all the elements of the array, but keeps the actual array so that references to it are preserved
-		source = $tw.wiki.makeTiddlerIterator(results);
-		results.splice(0,results.length);
-		$tw.utils.pushTop(results,operationSubFunction(source,widget));
+		source = $tw.wiki.makeTiddlerIterator(results.toArray());
+		results.clear();
+		results.pushTop(operationSubFunction(source,widget));
 	};
 };
 

--- a/core/modules/filterrunprefixes/else.js
+++ b/core/modules/filterrunprefixes/else.js
@@ -19,7 +19,7 @@ exports.else = function(operationSubFunction) {
 	return function(results,source,widget) {
 		if(results.length === 0) {
 			// Main result so far is empty
-			$tw.utils.pushTop(results,operationSubFunction(source,widget));
+			results.pushTop(operationSubFunction(source,widget));
 		}
 	};
 };

--- a/core/modules/filterrunprefixes/except.js
+++ b/core/modules/filterrunprefixes/except.js
@@ -18,7 +18,7 @@ Export our filter prefix function
 */
 exports.except = function(operationSubFunction) {
 	return function(results,source,widget) {
-		$tw.utils.removeArrayEntries(results,operationSubFunction(source,widget));
+		results.remove(operationSubFunction(source,widget));
 	};
 };
 

--- a/core/modules/filterrunprefixes/filter.js
+++ b/core/modules/filterrunprefixes/filter.js
@@ -17,13 +17,13 @@ exports.filter = function(operationSubFunction) {
 	return function(results,source,widget) {
 		if(results.length > 0) {
 			var resultsToRemove = [];
-			$tw.utils.each(results,function(result) {
+			results.each(function(result) {
 				var filtered = operationSubFunction($tw.wiki.makeTiddlerIterator([result]),widget);
 				if(filtered.length === 0) {
 					resultsToRemove.push(result);
 				}
 			});
-			$tw.utils.removeArrayEntries(results,resultsToRemove);
+			results.remove(resultsToRemove);
 		}
 	}
 };

--- a/core/modules/filterrunprefixes/intersection.js
+++ b/core/modules/filterrunprefixes/intersection.js
@@ -17,7 +17,8 @@ exports.intersection = function(operationSubFunction) {
 	return function(results,source,widget) {
 		if(results.length !== 0) {
 			var secondRunResults = operationSubFunction(source,widget);
-			var firstRunResults = results.splice(0);
+			var firstRunResults = results.toArray();
+			results.clear();
 			$tw.utils.each(firstRunResults,function(title) {
 				if(secondRunResults.indexOf(title) !== -1) {
 					results.push(title);

--- a/core/modules/filterrunprefixes/or.js
+++ b/core/modules/filterrunprefixes/or.js
@@ -17,7 +17,7 @@ Export our filter prefix function
 */
 exports.or = function(operationSubFunction) {
 	return function(results,source,widget) {
-		$tw.utils.pushTop(results,operationSubFunction(source,widget));
+		results.pushTop(operationSubFunction(source,widget));
 	};
 };
 

--- a/core/modules/filterrunprefixes/reduce.js
+++ b/core/modules/filterrunprefixes/reduce.js
@@ -16,9 +16,9 @@ exports.reduce = function(operationSubFunction) {
 	return function(results,source,widget) {
 		if(results.length > 0) {
 			var accumulator = "";
-			for(var index=0; index<results.length; index++) {
-				var title = results[index],
-					list = operationSubFunction($tw.wiki.makeTiddlerIterator([title]),{
+			var index = 0;
+			results.each(function(title) {
+				var list = operationSubFunction($tw.wiki.makeTiddlerIterator([title]),{
 						getVariable: function(name) {
 							switch(name) {
 								case "currentTiddler":
@@ -39,8 +39,9 @@ exports.reduce = function(operationSubFunction) {
 				if(list.length > 0) {
 					accumulator = "" + list[0];
 				}
-			}
-			results.splice(0,results.length);
+				++index;
+			});
+			results.clear();
 			results.push(accumulator);	
 		}
 	}

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -310,11 +310,11 @@ exports.compileFilter = function(filterString) {
 		} else if(typeof source === "object") { // Array or hashmap
 			source = self.makeTiddlerIterator(source);
 		}
-		var results = [];
+		var builder = new $tw.utils.LinkedList();
 		$tw.utils.each(operationFunctions,function(operationFunction) {
-			operationFunction(results,source,widget);
+			operationFunction(builder,source,widget);
 		});
-		return results;
+		return builder.toArray();
 	});
 };
 

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -310,11 +310,11 @@ exports.compileFilter = function(filterString) {
 		} else if(typeof source === "object") { // Array or hashmap
 			source = self.makeTiddlerIterator(source);
 		}
-		var builder = new $tw.utils.LinkedList();
+		var results = new $tw.utils.LinkedList();
 		$tw.utils.each(operationFunctions,function(operationFunction) {
-			operationFunction(builder,source,widget);
+			operationFunction(results,source,widget);
 		});
-		return builder.toArray();
+		return results.toArray();
 	});
 };
 

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -15,14 +15,15 @@ function LinkedList() {
 
 LinkedList.prototype.clear = function() {
 	this.index = Object.create(null);
+	// LinkedList performs the duty of both the head and tail node
 	this.next = this;
 	this.prev = this;
 	this.length = 0;
 };
 
 LinkedList.prototype.remove = function(value) {
-	if ($tw.utils.isArray(value)) {
-		for (var t=0; t<value.length; t++) {
+	if($tw.utils.isArray(value)) {
+		for(var t=0; t<value.length; t++) {
 			this._removeOne(value[t]);
 		}
 	} else {
@@ -32,7 +33,7 @@ LinkedList.prototype.remove = function(value) {
 
 LinkedList.prototype._removeOne = function(value) {
 	var node = this.index[value];
-	if (node) {
+	if(node) {
 		node.prev.next = node.next;
 		node.next.prev = node.prev;
 		this.length -= 1;
@@ -52,12 +53,12 @@ LinkedList.prototype._linkToEnd = function(node) {
 };
 
 LinkedList.prototype.push = function(/* values */) {
-	for (var i = 0; i < arguments.length; i++) {
+	for(var i = 0; i < arguments.length; i++) {
 		var value = arguments[i];
 		var node = {value: value};
 		var preexistingNode = this.index[value];
 		this._linkToEnd(node);
-		if (preexistingNode) {
+		if(preexistingNode) {
 			// We want to keep pointing to the first instance, but we want
 			// to have that instance (or chain of instances) point to the
 			// new one.
@@ -72,14 +73,14 @@ LinkedList.prototype.push = function(/* values */) {
 };
 
 LinkedList.prototype.pushTop = function(value) {
-	if ($tw.utils.isArray(value)) {
-		for (var t=0; t<value.length; t++) {
+	if($tw.utils.isArray(value)) {
+		for(var t=0; t<value.length; t++) {
 			this._removeOne(value[t]);
 		}
 		this.push.apply(this, value);
 	} else {
 		var node = this._removeOne(value);
-		if (!node) {
+		if(!node) {
 			node = {value: value};
 			this.index[value] = node;
 		}
@@ -88,14 +89,14 @@ LinkedList.prototype.pushTop = function(value) {
 };
 
 LinkedList.prototype.each = function(callback) {
-	for (var ptr = this.next; ptr !== this; ptr = ptr.next) {
+	for(var ptr = this.next; ptr !== this; ptr = ptr.next) {
 		callback(ptr.value);
 	}
 };
 
 LinkedList.prototype.toArray = function() {
 	var output = [];
-	for (var ptr = this.next; ptr !== this; ptr = ptr.next) {
+	for(var ptr = this.next; ptr !== this; ptr = ptr.next) {
 		output.push(ptr.value);
 	}
 	return output;

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -83,6 +83,17 @@ LinkedList.prototype.pushTop = function(value) {
 		if(!node) {
 			node = {value: value};
 			this.index[value] = node;
+		} else {
+			// Put this node at the end of the copy chain.
+			var preexistingNode = node;
+			while(preexistingNode.copy) {
+				preexistingNode = preexistingNode.copy;
+			}
+			// The order of these three statements is important,
+			// because sometimes preexistingNode == node.
+			preexistingNode.copy = node;
+			this.index[value] = node.copy;
+			node.copy = undefined;
 		}
 		this._linkToEnd(node);
 	}

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -1,0 +1,102 @@
+/*\
+module-type: utils
+title: $:/core/modules/utils/linkedlist.js
+type: application/javascript
+
+\*/
+
+exports.LinkedList = function() {
+	this.clear();
+};
+
+var Lp = exports.LinkedList.prototype;
+
+Lp.clear = function() {
+	this.index = Object.create(null);
+	this.next = this;
+	this.prev = this;
+	this.length = 0;
+};
+
+Lp.pushOne = function(value) {
+	var node = this.index[value];
+	if (node) {
+		// If it already exists, pluck it out.
+		node.prev.next = node.next;
+		node.next.prev = node.prev;
+		this.length -= 1;
+	} else {
+		node = {value: value};
+		this.index[value] = node;
+	}
+	this._linkToEnd(node);
+};
+
+Lp.remove = function(value) {
+	if ($tw.utils.isArray(value)) {
+		for (var t=0; t<value.length; t++) {
+			this._removeOne(value[t]);
+		}
+	} else {
+		this._removeOne(value);
+	}
+};
+
+Lp._removeOne = function(value) {
+	var node = this.index[value];
+	if (node) {
+		this.index[value] = undefined;
+		node.prev.next = node.next;
+		node.next.prev = node.prev;
+		this.length -= 1;
+	}
+};
+
+Lp._linkToEnd = function(node) {
+	this.prev.next = node;
+	node.prev = this.prev;
+	this.prev = node;
+	node.next = this;
+	this.length += 1;
+};
+
+Lp.push = function(/* values */) {
+	for (var i = 0; i < arguments.length; i++) {
+		var value = arguments[i];
+		var node = {value: value};
+		this._linkToEnd(node);
+		if (!this.index[value]) {
+			this.index[value] = node;
+		} else {
+			// We want to keep pointing to the first instance, but we want
+			// to have that instance point to the new one.
+		}
+	}
+};
+
+Lp.pushTop = function(value) {
+	if ($tw.utils.isArray(value)) {
+		for (var t=0; t<value.length; t++) {
+			this._removeOne(value[t]);
+		}
+		this.push.apply(this, value);
+	} else {
+		this.pushOne(value);
+	}
+};
+
+Lp.each = function(callback) {
+	var ptr = this.next;
+	while (ptr !== this) {
+		callback(ptr.value);
+		ptr = ptr.next;
+	}
+};
+
+Lp.toArray = function() {
+	var output = [];
+	for (var ptr = this.next; ptr !== this; ptr = ptr.next) {
+		output.push(ptr.value);
+	}
+	return output;
+};

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -3,22 +3,24 @@ module-type: utils
 title: $:/core/modules/utils/linkedlist.js
 type: application/javascript
 
-\*/
+This is a doubly-linked indexed list intended for manipulation, particularly
+pushTop, which it does with significantly better performance than an array.
 
-exports.LinkedList = function() {
+\*/
+(function(){
+
+function LinkedList() {
 	this.clear();
 };
 
-var Lp = exports.LinkedList.prototype;
-
-Lp.clear = function() {
+LinkedList.prototype.clear = function() {
 	this.index = Object.create(null);
 	this.next = this;
 	this.prev = this;
 	this.length = 0;
 };
 
-Lp.remove = function(value) {
+LinkedList.prototype.remove = function(value) {
 	if ($tw.utils.isArray(value)) {
 		for (var t=0; t<value.length; t++) {
 			this._removeOne(value[t]);
@@ -28,19 +30,20 @@ Lp.remove = function(value) {
 	}
 };
 
-Lp._removeOne = function(value) {
+LinkedList.prototype._removeOne = function(value) {
 	var node = this.index[value];
 	if (node) {
 		node.prev.next = node.next;
 		node.next.prev = node.prev;
 		this.length -= 1;
-		// Point the index to the next copy of the value, maybe nothing.
+		// Point index to the next instance of the same value, maybe nothing.
 		this.index[value] = node.copy;
 	}
 	return node;
 };
 
-Lp._linkToEnd = function(node) {
+LinkedList.prototype._linkToEnd = function(node) {
+	// Sticks the given node onto the end of the list.
 	this.prev.next = node;
 	node.prev = this.prev;
 	this.prev = node;
@@ -48,7 +51,7 @@ Lp._linkToEnd = function(node) {
 	this.length += 1;
 };
 
-Lp.push = function(/* values */) {
+LinkedList.prototype.push = function(/* values */) {
 	for (var i = 0; i < arguments.length; i++) {
 		var value = arguments[i];
 		var node = {value: value};
@@ -68,7 +71,7 @@ Lp.push = function(/* values */) {
 	}
 };
 
-Lp.pushTop = function(value) {
+LinkedList.prototype.pushTop = function(value) {
 	if ($tw.utils.isArray(value)) {
 		for (var t=0; t<value.length; t++) {
 			this._removeOne(value[t]);
@@ -84,18 +87,20 @@ Lp.pushTop = function(value) {
 	}
 };
 
-Lp.each = function(callback) {
-	var ptr = this.next;
-	while (ptr !== this) {
+LinkedList.prototype.each = function(callback) {
+	for (var ptr = this.next; ptr !== this; ptr = ptr.next) {
 		callback(ptr.value);
-		ptr = ptr.next;
 	}
 };
 
-Lp.toArray = function() {
+LinkedList.prototype.toArray = function() {
 	var output = [];
 	for (var ptr = this.next; ptr !== this; ptr = ptr.next) {
 		output.push(ptr.value);
 	}
 	return output;
 };
+
+exports.LinkedList = LinkedList;
+
+})();

--- a/editions/test/tiddlers/tests/test-linked-list.js
+++ b/editions/test/tiddlers/tests/test-linked-list.js
@@ -1,0 +1,116 @@
+/*\
+title: test-linked-list.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests the utils.LinkedList class.
+
+LinkedList was built to behave exactly as $tw.utils.pushTop and
+Array.prototype.push would behave with an array.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+describe("LinkedList class tests", function() {
+
+	it("can pushTop", function() {
+		var list = new $tw.utils.LinkedList();
+		list.push('A', 'B', 'C');
+		// singles
+		list.pushTop('X');
+		list.pushTop('B');
+		expect(list.toArray()).toEqual(['A', 'C', 'X', 'B']);
+		expect(list.length).toBe(4);
+		//arrays
+		list.pushTop(['X', 'A', 'G', 'A']);
+		// If the pushedTopped list has duplicates, they go in unempeded.
+		expect(list.toArray()).toEqual(['C', 'B', 'X', 'A', 'G', 'A']);
+		expect(list.length).toBe(6);
+	});
+
+	it("can pushTop with tricky duplicates", function() {
+		var list = new $tw.utils.LinkedList();
+		list.push('A', 'B', 'A', 'C', 'A', 'end');
+		// If the original list contains duplicates, only one instance is cut
+		list.pushTop('A');
+		expect(list.toArray()).toEqual(['B', 'A', 'C', 'A', 'end', 'A']);
+		expect(list.length).toBe(6);
+
+		// And the Llist properly knows the next 'A' to cut if pushed again
+		list.pushTop(['X', 'A']);
+		expect(list.toArray()).toEqual(['B', 'C', 'A', 'end', 'A', 'X', 'A']);
+		expect(list.length).toBe(7);
+
+		// One last time, to make sure we maintain the linked chain of copies
+		list.pushTop('A');
+		expect(list.toArray()).toEqual(['B', 'C', 'end', 'A', 'X', 'A', 'A']);
+		expect(list.length).toBe(7);
+	});
+
+	it("can push", function() {
+		var list = new $tw.utils.LinkedList();
+		list.push('A', 'B', 'C');
+		// singles
+		list.push('B');
+		expect(list.toArray()).toEqual(['A', 'B', 'C', 'B']);
+		expect(list.length).toBe(4);
+
+		// multiple args
+		list.push('A', 'B', 'C');
+		expect(list.toArray()).toEqual(['A', 'B', 'C', 'B', 'A', 'B', 'C']);
+		expect(list.length).toBe(7);
+	});
+
+	it("can clear", function() {
+		var list = new $tw.utils.LinkedList();
+		list.push('A', 'B', 'C');
+		list.clear();
+		expect(list.toArray()).toEqual([]);
+		expect(list.length).toBe(0);
+	});
+
+	it("can remove", function() {
+		var list = new $tw.utils.LinkedList();
+		list.push('A', 'x', 'C', 'x', 'D', 'x', 'E', 'x');
+		// single
+		list.remove('x');
+		expect(list.toArray()).toEqual(['A', 'C', 'x', 'D', 'x', 'E', 'x']);
+		expect(list.length).toBe(7);
+
+		// arrays
+		list.remove(['x', 'A', 'x']);
+		expect(list.toArray()).toEqual(['C', 'D', 'E', 'x']);
+		expect(list.length).toBe(4);
+	});
+
+	it('can ignore removal of nonexistent items', function() {
+		var list = new $tw.utils.LinkedList();
+		list.push('A', 'B', 'C', 'D');
+		// single
+		list.remove('Z');
+		expect(list.toArray()).toEqual(['A', 'B', 'C', 'D']);
+		expect(list.length).toBe(4);
+
+		// array
+		list.remove(['Z', 'B', 'X']);
+		expect(list.toArray()).toEqual(['A', 'C', 'D']);
+		expect(list.length).toBe(3);
+	});
+
+	it('can iterate with each', function() {
+		var list = new $tw.utils.LinkedList();
+		list.push('0', '1', '2', '3');
+		var counter = 0;
+		list.each(function(value) {
+			expect(value).toBe(counter.toString());
+			counter = counter + 1;
+		});
+		expect(counter).toBe(4);
+	});
+});
+
+})();

--- a/editions/test/tiddlers/tests/test-linked-list.js
+++ b/editions/test/tiddlers/tests/test-linked-list.js
@@ -51,6 +51,20 @@ describe("LinkedList class tests", function() {
 		expect(list.length).toBe(7);
 	});
 
+	it("can handle particularly nasty pushTop pitfall", function() {
+		var list = new $tw.utils.LinkedList();
+		list.push('A', 'B', 'A', 'C');
+		list.pushTop('A'); // BACA
+		list.pushTop('X'); // BACAX
+		list.remove('A');  // BCAX
+		list.pushTop('A'); // BCXA
+		list.remove('A');  // BCX
+		// But! The way I initially coded the copy chains, a mystery A could
+		// hang around.
+		expect(list.toArray()).toEqual(['B', 'C', 'X']);
+		expect(list.length).toBe(3);
+	});
+
 	it("can push", function() {
 		var list = new $tw.utils.LinkedList();
 		list.push('A', 'B', 'C');


### PR DESCRIPTION
I know V5.1.23 is just about to release, but hear me out.

Right now, filters use `$tw.utils.pushTop` to assemble filter results, but it's really not scalable. It uses an array, and every pushTop is an O(n) operation, and since we build filters using that, it means filter manipulation is an O(n^2) task.

Link lists though allow for O(1) manipulation, whether it's pushTop, or push, or remove, or anything. How much of a benefit are they? Take this:
```javascript
var wiki = new $tw.Wiki();
for (var i = 0; i < 30000; i++) {
    wiki.addTiddler({title: i.toString()});
}
$tw.testWiki = wiki;
```
Then, lets use my dinky laptop to run this filter: `$tw.testWiki.filterTiddlers("[!tag[A]] [!tag[B]]")`

![Screen Shot 2020-12-05 at 10 46 45 AM](https://user-images.githubusercontent.com/205465/101247369-418c6f80-36e7-11eb-9416-2f8eb28f3a1b.png)

It took over 2 seconds. (This is on Chrome. On Firefox it's way worse, but the profiler doesn't work as well.) Now let's try it with a _linked list_.

![Screen Shot 2020-12-05 at 10 50 33 AM](https://user-images.githubusercontent.com/205465/101247445-bc558a80-36e7-11eb-94ea-4189eae2b346.png)

About 35 ms.

It's that unavoidable indexOf call in pushTop which bottlenecks things. I realize not a lot of people are going to have 30,000+ tiddlers in their project. I've only got about 6000, but I'm noticing that my filters are getting a little sluggish.

So I know that 5.1.23 is about to ship, which is why I finally decided to get this implemented now. I can understand if we don't get it in, but I'd hate to lock down the filterrunprefix methods with passing them arrays when something so much better exists.