### PR TITLE
Converting [links[]] to use better LinkedList

### DIFF
--- a/core/modules/filters/links.js
+++ b/core/modules/filters/links.js
@@ -16,11 +16,11 @@ Filter operator for returning all the links from a tiddler
 Export our filter function
 */
 exports.links = function(source,operator,options) {
-	var results = [];
+	var results = new $tw.utils.LinkedList();
 	source(function(tiddler,title) {
-		$tw.utils.pushTop(results,options.wiki.getTiddlerLinks(title));
+		results.pushTop(options.wiki.getTiddlerLinks(title));
 	});
-	return results;
+	return results.toArray();
 };
 
 })();


### PR DESCRIPTION
Using the same framework as #5362 (30,000 tiddlers. In this case they each point to the next) Here is the before an after when switching to Linked Lists.

## Before
![Screen Shot 2021-01-05 at 12 24 05 AM](https://user-images.githubusercontent.com/205465/103610185-7f023980-4eed-11eb-9534-59c101ee8050.png)
## After
![Screen Shot 2021-01-05 at 12 25 01 AM](https://user-images.githubusercontent.com/205465/103610186-80336680-4eed-11eb-87bc-21aeb7f19623.png)

`$tw.testWiki.filterTiddlers("[links[]]")` goes from 3.3s to 27ms. I may refrain from doing these screenshots for the future PRs, but I'll still post the number improvements.

The Linked List pushtop is taking a lot of time doing garbage collection. Even though it's way more efficient, it kinda bugs me that it's doing that. I know exactly why, and it's only 7 lines of extra code to stop that and make it way more memory efficient. That change will probably its own PR here soon.