### PR TITLE
Fix refresh for all attributes of droppable widget. Add disabled class

### DIFF
--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -50,6 +50,8 @@ DroppableWidget.prototype.render = function(parent,nextSibling) {
 			{name: "dragleave", handlerObject: this, handlerMethod: "handleDragLeaveEvent"},
 			{name: "drop", handlerObject: this, handlerMethod: "handleDropEvent"}
 		]);		
+	} else {
+		$tw.utils.addClass(this.domNode,this.disabledClass);
 	}
 	// Insert element
 	parent.insertBefore(domNode,nextSibling);
@@ -145,6 +147,7 @@ DroppableWidget.prototype.execute = function() {
 	this.droppableEffect = this.getAttribute("effect","copy");
 	this.droppableTag = this.getAttribute("tag");
 	this.droppableEnable = (this.getAttribute("enable") || "yes") === "yes";
+	this.disabledClass = this.getAttribute("disabledClass","");
 	// Make child widgets
 	this.makeChildWidgets();
 };
@@ -160,7 +163,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 DroppableWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tag || changedAttributes.enable) {
+	if(changedAttributes.tag || changedAttributes.enable || changedAttributes.disabledClass || changedAttributes.actions || changedAttributes.effect) {
 		this.refreshSelf();
 		return true;
 	} else if(changedAttributes["class"]) {


### PR DESCRIPTION
This PR fixes the refresh handling of the `DroppableWidget` so that the widget is also refreshed when the `action` or `effect` attributes change.

It also adds a `disabledClass` that is applied to the generated DOM node when drag and drop is disabled.