### PR TITLE
Is there a reason for the <$browse> widget not being within the <$button> scope?

### DIFF
--- a/core/ui/PageControls/import.tid
+++ b/core/ui/PageControls/import.tid
@@ -11,6 +11,6 @@ description: {{$:/language/Buttons/Import/Hint}}
 <$list filter="[<tv-config-toolbar-text>match[yes]]">
 <span class="tc-btn-text"><$text text={{$:/language/Buttons/Import/Caption}}/></span>
 </$list>
-</$button>
 <$browse tooltip={{$:/language/Buttons/Import/Hint}}/>
+</$button>
 </div>


### PR DESCRIPTION
This PR moves the `<$browse>` widget from outside the button to within the button, which makes hover effects on the button work. The file input is triggered nevertheless in my tests (chrome,firefox and IE) ... is there a special reason that it's not been done like that?