### PR TITLE
double quotes are no longer escaped in html bodies

### DIFF
--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -515,6 +515,15 @@ exports.htmlEncode = function(s) {
 	}
 };
 
+// Converts like htmlEncode, but forgets the double quote for brevity
+exports.htmlTextEncode = function(s) {
+	if(s) {
+		return s.toString().replace(/&/mg,"&amp;").replace(/</mg,"&lt;").replace(/>/mg,"&gt;");
+	} else {
+		return "";
+	}
+};
+
 // Converts all HTML entities to their character equivalents
 exports.entityDecode = function(s) {
 	var converter = String.fromCodePoint || String.fromCharCode,

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -65,6 +65,9 @@ ViewWidget.prototype.execute = function() {
 		case "htmlencoded":
 			this.text = this.getValueAsHtmlEncoded();
 			break;
+		case "htmltextencoded":
+			this.text = this.getValueAsHtmlTextEncoded();
+			break;
 		case "urlencoded":
 			this.text = this.getValueAsUrlEncoded();
 			break;
@@ -158,6 +161,10 @@ ViewWidget.prototype.getValueAsHtmlEncodedPlainWikified = function(mode) {
 
 ViewWidget.prototype.getValueAsHtmlEncoded = function() {
 	return $tw.utils.htmlEncode(this.getValueAsText());
+};
+
+ViewWidget.prototype.getValueAsHtmlTextEncoded = function() {
+	return $tw.utils.htmlTextEncode(this.getValueAsText());
 };
 
 ViewWidget.prototype.getValueAsUrlEncoded = function() {

--- a/core/templates/html-div-tiddler.tid
+++ b/core/templates/html-div-tiddler.tid
@@ -5,5 +5,5 @@ title: $:/core/templates/html-div-tiddler
 This template is used for saving tiddlers as an HTML DIV tag with attributes representing the tiddler fields.
 
 -->`<div`<$fields template=' $name$="$encoded_value$"'></$fields>`>
-<pre>`<$view field="text" format="htmlencoded" />`</pre>
+<pre>`<$view field="text" format="htmltextencoded" />`</pre>
 </div>`

--- a/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
@@ -29,6 +29,7 @@ The following formats can be specified in the `format` attribute:
 |!Format |!Description |
 |''text'' |Plain text (default) |
 |''htmlencoded'' |The field is displayed with HTML encoding |
+|''htmltextencoded'' |The field is displayed with HTML encoding, only double quotes (") are not escaped. This creates a more compact htmlencoding appropriate for html text content, but //not// for attributes. |
 |''urlencoded'' |The field is displayed with URL encoding |
 |''doubleurlencoded'' |The field is displayed with double URL encoding |
 |''htmlwikified'' |The field is wikified according to the mode attribute and the resulting HTML returned as plain text (ie HTML elements will appear in plain text) |

--- a/plugins/tiddlywiki/tiddlyweb/html-div-tiddler.tid
+++ b/plugins/tiddlywiki/tiddlyweb/html-div-tiddler.tid
@@ -5,5 +5,5 @@ title: $:/core/templates/html-div-tiddler
 This template is used for saving tiddlers as an HTML DIV tag with attributes representing the tiddler fields. This version includes the tiddler changecount as the field `revision`.
 
 -->`<div`<$fields exclude='text revision bag' template=' $name$="$encoded_value$"'></$fields>` revision="`<<changecount>>`" bag="default">
-<pre>`<$view field="text" format="htmlencoded" />`</pre>
+<pre>`<$view field="text" format="htmltextencoded" />`</pre>
 </div>`


### PR DESCRIPTION
It's entirely cool if you don't merge this PR. If nothing else, I'd need to update the documentation on $view before it'd be ready.

This is to discuss double quotes in Tiddlywiki. We escape them _all_, _and_ it's part of the style guide. However if we _didn't_ escape them, then we shave nearly 300 kB off of the generated Tiddlywiki file (that's about 10%). I've done this with this PR, and it all works fine.

According to the [Google style guide](https://google.github.io/styleguide/htmlcssguide.html), they even recommend that you don't.

> Do not use entity references.
> 
> There is no need to use entity references like `&mdash;`, `&rdquo;`, or `&#x263a;`, assuming the same encoding (UTF-8) is used for files and editors as well as among teams.
> 
> The only exceptions apply to characters with special meaning in HTML (like < and &) as well as control or “invisible” characters (like no-break spaces).

As far as I can tell, in the textContent of HTML, the double quote has no special meaning.

The only trick about this is we need a separate htmltextencode keyword for view, because attributes _do_ still need to escape double quotes.

So, why not?