### PR TITLE
Remove menubar from print

### DIFF
--- a/plugins/tiddlywiki/menubar/styles.tid
+++ b/plugins/tiddlywiki/menubar/styles.tid
@@ -213,3 +213,10 @@ nav.tc-menubar .tc-more-sidebar > .tc-tab-set > .tc-tab-buttons > button {
 	<<set-sidebar-scrollable-top>>
 
 }
+@media print {
+
+	nav.tc-menubar {
+		display: none;
+	}
+
+}


### PR DESCRIPTION
In the print view, a shadow appeared at the top of each page, and the first lines were not visible.

![image](https://user-images.githubusercontent.com/7034200/102008355-0534c100-3d30-11eb-93d0-0566a163029c.png)

---

I hide the menubar in the print view.

![image](https://user-images.githubusercontent.com/7034200/102008398-59d83c00-3d30-11eb-8bd5-630c3c9b0b11.png)

