### PR TITLE
fix viewtemplate quirks

### DIFF
--- a/core/ui/TiddlerInfo/Advanced.tid
+++ b/core/ui/TiddlerInfo/Advanced.tid
@@ -3,6 +3,6 @@ tags: $:/tags/TiddlerInfo
 caption: {{$:/language/TiddlerInfo/Advanced/Caption}}
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfo/Advanced]!has[draft.of]]" variable="listItem">
-<$transclude tiddler=<<listItem>>/>
 
+<$transclude tiddler=<<listItem>> mode="block"/>
 </$list>

--- a/core/ui/ViewTemplate/plugin.tid
+++ b/core/ui/ViewTemplate/plugin.tid
@@ -1,6 +1,8 @@
 title: $:/core/ui/ViewTemplate/plugin
 tags: $:/tags/ViewTemplate
 
+<$reveal tag="div" class="tc-tiddler-plugin-info" type="nomatch" stateTitle=<<folded-state>> text="hide" retain="yes" animate="yes">
+
 <$list filter="[all[current]has[plugin-type]] -[all[current]field:plugin-type[import]]">
 <$set name="plugin-type" value={{!!plugin-type}}>
 <$set name="default-popup-state" value="yes">
@@ -10,3 +12,4 @@ tags: $:/tags/ViewTemplate
 </$set>
 </$set>
 </$list>
+</$reveal>


### PR DESCRIPTION
@Jermolene  This fixes 2 quirks with the view template that I ran into while experimenting with my "custom view template injections" branch.

 - Add a $reveal to the Plugin section of the view template to match the rest of the view template sections.
 - Ads `mode="block" to the $:/core/ui/TiddlerInfo/Advanced tiddler, so that if other tiddlers are tagged "$:/tags/TiddlerInfo/Advanced" do not appear inline alongside the Advanced/ShadowInfo or Advanced/PluginInfo transclusions.