### PR TITLE
Make search-matches button discoverable on dark palettes

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -598,6 +598,10 @@ html body.tc-body .tc-btn-rounded:hover svg {
 	color: <<colour sidebar-muted-foreground-hover>>;
 }
 
+.tc-sidebar-lists button small {
+	color: <<colour foreground>>;
+}
+
 button svg.tc-image-button, button .tc-image-button img {
 	height: 1em;
 	width: 1em;


### PR DESCRIPTION
This PR makes `.tc-sidebar-lists button small` the foreground-color of the palette. Like that, the search-matches button becomes visible on dark  palettes, too