### PR TITLE
getCacheForTiddler can cache falsy values

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -844,7 +844,7 @@ exports.clearGlobalCache = function() {
 exports.getCacheForTiddler = function(title,cacheName,initializer) {
 	this.caches = this.caches || Object.create(null);
 	var caches = this.caches[title];
-	if(caches && caches[cacheName]) {
+	if(caches && $tw.utils.hop(caches,cacheName)) {
 		return caches[cacheName];
 	} else {
 		if(!caches) {

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -844,7 +844,7 @@ exports.clearGlobalCache = function() {
 exports.getCacheForTiddler = function(title,cacheName,initializer) {
 	this.caches = this.caches || Object.create(null);
 	var caches = this.caches[title];
-	if(caches && $tw.utils.hop(caches,cacheName)) {
+	if(caches && caches[cacheName] !== undefined) {
 		return caches[cacheName];
 	} else {
 		if(!caches) {


### PR DESCRIPTION
`getCacheForTiddler` should be able to cache falsy values just like `getGlobalCache` can. Otherwise it's inconsistent, and a little annoying when my initializer keeps reevaluating an empty string.