### PR TITLE
All colour codes use 6 digits now

### DIFF
--- a/core/palettes/Blanca.tid
+++ b/core/palettes/Blanca.tid
@@ -23,7 +23,7 @@ dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
 dropdown-background: <<colour background>>
 dropdown-border: <<colour muted-foreground>>
-dropdown-tab-background-selected: #fff
+dropdown-tab-background-selected: #ffffff
 dropdown-tab-background: #ececec
 dropzone-background: rgba(0,200,0,0.7)
 external-link-background-hover: inherit
@@ -53,7 +53,7 @@ select-tag-background:
 select-tag-foreground:
 sidebar-button-foreground: <<colour foreground>>
 sidebar-controls-foreground-hover: #000000
-sidebar-controls-foreground: #ccc
+sidebar-controls-foreground: #cccccc
 sidebar-foreground-shadow: rgba(255,255,255, 0.8)
 sidebar-foreground: #acacac
 sidebar-muted-foreground-hover: #444444
@@ -80,7 +80,7 @@ table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
 tag-background: #ffeedd
-tag-foreground: #000
+tag-foreground: #000000
 tiddler-background: <<colour background>>
 tiddler-border: #eee
 tiddler-controls-foreground-hover: #888888

--- a/core/palettes/Blue.tid
+++ b/core/palettes/Blue.tid
@@ -8,7 +8,7 @@ alert-background: #ffe476
 alert-border: #b99e2f
 alert-highlight: #881122
 alert-muted-foreground: #b99e2f
-background: #fff
+background: #ffffff
 blockquote-bar: <<colour muted-foreground>>
 button-background:
 button-foreground:
@@ -23,7 +23,7 @@ dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
 dropdown-background: <<colour background>>
 dropdown-border: <<colour muted-foreground>>
-dropdown-tab-background-selected: #fff
+dropdown-tab-background-selected: #ffffff
 dropdown-tab-background: #ececec
 dropzone-background: rgba(0,200,0,0.7)
 external-link-background-hover: inherit
@@ -80,7 +80,7 @@ table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
 tag-background: #eeeeff
-tag-foreground: #000
+tag-foreground: #000000
 tiddler-background: <<colour background>>
 tiddler-border: <<colour background>>
 tiddler-controls-foreground-hover: #666666

--- a/core/palettes/BrightMute.tid
+++ b/core/palettes/BrightMute.tid
@@ -23,7 +23,7 @@ dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
 dropdown-background: <<colour background>>
 dropdown-border: <<colour muted-foreground>>
-dropdown-tab-background-selected: #fff
+dropdown-tab-background-selected: #ffffff
 dropdown-tab-background: #ececec
 dropzone-background: rgba(0,200,0,0.7)
 external-link-background-hover: inherit
@@ -42,7 +42,7 @@ modal-border: #999999
 modal-footer-background: #f5f5f5
 modal-footer-border: #dddddd
 modal-header-border: #eeeeee
-muted-foreground: #bbb
+muted-foreground: #bbbbbb
 notification-background: #ffffdd
 notification-border: #999999
 page-background: #6f6f70
@@ -60,11 +60,11 @@ sidebar-muted-foreground-hover: #444444
 sidebar-muted-foreground: #c0c0c0
 sidebar-tab-background-selected: #6f6f70
 sidebar-tab-background: #666667
-sidebar-tab-border-selected: #999
+sidebar-tab-border-selected: #999999
 sidebar-tab-border: #515151
-sidebar-tab-divider: #999
+sidebar-tab-divider: #999999
 sidebar-tab-foreground-selected: 
-sidebar-tab-foreground: #999
+sidebar-tab-foreground: #999999
 sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #d1d0d2
 site-title-foreground: <<colour tiddler-title-foreground>>
@@ -98,14 +98,14 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: #c0c0c0
 tiddler-title-foreground: #182955
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: #999999
 very-muted-foreground: #888888

