### PR TITLE
Fix backtracking issue with regex

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -78,7 +78,7 @@ function parseFilterOperation(operators,filterString,p) {
 					nextBracketPos = filterString.indexOf(">",p);
 					break;
 				case "/": // regexp brackets
-					var rex = /^((?:[^\\\/]*|\\.)*)\/(?:\(([mygi]+)\))?/g,
+					var rex = /^((?:[^\\\/]|\\.)*)\/(?:\(([mygi]+)\))?/g,
 						rexMatch = rex.exec(filterString.substring(p));
 					if(rexMatch) {
 						operator.regexp = new RegExp(rexMatch[1], rexMatch[2]);


### PR DESCRIPTION
There was an unnecessary qualifier on the regex which was causing exponential backtracking.

I believe the updated regex should not demonstrate this behavior and it does not take a long time when using the example of `..........................................................................` when tested with https://regex101.com/ while the previous version would timeout.

This is in relation to the bug #5305 