### PR TITLE
add pragmacomment wikirule

### DIFF
--- a/core/modules/parsers/wikiparser/rules/pragmacomment.js
+++ b/core/modules/parsers/wikiparser/rules/pragmacomment.js
@@ -1,0 +1,59 @@
+/*\
+title: $:/core/modules/parsers/wikiparser/rules/pragmacomment.js
+type: application/javascript
+module-type: wikirule
+
+Wiki pragma rule for pragma comment specifications
+
+```
+\\ this is comment in pragma "space"
+\\ fast comment, since it doesn't produce a parse-tree element
+
+\\define xx()
+\\ slow comment because it WILL produce parse-tree elements
+\\end
+```
+
+\*/
+(function(){
+    /*jslint node: true, browser: true */
+    /*global $tw:false, exports:false*/
+    "use strict";
+    
+    exports.name = "pragmacomment";
+    exports.types = {
+        pragma: true
+    };
+    
+    /*
+    Instantiate parse rule
+    */
+    exports.init = function (parser) {
+        var self = this;
+        this.parser = parser;
+        // Regexp to match
+        this.matchRegExp = /^\\\\/mg;
+    };
+    
+    /*
+    Parse the most recent match
+    */
+    exports.parse = function () {
+        // Move past the pragma invocation
+        this.parser.pos = this.matchRegExp.lastIndex;
+        // Parse line terminated by a line break
+        var reMatch = /([^\n]*\S)|(\r?\n)/mg;
+    
+        reMatch.lastIndex = this.parser.pos;
+        var match = reMatch.exec(this.parser.source);
+        while (match && match.index === this.parser.pos) {
+            this.parser.pos = reMatch.lastIndex;
+            // Exit if we've got the line break
+            if (match[2]) {
+                break;
+            }
+        }
+        return [];
+    };
+    })();
+    


### PR DESCRIPTION
This PR allows us to use comments outside of macro definitions, which isn't possible with html-comments `<!-- comment -->`

You can [play with it at a demo site](https://wikilabs.github.io/editions/custom-markup/#Pragma%20Comment:%5B%5BPragma%20Comment%5D%5D%20%5B%5BDraft%20of%20'New%20Tiddler'%5D%5D)

Since the parse-tree is cached, those elements only need to be handled once. 

```
\\ comment comes here till the end of the line
\\ comments like this are fast since they are ignored and the result is cached!

\define test()
\\ This comment is as slow as the next line
<!-- HTML comment -->
\end

\\ The whole definition is deactivated. .... Works well for a few lines of code!
\\define test()
\\end

\\ if you have big junks of code, it's easier to rename the macro eg: testXXXX() as shown below!
\define testXXXX()
x
x
x
x
\end
```