### PR TITLE
Add a hook to allow modifying the the behaviour creating tiddler paths

### DIFF
--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -382,13 +382,15 @@ exports.generateTiddlerFilepath = function(title,options) {
 		count++;
 	} while(fs.existsSync(fullPath));
 	//If the path does not start with the wikiPath directory or the wikiTiddlersPath directory, or if the last write failed
-	var encode = !(fullPath.indexOf(path.resolve($tw.boot.wikiPath)) == 0 || fullPath.indexOf($tw.boot.wikiTiddlersPath) == 0) || ((options.fileInfo || {writeError: false}).writeError == true);
+	var newPath;
+	var encode = !(fullPath.indexOf($tw.boot.wikiPath) == 0 || fullPath.indexOf($tw.boot.wikiTiddlersPath) == 0) || ((options.fileInfo || {writeError: false}).writeError == true);
 	if(encode){
 		//encodeURIComponent() and then resolve to tiddler directory
-		fullPath = path.resolve(directory, encodeURIComponent(fullPath));
+		newPath = path.resolve(directory, encodeURIComponent(fullPath));
 	}
+	var alternatePath = $tw.hooks.invokeHook("th-make-tiddler-path", null, fullPath);
 	// Return the full path to the file
-	return fullPath;
+	return alternatePath || newPath || fullPath;
 };
 
 /*

--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -382,15 +382,15 @@ exports.generateTiddlerFilepath = function(title,options) {
 		count++;
 	} while(fs.existsSync(fullPath));
 	//If the path does not start with the wikiPath directory or the wikiTiddlersPath directory, or if the last write failed
-	var newPath;
+	var newPath = fullPath;
 	var encode = !(fullPath.indexOf($tw.boot.wikiPath) == 0 || fullPath.indexOf($tw.boot.wikiTiddlersPath) == 0) || ((options.fileInfo || {writeError: false}).writeError == true);
 	if(encode){
 		//encodeURIComponent() and then resolve to tiddler directory
 		newPath = path.resolve(directory, encodeURIComponent(fullPath));
 	}
-	var alternatePath = $tw.hooks.invokeHook("th-make-tiddler-path", null, fullPath);
+	fullPath = $tw.hooks.invokeHook("th-make-tiddler-path", newPath, fullPath);
 	// Return the full path to the file
-	return alternatePath || newPath || fullPath;
+	return fullPath;
 };
 
 /*


### PR DESCRIPTION
This is needed for Bob to use the core to generate tiddler fileInfo 

I don't know if this is the best way to make the hook, but it works for what I need

The hook can return a new path, which is used if it exists, otherwise it uses the new path with the uri encoding if that exists, otherwise it uses the default path