### PR TITLE
Logging widgets :Fixed issue on Firefox where logging does not work

### DIFF
--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -56,7 +56,7 @@ exports.warning = function(text) {
 /*
 Log a table of name: value pairs
 */
-exports.logTable = function(data,columnNames) {
+exports.logTable = function(data) {
 	if(console.table) {
 		console.table(data);
 	} else {

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -58,7 +58,7 @@ Log a table of name: value pairs
 */
 exports.logTable = function(data,columnNames) {
 	if(console.table) {
-		console.table(data,columnNames);
+		console.table(data);
 	} else {
 		$tw.utils.each(data,function(value,name) {
 			console.log(name + ": " + value);

--- a/core/modules/widgets/action-log.js
+++ b/core/modules/widgets/action-log.js
@@ -78,7 +78,7 @@ LogWidget.prototype.log = function() {
 
 	console.group(this.message);
 	if(dataCount > 0) {
-		$tw.utils.logTable(data,["name","value"]);
+		$tw.utils.logTable(data);
 	}
 	if(this.logAll || !dataCount) {
 		console.groupCollapsed("All variables");

--- a/core/modules/widgets/action-log.js
+++ b/core/modules/widgets/action-log.js
@@ -82,7 +82,7 @@ LogWidget.prototype.log = function() {
 	}
 	if(this.logAll || !dataCount) {
 		console.groupCollapsed("All variables");
-		$tw.utils.logTable(allVars,["name","value"]);
+		$tw.utils.logTable(allVars);
 		console.groupEnd();
 	}
 	console.groupEnd();


### PR DESCRIPTION
Fixes #5219 

In Firefox variables were not being logged properly. It turns out that the second argument (column names) to console.logTable is only supported for arrays and not objects. In Chrome the second argument is ignored for objects but in Firefox it causes the data not be logged properly.

I've tested this on Chrome and Firefox on Windows 10 and Linux. 

@Jermolene please confirm on Safari/OSX. I assume the original implementation was failing gracefully for you as it does for webkit based browsers in Windows 10 and Linux.

@rmunn Confirmation that this resolves the problem would be great.