### PR TITLE
Add server/client sync filters

### DIFF
--- a/core/wiki/config/SyncClientFilter.tid
+++ b/core/wiki/config/SyncClientFilter.tid
@@ -1,0 +1,2 @@
+title: $:/config/SyncClientFilter
+text:

--- a/core/wiki/config/SyncFilter.tid
+++ b/core/wiki/config/SyncFilter.tid
@@ -1,3 +1,0 @@
-title: $:/config/SyncFilter
-
-[is[tiddler]] -[[$:/core]] -[[$:/library/sjcl.js]] -[prefix[$:/boot/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/isEncrypted]] -[prefix[$:/status/]] -[prefix[$:/state/]] -[prefix[$:/temp/]]

--- a/core/wiki/config/SyncServerFilter.tid
+++ b/core/wiki/config/SyncServerFilter.tid
@@ -1,0 +1,2 @@
+title: $:/config/SyncServerFilter
+text: [is[tiddler]] -[[$:/core]] -[[$:/library/sjcl.js]] -[prefix[$:/boot/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/isEncrypted]] -[prefix[$:/status/]] -[prefix[$:/state/]] -[prefix[$:/temp/]]

--- a/plugins/tiddlywiki/tiddlyweb/config-tiddlers-filter.tid
+++ b/plugins/tiddlywiki/tiddlyweb/config-tiddlers-filter.tid
@@ -1,2 +1,2 @@
-title: $:/config/Server/ExternalFilters/[all[tiddlers]] -[[$:/isEncrypted]] -[prefix[$:/temp/]] -[prefix[$:/status/]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] -[[$:/library/sjcl.js]] -[[$:/core]]
+title: $:/config/Server/ExternalFilters/[is[tiddler]] -[[$:/core]] -[[$:/library/sjcl.js]] -[prefix[$:/boot/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/isEncrypted]] -[prefix[$:/status/]] -[prefix[$:/state/]] -[prefix[$:/temp/]]
 text: yes

--- a/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
+++ b/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
@@ -12,8 +12,10 @@ A sync adaptor module for synchronising with TiddlyWeb compatible servers
 /*global $tw: false */
 "use strict";
 
-var CONFIG_HOST_TIDDLER = "$:/config/tiddlyweb/host",
-	DEFAULT_HOST_TIDDLER = "$protocol$//$host$/";
+TiddlyWebAdaptor.prototype.CONFIG_HOST_TIDDLER = "$:/config/tiddlyweb/host";
+TiddlyWebAdaptor.prototype.DEFAULT_HOST_TIDDLER = "$protocol$//$host$/";
+TiddlyWebAdaptor.prototype.titleSyncServerFilter = "$:/config/SyncServerFilter";
+TiddlyWebAdaptor.prototype.titleSyncClientFilter = "$:/config/SyncClientFilter";
 
 function TiddlyWebAdaptor(options) {
 	this.wiki = options.wiki;
@@ -23,6 +25,8 @@ function TiddlyWebAdaptor(options) {
 	this.logger = new $tw.utils.Logger("TiddlyWebAdaptor");
 	this.isLoggedIn = false;
 	this.isReadOnly = false;
+	this.skinnyTiddlerFilter = this.wiki.getTiddlerText(this.titleSyncServerFilter);
+	this.wiki.setText("$:/config/Server/ExternalFilters/" + this.titleSyncServerFilter, null, null, "yes");
 }
 
 TiddlyWebAdaptor.prototype.name = "tiddlyweb";
@@ -38,7 +42,7 @@ TiddlyWebAdaptor.prototype.isReady = function() {
 };
 
 TiddlyWebAdaptor.prototype.getHost = function() {
-	var text = this.wiki.getTiddlerText(CONFIG_HOST_TIDDLER,DEFAULT_HOST_TIDDLER),
+	var text = this.wiki.getTiddlerText(this.CONFIG_HOST_TIDDLER,this.DEFAULT_HOST_TIDDLER),
 		substitutions = [
 			{name: "protocol", value: document.location.protocol},
 			{name: "host", value: document.location.host}
@@ -159,7 +163,7 @@ TiddlyWebAdaptor.prototype.getSkinnyTiddlers = function(callback) {
 	$tw.utils.httpRequest({
 		url: this.host + "recipes/" + this.recipe + "/tiddlers.json",
 		data: {
-			filter: "[all[tiddlers]] -[[$:/isEncrypted]] -[prefix[$:/temp/]] -[prefix[$:/status/]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] -[[$:/library/sjcl.js]] -[[$:/core]]"
+			filter: this.skinnyTiddlerFilter
 		},
 		callback: function(err,data) {
 			// Check for errors


### PR DESCRIPTION
This adds the server and client sync filters as proposed by me in #5342. 

The changes are mainly to the syncer, and apply to the file system adapter as well, but that does not break anything as write-only tiddlers will still be saved, and read-only tiddlers are ignored anyway because the file system adapter does not read the file system. In the future, whatever mechanism is used for bags will most likely overcome this problem. 