--- a/core/palettes/ContrastDark.tid
+++ b/core/palettes/ContrastDark.tid
@@ -4,11 +4,11 @@ description: High contrast and unambiguous (light version)
 tags: $:/tags/Palette
 type: application/x-tiddler-dictionary
 
-alert-background: #f00
+alert-background: #ff0000
 alert-border: <<colour background>>
 alert-highlight: <<colour foreground>>
-alert-muted-foreground: #800
-background: #fff
+alert-muted-foreground: #880000
+background: #ffffff
 blockquote-bar: <<colour muted-foreground>>
 button-background: <<colour background>>
 button-foreground: <<colour foreground>>
@@ -16,8 +16,8 @@ button-border: <<colour foreground>>
 code-background: <<colour background>>
 code-border: <<colour foreground>>
 code-foreground: <<colour foreground>>
-dirty-indicator: #f00
-download-background: #080
+dirty-indicator: #ff0000
+download-background: #008800
 download-foreground: <<colour background>>
 dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
@@ -30,9 +30,9 @@ external-link-background-hover: inherit
 external-link-background-visited: inherit
 external-link-background: inherit
 external-link-foreground-hover: inherit
-external-link-foreground-visited: #00a
-external-link-foreground: #00e
-foreground: #000
+external-link-foreground-visited: #0000aa
+external-link-foreground: #0000ee
+foreground: #000000
 message-background: <<colour foreground>>
 message-border: <<colour background>>
 message-foreground: <<colour background>>
@@ -48,7 +48,7 @@ notification-border: <<colour foreground>>
 page-background: <<colour background>>
 pre-background: <<colour background>>
 pre-border: <<colour foreground>>
-primary: #00f
+primary: #0000ff
 select-tag-background:
 select-tag-foreground:
 sidebar-button-foreground: <<colour foreground>>
@@ -79,12 +79,12 @@ tab-foreground: <<colour background>>
 table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
-tag-background: #000
-tag-foreground: #fff
+tag-background: #000000
+tag-foreground: #ffffff
 tiddler-background: <<colour background>>
 tiddler-border: <<colour foreground>>
-tiddler-controls-foreground-hover: #ddd
-tiddler-controls-foreground-selected: #fdd
+tiddler-controls-foreground-hover: #dddddd
+tiddler-controls-foreground-selected: #ffdddd
 tiddler-controls-foreground: <<colour foreground>>
 tiddler-editor-background: <<colour background>>
 tiddler-editor-border-image: <<colour foreground>>
@@ -98,14 +98,14 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: <<colour foreground>>
 tiddler-title-foreground: <<colour foreground>>
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: <<colour foreground>>
 very-muted-foreground: #888888

--- a/core/palettes/ContrastLight.tid
+++ b/core/palettes/ContrastLight.tid
@@ -4,11 +4,11 @@ description: High contrast and unambiguous (dark version)
 tags: $:/tags/Palette
 type: application/x-tiddler-dictionary
 
-alert-background: #f00
+alert-background: #ff0000
 alert-border: <<colour background>>
 alert-highlight: <<colour foreground>>
-alert-muted-foreground: #800
-background: #000
+alert-muted-foreground: #880000
+background: #000000
 blockquote-bar: <<colour muted-foreground>>
 button-background: <<colour background>>
 button-foreground: <<colour foreground>>
@@ -16,8 +16,8 @@ button-border: <<colour foreground>>
 code-background: <<colour background>>
 code-border: <<colour foreground>>
 code-foreground: <<colour foreground>>
-dirty-indicator: #f00
-download-background: #080
+dirty-indicator: #ff0000
+download-background: #008800
 download-foreground: <<colour background>>
 dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
@@ -30,9 +30,9 @@ external-link-background-hover: inherit
 external-link-background-visited: inherit
 external-link-background: inherit
 external-link-foreground-hover: inherit
