### PR TITLE
Rename $:/language/Exporters/TidFile

### DIFF
--- a/core/language/en-GB/Exporters.multids
+++ b/core/language/en-GB/Exporters.multids
@@ -3,4 +3,4 @@ title: $:/language/Exporters/
 StaticRiver: Static HTML
 JsonFile: JSON file
 CsvFile: CSV file
-TidFile: ".tid" file
+TidFile: ".tid" file (the first match only)


### PR DESCRIPTION
from `".tid" file` to `".tid" file (the first match only)` ... so that it's clearer that only one file is exported