### PR TITLE
fix tiddler info area content bleeding on close animation

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -995,6 +995,7 @@ button.tc-btn-invisible.tc-remove-tag-button {
 {{$:/themes/tiddlywiki/vanilla/sticky}}
 
 .tc-tiddler-info {
+	overflow: hidden;
 	padding: 14px 42px 14px 42px;
 	background-color: <<colour tiddler-info-background>>;
 	border-top: 1px solid <<colour tiddler-info-border>>;


### PR DESCRIPTION
This is a fix for the following problem: 

 - Set https://tiddlywiki.com/#%24%3A%2Fconfig%2FAnimationDuration  to eg: 2400
 - Open the tiddler **More : Info area**
 - You can see, that the "info text" becomes visible while it is still part of the main text area
 - The same "info text" "bleeding" also happens, if you close the info-area

This PR fixes the problem

