### PR TITLE
Speculatively moved viewformats to a new module-type

### DIFF
--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -44,6 +44,8 @@ ViewWidget.prototype.render = function(parent,nextSibling) {
 Compute the internal state of the widget
 */
 ViewWidget.prototype.execute = function() {
+	var formats = getViewWidgetFormats(),
+		formatMethod;
 	// Get parameters from our attributes
 	this.viewTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
 	this.viewSubtiddler = this.getAttribute("subtiddler");
@@ -52,46 +54,28 @@ ViewWidget.prototype.execute = function() {
 	this.viewFormat = this.getAttribute("format","text");
 	this.viewTemplate = this.getAttribute("template","");
 	this.viewMode = this.getAttribute("mode","block");
-	switch(this.viewFormat) {
-		case "htmlwikified":
-			this.text = this.getValueAsHtmlWikified(this.viewMode);
-			break;
-		case "plainwikified":
-			this.text = this.getValueAsPlainWikified(this.viewMode);
-			break;
-		case "htmlencodedplainwikified":
-			this.text = this.getValueAsHtmlEncodedPlainWikified(this.viewMode);
-			break;
-		case "htmlencoded":
-			this.text = this.getValueAsHtmlEncoded();
-			break;
-		case "urlencoded":
-			this.text = this.getValueAsUrlEncoded();
-			break;
-		case "doubleurlencoded":
-			this.text = this.getValueAsDoubleUrlEncoded();
-			break;
-		case "date":
-			this.text = this.getValueAsDate(this.viewTemplate);
-			break;
-		case "relativedate":
-			this.text = this.getValueAsRelativeDate();
-			break;
-		case "stripcomments":
-			this.text = this.getValueAsStrippedComments();
-			break;
-		case "jsencoded":
-			this.text = this.getValueAsJsEncoded();
-			break;
-		default: // "text"
-			this.text = this.getValueAsText();
-			break;
+
+	formatMethod = formats[this.viewFormat];
+	if(!formatMethod) {
+		// Default to "text"
+		formatMethod = formats.text;
 	}
+	this.text = formatMethod(this,this.viewMode,this.viewTemplate);
 };
 
 /*
-The various formatter functions are baked into this widget for the moment. Eventually they will be replaced by macro functions
+The various formatter functions are defined by the viewwidgetformat module-type. The default format is "text".
 */
+
+var viewWidgetFormats;
+
+function getViewWidgetFormats() {
+	if(!viewWidgetFormats) {
+		viewWidgetFormats = Object.create(null);
+		$tw.modules.applyMethods("viewwidgetformat",viewWidgetFormats);
+	}
+	return viewWidgetFormats;
+};
 
 /*
 Retrieve the value of the widget. Options are:
@@ -129,78 +113,6 @@ ViewWidget.prototype.getValue = function(options) {
 		}
 	}
 	return value;
-};
-
-ViewWidget.prototype.getValueAsText = function() {
-	return this.getValue({asString: true});
-};
-
-ViewWidget.prototype.getValueAsHtmlWikified = function(mode) {
-	return this.wiki.renderText("text/html","text/vnd.tiddlywiki",this.getValueAsText(),{
-		parseAsInline: mode !== "block",
-		parentWidget: this
-	});
-};
-
-ViewWidget.prototype.getValueAsPlainWikified = function(mode) {
-	return this.wiki.renderText("text/plain","text/vnd.tiddlywiki",this.getValueAsText(),{
-		parseAsInline: mode !== "block",
-		parentWidget: this
-	});
-};
-
-ViewWidget.prototype.getValueAsHtmlEncodedPlainWikified = function(mode) {
-	return $tw.utils.htmlEncode(this.wiki.renderText("text/plain","text/vnd.tiddlywiki",this.getValueAsText(),{
-		parseAsInline: mode !== "block",
-		parentWidget: this
-	}));
-};
-
-ViewWidget.prototype.getValueAsHtmlEncoded = function() {
-	return $tw.utils.htmlEncode(this.getValueAsText());
-};
-
-ViewWidget.prototype.getValueAsUrlEncoded = function() {
-	return encodeURIComponent(this.getValueAsText());
-};
-
-ViewWidget.prototype.getValueAsDoubleUrlEncoded = function() {
-	return encodeURIComponent(encodeURIComponent(this.getValueAsText()));
-};
-
-ViewWidget.prototype.getValueAsDate = function(format) {
-	format = format || "YYYY MM DD 0hh:0mm";
-	var value = $tw.utils.parseDate(this.getValue());
-	if(value && $tw.utils.isDate(value) && value.toString() !== "Invalid Date") {
-		return $tw.utils.formatDateString(value,format);
-	} else {
-		return "";
-	}
-};
-
-ViewWidget.prototype.getValueAsRelativeDate = function(format) {
-	var value = $tw.utils.parseDate(this.getValue());
-	if(value && $tw.utils.isDate(value) && value.toString() !== "Invalid Date") {
-		return $tw.utils.getRelativeDate((new Date()) - (new Date(value))).description;
-	} else {
-		return "";
-	}
-};
-
-ViewWidget.prototype.getValueAsStrippedComments = function() {
-	var lines = this.getValueAsText().split("\n"),
-		out = [];
-	for(var line=0; line<lines.length; line++) {
-		var text = lines[line];
-		if(!/^\s*\/\/#/.test(text)) {
-			out.push(text);
-		}
-	}
-	return out.join("\n");
-};
-
-ViewWidget.prototype.getValueAsJsEncoded = function() {
-	return $tw.utils.stringify(this.getValueAsText());
 };
 
 /*

--- a/core/modules/widgets/view/formats.js
+++ b/core/modules/widgets/view/formats.js
@@ -1,0 +1,87 @@
+/*\
+title: $:/core/modules/widgets/view/formats.js
+type: application/javascript
+module-type: viewwidgetformat
+
+All the core View Widget formats.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.text = function(widget) {
+	return widget.getValue({asString: true});
+};
+
+exports.htmlwikified = function(widget,mode,template) {
+	return widget.wiki.renderText("text/html","text/vnd.tiddlywiki",exports.text(widget),{
+		parseAsInline: mode !== "block",
+		parentWidget: widget
+	});
+};
+
+exports.plainwikified = function(widget,mode,template) {
+	return widget.wiki.renderText("text/plain","text/vnd.tiddlywiki",exports.text(widget),{
+		parseAsInline: mode !== "block",
+		parentWidget: widget
+	});
+};
+
+exports.htmlencodedplainwikified = function(widget,mode,template) {
+	return $tw.utils.htmlEncode(widget.wiki.renderText("text/plain","text/vnd.tiddlywiki",exports.text(widget),{
+		parseAsInline: mode !== "block",
+		parentWidget: widget
+	}));
+};
+
+exports.htmlencoded = function(widget) {
+	return $tw.utils.htmlEncode(exports.text(widget));
+};
+
+exports.urlencoded = function(widget) {
+	return encodeURIComponent(exports.text(widget));
+};
+
+exports.doubleurlencoded = function(widget) {
+	return encodeURIComponent(encodeURIComponent(exports.text(widget)));
+};
+
+exports.date = function(widget,mode,format) {
+	format = format || "YYYY MM DD 0hh:0mm";
+	var value = $tw.utils.parseDate(widget.getValue());
+	if(value && $tw.utils.isDate(value) && value.toString() !== "Invalid Date") {
+		return $tw.utils.formatDateString(value,format);
+	} else {
+		return "";
+	}
+};
+
+exports.relativedate = function(widget) {
+	var value = $tw.utils.parseDate(widget.getValue());
+	if(value && $tw.utils.isDate(value) && value.toString() !== "Invalid Date") {
+		return $tw.utils.getRelativeDate((new Date()) - (new Date(value))).description;
+	} else {
+		return "";
+	}
+};
+
+exports.stripcomments = function(widget) {
+	var lines = exports.text(widget).split("\n"),
+		out = [];
+	for(var line=0; line<lines.length; line++) {
+		var text = lines[line];
+		if(!/^\s*\/\/#/.test(text)) {
+			out.push(text);
+		}
+	}
+	return out.join("\n");
+};
+
+exports.jsencoded = function(widget) {
+	return $tw.utils.stringify(exports.text(widget));
+};
+
+})();


### PR DESCRIPTION
This is my proposed crack at making the view widget's formats a module-type of their own. However, @Jermolene, I saw that you had a comment in the code saying:
> The various formatter functions are baked into this widget for the moment. Eventually they will be replaced by macro functions

which makes me think you had something a little different in mind. And that's cool. Although I'm not sure what you meant by macro functions. If you show me what you mean, I can do that instead.

All I care about is that they are separated. My tw5-xml plugin would have _loved_ to have defined it's own `xmlencoded` format type, as well as other personal plugins I've written, but mostly if I were to do my minify plugin, I'd need to be able to override some of these format types, and I'd rather be able to do that without overriding shadow tiddlers.

Your thoughts on this?

Quick note: If you merge #5383, this will conflict, but I'll happily take care of resolving it.