### PR TITLE
tabs actions: currentTiddler should remain visible

### DIFF
--- a/core/wiki/macros/tabs.tid
+++ b/core/wiki/macros/tabs.tid
@@ -14,7 +14,7 @@ tags: $:/tags/Macro
 <$macrocall $name="currentTab" $type="text/plain" $output="text/plain"/>
 </$transclude>
 </$transclude>
-</$set></$tiddler>$actions$</$button></$tiddler></$set></$list>
+</$set>$actions$</$tiddler></$button></$tiddler></$set></$list>
 </div>
 <div class="tc-tab-divider $class$"/>
 <div class="tc-tab-content $class$">


### PR DESCRIPTION
Actions are a great addition to the tabs macro, but **currentTiddler** (the tiddler outside the macro call) should be readily exposed to them, as **currentTab** is. 

Fortunately, it is only a matter of moving the value of the _actions_ attribute under the scope of **save-currentTiddler**.

Since **currentTab** remains exposed to _actions_ as well after this fix,  no harm was done to the 3 _actions_ calls I've found in search-related tiddlers. 

- https://github.com/Jermolene/TiddlyWiki5/blob/84479bc403de0dbcee775c5c9921c82f71224906/core/ui/SearchResults.tid#L11
- https://github.com/Jermolene/TiddlyWiki5/blob/2a7cdb22c03eb47b7a66ccbc77f2cfa8e615d503/core/ui/AdvancedSearch.tid#L6
- https://github.com/Jermolene/TiddlyWiki5/blob/4d85d267a195725ed84659d9ca2e7612c46a210a/core/ui/AdvancedSearch/Standard.tid#L49