### PR TITLE
Fix  #5308 - WidgetSubclassingMechanism not working with widgets that add EventListeners (or logic ?) in constructor

### DIFF
--- a/core/modules/widgets/edit-bitmap.js
+++ b/core/modules/widgets/edit-bitmap.js
@@ -38,17 +38,17 @@ Render this widget into the DOM
 */
 EditBitmapWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
+	// Initialise the editor operations if they've not been done already
+	if(!this.editorOperations) {
+		EditBitmapWidget.prototype.editorOperations = {};
+		$tw.modules.applyMethods("bitmapeditoroperation",this.editorOperations);
+	}
 	// Save the parent dom node
 	this.parentDomNode = parent;
 	// Compute our attributes
 	this.computeAttributes();
 	// Execute our logic
 	this.execute();
-	// Initialise the editor operations if they've not been done already
-	if(!this.editorOperations) {
-		EditBitmapWidget.prototype.editorOperations = {};
-		$tw.modules.applyMethods("bitmapeditoroperation",this.editorOperations);
-	}
 	// Create the wrapper for the toolbar and render its content
 	this.toolbarNode = this.document.createElement("div");
 	this.toolbarNode.className = "tc-editor-toolbar";

--- a/core/modules/widgets/edit-bitmap.js
+++ b/core/modules/widgets/edit-bitmap.js
@@ -25,11 +25,6 @@ var LINE_WIDTH_TITLE = "$:/config/BitmapEditor/LineWidth",
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var EditBitmapWidget = function(parseTreeNode,options) {
-	// Initialise the editor operations if they've not been done already
-	if(!this.editorOperations) {
-		EditBitmapWidget.prototype.editorOperations = {};
-		$tw.modules.applyMethods("bitmapeditoroperation",this.editorOperations);
-	}
 	this.initialise(parseTreeNode,options);
 };
 
@@ -49,6 +44,11 @@ EditBitmapWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	// Execute our logic
 	this.execute();
+	// Initialise the editor operations if they've not been done already
+	if(!this.editorOperations) {
+		EditBitmapWidget.prototype.editorOperations = {};
+		$tw.modules.applyMethods("bitmapeditoroperation",this.editorOperations);
+	}
 	// Create the wrapper for the toolbar and render its content
 	this.toolbarNode = this.document.createElement("div");
 	this.toolbarNode.className = "tc-editor-toolbar";

--- a/core/modules/widgets/fieldmangler.js
+++ b/core/modules/widgets/fieldmangler.js
@@ -16,12 +16,6 @@ var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var FieldManglerWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
-	this.addEventListeners([
-		{type: "tm-remove-field", handler: "handleRemoveFieldEvent"},
-		{type: "tm-add-field", handler: "handleAddFieldEvent"},
-		{type: "tm-remove-tag", handler: "handleRemoveTagEvent"},
-		{type: "tm-add-tag", handler: "handleAddTagEvent"}
-	]);
 };
 
 /*
@@ -36,6 +30,12 @@ FieldManglerWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
+	this.addEventListeners([
+		{type: "tm-remove-field", handler: "handleRemoveFieldEvent"},
+		{type: "tm-add-field", handler: "handleAddFieldEvent"},
+		{type: "tm-remove-tag", handler: "handleRemoveTagEvent"},
+		{type: "tm-add-tag", handler: "handleAddTagEvent"}
+	]);
 	this.renderChildren(parent,nextSibling);
 };
 

--- a/core/modules/widgets/fieldmangler.js
+++ b/core/modules/widgets/fieldmangler.js
@@ -27,15 +27,15 @@ FieldManglerWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 FieldManglerWidget.prototype.render = function(parent,nextSibling) {
-	this.parentDomNode = parent;
-	this.computeAttributes();
-	this.execute();
 	this.addEventListeners([
 		{type: "tm-remove-field", handler: "handleRemoveFieldEvent"},
 		{type: "tm-add-field", handler: "handleAddFieldEvent"},
 		{type: "tm-remove-tag", handler: "handleRemoveTagEvent"},
 		{type: "tm-add-tag", handler: "handleAddTagEvent"}
 	]);
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
 	this.renderChildren(parent,nextSibling);
 };
 

--- a/core/modules/widgets/linkcatcher.js
+++ b/core/modules/widgets/linkcatcher.js
@@ -16,9 +16,6 @@ var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var LinkCatcherWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
-	this.addEventListeners([
-		{type: "tm-navigate", handler: "handleNavigateEvent"}
-	]);
 };
 
 /*
@@ -33,6 +30,9 @@ LinkCatcherWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
+	this.addEventListeners([
+		{type: "tm-navigate", handler: "handleNavigateEvent"}
+	]);
 	this.renderChildren(parent,nextSibling);
 };
 

--- a/core/modules/widgets/linkcatcher.js
+++ b/core/modules/widgets/linkcatcher.js
@@ -27,12 +27,12 @@ LinkCatcherWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 LinkCatcherWidget.prototype.render = function(parent,nextSibling) {
-	this.parentDomNode = parent;
-	this.computeAttributes();
-	this.execute();
 	this.addEventListeners([
 		{type: "tm-navigate", handler: "handleNavigateEvent"}
 	]);
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
 	this.renderChildren(parent,nextSibling);
 };
 

--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -19,11 +19,6 @@ The list widget creates list element sub-widgets that reach back into the list w
 */
 
 var ListWidget = function(parseTreeNode,options) {
-	// Initialise the storyviews if they've not been done already
-	if(!this.storyViews) {
-		ListWidget.prototype.storyViews = {};
-		$tw.modules.applyMethods("storyview",this.storyViews);
-	}
 	// Main initialisation inherited from widget.js
 	this.initialise(parseTreeNode,options);
 };
