### PR TITLE
rename to-be-defined methods in Story

### DIFF
--- a/core/modules/story.js
+++ b/core/modules/story.js
@@ -100,35 +100,35 @@ Story.prototype.addToHistory = function(navigateTo,navigateFromClientRect) {
 	this.wiki.setTiddlerData(this.historyTitle,historyList,{"current-tiddler": titles[titles.length-1]});
 };
 
-Story.prototype.storyCloseTiddler = function(targetTitle) {
+Story.prototype.closeTiddler = function(targetTitle) {
 // TBD
 };
 
-Story.prototype.storyCloseAllTiddlers = function() {
+Story.prototype.closeAllTiddler = function() {
 // TBD
 };
 
-Story.prototype.storyCloseOtherTiddlers = function(targetTitle) {
+Story.prototype.CloseOtherTiddlers = function(targetTitle) {
 // TBD
 };
 
-Story.prototype.storyEditTiddler = function(targetTitle) {
+Story.prototype.EditTiddler = function(targetTitle) {
 // TBD
 };
 
-Story.prototype.storyDeleteTiddler = function(targetTitle) {
+Story.prototype.DeleteTiddler = function(targetTitle) {
 // TBD
 };
 
-Story.prototype.storySaveTiddler = function(targetTitle) {
+Story.prototype.SaveTiddler = function(targetTitle) {
 // TBD
 };
 
-Story.prototype.storyCancelTiddler = function(targetTitle) {
+Story.prototype.CancelTiddler = function(targetTitle) {
 // TBD
 };
 
-Story.prototype.storyNewTiddler = function(targetTitle) {
+Story.prototype.NewTiddler = function(targetTitle) {
 // TBD
 };
 


### PR DESCRIPTION
Having 'story' appended in front of all method names seem unnecessary- they are methods in Story class!

Also, do you still intend to move story manipulation to Story class, instead of NavigatorWidget? I've noticed that the code is 6 years old, and while I'd be willing to move the methods over, I wasn't sure of your intentions.