### PR TITLE
add possibility to import system tiddlers and allow the import list to be filtered

### DIFF
--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -18,10 +18,12 @@ Listing/Rename/Prompt: Rename to:
 Listing/Rename/ConfirmRename: Rename tiddler
 Listing/Rename/CancelRename: Cancel
 Listing/Rename/OverwriteWarning: A tiddler with this title already exists.
+Listing/Filter/Prompt: Filter Titles:
+Listing/Filtered/Hint: ''This list is filtered!''
 Upgrader/Plugins/Suppressed/Incompatible: Blocked incompatible or obsolete plugin.
 Upgrader/Plugins/Suppressed/Version: Blocked plugin (due to incoming <<incoming>> not being newer than existing <<existing>>).
 Upgrader/Plugins/Upgraded: Upgraded plugin from <<incoming>> to <<upgraded>>.
-Upgrader/State/Suppressed: Blocked temporary state tiddler.
+Upgrader/System/Disabled: Disabled system tiddler.
 Upgrader/System/Suppressed: Blocked system tiddler.
 Upgrader/System/Warning: Core module tiddler.
 Upgrader/System/Alert: You are about to import a tiddler that will overwrite a core module tiddler. This is not recommended as it may make the system unstable.

--- a/core/modules/upgraders/system.js
+++ b/core/modules/upgraders/system.js
@@ -12,8 +12,8 @@ Upgrader module that suppresses certain system tiddlers that shouldn't be import
 /*global $tw: false */
 "use strict";
 