-external-link-foreground-visited: #00a
-external-link-foreground: #00e
-foreground: #fff
+external-link-foreground-visited: #0000aa
+external-link-foreground: #0000ee
+foreground: #ffffff
 message-background: <<colour foreground>>
 message-border: <<colour background>>
 message-foreground: <<colour background>>
@@ -48,7 +48,7 @@ notification-border: <<colour foreground>>
 page-background: <<colour background>>
 pre-background: <<colour background>>
 pre-border: <<colour foreground>>
-primary: #00f
+primary: #0000ff
 select-tag-background:
 select-tag-foreground:
 sidebar-button-foreground: <<colour foreground>>
@@ -79,12 +79,12 @@ tab-foreground: <<colour background>>
 table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
-tag-background: #fff
-tag-foreground: #000
+tag-background: #ffffff
+tag-foreground: #000000
 tiddler-background: <<colour background>>
 tiddler-border: <<colour foreground>>
-tiddler-controls-foreground-hover: #ddd
-tiddler-controls-foreground-selected: #fdd
+tiddler-controls-foreground-hover: #dddddd
+tiddler-controls-foreground-selected: #ffdddd
 tiddler-controls-foreground: <<colour foreground>>
 tiddler-editor-background: <<colour background>>
 tiddler-editor-border-image: <<colour foreground>>
@@ -98,14 +98,14 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: <<colour foreground>>
 tiddler-title-foreground: <<colour foreground>>
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: <<colour foreground>>
 very-muted-foreground: #888888

--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -98,15 +98,15 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: <<colour muted-foreground>>
 tiddler-title-foreground: #FFFFFF
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: <<colour very-muted-foreground>>
 very-muted-foreground: #464646
 selection-background: #3F638B

--- a/core/palettes/DarkPhotos.tid
+++ b/core/palettes/DarkPhotos.tid
@@ -12,9 +12,9 @@ alert-highlight: #881122
 alert-muted-foreground: #b99e2f
 background: #ffffff
 blockquote-bar: <<colour muted-foreground>>
-button-background: 
-button-foreground: 
-button-border: 
+button-background:
+button-foreground:
+button-border:
 code-background: #f7f7f9
 code-border: #e1e1e8
 code-foreground: #dd1144
@@ -25,7 +25,7 @@ dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
 dropdown-background: <<colour background>>
 dropdown-border: <<colour muted-foreground>>
-dropdown-tab-background-selected: #fff
+dropdown-tab-background-selected: #ffffff
 dropdown-tab-background: #ececec
 dropzone-background: rgba(0,200,0,0.7)
 external-link-background-hover: inherit
@@ -44,7 +44,7 @@ modal-border: #999999
 modal-footer-background: #f5f5f5
 modal-footer-border: #dddddd
 modal-header-border: #eeeeee
-muted-foreground: #ddd
+muted-foreground: #dddddd
 notification-background: #ffffdd
 notification-border: #999999
 page-background: #336438
@@ -81,7 +81,7 @@ tab-foreground: #666666
 table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
-tag-background: #ec6
+tag-background: #eecc66
 tag-foreground: #ffffff
 tiddler-background: <<colour background>>
 tiddler-border: <<colour background>>
@@ -100,14 +100,14 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: #c0c0c0
 tiddler-title-foreground: #182955
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: #999999
 very-muted-foreground: #888888

--- a/core/palettes/DesertSand.tid
+++ b/core/palettes/DesertSand.tid
@@ -16,11 +16,11 @@ code-border: #C3BAA1
 code-foreground: #ab3250
 diff-delete-background: #bd8b8b
 diff-delete-foreground: <<colour foreground>>
-diff-equal-background: 
+diff-equal-background:
 diff-equal-foreground: <<colour foreground>>
 diff-insert-background: #91c093
 diff-insert-foreground: <<colour foreground>>
-diff-invisible-background: 
+diff-invisible-background:
 diff-invisible-foreground: <<colour muted-foreground>>
 dirty-indicator: #ad3434
 download-background: #6ca16c
