### PR TITLE
Include named prefixes in railroad diagram for Filter Expression tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
@@ -1,5 +1,5 @@
 created: 20150124182421000
-modified: 20201208185257875
+modified: 20201214053032397
 tags: [[Filter Syntax]]
 title: Filter Expression
 type: text/vnd.tiddlywiki
@@ -7,7 +7,7 @@ type: text/vnd.tiddlywiki
 <$railroad text="""
 [{:
   [: [[whitespace|"Filter Whitespace"]] ]
-  ("+"|"~"|:-|"-"|"=")
+  ("+"|"~"|:-|"-"|"="|":"[[named-prefix|"Named Filter Run Prefix"]])
   [[run|"Filter Run"]]
 }]
 """/>

--- a/editions/tw5.com/tiddlers/filters/syntax/Named Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Named Filter Run Prefix.tid
@@ -1,0 +1,10 @@
+created: 20201214044413473
+modified: 20201214053018350
+tags: 
+title: Named Filter Run Prefix
+
+<$set name="prefixlist" filter="""[all[shadows+tiddlers]has[module-type]module-type[filterrunprefix]trim:prefix[$:/core/modules/filterrunprefixes/]trim:suffix[.js]addprefix["]addsuffix["]join[|]addprefix[(]addsuffix[)]]""">
+<$railroad text=<<prefixlist>>/>
+</$set>
+
+A named filter run prefix can precede any [[run|Filter Run]] of a [[filter expression|Filter Expression]] in place of a single-character prefix (`+`, `-` and so on). To create a new filter run prefix, create a [[Javascript module|Modules]] with a [[module-type|ModuleType]] of `filerrunprefix`.


### PR DESCRIPTION
Fixes #5277 and tries to be future-proof by building the list of valid named prefixes dynamically.

I had a little trouble deciding how to build the railroad diagram that lists all the named prefixes, because their actual names are determined by what the module puts into its exports (e.g., in `all.js` you get `exports.all = function(...)` and so that named prefix is called `all`). I could not find a way inside TW to say "What does this module export?", so in the end I decided to go with the name of the module as the name I put into the railroad diagram. This means that if someone in the future creates a named prefix called `foo` in a file called `bar.js`, it will list as `bar` in the diagram I wrote, when it should list as `foo`.

Also, it might be better to build the list by first trimming a `.js` suffix, and then using the `splitregexp` operator to split on non-word characters, then grab the last item of the resulting list and use that. That way if a user creates a module called "MyPrefixes/foo.js", it would be shown as "foo" in the resulting diagram instead of as "MyPrefixes/foo". I plan to add to this PR later on to improve that, but I'm running out of time for today so I'm submitting this as-is. It will at least be good for documenting the current valid prefixes in the core.