### PR TITLE
Fix the right margin of tags used outside of the tags wrapper

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -685,11 +685,14 @@ button svg.tc-image-button, button .tc-image-button img {
 .tc-tag-list-item {
 	position: relative;
 	display: inline-block;
-	margin-right: 7px;
 }
 
 .tc-tags-wrapper {
 	margin: 4px 0 14px 0;
+}
+
+.tc-tags-wrapper .tc-tag-list-item {
+	margin-right: 7px;
 }
 
 .tc-missing-tiddler-label {


### PR DESCRIPTION
Only add a right margin to tag items rendered within the tags-wrapper.
This fixes the margin of tags used inline using for instance the `tag`
macro.

###### Before

![Screenshot from 2021-01-24 20-30-13](https://user-images.githubusercontent.com/123539/105641197-16bace00-5e83-11eb-8299-3a92023c33d8.png)

###### After

![Screenshot from 2021-01-24 20-29-52](https://user-images.githubusercontent.com/123539/105641205-1c181880-5e83-11eb-8185-aa98ee1e25a7.png)
