### PR TITLE
Fix for LinkedLists when using bad filter prefix

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -297,7 +297,7 @@ exports.compileFilter = function(filterString) {
 						return filterRunPrefixes[operation.namedPrefix](operationSubFunction, options);
 					} else {
 						return function(results,source,widget) {
-							results.splice(0,results.length);
+							results.clear();
 							results.push($tw.language.getString("Error/FilterRunPrefix"));
 						};
 					}

--- a/editions/test/tiddlers/tests/test-prefixes-filter.js
+++ b/editions/test/tiddlers/tests/test-prefixes-filter.js
@@ -12,6 +12,14 @@ Tests the reduce prefix and filter.
 /* global $tw, require */
 "use strict";
 
+describe("general filter prefix tests", function() {
+	it("should handle nonexistent prefixes gracefully", function() {
+		var wiki = new $tw.Wiki();
+		var results = wiki.filterTiddlers("[tag[A]] :nonexistent[tag[B]]");
+		expect(results).toEqual(["Filter Error: Unknown prefix for filter run"]);
+	});
+});
+
 describe("'reduce' and 'intersection' filter prefix tests", function() {
 
 	var wiki = new $tw.Wiki();


### PR DESCRIPTION
Quick fix for bug introduced by Linked Lists when the filter prefix used doesn't exist.