### PR TITLE
Fix blank favicon if root-tiddler=$:/core/save/lazy-images is set

### DIFF
--- a/core/templates/save-lazy-images.tid
+++ b/core/templates/save-lazy-images.tid
@@ -4,6 +4,6 @@ title: $:/core/save/lazy-images
 [is[tiddler]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] -[!is[system]is[image]] +[sort[title]] 
 \end
 \define skinnySaveTiddlerFilter()
-[is[image]]
+[!is[system]is[image]]
 \end
 {{$:/core/templates/tiddlywiki5.html}}


### PR DESCRIPTION
If image lazy loading is used with node.js the favicon is blank. The line `-[!is[system]is[image]]` excludes only non system images from begin saved as full tiddlers. But the `[is[image]]` in the `skinnySaveTiddlerFilter` includes all (even system) images as skinny tiddlers. The created HTML file has the favicon tlisted twice. And the skinny tiddler seems to win. This breaks the display of the favicon.

This patch fixes this issue by excluding system images from the skinny tiddlers list.