@@ -108,15 +108,15 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: #867F69
 tiddler-title-foreground: #374464
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: #8A8885
 very-muted-foreground: #CDC2A6
 wikilist-background: <<colour page-background>>

--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -17,11 +17,11 @@ code-border: #504945
 code-foreground: #fb4934
 diff-delete-background: #fb4934
 diff-delete-foreground: <<colour foreground>>
-diff-equal-background: 
+diff-equal-background:
 diff-equal-foreground: <<colour foreground>>
 diff-insert-background: #b8bb26
 diff-insert-foreground: <<colour foreground>>
-diff-invisible-background: 
+diff-invisible-background:
 diff-invisible-foreground: <<colour muted-foreground>>
 dirty-indicator: #fb4934
 download-background: #b8bb26
@@ -109,15 +109,15 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: #7c6f64
 tiddler-title-foreground: #a89984
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: #504945
 very-muted-foreground: #bdae93
 wikilist-background: <<colour page-background>>

--- a/core/palettes/Nord.tid
+++ b/core/palettes/Nord.tid
@@ -17,11 +17,11 @@ code-border: #2E3440
 code-foreground: #BF616A
 diff-delete-background: #BF616A
 diff-delete-foreground: <<colour foreground>>
-diff-equal-background: 
+diff-equal-background:
 diff-equal-foreground: <<colour foreground>>
 diff-insert-background: #A3BE8C
 diff-insert-foreground: <<colour foreground>>
-diff-invisible-background: 
+diff-invisible-background:
 diff-invisible-foreground: <<colour muted-foreground>>
 dirty-indicator: #BF616A
 download-background: #A3BE8C
@@ -94,7 +94,7 @@ tag-background: #A3BE8C
 tag-foreground: #4C566A
 tiddler-background: <<colour background>>
 tiddler-border: <<colour background>>
-tiddler-controls-foreground-hover: 
+tiddler-controls-foreground-hover:
 tiddler-controls-foreground-selected: #EBCB8B
 tiddler-controls-foreground: #4C566A
 tiddler-editor-background: #2e3440
@@ -109,15 +109,15 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: #4C566A
 tiddler-title-foreground: #81A1C1
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: #2d3038
 very-muted-foreground: #2d3038
 wikilist-background: <<colour page-background>>

--- a/core/palettes/Rocker.tid
+++ b/core/palettes/Rocker.tid
@@ -23,7 +23,7 @@ dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
 dropdown-background: <<colour background>>
 dropdown-border: <<colour muted-foreground>>
-dropdown-tab-background-selected: #fff
+dropdown-tab-background-selected: #ffffff
 dropdown-tab-background: #ececec
 dropzone-background: rgba(0,200,0,0.7)
 external-link-background-hover: inherit
@@ -45,7 +45,7 @@ modal-header-border: #eeeeee
 muted-foreground: #999999
 notification-background: #ffffdd
 notification-border: #999999
-page-background: #000
+page-background: #000000
 pre-background: #f5f5f5
 pre-border: #cccccc
 primary: #cc0000
@@ -58,7 +58,7 @@ sidebar-foreground-shadow: rgba(255,255,255, 0.0)
 sidebar-foreground: #acacac
 sidebar-muted-foreground-hover: #444444
 sidebar-muted-foreground: #c0c0c0
-sidebar-tab-background-selected: #000
+sidebar-tab-background-selected: #000000
 sidebar-tab-background: <<colour tab-background>>
 sidebar-tab-border-selected: <<colour tab-border-selected>>
 sidebar-tab-border: <<colour tab-border>>
@@ -80,7 +80,7 @@ table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
 tag-background: #ffbb99
-tag-foreground: #000
+tag-foreground: #000000
 tiddler-background: <<colour background>>
 tiddler-border: <<colour background>>
 tiddler-controls-foreground-hover: #888888

