### PR TITLE
Docs update for Set Widget

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/SetWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SetWidget.tid
@@ -24,7 +24,7 @@ The content of the `<$set>` widget is the scope for the value assigned to the va
 |select |<<.from-version "5.1.14">> An optional zero-based index of the item to return from the filter output (see below) |
 |emptyValue |The value to assign to the variable if the specified value is missing or empty (see below) |
 
-<<.tip """If the value of your variable is enclosed in double square brackets this might indicate that you are returning a list of values from the filter. To use single title from the results without the double square brackets see ''Filtered Item Variable Assignment'' below.""">>
+<<.tip """If the value of your variable is enclosed in double square brackets this might indicate that you are returning a list of values from the filter. To use a single title from the filter output without the double square brackets see ''Filtered Item Variable Assignment'' below.""">>
 
 !! Simple Variable Assignment
 

--- a/editions/tw5.com/tiddlers/widgets/SetWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SetWidget.tid
@@ -24,6 +24,8 @@ The content of the `<$set>` widget is the scope for the value assigned to the va
 |select |<<.from-version "5.1.14">> An optional zero-based index of the item to return from the filter output (see below) |
 |emptyValue |The value to assign to the variable if the specified value is missing or empty (see below) |
 
+<<.tip """If the value of your variable is enclosed in double square brackets this might indicate that you are returning a list of values from the filter. To use single title from the results without the double square brackets see ''Filtered Item Variable Assignment'' below.""">>
+
 !! Simple Variable Assignment
 
 The simplest way of using set variable widget assigns a string to a variable. The following example assigns a literal string


### PR DESCRIPTION
@Jermolene This updates the docs for **Set Widget** to add a tip regarding a common source of misunderstanding for users, i.e. using _Filtered List Variable Assignment_ and being confused as to why the value of the variable is in double square brackets. This is compounded by the oft given erroneous advice on the google group, to then wikify the value to remove the double square brackets.