### PR TITLE
always test ext in tiddler title and remove it

### DIFF
--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -342,10 +342,6 @@ exports.generateTiddlerFilepath = function(title,options) {
 		filepath = originalpath.substring(0,originalpath.length - ext.length);
 	} else if(!filepath) {
 		filepath = title;
-		// If the filepath already ends in the extension then remove it
-		if(filepath.substring(filepath.length - extension.length) === extension) {
-			filepath = filepath.substring(0,filepath.length - extension.length);
-		}
 		// Remove any forward or backward slashes so we don't create directories
 		filepath = filepath.replace(/\/|\\/g,"_");
 	}
@@ -353,6 +349,10 @@ exports.generateTiddlerFilepath = function(title,options) {
 	if(!/^\.{1,2}[/\\]/g.test(filepath)) {
 		// Don't let the filename start with any dots because such files are invisible on *nix
 		filepath = filepath.replace(/^\.+/g,"_");
+	}
+	// If the filepath already ends in the extension then remove it
+	if(filepath.substring(filepath.length - extension.length) === extension) {
+		filepath = filepath.substring(0,filepath.length - extension.length);
 	}
 	// Remove any characters that can't be used in cross-platform filenames
 	filepath = $tw.utils.transliterate(filepath.replace(/<|>|~|\:|\"|\||\?|\*|\^/g,"_"));

--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -360,6 +360,10 @@ exports.generateTiddlerFilepath = function(title,options) {
 	if(filepath.length > 200) {
 		filepath = filepath.substr(0,200);
 	}
+	// Truncate the extension if it is too long
+	if(extension.length > 32) {
+		extension = extension.substr(0,32);
+	}
 	// If the resulting filename is blank (eg because the title is just punctuation characters)
 	if(!filepath) {
 		// ...then just use the character codes of the title


### PR DESCRIPTION
Fixes a few small bug with filesystem extensions. Adds a 32 character limit (avoids a fs vulernability),k and makes it so that you do not need to remove extensions from the tiddler title in FileSystemPaths filters.