### PR TITLE
allow unusedtitle macro to use the prefix parameter and fix wiki.generateNewTitle()

### DIFF
--- a/core/modules/macros/unusedtitle.js
+++ b/core/modules/macros/unusedtitle.js
@@ -2,6 +2,7 @@
 title: $:/core/modules/macros/unusedtitle.js
 type: application/javascript
 module-type: macro
+
 Macro to return a new title that is unused in the wiki. It can be given a name as a base.
 \*/
 (function(){
@@ -10,25 +11,22 @@ Macro to return a new title that is unused in the wiki. It can be given a name a
 /*global $tw: false */
 "use strict";
 
-/*
-Information about this macro
-*/
-
 exports.name = "unusedtitle";
 
 exports.params = [
 	{name: "baseName"},
-	{name: "options"}
+	{name: "prefix"}
 ];
 
 /*
 Run the macro
 */
-exports.run = function(baseName, options) {
+exports.run = function(baseName, prefix) {
+	prefix = prefix || " ";
 	if(!baseName) {
 		baseName = $tw.language.getString("DefaultNewTiddlerTitle");
 	}
-	return this.wiki.generateNewTitle(baseName, options);
+	return this.wiki.generateNewTitle(baseName, {"prefix":prefix});
 };
 
 })();

--- a/core/modules/macros/unusedtitle.js
+++ b/core/modules/macros/unusedtitle.js
@@ -26,7 +26,7 @@ exports.run = function(baseName, prefix) {
 	if(!baseName) {
 		baseName = $tw.language.getString("DefaultNewTiddlerTitle");
 	}
-	return this.wiki.generateNewTitle(baseName, {"prefix":prefix});
+	return this.wiki.generateNewTitle(baseName, {"prefix": prefix});
 };
 
 })();

--- a/core/modules/macros/unusedtitle.js
+++ b/core/modules/macros/unusedtitle.js
@@ -15,20 +15,21 @@ exports.name = "unusedtitle";
 
 exports.params = [
 	{name: "baseName"},
-	{name: "separator"}
+	{name: "separator"},
+	{name: "template"}
 ];
 
 /*
 Run the macro
 */
-exports.run = function(baseName, separator) {
+exports.run = function(baseName,separator,template) {
 	separator = separator || " ";
 	if(!baseName) {
 		baseName = $tw.language.getString("DefaultNewTiddlerTitle");
 	}
 	// $tw.wiki.generateNewTitle = function(baseTitle,options)
 	// options.prefix must be a string! 
-	return this.wiki.generateNewTitle(baseName, {"prefix": separator});
+	return this.wiki.generateNewTitle(baseName, {"prefix": separator, "template": template});
 };
 
 })();

--- a/core/modules/macros/unusedtitle.js
+++ b/core/modules/macros/unusedtitle.js
@@ -15,18 +15,20 @@ exports.name = "unusedtitle";
 
 exports.params = [
 	{name: "baseName"},
-	{name: "prefix"}
+	{name: "separator"}
 ];
 
 /*
 Run the macro
 */
