### PR TITLE
tabsState should hold a tiddler name rather than a list singleton

### DIFF
--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -3,7 +3,7 @@ tags: $:/tags/Macro
 
 \define tabs(tabsList,default,state:"$:/state/tab",class,template,buttonTemplate,retain,actions,explicitState)
 <$set name="qualifiedState" value=<<qualify "$state$">>>
-<$set name="tabsState" value={{{ [<__explicitState__>minlength[1]] ~[<qualifiedState>] }}}>
+<$vars tabsState={{{ [<__explicitState__>minlength[1]] ~[<qualifiedState>] }}}>
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
 <$list filter="$tabsList$" variable="currentTab" storyview="pop"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<tabsState>> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>
@@ -33,6 +33,6 @@ tags: $:/tags/Macro
 </$list>
 </div>
 </div>
-</$set>
+</$vars>
 </$set>
 \end

--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -3,7 +3,7 @@ tags: $:/tags/Macro
 
 \define tabs(tabsList,default,state:"$:/state/tab",class,template,buttonTemplate,retain,actions,explicitState)
 <$set name="qualifiedState" value=<<qualify "$state$">>>
-<$set name="tabsState" filter="[<__explicitState__>minlength[1]] ~[<qualifiedState>]">
+<$set name="tabsState" value={{{ [<__explicitState__>minlength[1]] ~[<qualifiedState>] }}}>
 <div class="tc-tab-set $class$">
 <div class="tc-tab-buttons $class$">
 <$list filter="$tabsList$" variable="currentTab" storyview="pop"><$set name="save-currentTiddler" value=<<currentTiddler>>><$tiddler tiddler=<<currentTab>>><$button set=<<tabsState>> setTo=<<currentTab>> default="$default$" selectedClass="tc-tab-selected" tooltip={{!!tooltip}}>


### PR DESCRIPTION
Before this fix, state tiddlers were created by the tab macro with names like `[[$:/state/my tab state--1845137525]]` instead of `$:/state/my tab state--1845137525`.

Not sure that this syntax is better than `<$set name="tabsState" filter="[<__explicitState__>minlength[1]] ~[<qualifiedState>]" select="0">` though. It just seemed more "modern" to me.