### PR TITLE
Ensure jasmine-plugin startup module is executed in the right order

### DIFF
--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -14,6 +14,15 @@ The main module of the Jasmine test plugin for TiddlyWiki5
 
 var TEST_TIDDLER_FILTER = "[type[application/javascript]tag[$:/tags/test-spec]]";
 
+// Ensure this startup module is executed in the right order.
+// Jasmine calls `process.exit()` with a non-zero exit code if there's
+// any failed tests. Because of that, we want to make sure all critical
+// startup modules are run before this one.
+// * The "commands" module handles the --rendertiddler command-line flag,
+//   which is typically given to export an HTML file that can be opened with
+//   a browser to run tests.
+exports.after = ["commands"];
+
 /*
 Startup function for running tests
 


### PR DESCRIPTION
This is a follow-up to #4889

Ensures `editions/test/output/test.html` is written regardless of the order by which startup modules are initially loaded.

There is a chance that this scenario happens (although currently this doesn't seem to be the case):

- Run `bin/test.sh`
- `jasmine-plugin` startup module is executed
- There's a test failure
- Jasmine calls `process.exit(1)` (#4889 introduced this behavior)
- `--rendertiddler` command is not executed, i.e. `editions/test/output/test.html` does _not_ get written

If this ever happens, it'll be annoying but not a blocker, as it can be 'fixed' by fixing the failing test first. Also it'll only be an issue for local development, as CI currently doesn't run browser tests. 

Alternative fix: We discussed only setting `process.exitCode` by overriding the `process.exit` function (within Jasmine's context) in #4889 -- I was a little hesitant to do that, as overrides can make things harder to understand.