### PR TITLE
Fix a typo in WebServer Parameter_ sse-enabled.tid

### DIFF
--- a/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ sse-enabled.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ sse-enabled.tid
@@ -1,11 +1,11 @@
 caption: sse-enabled
 created: 20210113204602693
-modified: 20210113205535065
+modified: 20210115120126953
 tags: [[WebServer Parameters]]
 title: WebServer Parameter: sse-enabled
 type: text/vnd.tiddlywiki
 
-The [[web server configuration parameter|WebServer Parameters]] ''sse-enabled'' enabled [[Server sent events|https://en.wikipedia.org/wiki/Server-sent_events]], allowing changes to be propagated in almost real time to all browser windows or tabs.
+The [[web server configuration parameter|WebServer Parameters]] ''sse-enabled'' enables [[Server sent events|https://en.wikipedia.org/wiki/Server-sent_events]], allowing changes to be propagated in almost real time to all browser windows or tabs.
 
 Setting ''sse-enabled'' to `yes` enables Server-sent events; `no`, or any other value, disables them.
 


### PR DESCRIPTION
This PR fixes a typo that I left in `WebServer Parameter_ sse-enabled.tid` in #5279.
