### PR TITLE
Fix blank favicon if root-tiddler=save-lazy-*

### DIFF
--- a/core/templates/save-lazy-all.tid
+++ b/core/templates/save-lazy-all.tid
@@ -1,9 +1,9 @@
 title: $:/core/save/lazy-all
 
 \define saveTiddlerFilter()
-[is[system]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] 
+[is[system]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] =[[$:/favicon.ico]] +[sort[title]]
 \end
 \define skinnySaveTiddlerFilter()
-[!is[system]]
+[!is[system]] -[[$:/favicon.ico]]
 \end
 {{$:/core/templates/tiddlywiki5.html}}

--- a/core/templates/save-lazy-images.tid
+++ b/core/templates/save-lazy-images.tid
@@ -1,9 +1,9 @@
 title: $:/core/save/lazy-images
 
 \define saveTiddlerFilter()
-[is[tiddler]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] -[!is[system]is[image]] +[sort[title]] 
+[is[tiddler]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] -[!is[system]is[image]] =[[$:/favicon.ico]] +[sort[title]]
 \end
 \define skinnySaveTiddlerFilter()
-[is[image]]
+[is[image]] -[[$:/favicon.ico]]
 \end
 {{$:/core/templates/tiddlywiki5.html}}


### PR DESCRIPTION
If the `root-tiddler` option is set to `save-lazy-images` or `save-lazy-all` on node.js the favicon is empty because the tiddler `$:/favicon.ico` is lazy loaded and is empty at first.

This patch excludes the `$:/favicon.ico` tiddler from lazy loading and restores the favicon functionality.