### PR TITLE
Cleaned up jasmine test suite output

### DIFF
--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -14,6 +14,22 @@ Tests the filtering mechanism.
 /* global $tw, require */
 "use strict";
 
+// This wrapper method is used to collect warnings which should be emitted
+// by certain deprecated tests.
+function collectLog(block) {
+	var messages = [];
+	var oldLog = console.log;
+	console.log = function(a) {
+		messages.push(Array.prototype.join.call(arguments, ' '));
+	}
+	try {
+		block();
+	} finally {
+		console.log = oldLog;
+	}
+	return messages;
+};
+
 describe("Filter tests", function() {
 
 	// Test filter parsing
@@ -249,8 +265,14 @@ function runTests(wiki) {
 	// The following 2 tests should write a log -> WARNING: Filter modifier has a deprecated regexp operand XXXX
 	// The test should pass anyway.
 	it("should handle the field operator with a regular expression operand", function() {
-		expect(wiki.filterTiddlers("[modifier/JoeBloggs/]").join(",")).toBe("TiddlerOne");
-		expect(wiki.filterTiddlers("[modifier/Jo/]").join(",")).toBe("TiddlerOne,$:/TiddlerTwo,Tiddler Three,a fourth tiddler,one");
+		var warnings = collectLog(function() {
+			expect(wiki.filterTiddlers("[modifier/JoeBloggs/]").join(",")).toBe("TiddlerOne");
+		});
+		expect(warnings).toEqual(["WARNING: Filter modifier has a deprecated regexp operand /JoeBloggs/"]);
+		warnings = collectLog(function() {
+			expect(wiki.filterTiddlers("[modifier/Jo/]").join(",")).toBe("TiddlerOne,$:/TiddlerTwo,Tiddler Three,a fourth tiddler,one");
+		});
+		expect(warnings).toEqual(["WARNING: Filter modifier has a deprecated regexp operand /Jo/"]);
 	});
 
 	it("should handle the prefix operator", function() {

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -20,7 +20,7 @@ function collectLog(block) {
 	var messages = [];
 	var oldLog = console.log;
 	console.log = function(a) {
-		messages.push(Array.prototype.join.call(arguments, ' '));
+		messages.push(Array.prototype.join.call(arguments, " "));
 	}
 	try {
 		block();


### PR DESCRIPTION
Also testing for expected log messages, instead of just letting them print
to the console every single time, constantly making you think there's some
warning you need to worry about, and making all those dots not line up nicely.

![Screen Shot 2021-01-07 at 2 32 45 PM](https://user-images.githubusercontent.com/205465/103936907-0ae6b200-50f6-11eb-826c-7ee35dac7adc.png)
:(


![Screen Shot 2021-01-07 at 2 31 46 PM](https://user-images.githubusercontent.com/205465/103936947-15a14700-50f6-11eb-9eb9-a402bfdea6f4.png)
:)
