### PR TITLE
Fix #5318 - remove-tag-button not having the correct fill color

### DIFF
--- a/core/ui/EditTemplate/tags.tid
+++ b/core/ui/EditTemplate/tags.tid
@@ -16,7 +16,7 @@ color:$(foregroundColor)$;
 <$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
 <span style=<<tag-styles>> class="tc-tag-label tc-tag-list-item">
 <$transclude tiddler="""$icon$"""/><$view field="title" format="text" />
-<$button class="tc-btn-invisible tc-remove-tag-button"><$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="-[{!!title}]"/>{{$:/core/images/close-button}}</$button>
+<$button class="tc-btn-invisible tc-remove-tag-button" style=<<tag-styles>>><$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="-[{!!title}]"/>{{$:/core/images/close-button}}</$button>
 </span>
 </$vars>
 \end


### PR DESCRIPTION
This PR fixes #5318

The remove-tag button doesn't have the correct fill color anymore because of our recent css changes for the `tc-btn-invisible` fill color.

This PR adds the tag-styles directly to the button, too