### PR TITLE
URGENT: Reveal widget - fixed problem with previous patch of refresh handling

### DIFF
--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -216,12 +216,7 @@ RevealWidget.prototype.refresh = function(changedTiddlers) {
 	if(changedAttributes.state || changedAttributes.type || changedAttributes.text || changedAttributes.position || changedAttributes.positionAllowNegative || changedAttributes["default"] || changedAttributes.animate || changedAttributes.stateTitle || changedAttributes.stateField || changedAttributes.stateIndex) {
 		this.refreshSelf();
 		return true;
-	} else if(changedAttributes.style) {
-		this.domNode.style = this.getAttribute("style");
-	} else if(changedAttributes["class"]) {
-		this.assignDomNodeClasses();
-	}
-	else {
+	} else {
 		var currentlyOpen = this.isOpen;
 		this.readState();
 		if(this.isOpen !== currentlyOpen) {
@@ -234,6 +229,12 @@ RevealWidget.prototype.refresh = function(changedTiddlers) {
 		} else if(this.type === "popup" && this.updatePopupPosition && (changedTiddlers[this.state] || changedTiddlers[this.stateTitle])) {
 			this.positionPopup(this.domNode);
 		}
+		if(changedAttributes.style) {
+			this.domNode.style = this.getAttribute("style");
+		}
+		if(changedAttributes["class"]) {
+			this.assignDomNodeClasses();
+		}		
 		return this.refreshChildren(changedTiddlers);
 	}
 };

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -230,7 +230,7 @@ RevealWidget.prototype.refresh = function(changedTiddlers) {
 			this.positionPopup(this.domNode);
 		}
 		if(changedAttributes.style) {
-			this.domNode.style = this.getAttribute("style");
+			this.domNode.style = this.getAttribute("style","");
 		}
 		if(changedAttributes["class"]) {
 			this.assignDomNodeClasses();


### PR DESCRIPTION
@Jermolene Please merge before 5.1.23!

Apologies, my previous patch was in haste and not well thought through. It did not properly account for the state tiddler changing in addition to the style and/or class. I have now tested this quite thoroughly.

It now follows the original logic of `refresh()`, but if we do not need to call `refreshSelf()` it also checks at the end whether the `style` and `class` need updating.