### PR TITLE
Fixed typo in Community.tid

### DIFF
--- a/editions/tw5.com/tiddlers/community/Community.tid
+++ b/editions/tw5.com/tiddlers/community/Community.tid
@@ -6,4 +6,4 @@ type: text/vnd.tiddlywiki
 
 Here we gather the latest and most useful material from the TiddlyWiki community.
 
-<<tabs "Forums Latest Tutorials [[Community Editions]] [[Community Plugins]] [[Community Themes]] [[Community Palettes]] [[Other resources]] Examples Articles Meetups" "Latest">>
+<<tabs "Forums Latest Tutorials [[Community Editions]] [[Community Plugins]] [[Community Themes]] [[Community Palettes]] [[Other Resources]] Examples Articles Meetups" "Latest">>


### PR DESCRIPTION
Saw this typo that prevents the Other Resources tab from being listed.