### PR TITLE
Memory efficient linked list

### DIFF
--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -110,7 +110,6 @@ function _removeOne(list,value) {
 		if(typeof list.next[prev] === 'object') {
 			if(next === undefined) {
 				// Must have been last, and 'i' would be last element.
-				// Just pop instead
 				list.next[prev].pop();
 			} else {
 				var i = list.next[prev].indexOf(value);
@@ -128,7 +127,7 @@ function _removeOne(list,value) {
 	if(next !== undefined) {
 		if(typeof list.prev[next] === 'object') {
 			if(prev === undefined) {
-				// Must have been first, and 'i' would be 0. Just shift instead
+				// Must have been first, and 'i' would be 0.
 				list.prev[next].shift();
 			} else {
 				var i = list.prev[next].indexOf(value);
@@ -162,7 +161,8 @@ function _linkToEnd(list,value) {
 				list.next[value] = [list.next[value]];
 				list.prev[value] = [list.prev[value]];
 			} else if(typeof list.next[value] === 'undefined') {
-				// special case. The list already contains exacly 1 "value".
+				// list.next[value] must be undefined.
+				// Special case. List already has 1 value. It's at the end.
 				list.next[value] = [];
 				list.prev[value] = [list.prev[value]];
 			}

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -95,52 +95,55 @@ LinkedList.prototype.toArray = function() {
 };
 
 function _removeOne(list,value) {
-	var prev = list.prev[value],
-		next = list.next[value],
-		oldPrev = prev,
-		newNext = next;
-	if(typeof next === 'object') {
-		newNext = next[0];
-		oldPrev = prev[0];
+	var prevEntry = list.prev[value],
+		nextEntry = list.next[value],
+		prev = prevEntry,
+		next = nextEntry;
+	if(typeof nextEntry === 'object') {
+		next = nextEntry[0];
+		prev = prevEntry[0];
 	}
+	// Relink preceding element.
 	if(list.first === value) {
-		list.first = newNext
-	} else if(oldPrev !== undefined) {
-		if(typeof list.next[oldPrev] === 'object') {
-			if(newNext === undefined) {
-				// Must have been first, and 'i' would be last element.
+		list.first = next
+	} else if(prev !== undefined) {
+		if(typeof list.next[prev] === 'object') {
+			if(next === undefined) {
+				// Must have been last, and 'i' would be last element.
 				// Just pop instead
-				list.next[oldPrev].pop();
+				list.next[prev].pop();
 			} else {
-				var i = list.next[oldPrev].indexOf(value);
-				list.next[oldPrev][i] = newNext;
+				var i = list.next[prev].indexOf(value);
+				list.next[prev][i] = next;
 			}
 		} else {
-			list.next[oldPrev] = newNext;
+			list.next[prev] = next;
 		}
 	} else {
 		return;
 	}
-	if(newNext !== undefined) {
-		if(typeof list.prev[newNext] === 'object') {
-			if(oldPrev === undefined) {
+	// Now relink following element
+	// Check "next !== undefined" rather than "list.last === value" because
+	// we need to know if the FIRST value is the last in the list, not the last.
+	if(next !== undefined) {
+		if(typeof list.prev[next] === 'object') {
+			if(prev === undefined) {
 				// Must have been first, and 'i' would be 0. Just shift instead
-				list.prev[newNext].shift();
+				list.prev[next].shift();
 			} else {
-				var i = list.prev[newNext].indexOf(value);
-				list.prev[newNext][i] = oldPrev;
+				var i = list.prev[next].indexOf(value);
+				list.prev[next][i] = prev;
 			}
 		} else {
-			list.prev[newNext] = oldPrev;
+			list.prev[next] = prev;
 		}
 	} else {
-		list.last = oldPrev;
+		list.last = prev;
 	}
-	// We either remove value, or if there were multiples, set the next value
-	// up as the first.
-	if(typeof next === 'object' && (list.next[value].length >= 1 || list.prev[value].length > 1)) {
-		list.next[value].shift();
-		list.prev[value].shift();
+	// Delink actual value. If it uses arrays, just remove first entries.
+	if(typeof nextEntry === 'object') {
+		nextEntry.shift();
+		prevEntry.shift();
 	} else {
 		list.next[value] = undefined;
 		list.prev[value] = undefined;
@@ -164,10 +167,8 @@ function _linkToEnd(list,value) {
 				list.prev[value] = [list.prev[value]];
 			}
 			list.prev[value].push(list.last);
-			// We do NOT append a new value onto this list. It is implied
-			// given that we'll now reference this value more times than this
-			// has references to something else.
-			// It's new "next" points to nothing
+			// We do NOT append a new value onto "next" list. Iteration will
+			// figure out it must point to End-of-List on its own.
 		} else {
 			list.prev[value] = list.last;
 		}

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -96,25 +96,36 @@ function _removeOne(list,value) {
 	}
 	if (list.first === value) {
 		list.first = newNext
-	} else if (oldPrev) {
+	} else if (oldPrev !== undefined) {
 		if (typeof list.next[oldPrev] === 'object') {
-			var i = list.next[oldPrev].indexOf(value);
-			list.next[oldPrev][i] = newNext;
+			if (newNext === undefined) {
+				// Must have been first, and 'i' would be last element.
+				// Just pop instead
+				list.next[oldPrev].pop();
+			} else {
+				var i = list.next[oldPrev].indexOf(value);
+				list.next[oldPrev][i] = newNext;
+			}
 		} else {
 			list.next[oldPrev] = newNext;
 		}
 	} else {
 		return;
 	}
-	if (next !== undefined) {
+	if (newNext !== undefined) {
 		if (typeof list.prev[newNext] === 'object') {
-			var i = list.prev[newNext].indexOf(value);
-			list.prev[newNext][i] = oldPrev;
+			if (oldPrev === undefined) {
+				// Must have been first, and 'i' would be 0. Just shift instead
+				list.prev[newNext].shift();
+			} else {
+				var i = list.prev[newNext].indexOf(value);
+				list.prev[newNext][i] = oldPrev;
+			}
 		} else {
 			list.prev[newNext] = oldPrev;
 		}
 	} else {
-		list.last = prev;
+		list.last = oldPrev;
 	}
 	// We either remove value, or if there were multiples, set the next value
 	// up as the first.
@@ -122,8 +133,8 @@ function _removeOne(list,value) {
 		list.next[value].shift();
 		list.prev[value].shift();
 	} else {
-		delete list.next[value];
-		delete list.prev[value];
+		list.next[value] = undefined;
+		list.prev[value] = undefined;
 	}
 	list.length -= 1;
 };
@@ -134,7 +145,7 @@ function _linkToEnd(list,value) {
 		list.first = value;
 	} else {
 		// Does it already exists?
-		if (list.first === value || list.prev[value]) {
+		if (list.first === value || list.prev[value] !== undefined) {
 			if (typeof list.next[value] === 'string') {
 				list.next[value] = [list.next[value]];
 				list.prev[value] = [list.prev[value]];

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -99,7 +99,7 @@ function _removeOne(list,value) {
 		nextEntry = list.next[value],
 		prev = prevEntry,
 		next = nextEntry;
-	if(typeof nextEntry === 'object') {
+	if(typeof nextEntry === "object") {
 		next = nextEntry[0];
 		prev = prevEntry[0];
 	}
@@ -107,7 +107,7 @@ function _removeOne(list,value) {
 	if(list.first === value) {
 		list.first = next
 	} else if(prev !== undefined) {
-		if(typeof list.next[prev] === 'object') {
+		if(typeof list.next[prev] === "object") {
 			if(next === undefined) {
 				// Must have been last, and 'i' would be last element.
 				list.next[prev].pop();
@@ -125,7 +125,7 @@ function _removeOne(list,value) {
 	// Check "next !== undefined" rather than "list.last === value" because
 	// we need to know if the FIRST value is the last in the list, not the last.
 	if(next !== undefined) {
-		if(typeof list.prev[next] === 'object') {
+		if(typeof list.prev[next] === "object") {
 			if(prev === undefined) {
 				// Must have been first, and 'i' would be 0.
 				list.prev[next].shift();
@@ -140,7 +140,7 @@ function _removeOne(list,value) {
 		list.last = prev;
 	}
 	// Delink actual value. If it uses arrays, just remove first entries.
-	if(typeof nextEntry === 'object') {
+	if(typeof nextEntry === "object") {
 		nextEntry.shift();
 		prevEntry.shift();
 	} else {
@@ -157,10 +157,10 @@ function _linkToEnd(list,value) {
 	} else {
 		// Does it already exists?
 		if(list.first === value || list.prev[value] !== undefined) {
-			if(typeof list.next[value] === 'string') {
+			if(typeof list.next[value] === "string") {
 				list.next[value] = [list.next[value]];
 				list.prev[value] = [list.prev[value]];
-			} else if(typeof list.next[value] === 'undefined') {
+			} else if(typeof list.next[value] === "undefined") {
 				// list.next[value] must be undefined.
 				// Special case. List already has 1 value. It's at the end.
 				list.next[value] = [];
@@ -173,7 +173,7 @@ function _linkToEnd(list,value) {
 			list.prev[value] = list.last;
 		}
 		// Make the old last point to this new one.
-		if(typeof list.next[list.last] === 'object') {
+		if(typeof list.next[list.last] === "object") {
 			list.next[list.last].push(value);
 		} else {
 			list.next[list.last] = value;
@@ -184,7 +184,7 @@ function _linkToEnd(list,value) {
 };
 
 function _assertString(value) {
-	if(typeof value !== 'string') {
+	if(typeof value !== "string") {
 		throw "Linked List only accepts string values, not " + value;
 	}
 };

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -36,13 +36,22 @@ LinkedList.prototype.remove = function(value) {
 	}
 };
 
+/*
+Push behaves like array.push and accepts multiple string arguments. But it also
+accepts a single array argument too, to be consistent with its other methods.
+*/
 LinkedList.prototype.push = function(/* values */) {
-	for(var i = 0; i < arguments.length; i++) {
-		_assertString(arguments[i]);
+	var values = arguments;
+	if($tw.utils.isArray(values[0])) {
+		values = values[0];
 	}
-	for(var i = 0; i < arguments.length; i++) {
-		_linkToEnd(this,arguments[i]);
+	for(var i = 0; i < values.length; i++) {
+		_assertString(values[i]);
 	}
+	for(var i = 0; i < values.length; i++) {
+		_linkToEnd(this,values[i]);
+	}
+	return this.length;
 };
 
 LinkedList.prototype.pushTop = function(value) {
@@ -66,10 +75,10 @@ LinkedList.prototype.pushTop = function(value) {
 LinkedList.prototype.each = function(callback) {
 	var visits = Object.create(null),
 		value = this.first;
-	while (value !== undefined) {
+	while(value !== undefined) {
 		callback(value);
 		var next = this.next[value];
-		if (typeof next === "object") {
+		if(typeof next === "object") {
 			var i = visits[value] || 0;
 			visits[value] = i+1;
 			value = next[i];
@@ -90,15 +99,15 @@ function _removeOne(list,value) {
 		next = list.next[value],
 		oldPrev = prev,
 		newNext = next;
-	if (typeof next === 'object') {
+	if(typeof next === 'object') {
 		newNext = next[0];
 		oldPrev = prev[0];
 	}
-	if (list.first === value) {
+	if(list.first === value) {
 		list.first = newNext
-	} else if (oldPrev !== undefined) {
-		if (typeof list.next[oldPrev] === 'object') {
-			if (newNext === undefined) {
+	} else if(oldPrev !== undefined) {
+		if(typeof list.next[oldPrev] === 'object') {
+			if(newNext === undefined) {
 				// Must have been first, and 'i' would be last element.
 				// Just pop instead
 				list.next[oldPrev].pop();
@@ -112,9 +121,9 @@ function _removeOne(list,value) {
 	} else {
 		return;
 	}
-	if (newNext !== undefined) {
-		if (typeof list.prev[newNext] === 'object') {
-			if (oldPrev === undefined) {
+	if(newNext !== undefined) {
+		if(typeof list.prev[newNext] === 'object') {
+			if(oldPrev === undefined) {
 				// Must have been first, and 'i' would be 0. Just shift instead
 				list.prev[newNext].shift();
 			} else {
@@ -129,7 +138,7 @@ function _removeOne(list,value) {
 	}
 	// We either remove value, or if there were multiples, set the next value
 	// up as the first.
-	if (typeof next === 'object' && (list.next[value].length >= 1 || list.prev[value].length > 1)) {
+	if(typeof next === 'object' && (list.next[value].length >= 1 || list.prev[value].length > 1)) {
 		list.next[value].shift();
 		list.prev[value].shift();
 	} else {
@@ -141,15 +150,15 @@ function _removeOne(list,value) {
 
 // Sticks the given node onto the end of the list.
 function _linkToEnd(list,value) {
-	if (list.first === undefined) {
+	if(list.first === undefined) {
 		list.first = value;
 	} else {
 		// Does it already exists?
-		if (list.first === value || list.prev[value] !== undefined) {
-			if (typeof list.next[value] === 'string') {
+		if(list.first === value || list.prev[value] !== undefined) {
+			if(typeof list.next[value] === 'string') {
 				list.next[value] = [list.next[value]];
 				list.prev[value] = [list.prev[value]];
-			} else if (typeof list.next[value] === 'undefined') {
+			} else if(typeof list.next[value] === 'undefined') {
 				// special case. The list already contains exacly 1 "value".
 				list.next[value] = [];
 				list.prev[value] = [list.prev[value]];
@@ -163,7 +172,7 @@ function _linkToEnd(list,value) {
 			list.prev[value] = list.last;
 		}
 		// Make the old last point to this new one.
-		if (typeof list.next[list.last] === 'object') {
+		if(typeof list.next[list.last] === 'object') {
 			list.next[list.last].push(value);
 		} else {
 			list.next[list.last] = value;
@@ -174,7 +183,7 @@ function _linkToEnd(list,value) {
 };
 
 function _assertString(value) {
-	if (typeof value !== 'string') {
+	if(typeof value !== 'string') {
 		throw "Linked List only accepts string values, not " + value;
 	}
 };

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -25,27 +25,39 @@ LinkedList.prototype.clear = function() {
 LinkedList.prototype.remove = function(value) {
 	if($tw.utils.isArray(value)) {
 		for(var t=0; t<value.length; t++) {
+			_assertString(value[t]);
+		}
+		for(var t=0; t<value.length; t++) {
 			_removeOne(this,value[t]);
 		}
 	} else {
+		_assertString(value);
 		_removeOne(this,value);
 	}
 };
 
 LinkedList.prototype.push = function(/* values */) {
 	for(var i = 0; i < arguments.length; i++) {
-		var value = arguments[i];
-		_linkToEnd(this,value);
+		_assertString(arguments[i]);
+	}
+	for(var i = 0; i < arguments.length; i++) {
+		_linkToEnd(this,arguments[i]);
 	}
 };
 
 LinkedList.prototype.pushTop = function(value) {
 	if($tw.utils.isArray(value)) {
+		for (var t=0; t<value.length; t++) {
+			_assertString(value[t]);
+		}
 		for(var t=0; t<value.length; t++) {
 			_removeOne(this,value[t]);
 		}
-		this.push.apply(this,value);
+		for(var t=0; t<value.length; t++) {
+			_linkToEnd(this,value[t]);
+		}
 	} else {
+		_assertString(value);
 		_removeOne(this,value);
 		_linkToEnd(this,value);
 	}
@@ -106,16 +118,9 @@ function _removeOne(list,value) {
 	}
 	// We either remove value, or if there were multiples, set the next value
 	// up as the first.
-	if (typeof next === 'object') {
-		if (list.prev[value].length <= 1) {
-			// It's a single value list-item again
-			// TODO: Do I need to convert arrays of 1 back into strings?
-			delete list.next[value];
-			delete list.prev[value];
-		} else {
-			list.next[value].shift();
-			list.prev[value].shift();
-		}
+	if (typeof next === 'object' && (list.next[value].length >= 1 || list.prev[value].length > 1)) {
+		list.next[value].shift();
+		list.prev[value].shift();
 	} else {
 		delete list.next[value];
 		delete list.prev[value];
@@ -155,6 +160,12 @@ function _linkToEnd(list,value) {
 	}
 	list.last = value;
 	list.length += 1;
+};
+
+function _assertString(value) {
+	if (typeof value !== 'string') {
+		throw "Linked List only accepts string values, not " + value;
+	}
 };
 
 exports.LinkedList = LinkedList;

--- a/editions/test/tiddlers/tests/test-linked-list.js
+++ b/editions/test/tiddlers/tests/test-linked-list.js
@@ -67,62 +67,62 @@ describe("LinkedList class tests", function() {
 	};
 
 	it("can pushTop", function() {
-		var pair = newPair(['A', 'B', 'C']);
+		var pair = newPair(["A", "B", "C"]);
 		// singles
-		pushTop(pair, 'X');
-		pushTop(pair, 'B');
+		pushTop(pair, "X");
+		pushTop(pair, "B");
 		compare(pair); // ACXB
 		//arrays
-		pushTop(pair, ['X', 'A', 'G', 'A']);
+		pushTop(pair, ["X", "A", "G", "A"]);
 		// If the pushedTopped list has duplicates, they go in unempeded.
 		compare(pair); // CBXAGA
 	});
 
 	it("can pushTop with tricky duplicates", function() {
-		var pair = newPair(['A', 'B', 'A', 'C', 'A', 'e']);
+		var pair = newPair(["A", "B", "A", "C", "A", "e"]);
 		// If the original list contains duplicates, only one instance is cut
-		compare(pushTop(pair, 'A')); // BACAeA
+		compare(pushTop(pair, "A")); // BACAeA
 
 		// And the Llist properly knows the next 'A' to cut if pushed again
-		compare(pushTop(pair, ['X', 'A'])); // BCAeAXA
+		compare(pushTop(pair, ["X", "A"])); // BCAeAXA
 
 		// One last time, to make sure we maintain the linked chain of copies
-		compare(pushTop(pair, 'A')); // BCeAXAA
+		compare(pushTop(pair, "A")); // BCeAXAA
 	});
 
 	it("can pushTop a single-value list with itself", function() {
 		// This simple case actually requires special handling in LinkedList.
-		compare(pushTop(newPair(['A']), 'A')); // A
+		compare(pushTop(newPair(["A"]), "A")); // A
 	});
 
 	it("can remove all instances of a multi-instance value", function() {
-		var pair = compare(remove(newPair(['A', 'A']), ['A', 'A'])); //
+		var pair = compare(remove(newPair(["A", "A"]), ["A", "A"])); //
 		// Now add 'A' back in, since internally it might be using arrays,
 		// even though those arrays must be empty.
-		compare(pushTop(pair, 'A')); // A
+		compare(pushTop(pair, "A")); // A
 		// Same idea, but push something else before readding 'A'
-		compare(pushTop(remove(newPair(['A', 'A']), ['A', 'A']), ['B', 'A'])); // BA
+		compare(pushTop(remove(newPair(["A", "A"]), ["A", "A"]), ["B", "A"])); // BA
 
 		// Again, but this time with other values mixed in
-		compare(remove(newPair(['B', 'A', 'A', 'C']), ['A', 'A'])) // BC;
+		compare(remove(newPair(["B", "A", "A", "C"]), ["A", "A"])) // BC;
 		// And again, but this time with value inbetween too.
-		compare(remove(newPair(['B', 'A', 'X', 'Y', 'Z', 'A', 'C']), ['A', 'A'])); // BXYZC
+		compare(remove(newPair(["B", "A", "X", "Y", "Z", "A", "C"]), ["A", "A"])); // BXYZC
 
 		// One last test, where removing a pair from the end could corrupt
 		// list.last.
-		pair = remove(newPair(['D', 'C', 'A', 'A']), ['A', 'A']);
+		pair = remove(newPair(["D", "C", "A", "A"]), ["A", "A"]);
 		// But I can't figure out another way to test this. It's wrong
 		// for list.last to be anything other than a string, but I
 		// can't figure out how to make that corruption manifest a problem.
 		// So I dig into its private members. Bleh...
-		expect(typeof pair.list.last).toBe('string');
+		expect(typeof pair.list.last).toBe("string");
 	});
 
 	it("can pushTop value linked to by a repeat item", function() {
-		var pair = newPair(['A', 'B', 'A', 'C', 'A', 'C', 'D']);
+		var pair = newPair(["A", "B", "A", "C", "A", "C", "D"]);
 		// This is tricky because that 'C' is referenced by a second 'A'
 		// It WAS a crash before
-		pushTop(pair, 'C');
+		pushTop(pair, "C");
 		compare(pair); // ABAACDC
 	});
 
@@ -130,102 +130,102 @@ describe("LinkedList class tests", function() {
 		// The 'next' ptrs for A would be polluted with an extraneous
 		// undefined after the pop, which would make pushing the 'X'
 		// back on problematic.
-		compare(pushTop(newPair(['A', 'A', 'X']), 'X')); // AACX
+		compare(pushTop(newPair(["A", "A", "X"]), "X")); // AACX
 		// And lets try a few other manipulations around pairs
-		compare(pushTop(newPair(['A', 'A', 'X', 'C']), 'X')); // AACX
-		compare(pushTop(newPair(['X', 'A', 'A']), 'X')); // AAX
-		compare(pushTop(newPair(['C', 'X', 'A', 'A']), 'X')); // CAAX
+		compare(pushTop(newPair(["A", "A", "X", "C"]), "X")); // AACX
+		compare(pushTop(newPair(["X", "A", "A"]), "X")); // AAX
+		compare(pushTop(newPair(["C", "X", "A", "A"]), "X")); // CAAX
 	});
 
 	it("can handle particularly nasty pushTop pitfall", function() {
-		var pair = newPair(['A', 'B', 'A', 'C']);
-		pushTop(pair, 'A'); // BACA
-		pushTop(pair, 'X'); // BACAX
-		remove(pair, 'A');  // BCAX
-		pushTop(pair, 'A'); // BCXA
-		remove(pair, 'A');  // BCX
+		var pair = newPair(["A", "B", "A", "C"]);
+		pushTop(pair, "A"); // BACA
+		pushTop(pair, "X"); // BACAX
+		remove(pair, "A");  // BCAX
+		pushTop(pair, "A"); // BCXA
+		remove(pair, "A");  // BCX
 
 		// But! The way I initially coded the copy chains, a mystery A could
 		// hang around.
 		compare(pair); // BCX
 	});
 
-	it('can handle past-duplicate items when pushing', function() {
-		var pair = newPair(['X', 'Y', 'A', 'C', 'A']);
+	it("can handle past-duplicate items when pushing", function() {
+		var pair = newPair(["X", "Y", "A", "C", "A"]);
 		// Removing an item, when it has a duplicat at the list's end
-		remove(pair, 'A');
+		remove(pair, "A");
 		compare(pair); // XYCA
 		// This actually caused an infinite loop once. So important test here.
-		push(pair, ['A']);
+		push(pair, ["A"]);
 		compare(pair); // XYCAA
-		pushTop(pair, 'A') // switch those last As
+		pushTop(pair, "A") // switch those last As
 		compare(pair); // XYCAA
-		remove(pair, ['A', 'A']); // Remove all As, then add them back
-		pushTop(pair, ['A', 'A'])
+		remove(pair, ["A", "A"]); // Remove all As, then add them back
+		pushTop(pair, ["A", "A"])
 		compare(pair); // XYCAA
 	});
 
 	it("can push", function() {
 		var list = new $tw.utils.LinkedList();
 		// singles
-		expect(list.push('A')).toBe(1);
-		expect(list.push('B')).toBe(2);
+		expect(list.push("A")).toBe(1);
+		expect(list.push("B")).toBe(2);
 		// multiple args
-		expect(list.push('C', 'D', 'E')).toBe(5);
+		expect(list.push("C", "D", "E")).toBe(5);
 		// array arg allowed
-		expect(list.push(['F', 'G'])).toBe(7);
+		expect(list.push(["F", "G"])).toBe(7);
 		// No-op
 		expect(list.push()).toBe(7);
-		expect(list.toArray()).toEqual(['A', 'B', 'C', 'D', 'E', 'F', 'G']);
+		expect(list.toArray()).toEqual(["A", "B", "C", "D", "E", "F", "G"]);
 	});
 
-	it('can handle empty string', function() {
-		compare(newPair(['', '', ''])); // ___
-		compare(push(newPair(['']), [''])); // __
-		compare(pushTop(newPair(['', '', '']), ['A', ''])); // __A_
-		compare(remove(newPair(['', 'A']), 'A')); // _
-		compare(push(newPair(['', 'A']), ['A'])); // _AA
-		compare(remove(newPair(['A', '']), 'A')); // _
-		compare(push(newPair(['A', '']), ['A'])); // A_A
+	it("can handle empty string", function() {
+		compare(newPair(["", "", ""])); // ___
+		compare(push(newPair([""]), [""])); // __
+		compare(pushTop(newPair(["", "", ""]), ["A", ""])); // __A_
+		compare(remove(newPair(["", "A"]), "A")); // _
+		compare(push(newPair(["", "A"]), ["A"])); // _AA
+		compare(remove(newPair(["A", ""]), "A")); // _
+		compare(push(newPair(["A", ""]), ["A"])); // A_A
 
 		// This one is tricky but precise. Remove 'B', and 'A' might mistake
 		// it as being first in the list since it's before ''. 'C' would get
 		// blasted from A's prev reference array.
-		compare(remove(newPair(['C', 'A', '', 'B', 'A']), ['B', 'A'])); // C_A
+		compare(remove(newPair(["C", "A", "", "B", "A"]), ["B", "A"])); // C_A
 		// Same idea, but with A mistaking B for being at the list's end, and
 		// thus removing C from its 'next' reference array.
-		compare(remove(newPair(['A', 'B', '', 'A', 'C']), ['B', 'A'])); // _AC
+		compare(remove(newPair(["A", "B", "", "A", "C"]), ["B", "A"])); // _AC
 	});
 
-	it('will throw if told to push non-strings', function() {
+	it("will throw if told to push non-strings", function() {
 		var message = "Linked List only accepts string values, not ";
 		var list = new $tw.utils.LinkedList();
 		expect(() => list.push(undefined)).toThrow(message + "undefined");
 		expect(() => list.pushTop(undefined)).toThrow(message + "undefined");
-		expect(() => list.pushTop(['c', undefined])).toThrow(message + "undefined");
+		expect(() => list.pushTop(["c", undefined])).toThrow(message + "undefined");
 		expect(() => list.pushTop(5)).toThrow(message + "5");
 		expect(() => list.pushTop(null)).toThrow(message + "null");
 
 		// now lets do a quick test to make sure this exception
 		// doesn't leave any side-effects
 		// A.K.A Strong guarantee
-		var pair = newPair(['A', '5', 'B', 'C']);
+		var pair = newPair(["A", "5", "B", "C"]);
 		expect(() => pushTop(pair, 5)).toThrow(message + "5");
 		compare(pair);
-		expect(() => push(pair, ['D', 7])).toThrow(message + "7");
+		expect(() => push(pair, ["D", 7])).toThrow(message + "7");
 		compare(pair);
 		expect(() => remove(pair, 5)).toThrow(message + "5");
 		compare(pair);
 		// This is the tricky one. 'A' and 'B' should not be removed or pushed.
-		expect(() => pushTop(pair, ['A', 'B', null])).toThrow(message + "null");
+		expect(() => pushTop(pair, ["A", "B", null])).toThrow(message + "null");
 		compare(pair);
-		expect(() => remove(pair, ['A', 'B', null])).toThrow(message + "null");
+		expect(() => remove(pair, ["A", "B", null])).toThrow(message + "null");
 		compare(pair);
 	});
 
 	it("can clear", function() {
 		var list = new $tw.utils.LinkedList();
-		list.push('A', 'B', 'C');
+		list.push("A", "B", "C");
 		list.clear();
 		expect(list.toArray()).toEqual([]);
 		expect(list.length).toBe(0);
@@ -233,26 +233,26 @@ describe("LinkedList class tests", function() {
 
 	it("can remove", function() {
 		var list = new $tw.utils.LinkedList();
-		list.push(['A', 'x', 'C', 'x', 'D', 'x', 'E', 'x']);
+		list.push(["A", "x", "C", "x", "D", "x", "E", "x"]);
 		// single
-		list.remove('x');
+		list.remove("x");
 		// arrays
-		list.remove(['x', 'A', 'XXX', 'x']);
-		expect(list.toArray()).toEqual(['C', 'D', 'E', 'x']);
+		list.remove(["x", "A", "XXX", "x"]);
+		expect(list.toArray()).toEqual(["C", "D", "E", "x"]);
 	});
 
-	it('can ignore removal of nonexistent items', function() {
-		var pair = newPair(['A', 'B', 'C', 'D']);
+	it("can ignore removal of nonexistent items", function() {
+		var pair = newPair(["A", "B", "C", "D"]);
 		// single
-		compare(remove(pair, 'Z')); // ABCD
+		compare(remove(pair, "Z")); // ABCD
 
 		// array
-		compare(remove(pair, ['Z', 'B', 'X'])); // ACD
+		compare(remove(pair, ["Z", "B", "X"])); // ACD
 	});
 
-	it('can iterate with each', function() {
+	it("can iterate with each", function() {
 		var list = new $tw.utils.LinkedList();
-		list.push('0', '1', '2', '3');
+		list.push("0", "1", "2", "3");
 		var counter = 0;
 		list.each(function(value) {
 			expect(value).toBe(counter.toString());
@@ -261,9 +261,9 @@ describe("LinkedList class tests", function() {
 		expect(counter).toBe(4);
 	});
 
-	it('can iterate a list of the same item', function() {
+	it("can iterate a list of the same item", function() {
 		// Seems simple. Caused an infinite loop during development.
-		compare(newPair(['A', 'A']));
+		compare(newPair(["A", "A"]));
 	});
 });
 

--- a/editions/test/tiddlers/tests/test-linked-list.js
+++ b/editions/test/tiddlers/tests/test-linked-list.js
@@ -12,6 +12,14 @@ Many of these tests function by performing operations on a paired set of
 an array and LinkedList. It uses equivalent actions on both.
 Then we confirm that the two come out functionally identical.
 
+NOTE TO FURTHER LINKED LIST DEVELOPERS:
+
+	If you want to add new functionality, like 'shift' or 'unshift', you'll
+	probably need to deal with the fact that Linked List will insert undefined
+	as a first entry into an item's 'prev' array when it's at the front of
+	the list, but it doesn't do the same for the 'next' array when it's at
+	the end. I think you'll probably be better off preventing 'prev' from ever
+	adding undefined.
 \*/
 (function(){
 

--- a/editions/test/tiddlers/tests/test-linked-list.js
+++ b/editions/test/tiddlers/tests/test-linked-list.js
@@ -32,20 +32,20 @@ describe("LinkedList class tests", function() {
 
 	// pushTops a value or array of values into both the array and linked list.
 	function pushTop(pair, valueOrValues) {
-		$tw.utils.pushTop(pair.array, valueOrValues);
 		pair.list.pushTop(valueOrValues);
+		$tw.utils.pushTop(pair.array, valueOrValues);
 	};
 
 	// pushes values into both the array and the linked list.
 	function push(pair, values) {
-		pair.array.push.apply(pair.array, values);
 		pair.list.push.apply(pair.list, values);
+		pair.array.push.apply(pair.array, values);
 	};
 
 	// operates a remove action on an array and a linked list in parallel.
 	function remove(pair, valueOrValues) {
-		$tw.utils.removeArrayEntries(pair.array, valueOrValues);
 		pair.list.remove(valueOrValues);
+		$tw.utils.removeArrayEntries(pair.array, valueOrValues);
 	};
 
 	// compares an array and a linked list to make sure they match up
@@ -153,13 +153,31 @@ describe("LinkedList class tests", function() {
 		compare(pair); // '' '' A ''
 	});
 
-/*
-	it('can handle undefined', function() {
-		var pair = newPair();
-		pushTop(pair, [undefined]);
-		compare(pair); // ''
+	it('will throw if told to push non-strings', function() {
+		var message = "Linked List only accepts string values, not ";
+		var list = new $tw.utils.LinkedList();
+		expect(() => list.push(undefined)).toThrow(message + "undefined");
+		expect(() => list.pushTop(undefined)).toThrow(message + "undefined");
+		expect(() => list.pushTop(['c', undefined])).toThrow(message + "undefined");
+		expect(() => list.pushTop(5)).toThrow(message + "5");
+		expect(() => list.pushTop(null)).toThrow(message + "null");
+
+		// now lets do a quick test to make sure this exception
+		// doesn't leave any side-effects
+		// A.K.A Strong guarantee
+		var pair = newPair(['A', '5', 'B', 'C']);
+		expect(() => pushTop(pair, 5)).toThrow(message + "5");
+		compare(pair);
+		expect(() => push(pair, ['D', 7])).toThrow(message + "7");
+		compare(pair);
+		expect(() => remove(pair, 5)).toThrow(message + "5");
+		compare(pair);
+		// This is the tricky one. 'A' and 'B' should not be removed or pushed.
+		expect(() => pushTop(pair, ['A', 'B', null])).toThrow(message + "null");
+		compare(pair);
+		expect(() => remove(pair, ['A', 'B', null])).toThrow(message + "null");
+		compare(pair);
 	});
-*/
 
 	it("can clear", function() {
 		var list = new $tw.utils.LinkedList();

--- a/editions/test/tiddlers/tests/test-linked-list.js
+++ b/editions/test/tiddlers/tests/test-linked-list.js
@@ -155,14 +155,17 @@ describe("LinkedList class tests", function() {
 	});
 
 	it("can push", function() {
-		var pair = newPair(['A', 'B', 'C']);
+		var list = new $tw.utils.LinkedList();
 		// singles
-		push(pair, ['B']);
-		compare(pair); // ABCB
-
+		expect(list.push('A')).toBe(1);
+		expect(list.push('B')).toBe(2);
 		// multiple args
-		push(pair, ['A', 'B', 'C']);
-		compare(pair); // ABCBABC
+		expect(list.push('C', 'D', 'E')).toBe(5);
+		// array arg allowed
+		expect(list.push(['F', 'G'])).toBe(7);
+		// No-op
+		expect(list.push()).toBe(7);
+		expect(list.toArray()).toEqual(['A', 'B', 'C', 'D', 'E', 'F', 'G']);
 	});
 
 	it('can handle empty string', function() {


### PR DESCRIPTION
The more I convert Tiddlywiki over to using the Linked List, the more of a hungry hungry memory hippo it reveals itself to be. Currently, it's never used in a context where it will be retained, which is good, because using it with large (60K entries) can spike the memory several mB.

I've created a new Linked List which (usually) only uses three objects, instead of an object for every entry. It's less of a link list and more of a link table which relies on these assumptions

1. The only entries are strings. No undefined, null, objects, or anything like that. Exceptions are thrown in those cases.
2. Duplicate values must be supported, but they are very rare (<1% of use cases), and thus it's okay to be a little inefficient with them.

Since the previous Linked List was already pretty good, I had to ramp up the test to really outline the difference.
`for (var i = 0; i < 4; i++) {$tw.testWiki.filterTiddlers("[all[tiddlers+tiddlers+tiddlers+tiddlers]]")}` on 60K tiddlers:

## Old Linked list
![Screen Shot 2021-01-08 at 7 53 11 PM](https://user-images.githubusercontent.com/205465/104079883-0ce26b00-51f3-11eb-9084-22c39f18d494.png)
Large clumps of garbage collection wasting time to pick up all those little objects.

## New improved Linked list
![Screen Shot 2021-01-08 at 7 54 12 PM](https://user-images.githubusercontent.com/205465/104079886-14097900-51f3-11eb-89f1-e4f42b3a3829.png)
Hardly a garbage collection in sight.

(Meanwhile, the tw5.com website takes 90 seconds to do this.)

Granted, it was a pretty intense test case, but even with my old 30K testing suites, the new form was usually completed in about 70% of the old time. Moreover, this opens the door to allowing Linked Lists to persist without eating up memory.

I've also nearly doubled the number of tests since this implementation was a much trickier. But I'm pretty sure it's solid now. Let me know your thoughts.

