### PR TITLE
removing redundant title fields from plugins

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1289,7 +1289,15 @@ $tw.Wiki = function(options) {
 			var tiddler = tiddlers[title];
 			if(tiddler) {
 				if(tiddler.fields.type === "application/json" && tiddler.hasField("plugin-type") && tiddler.fields.text) {
-					pluginInfo[tiddler.fields.title] = JSON.parse(tiddler.fields.text);
+					var info = JSON.parse(tiddler.fields.text);
+					if (info.tiddlers) {
+						// Put the title in just in case it was omitted for
+						// brevity's sake.
+						for (var title in info.tiddlers) {
+							info.tiddlers[title].title = title;
+						}
+					}
+					pluginInfo[tiddler.fields.title] = info;
 					results.modifiedPlugins.push(tiddler.fields.title);
 				}
 			} else {
@@ -1962,8 +1970,17 @@ $tw.loadPluginFolder = function(filepath,excludeRegExp) {
 			var tiddlers = pluginFiles[f].tiddlers;
 			for(var t=0; t<tiddlers.length; t++) {
 				var tiddler= tiddlers[t];
+				var abridgedFields = Object.create(null);
 				if(tiddler.title) {
-					pluginInfo.tiddlers[tiddler.title] = tiddler;
+					// We copy the fields to abridged fields without the title>
+					// keeping title in pluginInfo would be redundant, since
+					// the object keys are the titles.
+					for(var field in tiddler) {
+						if(field !== 'title') {
+							abridgedFields[field] = tiddler[field];
+						}
+					}
+					pluginInfo.tiddlers[tiddler.title] = abridgedFields;
 				}
 			}
 		}

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1290,10 +1290,10 @@ $tw.Wiki = function(options) {
 			if(tiddler) {
 				if(tiddler.fields.type === "application/json" && tiddler.hasField("plugin-type") && tiddler.fields.text) {
 					var info = JSON.parse(tiddler.fields.text);
-					if (info.tiddlers) {
+					if(info.tiddlers) {
 						// Put the title in just in case it was omitted for
 						// brevity's sake.
-						for (var title in info.tiddlers) {
+						for(var title in info.tiddlers) {
 							info.tiddlers[title].title = title;
 						}
 					}


### PR DESCRIPTION
All the tiddlers described in a plugin tiddler go something like this:
```json
    ...
    "$:/language/ControlPanel/Basics/Tiddlers/Prompt": {
        "title": "$:/language/ControlPanel/Basics/Tiddlers/Prompt",
        "text": "Number of tiddlers"
    },
    ...
```
We use the title as a key, and then we repeat the title as a field. In an empty tiddlywiki, this amounts to 180K of wasted space. Turns out, removing that title field is actually super simple. At first I thought it'd be a serious backward compatibility issue, but then I found the place where we create tiddlers from these JSON objects:
https://github.com/Jermolene/TiddlyWiki5/blob/ae273a08f138dc470cb034cdc9867bb6defc2323/boot/boot.js#L1375-L1383

 The ``tiddler: new $tw.Tiddler(constituentTiddler,{title: constituentTitle}) `` line means we already put in the key as the title in case the field is missing. And we've been doing this as far back as February 2013 (probably farther, but I got tired of git blaming into the past).

This PR does two things:

1. It removes the title field when we're creating pluginInfo JSON string for writing.
2. It puts it back in to the plugInfo JSON object we retain in memory. This isn't actually necessary for the core. It never uses that pluginInfo as far as I can tell, but maybe some plugin somewhere depended on the title being among the 'tiddler' keys.

That's it! However, I completely fine if this PR seems problematic, and you don't want to merge it. I'm close to releasing my TW5-Uglify plugin which while cull these redundant title fields. It's just such an easy optimization that I figured maybe the core would like it too.

If not, it just means TW5-Uglify will seem all the better at compressing.