### PR TITLE
An even faster version of the TagPickerTagTemplate

### DIFF
--- a/core/ui/TagPickerTagTemplate.tid
+++ b/core/ui/TagPickerTagTemplate.tid
@@ -13,5 +13,11 @@ title: $:/core/ui/TagPickerTagTemplate
 <$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
 </$list>
 <<actions>>
-<$macrocall $name="tag-pill-inner" tag=<<currentTiddler>> icon={{{ [<tag>get[icon]] }}} colour={{{ [<tag>get[color]] }}} fallbackTarget=<<fallbackTarget>> colourA=<<colourA>> colourB=<<colourB>> element-tag="span" element-attributes="" actions=<<actions>>/>
+<$set name="backgroundColor" value={{!!color}}>
+<$wikify name="foregroundColor" text="""<$macrocall $name="contrastcolour" target={{!!color}} fallbackTarget=<<fallbackTarget>> colourA=<<colourA>> colourB=<<colourB>>/>""">
+<span class="tc-tag-label tc-btn-invisible" style=<<tag-pill-styles>>>
+<$transclude tiddler={{!!icon}}/><$view field="title" format="text"/>
+</span>
+</$wikify>
+</$set>
 </$button>


### PR DESCRIPTION
In my tests (see https://github.com/Jermolene/TiddlyWiki5/issues/5188#issuecomment-739321726) this version of the TagPicker TagTemplate is a bit faster than the current version in the prerelease that uses the `tag-pill-inner` macrocall, even if this version uses the `wikify` widget