### PR TITLE
Fix for #3306, inline/block widget glitch

### DIFF
--- a/core/modules/parsers/wikiparser/rules/html.js
+++ b/core/modules/parsers/wikiparser/rules/html.js
@@ -54,14 +54,13 @@ exports.parse = function() {
 	// Parse the body if we need to
 	if(!tag.isSelfClosing && $tw.config.htmlVoidElements.indexOf(tag.tag) === -1) {
 			var reEndString = "</" + $tw.utils.escapeRegExp(tag.tag) + ">",
-				reEnd = new RegExp("(" + reEndString + ")","mg"),
 				options = {eatTerminator: true};
 		if(hasLineBreak) {
 			tag.children = this.parser.parseBlocks(reEndString,options);
 		} else {
+			var reEnd = new RegExp("(" + reEndString + ")","mg");
 			tag.children = this.parser.parseInlineRun(reEnd,options);
 		}
-		reEnd.lastIndex = this.parser.pos;
 	}
 	// Return the tag
 	return [tag];

--- a/core/modules/parsers/wikiparser/rules/html.js
+++ b/core/modules/parsers/wikiparser/rules/html.js
@@ -54,17 +54,14 @@ exports.parse = function() {
 	// Parse the body if we need to
 	if(!tag.isSelfClosing && $tw.config.htmlVoidElements.indexOf(tag.tag) === -1) {
 			var reEndString = "</" + $tw.utils.escapeRegExp(tag.tag) + ">",
-				reEnd = new RegExp("(" + reEndString + ")","mg");
+				reEnd = new RegExp("(" + reEndString + ")","mg"),
+				options = {eatTerminator: true};
 		if(hasLineBreak) {
-			tag.children = this.parser.parseBlocks(reEndString);
+			tag.children = this.parser.parseBlocks(reEndString,options);
 		} else {
-			tag.children = this.parser.parseInlineRun(reEnd);
+			tag.children = this.parser.parseInlineRun(reEnd,options);
 		}
 		reEnd.lastIndex = this.parser.pos;
-		var endMatch = reEnd.exec(this.parser.source);
-		if(endMatch && endMatch.index === this.parser.pos) {
-			this.parser.pos = endMatch.index + endMatch[0].length;
-		}
 	}
 	// Return the tag
 	return [tag];

--- a/core/modules/parsers/wikiparser/rules/html.js
+++ b/core/modules/parsers/wikiparser/rules/html.js
@@ -53,13 +53,12 @@ exports.parse = function() {
 	tag.isBlock = this.is.block || hasLineBreak;
 	// Parse the body if we need to
 	if(!tag.isSelfClosing && $tw.config.htmlVoidElements.indexOf(tag.tag) === -1) {
-			var reEndString = "</" + $tw.utils.escapeRegExp(tag.tag) + ">",
-				options = {eatTerminator: true};
+		var reEndString = "</" + $tw.utils.escapeRegExp(tag.tag) + ">";
 		if(hasLineBreak) {
-			tag.children = this.parser.parseBlocks(reEndString,options);
+			tag.children = this.parser.parseBlocks(reEndString);
 		} else {
 			var reEnd = new RegExp("(" + reEndString + ")","mg");
-			tag.children = this.parser.parseInlineRun(reEnd,options);
+			tag.children = this.parser.parseInlineRun(reEnd,{eatTerminator: true});
 		}
 	}
 	// Return the tag

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -103,6 +103,12 @@ describe("WikiText parser tests", function() {
 			[ { type : 'element', tag : 'p', children : [ { type : 'element', start : 0, attributes : {  }, tag : 'div', end : 5, isBlock : false, children : [ { type : 'element', start : 5, attributes : { attribute : { start : 9, name : 'attribute', type : 'indirect', textReference : 'TiddlerTitle!!field', end : 43 } }, tag : 'div', end : 44, isBlock : false, children : [ { type : 'text', text : '\n!some heading' } ] } ] } ] } ]
 
 		);
+		// Regression test for issue (#3306)
+		expect(parse("<div><span><span>\n\nSome text</span></span></div>")).toEqual(
+
+			[ { type : 'element', tag : 'p', children : [ { type : 'element', start : 0, attributes : {  }, tag : 'div', end : 5, isBlock : false, children : [ { type : 'element', start : 5, attributes : {  }, tag : 'span', end : 11, isBlock : false, children : [ { type : 'element', start : 11, attributes : {  }, tag : 'span', end : 17, isBlock : true, children : [ { type : 'element', tag : 'p', children : [ { type : 'text', text : 'Some text' } ] } ] } ] } ] } ] } ]
+
+		);
 	});
 
 	it("should parse macro definitions", function() {


### PR DESCRIPTION
This bug kept biting me from time to time. After my work on macrocall rules, figured I'd fix this since I was in the neighborhood.

What was causing this was the html rule calling either parseBlocks or parseInlineRun. They were inconsistent about when they'd eat the run terminator.

* parseInlineRun never would, which is fine since the html rule eats it.
* parseBlock wouldn't if it downgraded to an inline rule, but it _would_ if it successfully parsed as a block. So the parseBlock and the html rule would both try to eat the run terminator. This was okay most of the time, since one of them would fail. Not in my use case where there happen to be two closing `</$set>` (or `</span>` in the test case)

So now parseInlineRun is passed `eatTerminator: true`, which means both parseInlineRun and parseBlock always eat it, so the html rule never has to. 