-var DONT_IMPORT_LIST = ["$:/StoryList","$:/HistoryList"],
-	DONT_IMPORT_PREFIX_LIST = ["$:/temp/","$:/state/","$:/Import"],
+var DONT_IMPORT_LIST = ["$:/core","$:/Import"],
+	DISABLE_SYSTEM_LIST = ["$:/temp/","$:/state/","$:/StoryList","$:/HistoryList"],
 	WARN_IMPORT_PREFIX_LIST = ["$:/core/modules/"];
 
 exports.upgrade = function(wiki,titles,tiddlers) {
@@ -26,11 +26,10 @@ exports.upgrade = function(wiki,titles,tiddlers) {
 			tiddlers[title] = Object.create(null);
 			messages[title] = $tw.language.getString("Import/Upgrader/System/Suppressed");
 		} else {
-			for(var t=0; t<DONT_IMPORT_PREFIX_LIST.length; t++) {
-				var prefix = DONT_IMPORT_PREFIX_LIST[t];
+			for(var t=0; t<DISABLE_SYSTEM_LIST.length; t++) {
+				var prefix = DISABLE_SYSTEM_LIST[t];
 				if(title.substr(0,prefix.length) === prefix) {
-					tiddlers[title] = Object.create(null);
-					messages[title] = $tw.language.getString("Import/Upgrader/State/Suppressed");
+					messages[title] = $tw.language.getString("Import/Upgrader/System/Disabled");
 				}
 			}
 			for(var t=0; t<WARN_IMPORT_PREFIX_LIST.length; t++) {

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -523,7 +523,7 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	// Give the active upgrader modules a chance to process the incoming tiddlers
 	var messages = this.wiki.invokeUpgraders(incomingTiddlers,importData.tiddlers);
 	// Deselect any disabled, but _not_ suppressed tiddlers
-	var	systemMessage = $tw.language.getString("Import/Upgrader/System/Disabled");
+	var systemMessage = $tw.language.getString("Import/Upgrader/System/Disabled");
 	$tw.utils.each(messages,function(message,title) {
 		newFields["message-" + title] = message;
 		if (message === systemMessage) {

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -522,10 +522,15 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	});
 	// Give the active upgrader modules a chance to process the incoming tiddlers
 	var messages = this.wiki.invokeUpgraders(incomingTiddlers,importData.tiddlers);
+	// Deselect any disabled, but _not_ suppressed tiddlers
+	var	systemMessage = $tw.language.getString("Import/Upgrader/System/Disabled");
 	$tw.utils.each(messages,function(message,title) {
 		newFields["message-" + title] = message;
+		if (message === systemMessage) {
+			newFields["selection-" + title] = "unchecked";
+		}
 	});
-	// Deselect any suppressed tiddlers
+	// Deselect suppressed tiddlers ... they have been removed and can't be selected anymore
 	$tw.utils.each(importData.tiddlers,function(tiddler,title) {
 		if($tw.utils.count(tiddler) === 0) {
 			newFields["selection-" + title] = "unchecked";

--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -1,5 +1,7 @@
 title: $:/core/ui/ImportListing
 
+\whitespace trim
+
 \define lingo-base() $:/language/Import/
 
 \define messageField() message-$(payloadTiddler)$
@@ -33,61 +35,74 @@ title: $:/core/ui/ImportListing
 <table class="tc-import-table">
 <tbody>
 <tr>
-<th align="left">
-<$checkbox tiddler="$:/state/import/select-all" field="text" checked="checked" unchecked="unchecked" default="checked" actions=<<select-all-actions>>>
-<<lingo Listing/Select/Caption>>
-</$checkbox>
-</th>
-<th>
-<<lingo Listing/Title/Caption>>
-</th>
-<th>
-<<lingo Listing/Status/Caption>>
-</th>
+	<th align="left">
+		<$checkbox tiddler="$:/state/import/select-all" field="text" checked="checked" unchecked="unchecked" default="checked" actions=<<select-all-actions>> >
+			<span class="tc-small-gap-left"><<lingo Listing/Select/Caption>></span>
+		</$checkbox>
+	</th>
+	<th>
+		<<lingo Listing/Title/Caption>>
+	</th>
+	<th>
+		<<lingo Listing/Status/Caption>>
+	</th>
 </tr>
 <$list filter="[all[current]plugintiddlers[]sort[title]] +[search:title{$:/temp/import-search}]" variable="payloadTiddler">
 <tr class={{{[<currentTiddler>has<suppressedField>then[tc-row-disabled]] ~[subfilter<payloadTitleFilter>is[tiddler]then[tc-row-warning]] }}}>
-<td>
-<$checkbox field=<<selectionField>> checked="checked" unchecked="unchecked" default="checked" disabled={{{[<currentTiddler>has<suppressedField>then[yes]else[no]]}}}/>
-</td>
-<td>
-<$reveal type="nomatch" state=<<renameFieldState>> text="yes" tag="div">
-<$reveal type="nomatch" state=<<previewPopupState>> text="yes" tag="div" class="tc-flex">
-<$button class="tc-btn-invisible tc-btn-dropdown tc-flex-grow-1 tc-word-break" set=<<previewPopupState>> setTo="yes" disabled={{{[<currentTiddler>has<suppressedField>then[yes]else[no]]}}}>
-<span class="tc-small-gap-right">{{$:/core/images/right-arrow}}</span><$text text={{{[subfilter<payloadTitleFilter>]}}}/>
-</$button>
-<$list filter="[<currentTiddler>!has<suppressedField>]"><$button class="tc-btn-invisible" set=<<renameFieldState>> setTo="yes" tooltip={{{[<lingo-base>addsuffix[Listing/Rename/Tooltip]get[text]]}}}>{{$:/core/images/edit-button}}</$button></$list>
-</$reveal>
-<$reveal type="match" state=<<previewPopupState>> text="yes" tag="div">
-<$button class="tc-btn-invisible tc-btn-dropdown" set=<<previewPopupState>> setTo="no">
-<span class="tc-small-gap-right">{{$:/core/images/down-arrow}}</span><$text text={{{[subfilter<payloadTitleFilter>]}}}/>
-</$button>
-</$reveal>
-</$reveal>
-<$reveal type="match" state=<<renameFieldState>> text="yes" tag="div">
-<$text text={{{[<lingo-base>addsuffix[Listing/Rename/Prompt]get[text]]}}}/>
-</$reveal>
-</td>
-<td>
-<$view field=<<messageField>>/>
-<<overWriteWarning>>
-</td>
+	<td>
+		<$checkbox field=<<selectionField>> checked="checked" unchecked="unchecked" default="checked" disabled={{{[<currentTiddler>has<suppressedField>then[yes]else[no]]}}}/>
+	</td>
+	<td>
+		<$reveal type="nomatch" state=<<renameFieldState>> text="yes" tag="div">
+			<$reveal type="nomatch" state=<<previewPopupState>> text="yes" tag="div" class="tc-flex">
+			<$button class="tc-btn-invisible tc-btn-dropdown tc-flex-grow-1 tc-word-break" set=<<previewPopupState>> setTo="yes" disabled={{{[<currentTiddler>has<suppressedField>then[yes]else[no]]}}}>
+				<span class="tc-small-gap-right">{{$:/core/images/right-arrow}}</span><$text text={{{[subfilter<payloadTitleFilter>]}}}/>
+			</$button>
+			<$list filter="[<currentTiddler>!has<suppressedField>]">
+				<$button class="tc-btn-invisible" set=<<renameFieldState>> setTo="yes" tooltip={{{[<lingo-base>addsuffix[Listing/Rename/Tooltip]get[text]]}}}>{{$:/core/images/edit-button}}</$button>
+			</$list>
+			</$reveal>
+			<$reveal type="match" state=<<previewPopupState>> text="yes" tag="div">
+				<$button class="tc-btn-invisible tc-btn-dropdown" set=<<previewPopupState>> setTo="no">
+					<span class="tc-small-gap-right">{{$:/core/images/down-arrow}}</span><$text text={{{[subfilter<payloadTitleFilter>]}}}/>
+				</$button>
+			</$reveal>
+		</$reveal>
+		<$reveal type="match" state=<<renameFieldState>> text="yes" tag="div">
+			<$text text={{{[<lingo-base>addsuffix[Listing/Rename/Prompt]get[text]]}}}/>
+		</$reveal>
+	</td>
+	<td>
+		<$view field=<<messageField>>/>
+		<<overWriteWarning>>
+	</td>
 </tr>
 <$reveal type="match" state=<<renameFieldState>> text="yes" tag="tr">
-<td colspan="3">
-<div class="tc-flex">
-<$edit-text tiddler=<<newImportTitleTiddler>>  default={{{[subfilter<payloadTitleFilter>]}}} tag="input" class="tc-import-rename tc-flex-grow-1"/><span class="tc-small-gap-left"><$button  class="tc-btn-invisible" set=<<renameFieldState>> setTo="no" tooltip={{{[<lingo-base>addsuffix[Listing/Rename/CancelRename]get[text]]}}}>{{$:/core/images/close-button}}<$action-deletetiddler $tiddler=<<newImportTitleTiddler>>/></$button><span class="tc-small-gap-right"/></span><$button  class="tc-btn-invisible" set=<<renameFieldState>> setTo="no" tooltip={{{[<lingo-base>addsuffix[Listing/Rename/ConfirmRename]get[text]]}}}>{{$:/core/images/done-button}}<$action-setfield $field=<<renameField>> $value={{{[<newImportTitleTiddler>get[text]minlength[1]else<payloadTiddler>]}}} /><$action-deletetiddler $tiddler=<<newImportTitleTiddler>>/></$button>
-</div>
-</td>
+	<td colspan="3">
+		<div class="tc-flex">
+			<$edit-text tiddler=<<newImportTitleTiddler>>  default={{{[subfilter<payloadTitleFilter>]}}} tag="input" class="tc-import-rename tc-flex-grow-1"/>
+			<span class="tc-small-gap-left">
+				<$button  class="tc-btn-invisible" set=<<renameFieldState>> setTo="no" tooltip={{{[<lingo-base>addsuffix[Listing/Rename/CancelRename]get[text]]}}}>
+					{{$:/core/images/close-button}}<$action-deletetiddler $tiddler=<<newImportTitleTiddler>>/>
+				</$button>
+			</span>
+			<span class="tc-small-gap-right"/></span>
+			<$button class="tc-btn-invisible" set=<<renameFieldState>> setTo="no" tooltip={{{[<lingo-base>addsuffix[Listing/Rename/ConfirmRename]get[text]]}}}>
+				{{$:/core/images/done-button}}
+				<$action-setfield $field=<<renameField>> $value={{{[<newImportTitleTiddler>get[text]minlength[1]else<payloadTiddler>]}}} />
+				<$action-deletetiddler $tiddler=<<newImportTitleTiddler>>/>
+			</$button>
+		</div>
+	</td>
 </$reveal>
 <tr>
-<td colspan="3">
-<$reveal type="match" text="yes" state=<<previewPopupState>> tag="div">
-<$list filter="[{$:/state/importpreviewtype}has[text]]" variable="listItem" emptyMessage={{$:/core/ui/ImportPreviews/Text}}>
-<$transclude tiddler={{$:/state/importpreviewtype}}/>
-</$list>
-</$reveal>
-</td>
+	<td colspan="3">
+		<$reveal type="match" text="yes" state=<<previewPopupState>> tag="div">
+			<$list filter="[{$:/state/importpreviewtype}has[text]]" variable="listItem" emptyMessage={{$:/core/ui/ImportPreviews/Text}}>
+				<$transclude tiddler={{$:/state/importpreviewtype}}/>
+			</$list>
+		</$reveal>
+	</td>
 </tr>
 </$list>
 </tbody>

--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -25,7 +25,7 @@ title: $:/core/ui/ImportListing
 \define renameFieldState() $(currentTiddler)$!!state-rename-$(payloadTiddler)$
 
 \define select-all-actions()
-<$list filter="[all[current]plugintiddlers[]sort[title]]" variable="payloadTiddler">
+<$list filter="[all[current]plugintiddlers[]sort[title]] +[search:title{$:/temp/import-search}]" variable="payloadTiddler">
 <$action-setfield $field={{{ [<payloadTiddler>addprefix[selection-]] }}} $value={{$:/state/import/select-all}}/>
 </$list>
 \end
@@ -45,7 +45,7 @@ title: $:/core/ui/ImportListing
 <<lingo Listing/Status/Caption>>
 </th>
 </tr>
-<$list filter="[all[current]plugintiddlers[]sort[title]]" variable="payloadTiddler">
+<$list filter="[all[current]plugintiddlers[]sort[title]] +[search:title{$:/temp/import-search}]" variable="payloadTiddler">
 <tr class={{{[<currentTiddler>has<suppressedField>then[tc-row-disabled]] ~[subfilter<payloadTitleFilter>is[tiddler]then[tc-row-warning]] }}}>
 <td>
 <$checkbox field=<<selectionField>> checked="checked" unchecked="unchecked" default="checked" disabled={{{[<currentTiddler>has<suppressedField>then[yes]else[no]]}}}/>

--- a/core/ui/ViewTemplate/import.tid
+++ b/core/ui/ViewTemplate/import.tid
@@ -1,6 +1,7 @@
 title: $:/core/ui/ViewTemplate/import
 tags: $:/tags/ViewTemplate
 
+\whitespace trim
 \define lingo-base() $:/language/Import/
 \define import-search() $:/temp/import-search
 \define clearSearch() 
@@ -9,15 +10,21 @@ tags: $:/tags/ViewTemplate
 \define buttons()
 <$button message="tm-delete-tiddler" param=<<currentTiddler>> actions=<<clearSearch>>><<lingo Listing/Cancel/Caption>></$button>
 <$button message="tm-perform-import" param=<<currentTiddler>> actions=<<clearSearch>>><<lingo Listing/Import/Caption>></$button>
-<<lingo Listing/Preview>> <$select tiddler="$:/state/importpreviewtype" default="$:/core/ui/ImportPreviews/Text">
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/ImportPreview]!has[draft.of]]">
-<option value=<<currentTiddler>>>{{!!caption}}</option>
-</$list>
+\end
+\define topBar()
+\whitespace trim
+<<lingo Listing/Preview>> <$select tiddler="$:/state/importpreviewtype" default="$:/core/ui/ImportPreviews/Text" class="tc-small-gap">
+	<$list filter="[all[shadows+tiddlers]tag[$:/tags/ImportPreview]!has[draft.of]]">
+		<option value=<<currentTiddler>>>{{!!caption}}</option>
+	</$list>
 </$select>
-<<lingo Listing/Filter/Prompt>> <$edit-text tiddler=<<import-search>> field="text" tag="input" default=""/> <$reveal state=<<import-search>> type="nomatch" text=""><$button class="tc-btn-invisible">
-<$action-setfield $tiddler=<<import-search>> $field=text $value=""/>
-{{$:/core/images/close-button}}
-</$button>
+<<lingo Listing/Filter/Prompt>>
+<$edit-text tiddler=<<import-search>> field="text" tag="input" default="" class="tc-small-gap-left"/>
+<$reveal state=<<import-search>> type="nomatch" text="" class="tc-small-gap-left">
+	<$button class="tc-btn-invisible">
+		<$action-setfield $tiddler=<<import-search>> $field=text $value=""/>
+		{{$:/core/images/close-button}}
+	</$button>
 </$reveal>
 \end
 
@@ -27,7 +34,7 @@ tags: $:/tags/ViewTemplate
 
 <<lingo Listing/Hint>>
 
-<<buttons>>
+<<topBar>>
 
 <$reveal state=<<import-search>> type="nomatch" text="">
 <<lingo Listing/Filtered/Hint>>

--- a/core/ui/ViewTemplate/import.tid
+++ b/core/ui/ViewTemplate/import.tid
@@ -2,15 +2,23 @@ title: $:/core/ui/ViewTemplate/import
 tags: $:/tags/ViewTemplate
 
 \define lingo-base() $:/language/Import/
-
+\define import-search() $:/temp/import-search
+\define clearSearch() 
+<$action-deletetiddler $tiddler=<<import-search>>/>
+\end
 \define buttons()
-<$button message="tm-delete-tiddler" param=<<currentTiddler>>><<lingo Listing/Cancel/Caption>></$button>
-<$button message="tm-perform-import" param=<<currentTiddler>>><<lingo Listing/Import/Caption>></$button>
+<$button message="tm-delete-tiddler" param=<<currentTiddler>> actions=<<clearSearch>>><<lingo Listing/Cancel/Caption>></$button>
+<$button message="tm-perform-import" param=<<currentTiddler>> actions=<<clearSearch>>><<lingo Listing/Import/Caption>></$button>
 <<lingo Listing/Preview>> <$select tiddler="$:/state/importpreviewtype" default="$:/core/ui/ImportPreviews/Text">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ImportPreview]!has[draft.of]]">
 <option value=<<currentTiddler>>>{{!!caption}}</option>
 </$list>
 </$select>
+<<lingo Listing/Filter/Prompt>> <$edit-text tiddler=<<import-search>> field="text" tag="input" default=""/> <$reveal state=<<import-search>> type="nomatch" text=""><$button class="tc-btn-invisible">
+<$action-setfield $tiddler=<<import-search>> $field=text $value=""/>
+{{$:/core/images/close-button}}
+</$button>
+</$reveal>
 \end
 
 <$list filter="[all[current]field:plugin-type[import]]">
@@ -21,7 +29,15 @@ tags: $:/tags/ViewTemplate
 
 <<buttons>>
 
+<$reveal state=<<import-search>> type="nomatch" text="">
+<<lingo Listing/Filtered/Hint>>
+</$reveal>
+
 {{||$:/core/ui/ImportListing}}
+
+<$reveal state=<<import-search>> type="nomatch" text="">
+<<lingo Listing/Filtered/Hint>>
+</$reveal>
 
 <<buttons>>
 


### PR DESCRIPTION
# This PR does the following: 

 - Allows the user to re-activate "disabled" elements
 - Allows the user to filter the list. That's handy if you want to use the "select all" button
    - "select all" will only handle visible elements
 - If the list is filtered a hint will be shown
 - If a filtered list is shown **every selected** element will be imported. Even if it is invisible
 - $:/StoryList and $:/HistoryList are "prefixes" now. 
 - Every system tiddler is default **unchecked**
 - $:/core and $:/Import are blocked

![grafik](https://user-images.githubusercontent.com/374655/106879646-b37b3800-66db-11eb-85ec-56f5999c71ec.png)

# Filtered list

![grafik](https://user-images.githubusercontent.com/374655/106880116-487e3100-66dc-11eb-93cc-5b12912c62f7.png)


# Version 5.1.23

![grafik](https://user-images.githubusercontent.com/374655/106879701-c7269e80-66db-11eb-9e1c-51147872f36a.png)
