### PR TITLE
Reveal widget should update on changed class and style attributes

### DIFF
--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -35,9 +35,8 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 		tag = this.revealTag;
 	}
 	var domNode = this.document.createElement(tag);
-	var classes = this["class"].split(" ") || [];
-	classes.push("tc-reveal");
-	domNode.className = classes.join(" ");
+	this.domNode = domNode;
+	this.assignDomNodeClasses();
 	if(this.style) {
 		domNode.setAttribute("style",this.style);
 	}
@@ -110,7 +109,7 @@ RevealWidget.prototype.execute = function() {
 	this.text = this.getAttribute("text");
 	this.position = this.getAttribute("position");
 	this.positionAllowNegative = this.getAttribute("positionAllowNegative") === "yes";
-	this["class"] = this.getAttribute("class","");
+	// class attribute handled in assignDomNodeClasses()
 	this.style = this.getAttribute("style","");
 	this["default"] = this.getAttribute("default","");
 	this.animate = this.getAttribute("animate","no");
@@ -203,6 +202,12 @@ RevealWidget.prototype.readPopupState = function(state) {
 	}
 };
 
+RevealWidget.prototype.assignDomNodeClasses = function() {
+	var classes = this.getAttribute("class","").split(" ");
+	classes.push("tc-reveal");
+	this.domNode.className = classes.join(" ");
+};
+
 /*
 Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 */
@@ -211,7 +216,12 @@ RevealWidget.prototype.refresh = function(changedTiddlers) {
 	if(changedAttributes.state || changedAttributes.type || changedAttributes.text || changedAttributes.position || changedAttributes.positionAllowNegative || changedAttributes["default"] || changedAttributes.animate || changedAttributes.stateTitle || changedAttributes.stateField || changedAttributes.stateIndex) {
 		this.refreshSelf();
 		return true;
-	} else {
+	} else if(changedAttributes.style) {
+		this.domNode.style = this.getAttribute("style");
+	} else if(changedAttributes["class"]) {
+		this.assignDomNodeClasses();
+	}
+	else {
 		var currentlyOpen = this.isOpen;
 		this.readState();
 		if(this.isOpen !== currentlyOpen) {
@@ -222,7 +232,7 @@ RevealWidget.prototype.refresh = function(changedTiddlers) {
 				return true;
 			}
 		} else if(this.type === "popup" && this.updatePopupPosition && (changedTiddlers[this.state] || changedTiddlers[this.stateTitle])) {
-			this.positionPopup(this.domNodes[0]);
+			this.positionPopup(this.domNode);
 		}
 		return this.refreshChildren(changedTiddlers);
 	}


### PR DESCRIPTION
Fixes #5257 

Updates the` class/style` attributes for the DOMNode when the widget attributes change.