--- a/core/palettes/SpartanDay.tid
+++ b/core/palettes/SpartanDay.tid
@@ -15,7 +15,7 @@ button-foreground: inherit
 button-border: <<colour tag-background>>
 code-background: #ececec
 code-border: #ececec
-code-foreground: 
+code-foreground:
 dirty-indicator: #c80000
 download-background: <<colour primary>>
 download-foreground: <<colour background>>
@@ -31,7 +31,7 @@ external-link-background-visited: transparent
 external-link-background: transparent
 external-link-foreground-hover: 
 external-link-foreground-visited: 
-external-link-foreground: 
+external-link-foreground:
 foreground: rgba(0, 0, 0, 0.87)
 message-background: <<colour background>>
 message-border: <<colour very-muted-foreground>>
@@ -98,14 +98,14 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: <<colour muted-foreground>>
 tiddler-title-foreground: #000000
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: <<colour very-muted-foreground>>
 very-muted-foreground: rgba(0, 0, 0, 0.12)

--- a/core/palettes/SpartanNight.tid
+++ b/core/palettes/SpartanNight.tid
@@ -98,14 +98,14 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: <<colour muted-foreground>>
 tiddler-title-foreground: #FFFFFF
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: <<colour very-muted-foreground>>
 very-muted-foreground: rgba(255, 255, 255, 0.12)

--- a/core/palettes/Twilight.tid
+++ b/core/palettes/Twilight.tid
@@ -107,14 +107,14 @@ tiddler-link-background: rgb(38, 38, 38)
 tiddler-link-foreground: rgb(204, 204, 255)
 tiddler-subtitle-foreground: rgb(255, 255, 255)
 tiddler-title-foreground: rgb(255, 192, 76)
-toolbar-cancel-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-done-button: 
-toolbar-edit-button: 
-toolbar-info-button: 
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
+toolbar-cancel-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-done-button:
+toolbar-edit-button:
+toolbar-info-button:
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
 untagged-background: rgb(255, 255, 255)
 very-muted-foreground: rgba(240, 196, 117, 0.7)

--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -18,11 +18,11 @@ code-border: #e1e1e8
 code-foreground: #dd1144
 diff-delete-background: #ffc9c9
 diff-delete-foreground: <<colour foreground>>
-diff-equal-background: 
+diff-equal-background:
 diff-equal-foreground: <<colour foreground>>
 diff-insert-background: #aaefad
 diff-insert-foreground: <<colour foreground>>
-diff-invisible-background: 
+diff-invisible-background:
 diff-invisible-foreground: <<colour muted-foreground>>
 dirty-indicator: #ff0000
 download-background: #34c734
@@ -31,7 +31,7 @@ dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
 dropdown-background: <<colour background>>
 dropdown-border: <<colour muted-foreground>>
-dropdown-tab-background-selected: #fff
+dropdown-tab-background-selected: #ffffff
 dropdown-tab-background: #ececec
 dropzone-background: rgba(0,200,0,0.7)
 external-link-background-hover: inherit
@@ -50,7 +50,7 @@ modal-border: #999999
 modal-footer-background: #f5f5f5
 modal-footer-border: #dddddd
 modal-header-border: #eeeeee
-muted-foreground: #bbb
+muted-foreground: #bbbbbb
 notification-background: #ffffdd
 notification-border: #999999
 page-background: #f4f4f4
@@ -89,7 +89,7 @@ tab-foreground: #666666
 table-border: #dddddd
 table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
-tag-background: #ec6
+tag-background: #eecc66
 tag-foreground: #ffffff
 tiddler-background: <<colour background>>
 tiddler-border: <<colour background>>
@@ -120,19 +120,19 @@ toolbar-done-button:
 untagged-background: #999999
 very-muted-foreground: #888888
 wikilist-background: #e5e5e5
