### PR TITLE
Feature tiddlywiki.files "searchSubdirectories" flag

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1899,6 +1899,19 @@ $tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp) {
 			tiddlers.push({tiddlers: fileTiddlers});
 		}
 	};
+	// Helper to recursively search subdirectories
+	var getAllFiles = function(dirPath, arrayOfFiles) {
+		files = fs.readdirSync(dirPath)	;
+		arrayOfFiles = arrayOfFiles || [];	  
+		files.forEach(function(file) {
+		  if (fs.statSync(dirPath + path.sep + file).isDirectory()) {
+			arrayOfFiles = getAllFiles(dirPath + path.sep + file, arrayOfFiles)
+		  } else {
+			arrayOfFiles.push(path.join(dirPath, path.sep, file))
+		  }
+		})	  
+		return arrayOfFiles
+	  }
 	// Process the listed tiddlers
 	$tw.utils.each(filesInfo.tiddlers,function(tidInfo) {
 		if(tidInfo.prefix && tidInfo.suffix) {
@@ -1922,7 +1935,7 @@ $tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp) {
 			// Process directory specifier
 			var dirPath = path.resolve(filepath,dirSpec.path);
 			if(fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
-				var	files = fs.readdirSync(dirPath),
+				var	files = (dirSpec.searchSubdirectories)? getAllFiles(dirPath): fs.readdirSync(dirPath),
 					fileRegExp = new RegExp(dirSpec.filesRegExp || "^.*$"),
 					metaRegExp = /^.*\.meta$/;
 				for(var t=0; t<files.length; t++) {

--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -339,7 +339,7 @@ exports.generateTiddlerFilepath = function(title,options) {
 	if(!filepath && originalpath !== "") {
 		//Use the originalpath without the extension
 		var ext = path.extname(originalpath);
-		filepath = originalpath.substring(0,originalpath.length - ext.length);;
+		filepath = originalpath.substring(0,originalpath.length - ext.length);
 	} else if(!filepath) {
 		filepath = title;
 		// If the filepath already ends in the extension then remove it
@@ -381,13 +381,20 @@ exports.generateTiddlerFilepath = function(title,options) {
 		}
 		count++;
 	} while(fs.existsSync(fullPath));
-	//If the path does not start with the wikiPath directory or the wikiTiddlersPath directory, or if the last write failed
-	var newPath = fullPath;
-	var encode = !(fullPath.indexOf($tw.boot.wikiPath) == 0 || fullPath.indexOf($tw.boot.wikiTiddlersPath) == 0) || ((options.fileInfo || {writeError: false}).writeError == true);
+	// If the last write failed with an error, or if path does not start with:
+	//	the resolved options.directory, the resolved wikiPath directory, or the wikiTiddlersPath directory, 
+	//	then encodeURIComponent() and resolve to tiddler directory
+	var newPath = fullPath,
+		encode = (options.fileInfo || {writeError: false}).writeError == true;
+	if(!encode){
+		encode = !(fullPath.indexOf(path.resolve(directory)) == 0 ||
+			fullPath.indexOf(path.resolve($tw.boot.wikiPath)) == 0 ||
+			fullPath.indexOf($tw.boot.wikiTiddlersPath) == 0);
+		}
 	if(encode){
-		//encodeURIComponent() and then resolve to tiddler directory
-		newPath = path.resolve(directory, encodeURIComponent(fullPath));
+		fullPath = path.resolve(directory, encodeURIComponent(fullPath));
 	}
+	// Call hook to allow plugins to modify the final path
 	fullPath = $tw.hooks.invokeHook("th-make-tiddler-path", newPath, fullPath);
 	// Return the full path to the file
 	return fullPath;

--- a/editions/tw5.com/tiddlers/nodejs/tiddlywiki.files_Files.tid
+++ b/editions/tw5.com/tiddlers/nodejs/tiddlywiki.files_Files.tid
@@ -1,5 +1,5 @@
 created: 20161015114118243
-modified: 20201201000000000
+modified: 20201214040032987
 tags: TiddlyWikiFolders
 title: tiddlywiki.files Files
 type: text/vnd.tiddlywiki
@@ -48,13 +48,14 @@ Directory specifications in the `directories` array may take the following forms
 
 * a ''string'' literal, specifying the absolute or relative path to the directory containing the tiddler files (relative paths are interpreted relative to the path of the `tiddlywiki.files` file). The directory is recursively searched for tiddler files
 * <<.from-version "5.1.14">> an ''object'' with the following properties:
-** ''path'' - (required) the absolute or relative path to the directory containing the tiddler files (relative paths are interpreted relative to the path of the `tiddlywiki.files` file). Note that the directory is not recursively searched; sub-directories are ignored
+** ''path'' - (required) the absolute or relative path to the directory containing the tiddler files (relative paths are interpreted relative to the path of the `tiddlywiki.files` file). Note that by default the directory is not recursively searched; sub-directories are ignored unless the //searchSubdirectories// flag is set to `true` (see below).
 ** ''filesRegExp'' - (optional) a [[regular expression|https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions]] that matches the filenames of the files that should be processed within the directory
 ** ''isTiddlerFile'' - (required) if `true`, the file will be treated as a [[tiddler file|TiddlerFiles]] and deserialised to extract the tiddlers. Otherwise, the raw content of the file is assigned to the `text` field without any parsing
 ** ''isEditableFile'' - (optional) if `true`, changes to the tiddler be saved back to the original file. The tiddler will be saved back to the original filepath as long as it does not generate a result from the $:/config/FileSystemPath filters, which will override the final filepath generated if a result is returned from a filter. <<.from-version "5.1.23">>
+** ''searchSubdirectories'' - (optional) if `true`, all subdirectories of the //path// are searched recursively for files that match the (optional) //filesRegExp//. If no //filesRegExp// is provided, all files in all subdirectoies of the //path// are loaded. If this results is multiple files with the same tiddler title being loaded, only the last file loaded under that tiddler title will be in memory. In order to prevent this, you must have multiple directory objects listed and customize the title field with a //prefix// or //suffix// alongside the //source// attribute (see above). <<.from-version "5.1.23">>
 ** ''fields'' - (required) an object containing values that override or customise the fields provided in the tiddler file (see above)
 
-Fields can be overridden for particular files by creating a file with the same name plus the suffix `.meta` -- see TiddlerFiles.
+Fields can also be overridden for particular files by creating a file with the same name plus the suffix `.meta` -- see TiddlerFiles.
 
 ! Examples
 


### PR DESCRIPTION
@Jermolene This implements the recursive subdirectory search mentioned in https://github.com/Jermolene/TiddlyWiki5/issues/5240
 - If "searchSubdirectories" is `true`, then recurse all subdirectories of the given path to build the file list to import. Only import files where the filename matches the `filesRegExp`.
 - Docs for the same.
 - Cleanup in `filesystem.js` to whitelist the directory passed to `$tw.utils.generateTiddlerFilepath` and cleanup the comments around @inmysocks' new hook.