### PR TITLE
Rename control-panel-button to advanced-search-button in advanced-search button

### DIFF
--- a/core/ui/PageControls/advanced-search.tid
+++ b/core/ui/PageControls/advanced-search.tid
@@ -4,7 +4,7 @@ caption: {{$:/core/images/advanced-search-button}} {{$:/language/Buttons/Advance
 description: {{$:/language/Buttons/AdvancedSearch/Hint}}
 
 \whitespace trim
-\define control-panel-button(class)
+\define advanced-search-button(class)
 <$button to="$:/AdvancedSearch" tooltip={{$:/language/Buttons/AdvancedSearch/Hint}} aria-label={{$:/language/Buttons/AdvancedSearch/Caption}} class="""$(tv-config-toolbar-class)$ $class$""">
 <$list filter="[<tv-config-toolbar-icons>match[yes]]">
 {{$:/core/images/advanced-search-button}}
@@ -15,6 +15,6 @@ description: {{$:/language/Buttons/AdvancedSearch/Hint}}
 </$button>
 \end
 
-<$list filter="[list[$:/StoryList]] +[field:title[$:/AdvancedSearch]]" emptyMessage=<<control-panel-button>>>
-<<control-panel-button "tc-selected">>
+<$list filter="[list[$:/StoryList]] +[field:title[$:/AdvancedSearch]]" emptyMessage=<<advanced-search-button>>>
+<<advanced-search-button "tc-selected">>
 </$list>


### PR DESCRIPTION
This PR renames the macrocall for the advanced-search button so that it is semantically correct