-wikilist-item: #fff
-wikilist-info: #000
-wikilist-title: #666
+wikilist-item: #ffffff
+wikilist-info: #000000
+wikilist-title: #666666
 wikilist-title-svg: <<colour wikilist-title>>
-wikilist-url: #aaa
+wikilist-url: #aaaaaa
 wikilist-button-open: #4fb82b
-wikilist-button-open-hover: green
+wikilist-button-open-hover: #008000
 wikilist-button-reveal: #5778d8
-wikilist-button-reveal-hover: blue
+wikilist-button-reveal-hover: #0000ff
 wikilist-button-remove: #d85778
-wikilist-button-remove-hover: red
+wikilist-button-remove-hover: #ff0000
 wikilist-toolbar-background: #d3d3d3
-wikilist-toolbar-foreground: #888
+wikilist-toolbar-foreground: #888888
 wikilist-droplink-dragover: rgba(255,192,192,0.5)
 wikilist-button-background: #acacac
-wikilist-button-foreground: #000
+wikilist-button-foreground: #000000

--- a/plugins/tiddlywiki/translators/palette.tid
+++ b/plugins/tiddlywiki/translators/palette.tid
@@ -20,7 +20,7 @@ dragger-background: <<colour foreground>>
 dragger-foreground: <<colour background>>
 dropdown-background: <<colour background>>
 dropdown-border: <<colour muted-foreground>>
-dropdown-tab-background-selected: #fff
+dropdown-tab-background-selected: #ffffff
 dropdown-tab-background: #ececec
 dropzone-background: rgba(0,200,0,0.7)
 external-link-background-hover: inherit
@@ -39,7 +39,7 @@ modal-border: #999999
 modal-footer-background: #f5f5f5
 modal-footer-border: #dddddd
 modal-header-border: #eeeeee
-muted-foreground: #bbb
+muted-foreground: #bbbbbb
 notification-background: #ffffdd
 notification-border: #999999
 page-background: #b9ceb8
@@ -92,14 +92,14 @@ tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: #c0c0c0
 tiddler-title-foreground: #182955
-toolbar-new-button: 
-toolbar-options-button: 
-toolbar-save-button: 
-toolbar-info-button: 
-toolbar-edit-button: 
-toolbar-close-button: 
-toolbar-delete-button: 
-toolbar-cancel-button: 
-toolbar-done-button: 
+toolbar-new-button:
+toolbar-options-button:
+toolbar-save-button:
+toolbar-info-button:
+toolbar-edit-button:
+toolbar-close-button:
+toolbar-delete-button:
+toolbar-cancel-button:
+toolbar-done-button:
 untagged-background: #999999
 very-muted-foreground: #888888


### PR DESCRIPTION
While working on the $:/PaletteManager I did stumble upon this problem again. 

Does not work

![grafik](https://user-images.githubusercontent.com/374655/188934135-3c2aa9d5-b60d-4487-a832-6dfa30f02686.png)

Would work ... I know that this PR is only a partial fix, but it is a baby step in the right direction and the PR already changes 16 files. So the chance to get it merged with 16 more is close to 0. 

![grafik](https://user-images.githubusercontent.com/374655/188934335-227f07e7-30ac-4412-a0a7-5ee0541c938f.png)


<details><summary> Initial text for this PR </summary>
This PR is important for consistency reasons, to make it possible to create CSS settings as follows. 

To test the PR copy the following content to tiddlywiki.com and to your localhost, to see the difference!

```
<style>
.test-3 {
  background: <<colour "tag-background">>4;  /* this is the inconsistency that should be fixed */
}

.test-6 {
  background: <<colour "tag-background">>40;  /* it should always be possible like this */
}

.test-x {
  background: #eecc6640;
}

.test-full {
  background: #eecc66;
}
</style>

<div class="test-3">test text - works but is inconsistent</div>

<div class="test-6">test text - background color ''fails'' atm but should work</div>

<div class="test-x">test text - transparant background</div>

<div class="test-full">test text - full background</div>
```
</details>