@@ -40,6 +35,11 @@ ListWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
+	// Initialise the storyviews if they've not been done already
+	if(!this.storyViews) {
+		ListWidget.prototype.storyViews = {};
+		$tw.modules.applyMethods("storyview",this.storyViews);
+	}
 	this.renderChildren(parent,nextSibling);
 	// Construct the storyview
 	var StoryView = this.storyViews[this.storyViewName];

--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -32,14 +32,14 @@ ListWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 ListWidget.prototype.render = function(parent,nextSibling) {
-	this.parentDomNode = parent;
-	this.computeAttributes();
-	this.execute();
 	// Initialise the storyviews if they've not been done already
 	if(!this.storyViews) {
 		ListWidget.prototype.storyViews = {};
 		$tw.modules.applyMethods("storyview",this.storyViews);
 	}
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
 	this.renderChildren(parent,nextSibling);
 	// Construct the storyview
 	var StoryView = this.storyViews[this.storyViewName];

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -18,6 +18,20 @@ var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var NavigatorWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+NavigatorWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+NavigatorWidget.prototype.render = function(parent,nextSibling) {
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
 	this.addEventListeners([
 		{type: "tm-navigate", handler: "handleNavigateEvent"},
 		{type: "tm-edit-tiddler", handler: "handleEditTiddlerEvent"},
@@ -36,20 +50,6 @@ var NavigatorWidget = function(parseTreeNode,options) {
 		{type: "tm-unfold-all-tiddlers", handler: "handleUnfoldAllTiddlersEvent"},
 		{type: "tm-rename-tiddler", handler: "handleRenameTiddlerEvent"}
 	]);
-};
-
-/*
-Inherit from the base widget class
-*/
-NavigatorWidget.prototype = new Widget();
-
-/*
-Render this widget into the DOM
-*/
-NavigatorWidget.prototype.render = function(parent,nextSibling) {
-	this.parentDomNode = parent;
-	this.computeAttributes();
-	this.execute();
 	this.renderChildren(parent,nextSibling);
 };
 

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -29,9 +29,6 @@ NavigatorWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 NavigatorWidget.prototype.render = function(parent,nextSibling) {
-	this.parentDomNode = parent;
-	this.computeAttributes();
-	this.execute();
 	this.addEventListeners([
 		{type: "tm-navigate", handler: "handleNavigateEvent"},
 		{type: "tm-edit-tiddler", handler: "handleEditTiddlerEvent"},
@@ -50,6 +47,9 @@ NavigatorWidget.prototype.render = function(parent,nextSibling) {
 		{type: "tm-unfold-all-tiddlers", handler: "handleUnfoldAllTiddlersEvent"},
 		{type: "tm-rename-tiddler", handler: "handleRenameTiddlerEvent"}
 	]);
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
 	this.renderChildren(parent,nextSibling);
 };
 

--- a/core/modules/widgets/scrollable.js
+++ b/core/modules/widgets/scrollable.js
@@ -16,26 +16,6 @@ var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var ScrollableWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
-	this.scaleFactor = 1;
-	this.addEventListeners([
-		{type: "tm-scroll", handler: "handleScrollEvent"}
-	]);
-	if($tw.browser) {
-		this.requestAnimationFrame = window.requestAnimationFrame ||
-			window.webkitRequestAnimationFrame ||
-			window.mozRequestAnimationFrame ||
-			function(callback) {
-				return window.setTimeout(callback, 1000/60);
-			};
-		this.cancelAnimationFrame = window.cancelAnimationFrame ||
-			window.webkitCancelAnimationFrame ||
-			window.webkitCancelRequestAnimationFrame ||
-			window.mozCancelAnimationFrame ||
-			window.mozCancelRequestAnimationFrame ||
-			function(id) {
-				window.clearTimeout(id);
-			};
-	}
 };
 
 /*
@@ -152,6 +132,26 @@ ScrollableWidget.prototype.render = function(parent,nextSibling) {
 	// Compute attributes and execute state
 	this.computeAttributes();
 	this.execute();
+	this.scaleFactor = 1;
+	this.addEventListeners([
+		{type: "tm-scroll", handler: "handleScrollEvent"}
+	]);
+	if($tw.browser) {
+		this.requestAnimationFrame = window.requestAnimationFrame ||
+			window.webkitRequestAnimationFrame ||
+			window.mozRequestAnimationFrame ||
+			function(callback) {
+				return window.setTimeout(callback, 1000/60);
+			};
+		this.cancelAnimationFrame = window.cancelAnimationFrame ||
+			window.webkitCancelAnimationFrame ||
+			window.webkitCancelRequestAnimationFrame ||
+			window.mozCancelAnimationFrame ||
+			window.mozCancelRequestAnimationFrame ||
+			function(id) {
+				window.clearTimeout(id);
+			};
+	}
 	// Create elements
 	this.outerDomNode = this.document.createElement("div");
 	$tw.utils.setStyle(this.outerDomNode,[

--- a/core/modules/widgets/scrollable.js
+++ b/core/modules/widgets/scrollable.js
@@ -127,11 +127,6 @@ Render this widget into the DOM
 */
 ScrollableWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
-	// Remember parent
-	this.parentDomNode = parent;
-	// Compute attributes and execute state
-	this.computeAttributes();
-	this.execute();
 	this.scaleFactor = 1;
 	this.addEventListeners([
 		{type: "tm-scroll", handler: "handleScrollEvent"}
@@ -152,6 +147,11 @@ ScrollableWidget.prototype.render = function(parent,nextSibling) {
 				window.clearTimeout(id);
 			};
 	}
+	// Remember parent
+	this.parentDomNode = parent;
+	// Compute attributes and execute state
+	this.computeAttributes();
+	this.execute();
 	// Create elements
 	this.outerDomNode = this.document.createElement("div");
 	$tw.utils.setStyle(this.outerDomNode,[

--- a/core/modules/widgets/vars.js
+++ b/core/modules/widgets/vars.js
@@ -22,8 +22,6 @@ This widget allows multiple variables to be set in one go:
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var VarsWidget = function(parseTreeNode,options) {
-	// Call the constructor
-	Widget.call(this);
 	// Initialise	
 	this.initialise(parseTreeNode,options);
 };
@@ -40,6 +38,8 @@ VarsWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
+	// Call the constructor
+	Widget.call(this);
 	this.renderChildren(parent,nextSibling);
 };
 

--- a/core/modules/widgets/vars.js
+++ b/core/modules/widgets/vars.js
@@ -35,11 +35,11 @@ VarsWidget.prototype = Object.create(Widget.prototype);
 Render this widget into the DOM
 */
 VarsWidget.prototype.render = function(parent,nextSibling) {
+	// Call the constructor
+	Widget.call(this);
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
-	// Call the constructor
-	Widget.call(this);
 	this.renderChildren(parent,nextSibling);
 };
 


### PR DESCRIPTION
This PR is an attempt to fix  #5308

- The adding of EventListeners is moved from the constructor to render()
  - in the navigator widget
  - in the fieldmangler widget
  - in the scrollable widget
  - in the linkcatcher widget
- The additional adding of logic is also moved from the constructor to render()
  - in the edit-bitmap widget
  - in the list widget
  - in the vars widget. note the `Widget.call(this)` call - I'm not sure what it should do / if it can be removed entirely