### PR TITLE
Support upload saver without username/password

### DIFF
--- a/core/modules/savers/upload.js
+++ b/core/modules/savers/upload.js
@@ -28,10 +28,22 @@ UploadSaver.prototype.save = function(text,method,callback) {
 		password = $tw.utils.getPassword("upload"),
 		uploadDir = this.wiki.getTextReference("$:/UploadDir") || ".",
 		uploadFilename = this.wiki.getTextReference("$:/UploadFilename") || "index.html",
+		uploadWithUrlOnly = this.wiki.getTextReference("$:/UploadWithUrlOnly") || "no",
 		url = this.wiki.getTextReference("$:/UploadURL");
 	// Bail out if we don't have the bits we need
-	if(!username || username.toString().trim() === "" || !password || password.toString().trim() === "") {
-		return false;
+	if (uploadWithUrlOnly === "yes") {
+		// The url is good enough. No need for a username and password.
+		// Assume the server uses some other kind of auth mechanism.
+		if(!url || url.toString().trim() === "") {
+			return false;
+		}
+	}
+	else {
+		// Require username and password to be present.
+		// Assume the server uses the standard UploadPlugin username/password.
+		if(!username || username.toString().trim() === "" || !password || password.toString().trim() === "") {
+			return false;
+		}
 	}
 	// Construct the url if not provided
 	if(!url) {


### PR DESCRIPTION
The default behaviour is unchanged, but if you write "yes" to
$:/UploadWithUrlOnly then it will assume it's possible to upload
with a blank username and password, as long as the host is set.

The motivation is to support a upload plugin compatible upload
service that uses some method to authenticate other than the legacy
upload plugin user/password params.

Without this patch, the user would need to enter something random in
the user and password fields for TW to decide the upload plugin can
be used.