### PR TITLE
Fixed issue where [lookup[]] could emit undefined

### DIFF
--- a/core/modules/filters/lookup.js
+++ b/core/modules/filters/lookup.js
@@ -22,7 +22,7 @@ Export our filter function
 exports.lookup = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
-		results.push(options.wiki.getTiddlerText(operator.operand + title) || operator.suffix);
+		results.push(options.wiki.getTiddlerText(operator.operand + title) || operator.suffix || '');
 	});
 	return results;
 };


### PR DESCRIPTION
If [lookup[]] could not lookup the tiddler and it had no suffix, it would put `undefined` into the stream. Thus, a filter like: `[lookup[nonexistent]prefix[anything]]` would throw an exception, because prefixed tries to call `substr` on undefined. Here is a quick fix. 