### PR TITLE
Add missing config options to ControlPanel->Settings->CodeMirror

### DIFF
--- a/plugins/tiddlywiki/codemirror/config-language.multids
+++ b/plugins/tiddlywiki/codemirror/config-language.multids
@@ -4,10 +4,14 @@ homeUrl: http://codemirror.net
 addOnUrl: http://codemirror.net/doc/manual.html#addons
 configUrl: http://codemirror.net/doc/manual.html#config
 controlPanel/hint: These settings let you customise the behaviour of [[CodeMirror|$:/plugins/tiddlywiki/codemirror]].
+controlPanel/keyboard: Keyboard shortcuts
 controlPanel/usage: Usage information
+cursorBlinkRate/hint: Cursor blink rate
 editorFont/hint: Editor font family
 editorFont/info: Set the font family for the ~CodeMirror text-editor
-controlPanel/keyboard: Keyboard shortcuts
+indentUnit/hint: How many spaces a block should be indented
+indentWithTabs/hint: Enable indenting with tabs
+indentWithTabs/info: Whether, when indenting, the first N*`tabSize` spaces should be replaced by N tabs.
 keyMap/hint: ~CodeMirror keymap
 keyMap/info: ~The Keyboard KeyMap used within the ~CodeMirror text-editor
 lineNumbers/hint: Enable line numbers
@@ -16,7 +20,10 @@ lineWrapping/hint: Enable line wrapping
 lineWrapping/info: Whether CodeMirror should scroll or wrap for long lines. Defaults to `false` (scroll).
 showCursorWhenSelecting/hint: Show cursor, when selecting
 showCursorWhenSelecting/info: Whether the cursor should be drawn when a selection is active.
+smartIndent/hint: Enable smart indent
+smartIndent/info: Whether to use the context-sensitive indentation that the mode provides (or just indent the same as the line before). Defaults to `true`.
 styleActiveLine/hint: Highlight active line
 styleActiveLine/info: Whether or not to highlight the active text-editor line
+tabSize/hint: Width of a tab character
 theme/hint: Select a theme
 theme/info: Choose between ~CodeMirror themes

--- a/plugins/tiddlywiki/codemirror/settings/cursorBlinkRate.tid
+++ b/plugins/tiddlywiki/codemirror/settings/cursorBlinkRate.tid
@@ -1,0 +1,7 @@
+title: $:/core/ui/ControlPanel/Settings/codemirror/cursorBlinkRate
+tags: $:/tags/ControlPanel/Settings/CodeMirror
+caption: {{$:/language/codemirror/cursorBlinkRate/hint}}
+
+\define lingo-base() $:/language/codemirror/cursorBlinkRate/
+
+|<$link to="$:/config/codemirror/cursorBlinkRate"><<lingo hint>></$link> |<$edit-text tiddler="$:/config/codemirror/cursorBlinkRate" default="" placeholder="cursorBlinkRate" tag="input"/> |

--- a/plugins/tiddlywiki/codemirror/settings/indentUnit.tid
+++ b/plugins/tiddlywiki/codemirror/settings/indentUnit.tid
@@ -1,0 +1,7 @@
+title: $:/core/ui/ControlPanel/Settings/codemirror/indentUnit
+tags: $:/tags/ControlPanel/Settings/CodeMirror
+caption: {{$:/language/codemirror/indentUnit/hint}}
+
+\define lingo-base() $:/language/codemirror/indentUnit/
+
+|<$link to="$:/config/codemirror/indentUnit"><<lingo hint>></$link> |<$edit-text tiddler="$:/config/codemirror/indentUnit" default="" placeholder="indentUnit" tag="input"/> |

--- a/plugins/tiddlywiki/codemirror/settings/indentWithTabs.tid
+++ b/plugins/tiddlywiki/codemirror/settings/indentWithTabs.tid
@@ -1,0 +1,8 @@
+title: $:/core/ui/ControlPanel/Settings/codemirror/indentWithTabs
+tags: $:/tags/ControlPanel/Settings/CodeMirror
+caption: {{$:/language/codemirror/indentWithTabs/hint}}
+
+\define lingo-base() $:/language/codemirror/indentWithTabs/
+<<lingo hint>>
+
+<$checkbox tiddler="$:/config/codemirror/indentWithTabs" field="text" checked="true" unchecked="false" default="true"> <$link to="$:/config/codemirror/indentWithTabs"><<lingo info>></$link> </$checkbox>

--- a/plugins/tiddlywiki/codemirror/settings/smartIndent.tid
+++ b/plugins/tiddlywiki/codemirror/settings/smartIndent.tid
@@ -1,0 +1,8 @@
+title: $:/core/ui/ControlPanel/Settings/codemirror/smartIndent
+tags: $:/tags/ControlPanel/Settings/CodeMirror
+caption: {{$:/language/codemirror/smartIndent/hint}}
+
+\define lingo-base() $:/language/codemirror/smartIndent/
+<<lingo hint>>
+
+<$checkbox tiddler="$:/config/codemirror/smartIndent" field="text" checked="true" unchecked="false" default="true"> <$link to="$:/config/codemirror/smartIndent"><<lingo info>></$link> </$checkbox>

--- a/plugins/tiddlywiki/codemirror/settings/tabSize.tid
+++ b/plugins/tiddlywiki/codemirror/settings/tabSize.tid
@@ -1,0 +1,7 @@
+title: $:/core/ui/ControlPanel/Settings/codemirror/tabSize
+tags: $:/tags/ControlPanel/Settings/CodeMirror
+caption: {{$:/language/codemirror/tabSize/hint}}
+
+\define lingo-base() $:/language/codemirror/tabSize/
+
+|<$link to="$:/config/codemirror/tabSize"><<lingo hint>></$link> |<$edit-text tiddler="$:/config/codemirror/tabSize" default="" placeholder="tabSize" tag="input"/> |


### PR DESCRIPTION
This PR adds missing config options to the ControlPanel CodeMirror-Settings tab. Especially options for indenting