### PR TITLE
add missing tags for file-backups plugin info

### DIFF
--- a/editions/tw5.com/tiddlers/community/resources/_file-backups_ Extension Firefox by pmario.tid
+++ b/editions/tw5.com/tiddlers/community/resources/_file-backups_ Extension Firefox by pmario.tid
@@ -6,7 +6,7 @@ delivery: Browser Extension
 description: Browser extension for Firefox
 method: save
 modified: 20200507105159105
-tags: Firefox Saving Resources plugins
+tags: Firefox Windows Mac Linux Saving Resources plugins
 title: "file-backups" Extension for Firefox by pmario
 type: text/vnd.tiddlywiki
 url: https://github.com/pmario/file-backups


### PR DESCRIPTION
Just a little docs change: add missing tags for file-backups plugin info

@Jermolene ... We should really add some info about the "color codes" at: https://tiddlywiki.com/prerelease/#Saving ... It's super confusing even for me :/

