### PR TITLE
Update WikiRuleModules.tid

### DIFF
--- a/editions/dev/tiddlers/from tw5.com/moduletypes/WikiRuleModules.tid
+++ b/editions/dev/tiddlers/from tw5.com/moduletypes/WikiRuleModules.tid
@@ -1,11 +1,11 @@
-created: 201308252147
-modified: 201311011307
+created: 20130825214700000
+modified: 20210121054620146
 tags: dev moduletypes
 title: WikiRuleModules
 
-WikiRuleModules cover the module types `wikirunrule`, `wikiblockrule` and `wikipragmarule`. Modules of these types encapsulate the logic of individual parsing rules used by the WikiParser engine. For example, there is a `wikirunrule` module that identifies references to HTML entities by matching the pattern `&<chars>;`.
+WikiRuleModules have a `module-type` of `wikirule`, and may have following types: `pragma`, `block`, `inline`. Modules of these types encapsulate the logic of individual parsing rules used by the WikiParser engine. For example, `entity.js` rule module identifies references to HTML entities by matching the pattern `&<chars>;`.
 
-Pragma rules are applied at the start of a block of text, and cover definitions and declarations that affect the parsing of the rest of the text. Block rules are only applied at the beginning of a block of wikitext, while run rules can appear anywhere. The only current example of a pragma rule is for macro definitions.
+Pragma rules are applied at the start of a block of text, and cover definitions and declarations that affect the parsing of the rest of the text. Block rules are only applied at the beginning of a block of wikitext, while inline rules can appear anywhere. The only current example of a pragma rule is for macro definitions.
 
 Examples of block rules:
 
@@ -13,7 +13,7 @@ Examples of block rules:
 * Tables
 * Lists
 
-Examples of run rules:
+Examples of inline rules:
 
 * Entities
 * HTML tags
@@ -24,6 +24,7 @@ Parser rule modules extend the `$tw.WikiParserRule` class. This is done by insta
 The standard methods and properties of parser rules are as follows:
 
 * `name`: a string containing the name of this parse rule
+* `types`: an object that defines the module's type. For example, `exports.types = {block: true};`
 * `init(parser)`: initialisation function called immediately after the constructor with a pointer back to the parser containing this rule
 * `findNextMatch(pos)`: returns the position of the next match after the specified position
 * `parse()`: parses the most recent match, returning an array of the generated parse tree nodes. Pragma rules don't return parse tree nodes but instead modify the parser object directly (for example, to add local macro definitions)


### PR DESCRIPTION
The information on WikiRuleModules seems to be outdated. `module-type` such as `wikirunrule`, `wikiblockrule` and `wikipragmarule` does not exist, and instead such modules should have `module-type: wikirule` and set `exports.types = {inline: true, block: true, pragma: false}`