### PR TITLE
Taking advantage of linkedLists in all operator

### DIFF
--- a/core/modules/filters/all.js
+++ b/core/modules/filters/all.js
@@ -31,7 +31,7 @@ exports.all = function(source,operator,options) {
 	// Get our suboperators
 	var allFilterOperators = getAllFilterOperators();
 	// Cycle through the suboperators accumulating their results
-	var results = [],
+	var results = new $tw.utils.LinkedList(),
 		subops = operator.operand.split("+");
 	// Check for common optimisations
 	if(subops.length === 1 && subops[0] === "") {
@@ -49,10 +49,10 @@ exports.all = function(source,operator,options) {
 	for(var t=0; t<subops.length; t++) {
 		var subop = allFilterOperators[subops[t]];
 		if(subop) {
-			$tw.utils.pushTop(results,subop(source,operator.prefix,options));
+			results.pushTop(subop(source,operator.prefix,options));
 		}
 	}
-	return results;
+	return results.toArray();
 };
 
 })();

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -306,6 +306,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[all[shadows+tiddlers]]").join(",")).toBe("$:/TiddlerFive,TiddlerSix,TiddlerSeventh,Tiddler8,$:/ShadowPlugin,TiddlerOne,$:/TiddlerTwo,Tiddler Three,a fourth tiddler,one,hasList,has filter,filter regexp test");
 		expect(wiki.filterTiddlers("[all[tiddlers+shadows]]").join(",")).toBe("$:/ShadowPlugin,TiddlerOne,$:/TiddlerTwo,Tiddler Three,a fourth tiddler,one,hasList,has filter,filter regexp test,$:/TiddlerFive,TiddlerSix,TiddlerSeventh,Tiddler8");
 		expect(wiki.filterTiddlers("[all[tiddlers]tag[two]]").join(",")).toBe("$:/TiddlerTwo,Tiddler Three");
+		expect(wiki.filterTiddlers("[all[orphans+tiddlers+tags]]").join(",")).toBe("$:/ShadowPlugin,TiddlerOne,$:/TiddlerTwo,Tiddler Three,a fourth tiddler,hasList,has filter,filter regexp test,two,one");
 	});
 
 	it("should handle the tags operator", function() {


### PR DESCRIPTION
Now that we have linked lists in Tiddlywiki, we can take advantage of them elsewhere. Here is a three line change to `all[]`. When I take a wiki with 30,000 tiddlers, made like so:
```javascript
var wiki = new $tw.Wiki();
for (var i = 0; i < 30000; i++) {
    wiki.addTiddler({title: i.toString()});
}
$tw.testWiki = wiki;
```
And then I run `$tw.testWiki.filterTiddlers("[all[orphans+tiddlers]]")`, those three lines change this:

![Screen Shot 2021-01-03 at 3 00 39 PM](https://user-images.githubusercontent.com/205465/103487750-a960d380-4dd5-11eb-8a0a-6c9b1d7a1413.png)

Into this:

![Screen Shot 2021-01-03 at 3 03 18 PM](https://user-images.githubusercontent.com/205465/103487753-aebe1e00-4dd5-11eb-80f3-71fcada024ad.png)


2.5 seconds becomes 200 milliseconds. There's more room for improvement by cutting down all that garbage collection by improving LinkList's memory management, but let's not worry about that right now.

There are a ton of places where we can use LinkedLists like this with minimal changes. Should I continue to make them each their own PR? Or should I just do them all in one go?