-exports.run = function(baseName, prefix) {
-	prefix = prefix || " ";
+exports.run = function(baseName, separator) {
+	separator = separator || " ";
 	if(!baseName) {
 		baseName = $tw.language.getString("DefaultNewTiddlerTitle");
 	}
-	return this.wiki.generateNewTitle(baseName, {"prefix": prefix});
+	// $tw.wiki.generateNewTitle = function(baseTitle,options)
+	// options.prefix must be a string! 
+	return this.wiki.generateNewTitle(baseName, {"prefix": separator});
 };
 
 })();

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -301,16 +301,16 @@ exports.formatTitleString = function(template,options) {
 	var result = "",
 		t = template,
 		matches = [
-			[/^\$baseName\$/, function() {
+			[/^\$basename\$/i, function() {
 				return base;
 			}],
-			[/^\$CNT:(\d+)\$/, function(match) {
+			[/^\$count:(\d+)\$/i, function(match) {
 				return $tw.utils.pad(counter,match[1]);
 			}],
-			[/^\$SEP\$/, function() {
+			[/^\$separator\$/i, function() {
 				return separator;
 			}],
-			[/^\$CNT\$/, function() {
+			[/^\$count\$/i, function() {
 				return counter + "";
 			}]
 		];

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -294,6 +294,47 @@ exports.slowInSlowOut = function(t) {
 	return (1 - ((Math.cos(t * Math.PI) + 1) / 2));
 };
 
+exports.formatTitleString = function(template,options) {
+	var base = options.base || "",
+		separator = options.separator || "",
+		counter = options.counter || "";
+	var result = "",
+		t = template,
+		matches = [
+			[/^\$baseName\$/, function() {
+				return base;
+			}],
+			[/^\$CNT:(\d+)\$/, function(match) {
+				return $tw.utils.pad(counter,match[1]);
+			}],
+			[/^\$SEP\$/, function() {
+				return separator;
+			}],
+			[/^\$CNT\$/, function() {
+				return counter + "";
+			}]
+		];
+	while(t.length){
+		var matchString = "";
+		$tw.utils.each(matches, function(m) {
+			var match = m[0].exec(t);
+			if(match) {
+				matchString = m[1].call(null,match);
+				t = t.substr(match[0].length);
+				return false;
+			}
+		});
+		if(matchString) {
+			result += matchString;
+		} else {
+			result += t.charAt(0);
+			t = t.substr(1);
+		}
+	}
+	result = result.replace(/\\(.)/g,"$1");
+	return result;
+};
+
 exports.formatDateString = function(date,template) {
 	var result = "",
 		t = template,

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -199,8 +199,8 @@ exports.generateNewTitle = function(baseTitle,options) {
 		template = options.template,
 		prefix = (typeof(options.prefix) === "string") ? options.prefix : " ";
 	if (template) {
-		// CNT is important to avoid an endless loop in while(...)!!
-		template = (template.indexOf("$CNT") === -1) ? template + "$CNT$" : template;
+		// "count" is important to avoid an endless loop in while(...)!!
+		template = (/\$count:?(\d+)?\$/i.test(template)) ? template : template + "$count$";
 		title = $tw.utils.formatTitleString(template,{"base":baseTitle,"separator":prefix,"counter":c});
 		while(this.tiddlerExists(title) || this.isShadowTiddler(title) || this.findDraft(title)) {
 			title = $tw.utils.formatTitleString(template,{"base":baseTitle,"separator":prefix,"counter":(++c)});

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -196,9 +196,19 @@ exports.generateNewTitle = function(baseTitle,options) {
 	options = options || {};
 	var c = 0,
 		title = baseTitle,
+		template = options.template,
 		prefix = (typeof(options.prefix) === "string") ? options.prefix : " ";
-	while(this.tiddlerExists(title) || this.isShadowTiddler(title) || this.findDraft(title)) {
-		title = baseTitle + prefix + (++c);
+	if (template) {
+		// CNT is important to avoid an endless loop in while(...)!!
+		template = (template.indexOf("$CNT") === -1) ? template + "$CNT$" : template;
+		title = $tw.utils.formatTitleString(template,{"base":baseTitle,"separator":prefix,"counter":c});
+		while(this.tiddlerExists(title) || this.isShadowTiddler(title) || this.findDraft(title)) {
+			title = $tw.utils.formatTitleString(template,{"base":baseTitle,"separator":prefix,"counter":(++c)});
+		}
+	} else {
+		while(this.tiddlerExists(title) || this.isShadowTiddler(title) || this.findDraft(title)) {
+			title = baseTitle + prefix + (++c);
+		}
 	}
 	return title;
 };

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -190,15 +190,15 @@ exports.getChangeCount = function(title) {
 
 /*
 Generate an unused title from the specified base
+options.prefix must be a string
 */
 exports.generateNewTitle = function(baseTitle,options) {
 	options = options || {};
+	options.prefix = (typeof(options.prefix) === "string") ? options.prefix : " ";
 	var c = 0,
 		title = baseTitle;
 	while(this.tiddlerExists(title) || this.isShadowTiddler(title) || this.findDraft(title)) {
-		title = baseTitle + 
-			(options.prefix || " ") + 
-			(++c);
+		title = baseTitle + options.prefix + (++c);
 	}
 	return title;
 };

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -194,11 +194,11 @@ options.prefix must be a string
 */
 exports.generateNewTitle = function(baseTitle,options) {
 	options = options || {};
-	options.prefix = (typeof(options.prefix) === "string") ? options.prefix : " ";
 	var c = 0,
-		title = baseTitle;
+		title = baseTitle,
+		prefix = (typeof(options.prefix) === "string") ? options.prefix : " ";
 	while(this.tiddlerExists(title) || this.isShadowTiddler(title) || this.findDraft(title)) {
-		title = baseTitle + options.prefix + (++c);
+		title = baseTitle + prefix + (++c);
 	}
 	return title;
 };

--- a/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
@@ -1,6 +1,6 @@
 caption: unusedtitle
 created: 20210104143546885
-modified: 20210104144554913
+modified: 20210104144900428
 tags: Macros [[Core Macros]]
 title: unusedtitle Macro
 type: text/vnd.tiddlywiki
@@ -15,6 +15,6 @@ It uses the same method as the create new tiddler button, a number is appended t
 : A string specifying the desired base name, defaulting to `New Tiddler`
 
 ; prefix
-: A string specifying the separator between baseName and the unique number. eg: `prefix:"-"`. The macro is ''does not allow'' an ''empty'' string!
+: A string specifying the separator between baseName and the unique number. eg: `prefix:"-"`. The macro is ''does not allow'' an ''empty'' string!  <<.from-version "5.1.24">>
 
 <<.macro-examples "unusedtitle">>

--- a/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
@@ -1,5 +1,6 @@
-
 caption: unusedtitle
+created: 20210104143546885
+modified: 20210104144554913
 tags: Macros [[Core Macros]]
 title: unusedtitle Macro
 type: text/vnd.tiddlywiki
@@ -10,7 +11,10 @@ It uses the same method as the create new tiddler button, a number is appended t
 
 !! Parameters
 
-;baseName
+; baseName
 : A string specifying the desired base name, defaulting to `New Tiddler`
+
+; prefix
+: A string specifying the separator between baseName and the unique number. eg: `prefix:"-"`. The macro is ''does not allow'' an ''empty'' string!
 
 <<.macro-examples "unusedtitle">>

--- a/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
@@ -1,6 +1,6 @@
 caption: unusedtitle
 created: 20210104143546885
-modified: 20210226164133201
+modified: 20210228140649448
 tags: Macros [[Core Macros]]
 title: unusedtitle Macro
 type: text/vnd.tiddlywiki
@@ -15,6 +15,25 @@ It uses the same method as the create new tiddler button, a number is appended t
 : A string specifying the desired base name, defaulting to `New Tiddler`. <br>The default setting can be adjusted in the $:/ControlPanel '': Info : Basics - tab.''
 
 ; separator
-: <<.from-version "5.1.24">> A string specifying the separator between baseName and the unique number. eg: `separator:"-"`. The macro ''does not allow'' an ''empty'' string!
+: <<.from-version "5.1.24">> An ''optional'' string specifying the separator between baseName and the unique number. eg: `separator:"-"`. Defaults to a space: `" "`. If you need an empty separator use the ''template''!
+
+; template
+: <<.from-version "5.1.24">> A ''optional'' template string can be used to allow you maximum flexibility. If the template string is used, there will always be a counter value. 
+
+!! Template String
+
+; `$baseName$`
+: This variable will be replaced by the content of the ''baseName'' parameter
+
+; `$SEP$`
+: This variable will be replaced by the ''separator'' parameter
+
+;`$CNT$`
+: This variable will be createad automatically and is a counter starting with 0
+
+;`$CNT:4$`
+: This variable will be createad automatically and starts at 0000
+: `:4` represents the number of digits
+
 
 <<.macro-examples "unusedtitle">>

--- a/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
@@ -1,6 +1,6 @@
 caption: unusedtitle
 created: 20210104143546885
-modified: 20210228140649448
+modified: 20210427184035684
 tags: Macros [[Core Macros]]
 title: unusedtitle Macro
 type: text/vnd.tiddlywiki
@@ -22,18 +22,19 @@ It uses the same method as the create new tiddler button, a number is appended t
 
 !! Template String
 
-; `$baseName$`
+; `$basename$`
 : This variable will be replaced by the content of the ''baseName'' parameter
 
-; `$SEP$`
+; `$separator$`
 : This variable will be replaced by the ''separator'' parameter
 
-;`$CNT$`
+;`$count$`
 : This variable will be createad automatically and is a counter starting with 0
 
-;`$CNT:4$`
+;`$count:4$`
 : This variable will be createad automatically and starts at 0000
 : `:4` represents the number of digits
 
+!! Examples
 
-<<.macro-examples "unusedtitle">>
+<<list-links "[prefix[unusedtitle Macro (E]!sort[]]">>

--- a/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
@@ -1,6 +1,6 @@
 caption: unusedtitle
 created: 20210104143546885
-modified: 20210104144900428
+modified: 20210226164133201
 tags: Macros [[Core Macros]]
 title: unusedtitle Macro
 type: text/vnd.tiddlywiki
@@ -12,9 +12,9 @@ It uses the same method as the create new tiddler button, a number is appended t
 !! Parameters
 
 ; baseName
-: A string specifying the desired base name, defaulting to `New Tiddler`
+: A string specifying the desired base name, defaulting to `New Tiddler`. <br>The default setting can be adjusted in the $:/ControlPanel '': Info : Basics - tab.''
 
-; prefix
-: A string specifying the separator between baseName and the unique number. eg: `prefix:"-"`. The macro is ''does not allow'' an ''empty'' string!  <<.from-version "5.1.24">>
+; separator
+: <<.from-version "5.1.24">> A string specifying the separator between baseName and the unique number. eg: `separator:"-"`. The macro ''does not allow'' an ''empty'' string!
 
 <<.macro-examples "unusedtitle">>

--- a/editions/tw5.com/tiddlers/macros/examples/unusedtitle Macro (Examples 1).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/unusedtitle Macro (Examples 1).tid
@@ -1,0 +1,45 @@
+created: 20210227212730299
+modified: 20210228141103124
+tags: 
+title: unusedtitle Macro (Examples 1)
+type: text/vnd.tiddlywiki
+
+\define testCreate()
+<$action-createtiddler $basetitle=<<unusedtitle template:"$CNT:2$-new">>/>
+\end
+
+\define testCreate1()
+<$action-createtiddler $basetitle=<<unusedtitle baseName:"new" separator:"-" template:"$CNT:2$$SEP$$baseName$">>/>
+
+\end
+
+\define testNew()
+<$action-sendmessage $message="tm-new-tiddler" title=<<unusedtitle baseName:"new" template:"$CNT:2$-$baseName$">> />
+\end
+
+```
+<<unusedtitle template:"$CNT:2$-new">>
+```
+
+<$button actions=<<testCreate>> >
+<$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
+Create Tiddler
+</$button>
+
+```
+<<unusedtitle baseName:"new" template:"$CNT:2$-$baseName$">>
+```
+
+<$button actions=<<testNew>>>
+<$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
+New Tiddler
+</$button>
+
+```
+<<unusedtitle baseName:"new" separator:"-" template:"$CNT:2$$SEP$$baseName$">>
+```
+
+<$button actions=<<testCreate1>>>
+<$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
+Create Tiddler
+</$button>

--- a/editions/tw5.com/tiddlers/macros/examples/unusedtitle Macro (Examples 1).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/unusedtitle Macro (Examples 1).tid
@@ -1,24 +1,23 @@
 created: 20210227212730299
-modified: 20210228141103124
+modified: 20210427184057456
 tags: 
 title: unusedtitle Macro (Examples 1)
 type: text/vnd.tiddlywiki
 
 \define testCreate()
-<$action-createtiddler $basetitle=<<unusedtitle template:"$CNT:2$-new">>/>
+<$action-createtiddler $basetitle=<<unusedtitle template:"$count:2$-new">>/>
 \end
 
 \define testCreate1()
-<$action-createtiddler $basetitle=<<unusedtitle baseName:"new" separator:"-" template:"$CNT:2$$SEP$$baseName$">>/>
-
+<$action-createtiddler $basetitle=<<unusedtitle baseName:"new" separator:"-" template:"$count:2$$separator$$basename$">>/>
 \end
 
 \define testNew()
-<$action-sendmessage $message="tm-new-tiddler" title=<<unusedtitle baseName:"new" template:"$CNT:2$-$baseName$">> />
+<$action-sendmessage $message="tm-new-tiddler" title=<<unusedtitle baseName:"new" template:"$count:2$-$basename$">> />
 \end
 
 ```
-<<unusedtitle template:"$CNT:2$-new">>
+<<unusedtitle template:"$count:2$-new">>
 ```
 
 <$button actions=<<testCreate>> >
@@ -27,7 +26,7 @@ Create Tiddler
 </$button>
 
 ```
-<<unusedtitle baseName:"new" template:"$CNT:2$-$baseName$">>
+<<unusedtitle baseName:"new" template:"$count:2$-$basename$">>
 ```
 
 <$button actions=<<testNew>>>
@@ -36,10 +35,17 @@ New Tiddler
 </$button>
 
 ```
-<<unusedtitle baseName:"new" separator:"-" template:"$CNT:2$$SEP$$baseName$">>
+<<unusedtitle baseName:"new" separator:"-" template:"$count:2$$separator$$basename$">>
 ```
 
 <$button actions=<<testCreate1>>>
 <$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
 Create Tiddler
 </$button>
+
+---
+
+<details>
+    <summary>Show the code</summary>
+    <pre><code><$view><pre><code>
+</details>

--- a/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
+++ b/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
@@ -1,5 +1,5 @@
 created: 20210104143940715
-modified: 20210226165257588
+modified: 20210228141241657
 tags: [[unusedtitle Macro]] [[Macro Examples]]
 title: unusedtitle Macro (Examples)
 type: text/vnd.tiddlywiki
@@ -9,3 +9,8 @@ type: text/vnd.tiddlywiki
 <$macrocall $name=".example" n="2" eg="""<<unusedtitle separator:"-">>"""/>
 <$macrocall $name=".example" n="3" eg="""<<unusedtitle baseName:"anotherBase">>"""/>
 <$macrocall $name=".example" n="4" eg="""<<unusedtitle baseName:"About" separator:"-">>"""/>
+<$macrocall $name=".example" n="5" eg="""<<unusedtitle template:"$CNT:2$-test">>"""/>
+
+---
+
+Working buttons can be found at: [[unusedtitle Macro (Examples 1)]]. You'll have to examine the code to see, what's going on.

--- a/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
+++ b/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
@@ -1,11 +1,11 @@
 created: 20210104143940715
-modified: 20210104144457235
+modified: 20210226165257588
 tags: [[unusedtitle Macro]] [[Macro Examples]]
 title: unusedtitle Macro (Examples)
 type: text/vnd.tiddlywiki
 
 <$macrocall $name=".example" n="1" eg="""<<unusedtitle>>"""/>
-''Before you try the next example, open a new tiddler in edit mode.''
-<$macrocall $name=".example" n="2" eg="""<<unusedtitle prefix:"-">>"""/>
-<$macrocall $name=".example" n="3" eg="""<<unusedtitle AnotherBase>>"""/>
-<$macrocall $name=".example" n="4" eg="""<<unusedtitle TiddlyWiki>>"""/>
+''The following example works best if there is an open tiddler in draft mode, or there is a tiddler named "New Tiddler".'' So you can see the automatic numbering.
+<$macrocall $name=".example" n="2" eg="""<<unusedtitle separator:"-">>"""/>
+<$macrocall $name=".example" n="3" eg="""<<unusedtitle baseName:"anotherBase">>"""/>
+<$macrocall $name=".example" n="4" eg="""<<unusedtitle baseName:"About" separator:"-">>"""/>

--- a/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
+++ b/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
@@ -1,7 +1,11 @@
+created: 20210104143940715
+modified: 20210104144457235
 tags: [[unusedtitle Macro]] [[Macro Examples]]
 title: unusedtitle Macro (Examples)
 type: text/vnd.tiddlywiki
 
 <$macrocall $name=".example" n="1" eg="""<<unusedtitle>>"""/>
-<$macrocall $name=".example" n="2" eg="""<<unusedtitle AnotherBase>>"""/>
-<$macrocall $name=".example" n="3" eg="""<<unusedtitle TiddlyWiki>>"""/>
+''Before you try the next example, open a new tiddler in edit mode.''
+<$macrocall $name=".example" n="2" eg="""<<unusedtitle prefix:"-">>"""/>
+<$macrocall $name=".example" n="3" eg="""<<unusedtitle AnotherBase>>"""/>
+<$macrocall $name=".example" n="4" eg="""<<unusedtitle TiddlyWiki>>"""/>

--- a/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
+++ b/editions/tw5.com/tiddlers/macros/examples/unusedtitle.tid
@@ -9,7 +9,7 @@ type: text/vnd.tiddlywiki
 <$macrocall $name=".example" n="2" eg="""<<unusedtitle separator:"-">>"""/>
 <$macrocall $name=".example" n="3" eg="""<<unusedtitle baseName:"anotherBase">>"""/>
 <$macrocall $name=".example" n="4" eg="""<<unusedtitle baseName:"About" separator:"-">>"""/>
-<$macrocall $name=".example" n="5" eg="""<<unusedtitle template:"$CNT:2$-test">>"""/>
+<$macrocall $name=".example" n="5" eg="""<<unusedtitle template:"$count:2$-test">>"""/>
 
 ---
 


### PR DESCRIPTION
A working demo: https://pmario.github.io/kitchensink/5361-unusedtitle-macro.html#unusedtitle%20Macro%20(Examples%201):%5B%5Bunusedtitle%20Macro%5D%5D%20%5B%5Bunusedtitle%20Macro%20(Examples)%5D%5D%20%5B%5Bunusedtitle%20Macro%20(Examples%201)%5D%5D

This PR is backwards compatible!

This PR allows us to use the following wikitext in the right way: 

```
<<unusedtitle newTiddler prefix:"-">> ... will result in "newTiddler-1"
```

@Jermolene ... If you are willing to merge it, I'll ad the missing docs

It will also fix PR #1641, which outdated and couldn't reach consensus. 
