### PR TITLE
Remove extra dashes in page title

### DIFF
--- a/core/wiki/title.tid
+++ b/core/wiki/title.tid
@@ -1,3 +1,6 @@
 title: $:/core/wiki/title
 
-{{$:/SiteTitle}} --- {{$:/SiteSubtitle}}
+{{$:/SiteTitle}}
+<$list filter="[{$:/SiteSubtitle}trim[]minlength[1]]" variable="ignore">
+--- {{$:/SiteSubtitle}}
+</$list>


### PR DESCRIPTION
When Tiddlywiki has no subtitle you see extra dashes! See https://github.com/Jermolene/TiddlyWiki5/issues/5341

This PR smartly adds double dashes as separator when there is a site subtitle and show only site title when site subtitle is empty.