### PR TITLE
Add throttling for changed tiddlers prefixed with $:/volatile/

### DIFF
--- a/core/modules/startup/render.js
+++ b/core/modules/startup/render.js
@@ -82,7 +82,7 @@ exports.startup = function() {
 		var onlyThrottledTiddlersHaveChanged = true;
 		for(var title in changes) {
 			var tiddler = $tw.wiki.getTiddler(title);
-			if(!tiddler || !(tiddler.hasField("draft.of") || tiddler.hasField("throttle.refresh"))) {
+			if(!$tw.wiki.isVolatileTiddler(title) && (!tiddler || !(tiddler.hasField("draft.of") || tiddler.hasField("throttle.refresh")))) {
 				onlyThrottledTiddlersHaveChanged = false;
 			}
 		}

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -211,6 +211,10 @@ exports.isTemporaryTiddler = function(title) {
 	return title && title.indexOf("$:/temp/") === 0;
 };
 
+exports.isVolatileTiddler = function(title) {
+	return title && title.indexOf("$:/temp/volatile/") === 0;
+};
+
 exports.isImageTiddler = function(title) {
 	var tiddler = this.getTiddler(title);
 	if(tiddler) {		
@@ -1539,4 +1543,3 @@ exports.slugify = function(title,options) {
 };
 
 })();
-

--- a/editions/tw5.com/tiddlers/mechanisms/RefreshThrottling.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/RefreshThrottling.tid
@@ -1,5 +1,5 @@
 created: 20191013095916159
-modified: 20191014093837558
+modified: 20210203231820284
 tags: RefreshMechanism
 title: RefreshThrottling
 type: text/vnd.tiddlywiki
@@ -11,6 +11,7 @@ The rules governing refresh throttling are:
 * When a change notification occurs, throttling will only take place if all of the modified tiddlers meet at least one of these criteria:
 ** Has the field `draft.of`
 ** Has the field `throttle.refresh`
+** Has a title prefixed with `$:/temp/volatile/`
 * If the refresh cycle is to be throttled, a timer is set for the internal specified in [[$:/config/Drafts/TypingTimeout|Hidden Setting: Typing Refresh Delay]] (cancelling any preciously set timer)
 ** When the timer fires, the refresh cycle is triggered, passing the aggregated titles of all the deferred refresh cycles
 


### PR DESCRIPTION
TiddlyWiki already supports rendering throttling when changed tiddlers have
`throttle.refresh`. Ensuring that the edited tiddler has that field is not very
convenient in many situations.

I believe that throttling is a very effective optimization that could be used in more situations if it was more convenient to use.
This PR adds support for throttling render updates when editing a tiddler that is prefixed with `$:/volatile/`.

The original idea of using `$:/volatile/` was from @Jermolene (I can't find the reference anymore though).