### PR TITLE
set initial tab size to 4

### DIFF
--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -11,33 +11,33 @@ tags: $:/tags/Macro
 
 \define box-shadow(shadow)
 ``
-  -webkit-box-shadow: $shadow$;
-     -moz-box-shadow: $shadow$;
-          box-shadow: $shadow$;
+-webkit-box-shadow: $shadow$;
+-moz-box-shadow: $shadow$;
+box-shadow: $shadow$;
 ``
 \end
 
 \define filter(filter)
 ``
-  -webkit-filter: $filter$;
-     -moz-filter: $filter$;
-          filter: $filter$;
+-webkit-filter: $filter$;
+-moz-filter: $filter$;
+filter: $filter$;
 ``
 \end
 
 \define transition(transition)
 ``
-  -webkit-transition: $transition$;
-     -moz-transition: $transition$;
-          transition: $transition$;
+-webkit-transition: $transition$;
+-moz-transition: $transition$;
+transition: $transition$;
 ``
 \end
 
 \define transform-origin(origin)
 ``
-  -webkit-transform-origin: $origin$;
-     -moz-transform-origin: $origin$;
-          transform-origin: $origin$;
+-webkit-transform-origin: $origin$;
+-moz-transform-origin: $origin$;
+transform-origin: $origin$;
 ``
 \end
 
@@ -73,4 +73,11 @@ column-count: $columns$;
 
 \define if-background-attachment(text)
 <$reveal state="$:/themes/tiddlywiki/vanilla/settings/backgroundimage" type="nomatch" text="">$text$</$reveal>
+\end
+
+\define tab-size(size)
+``
+-moz-tab-size: $size$;
+tab-size: $size$;
+``
 \end

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -273,6 +273,7 @@ pre > code {
 	border: none;
 	background-color: inherit;
 	color: inherit;
+	<<tab-size 4>>
 }
 
 table {


### PR DESCRIPTION
related to:  how to change code block indent size？ #5290 

I did test it with windows 10 Edge, FireFox 84 (needs the prefix), Safari latest 

So a bit more testing would be nice. 