### PR TITLE
Fix typos and Refnotes URL in kookma resources

### DIFF
--- a/editions/tw5.com/tiddlers/community/plugins/Favorites by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Favorites by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201117155737569
-modified: 20210101191843666
-tags: [[Community Plugins]] Plugings
+modified: 20201117155943559
+tags: [[Community Plugins]]
 title: Favorites by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/TW-Favorites/

--- a/editions/tw5.com/tiddlers/community/plugins/Kookma Plugin Library by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Kookma Plugin Library by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201117160603290
-modified: 20210101201435693
-tags: [[Community Plugins]] Plugings
+modified: 20201117160819308
+tags: [[Community Plugins]]
 title: Kookma Plugin Library by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/TW-PluginLibrary/

--- a/editions/tw5.com/tiddlers/community/plugins/Refnotes by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Refnotes by Mohammad.tid
@@ -1,11 +1,11 @@
 created: 20201117161853918
-modified: 20210101191843666
-tags: [[Community Plugins]] Plugings
+modified: 20201117162122822
+tags: [[Community Plugins]]
 title: Refnotes by Mohammad
 type: text/vnd.tiddlywiki
-url: https://kookma.github.io/Refnotes/
+url: https://kookma.github.io/TW-Refnotes/
 
-Refnotes plugin is a set of macros and stylesheets for creating abbreviations, footnotes and citations. It also makes tables of footnotes, abbreviations (glossaery) and references (bibliography table).
+Refnotes plugin is a set of macros and stylesheets for creating abbreviations, footnotes and citations. It also makes tables of footnotes, abbreviations (glossary) and references (bibliography table).
 
 {{!!url}}
 
@@ -18,5 +18,5 @@ Refnotes contains codes and elements to
 
 ;Create tables of
 :Abbreviations or glossary
-:Footnotes and endnote
+:Footnotes and endnotes
 :References (bibliography) using different output style 

--- a/editions/tw5.com/tiddlers/community/plugins/Searchwikis by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Searchwikis by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201117160302426
-modified: 20210101191843666
-tags: [[Community Plugins]] Plugings
+modified: 20201117160443306
+tags: [[Community Plugins]]
 title: Searchwikis by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/TW-Searchwikis/
@@ -15,7 +15,7 @@ It has two parts
 # An indexer, to build an index of all tiddlers in an external wiki
 # A search tool to search indexes and display a link to a tiddler found in an external wiki
 
-Then one master wiki can hosts many index tiddlers and lets to search several external wikis through index tiddlers.
+Then one master wiki can host many index tiddlers and lets to search several external wikis through index tiddlers.
 
 Searchwikis enable to have a central wiki and search all other wikis from one place.
 

--- a/editions/tw5.com/tiddlers/community/plugins/Shiraz by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Shiraz by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201116204317018
-modified: 20210101201435693
-tags: [[Community Plugins]] Plugings
+modified: 20201116210618803
+tags: [[Community Plugins]]
 title: Shiraz by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/TW-Shiraz/
@@ -29,4 +29,4 @@ Some of Shiraz features are:
 * Stylish buttons
 
 
-Adding Shiraz plugin to any Tiddlywiki, convert it to a full production tool. Shiraz uses modified CSS classes from [[Bootstrap|https://getbootstrap.com/]].
+Adding Shiraz plugin to any Tiddlywiki converts it to a full production tool. Shiraz uses modified CSS classes from [[Bootstrap|https://getbootstrap.com/]].

--- a/editions/tw5.com/tiddlers/community/plugins/Slider by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Slider by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201117162655614
-modified: 20210101201435693
-tags: [[Community Plugins]] Plugings
+modified: 20201117162926714
+tags: [[Community Plugins]]
 title: Slider by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/slider/

--- a/editions/tw5.com/tiddlers/community/plugins/Tiddler Commander by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Tiddler Commander by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201116203717105
-modified: 20210101201435693
-tags: [[Community Plugins]] Plugings
+modified: 20201116204652385
+tags: [[Community Plugins]]
 title: Tiddler Commander by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/TW-Commander/

--- a/editions/tw5.com/tiddlers/community/plugins/Tiddlyshow by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Tiddlyshow by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201117160944367
-modified: 20210101191843666
-tags: [[Community Plugins]] Plugings
+modified: 20201117162735263
+tags: [[Community Plugins]]
 title: Tiddlyshow by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/Tiddlyshow/

--- a/editions/tw5.com/tiddlers/community/plugins/Timelines by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Timelines by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201117161434779
-modified: 20210101191843666
-tags: [[Community Plugins]] Plugings
+modified: 20201117161728094
+tags: [[Community Plugins]]
 title: Timelines by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/TW-Timelines/

--- a/editions/tw5.com/tiddlers/community/plugins/Todolist by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Todolist by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201116210711381
-modified: 20210101191843666
-tags: [[Community Plugins]] Plugings
+modified: 20201116212041642
+tags: [[Community Plugins]]
 title: Todolist by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/TW-Todolist/

--- a/editions/tw5.com/tiddlers/community/plugins/Trashbin by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Trashbin by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201117155328920
-modified: 20210101191843666
-tags: [[Community Plugins]] Plugings
+modified: 20201117155604253
+tags: [[Community Plugins]]
 title: Trashbin by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/TW-Trashbin/

--- a/editions/tw5.com/tiddlers/community/plugins/Utility by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Utility by Mohammad.tid
@@ -1,6 +1,6 @@
 created: 20201117160011169
-modified: 20210101191843666
-tags: [[Community Plugins]] Plugings
+modified: 20201117160235750
+tags: [[Community Plugins]]
 title: Utility by Mohammad
 type: text/vnd.tiddlywiki
 url: https://kookma.github.io/TW-Utility/


### PR DESCRIPTION
Removed the "Plugings" (sp) tag and corrected the Refnotes URL; fixed a couple more typos.