### PR TITLE
allow us to import formerly blocked system tiddlers

### DIFF
--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -21,7 +21,7 @@ Listing/Rename/OverwriteWarning: A tiddler with this title already exists.
 Upgrader/Plugins/Suppressed/Incompatible: Blocked incompatible or obsolete plugin.
 Upgrader/Plugins/Suppressed/Version: Blocked plugin (due to incoming <<incoming>> not being newer than existing <<existing>>).
 Upgrader/Plugins/Upgraded: Upgraded plugin from <<incoming>> to <<upgraded>>.
-Upgrader/System/Disabled: Disabled system tiddler.
+Upgrader/Disabled/Tiddler: Disabled tiddler.
 Upgrader/System/Suppressed: Blocked system tiddler.
 Upgrader/System/Warning: Core module tiddler.
 Upgrader/System/Alert: You are about to import a tiddler that will overwrite a core module tiddler. This is not recommended as it may make the system unstable.

--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -21,6 +21,7 @@ Listing/Rename/OverwriteWarning: A tiddler with this title already exists.
 Upgrader/Plugins/Suppressed/Incompatible: Blocked incompatible or obsolete plugin.
 Upgrader/Plugins/Suppressed/Version: Blocked plugin (due to incoming <<incoming>> not being newer than existing <<existing>>).
 Upgrader/Plugins/Upgraded: Upgraded plugin from <<incoming>> to <<upgraded>>.
+Upgrader/State/Suppressed: Blocked temporary state tiddler.
 Upgrader/System/Disabled: Disabled system tiddler.
 Upgrader/System/Suppressed: Blocked system tiddler.
 Upgrader/System/Warning: Core module tiddler.

--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -21,8 +21,11 @@ Listing/Rename/OverwriteWarning: A tiddler with this title already exists.
 Upgrader/Plugins/Suppressed/Incompatible: Blocked incompatible or obsolete plugin.
 Upgrader/Plugins/Suppressed/Version: Blocked plugin (due to incoming <<incoming>> not being newer than existing <<existing>>).
 Upgrader/Plugins/Upgraded: Upgraded plugin from <<incoming>> to <<upgraded>>.
-Upgrader/Disabled/Tiddler: Disabled tiddler.
+Upgrader/System/Disabled: Disabled system tiddler.
 Upgrader/System/Suppressed: Blocked system tiddler.
 Upgrader/System/Warning: Core module tiddler.
 Upgrader/System/Alert: You are about to import a tiddler that will overwrite a core module tiddler. This is not recommended as it may make the system unstable.
 Upgrader/ThemeTweaks/Created: Migrated theme tweak from <$text text=<<from>>/>.
+Upgrader/Tiddler/Disabled: Disabled tiddler.
+Upgrader/Tiddler/Selected: User re-selected.
+Upgrader/Tiddler/Unselected: Unselected tiddler.

--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -28,5 +28,5 @@ Upgrader/System/Warning: Core module tiddler.
 Upgrader/System/Alert: You are about to import a tiddler that will overwrite a core module tiddler. This is not recommended as it may make the system unstable.
 Upgrader/ThemeTweaks/Created: Migrated theme tweak from <$text text=<<from>>/>.
 Upgrader/Tiddler/Disabled: Disabled tiddler.
-Upgrader/Tiddler/Selected: User re-selected.
+Upgrader/Tiddler/Selected: User selected.
 Upgrader/Tiddler/Unselected: Unselected tiddler.

--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -21,7 +21,7 @@ Listing/Rename/OverwriteWarning: A tiddler with this title already exists.
 Upgrader/Plugins/Suppressed/Incompatible: Blocked incompatible or obsolete plugin.
 Upgrader/Plugins/Suppressed/Version: Blocked plugin (due to incoming <<incoming>> not being newer than existing <<existing>>).
 Upgrader/Plugins/Upgraded: Upgraded plugin from <<incoming>> to <<upgraded>>.
-Upgrader/State/Suppressed: Blocked temporary state tiddler.
+Upgrader/System/Disabled: Disabled system tiddler.
 Upgrader/System/Suppressed: Blocked system tiddler.
 Upgrader/System/Warning: Core module tiddler.
 Upgrader/System/Alert: You are about to import a tiddler that will overwrite a core module tiddler. This is not recommended as it may make the system unstable.

--- a/core/modules/upgraders/system.js
+++ b/core/modules/upgraders/system.js
@@ -13,7 +13,7 @@ Upgrader module that suppresses certain system tiddlers that shouldn't be import
 "use strict";
 
 var DONT_IMPORT_LIST = ["$:/Import"],
-	DISABLE_PREFIX_LIST = ["$:/temp/","$:/state/","$:/StoryList","$:/HistoryList"],
+	UNSELECT_PREFIX_LIST = ["$:/temp/","$:/state/","$:/StoryList","$:/HistoryList"],
 	WARN_IMPORT_PREFIX_LIST = ["$:/core/modules/"];
 
 exports.upgrade = function(wiki,titles,tiddlers) {
@@ -26,10 +26,10 @@ exports.upgrade = function(wiki,titles,tiddlers) {
 			tiddlers[title] = Object.create(null);
 			messages[title] = $tw.language.getString("Import/Upgrader/System/Suppressed");
 		} else {
-			for(var t=0; t<DISABLE_PREFIX_LIST.length; t++) {
-				var prefix = DISABLE_PREFIX_LIST[t];
+			for(var t=0; t<UNSELECT_PREFIX_LIST.length; t++) {
+				var prefix = UNSELECT_PREFIX_LIST[t];
 				if(title.substr(0,prefix.length) === prefix) {
-					messages[title] = $tw.language.getString("Import/Upgrader/Disabled/Tiddler");
+					messages[title] = $tw.language.getString("Import/Upgrader/Tiddler/Unselected");
 				}
 			}
 			for(var t=0; t<WARN_IMPORT_PREFIX_LIST.length; t++) {

--- a/core/modules/upgraders/system.js
+++ b/core/modules/upgraders/system.js
@@ -13,7 +13,7 @@ Upgrader module that suppresses certain system tiddlers that shouldn't be import
 "use strict";
 
 var DONT_IMPORT_LIST = ["$:/core","$:/Import"],
-	DISABLE_SYSTEM_LIST = ["$:/temp/","$:/state/","$:/StoryList","$:/HistoryList"],
+	DISABLE_PREFIX_LIST = ["$:/temp/","$:/state/","$:/StoryList","$:/HistoryList"],
 	WARN_IMPORT_PREFIX_LIST = ["$:/core/modules/"];
 
 exports.upgrade = function(wiki,titles,tiddlers) {
@@ -26,8 +26,8 @@ exports.upgrade = function(wiki,titles,tiddlers) {
 			tiddlers[title] = Object.create(null);
 			messages[title] = $tw.language.getString("Import/Upgrader/System/Suppressed");
 		} else {
-			for(var t=0; t<DISABLE_SYSTEM_LIST.length; t++) {
-				var prefix = DISABLE_SYSTEM_LIST[t];
+			for(var t=0; t<DISABLE_PREFIX_LIST.length; t++) {
+				var prefix = DISABLE_PREFIX_LIST[t];
 				if(title.substr(0,prefix.length) === prefix) {
 					messages[title] = $tw.language.getString("Import/Upgrader/System/Disabled");
 				}

--- a/core/modules/upgraders/system.js
+++ b/core/modules/upgraders/system.js
@@ -12,7 +12,7 @@ Upgrader module that suppresses certain system tiddlers that shouldn't be import
 /*global $tw: false */
 "use strict";
 
-var DONT_IMPORT_LIST = ["$:/core","$:/Import"],
+var DONT_IMPORT_LIST = ["$:/Import"],
 	DISABLE_PREFIX_LIST = ["$:/temp/","$:/state/","$:/StoryList","$:/HistoryList"],
 	WARN_IMPORT_PREFIX_LIST = ["$:/core/modules/"];
 

--- a/core/modules/upgraders/system.js
+++ b/core/modules/upgraders/system.js
@@ -29,7 +29,7 @@ exports.upgrade = function(wiki,titles,tiddlers) {
 			for(var t=0; t<DISABLE_PREFIX_LIST.length; t++) {
 				var prefix = DISABLE_PREFIX_LIST[t];
 				if(title.substr(0,prefix.length) === prefix) {
-					messages[title] = $tw.language.getString("Import/Upgrader/System/Disabled");
+					messages[title] = $tw.language.getString("Import/Upgrader/Disabled/Tiddler");
 				}
 			}
 			for(var t=0; t<WARN_IMPORT_PREFIX_LIST.length; t++) {

--- a/core/modules/upgraders/system.js
+++ b/core/modules/upgraders/system.js
@@ -12,8 +12,8 @@ Upgrader module that suppresses certain system tiddlers that shouldn't be import
 /*global $tw: false */
 "use strict";
 
-var DONT_IMPORT_LIST = ["$:/StoryList","$:/HistoryList"],
-	DONT_IMPORT_PREFIX_LIST = ["$:/temp/","$:/state/","$:/Import"],
+var DONT_IMPORT_LIST = ["$:/core","$:/Import"],
+	DISABLE_SYSTEM_LIST = ["$:/temp/","$:/state/","$:/StoryList","$:/HistoryList"],
 	WARN_IMPORT_PREFIX_LIST = ["$:/core/modules/"];
 
 exports.upgrade = function(wiki,titles,tiddlers) {
@@ -26,11 +26,10 @@ exports.upgrade = function(wiki,titles,tiddlers) {
 			tiddlers[title] = Object.create(null);
 			messages[title] = $tw.language.getString("Import/Upgrader/System/Suppressed");
 		} else {
-			for(var t=0; t<DONT_IMPORT_PREFIX_LIST.length; t++) {
-				var prefix = DONT_IMPORT_PREFIX_LIST[t];
+			for(var t=0; t<DISABLE_SYSTEM_LIST.length; t++) {
+				var prefix = DISABLE_SYSTEM_LIST[t];
 				if(title.substr(0,prefix.length) === prefix) {
-					tiddlers[title] = Object.create(null);
-					messages[title] = $tw.language.getString("Import/Upgrader/State/Suppressed");
+					messages[title] = $tw.language.getString("Import/Upgrader/System/Disabled");
 				}
 			}
 			for(var t=0; t<WARN_IMPORT_PREFIX_LIST.length; t++) {

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -523,7 +523,7 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	// Give the active upgrader modules a chance to process the incoming tiddlers
 	var messages = this.wiki.invokeUpgraders(incomingTiddlers,importData.tiddlers);
 	// Deselect any disabled, but _not_ suppressed tiddlers
-	var systemMessage = $tw.language.getString("Import/Upgrader/System/Disabled");
+	var systemMessage = $tw.language.getString("Import/Upgrader/Disabled/Tiddler");
 	$tw.utils.each(messages,function(message,title) {
 		newFields["message-" + title] = message;
 		if (message.indexOf(systemMessage) !== -1) {

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -523,7 +523,7 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	// Give the active upgrader modules a chance to process the incoming tiddlers
 	var messages = this.wiki.invokeUpgraders(incomingTiddlers,importData.tiddlers);
 	// Deselect any disabled, but _not_ suppressed tiddlers
-	var systemMessage = $tw.language.getString("Import/Upgrader/Disabled/Tiddler");
+	var systemMessage = $tw.language.getString("Import/Upgrader/Tiddler/Unselected");
 	$tw.utils.each(messages,function(message,title) {
 		newFields["message-" + title] = message;
 		if (message.indexOf(systemMessage) !== -1) {

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -526,7 +526,7 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	var systemMessage = $tw.language.getString("Import/Upgrader/System/Disabled");
 	$tw.utils.each(messages,function(message,title) {
 		newFields["message-" + title] = message;
-		if (message === systemMessage) {
+		if (message.indexOf(systemMessage) !== -1) {
 			newFields["selection-" + title] = "unchecked";
 		}
 	});

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -522,10 +522,15 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	});
 	// Give the active upgrader modules a chance to process the incoming tiddlers
 	var messages = this.wiki.invokeUpgraders(incomingTiddlers,importData.tiddlers);
+	// Deselect any disabled, but _not_ suppressed tiddlers
+	var systemMessage = $tw.language.getString("Import/Upgrader/System/Disabled");
 	$tw.utils.each(messages,function(message,title) {
 		newFields["message-" + title] = message;
+		if (message === systemMessage) {
+			newFields["selection-" + title] = "unchecked";
+		}
 	});
-	// Deselect any suppressed tiddlers
+	// Deselect suppressed tiddlers ... they have been removed and can't be selected anymore
 	$tw.utils.each(importData.tiddlers,function(tiddler,title) {
 		if($tw.utils.count(tiddler) === 0) {
 			newFields["selection-" + title] = "unchecked";

--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -12,6 +12,15 @@ title: $:/core/ui/ImportListing
 </$list>
 \end
 
+\define selectionInfo()
+\whitespace trim
+<$set name="escUnselected" value={{{[{$:/language/Import/Upgrader/Tiddler/Unselected}escaperegexp[]addprefix[(?g)]]}}}>
+	<$list filter="[all[current]get<messageField>regexp<escUnselected>]" variable="ignore">
+		<$text text={{{[all[current]get<selectionField>match[checked]then{$:/language/Import/Upgrader/Tiddler/Selected}else[]]}}}/>
+	</$list>
+</$set>
+\end
+
 \define selectionField() selection-$(payloadTiddler)$
 
 \define renameField() rename-$(payloadTiddler)$
@@ -69,7 +78,8 @@ title: $:/core/ui/ImportListing
 </$reveal>
 </td>
 <td>
-<$view field=<<messageField>>/>
+<!-- $view field=<<messageField>>/ -->
+<<selectionInfo>>
 <<overWriteWarning>>
 </td>
 </tr>

--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -78,7 +78,6 @@ title: $:/core/ui/ImportListing
 </$reveal>
 </td>
 <td>
-<!-- $view field=<<messageField>>/ -->
 <<selectionInfo>>
 <<overWriteWarning>>
 </td>

--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -21,6 +21,15 @@ title: $:/core/ui/ImportListing
 </$set>
 \end
 
+\define libraryInfo()
+\whitespace trim
+<$set name="escUnselected" value={{{[{$:/language/Import/Upgrader/Tiddler/Unselected}escaperegexp[]addprefix[(?g)]]}}}>
+	<$list filter="[all[current]get<messageField>!regexp<escUnselected>]" variable="ignore">
+		<$text text={{{[all[current]get<messageField>]}}}/>
+	</$list>
+</$set>
+\end
+
 \define selectionField() selection-$(payloadTiddler)$
 
 \define renameField() rename-$(payloadTiddler)$
@@ -79,6 +88,7 @@ title: $:/core/ui/ImportListing
 </td>
 <td>
 <<selectionInfo>>
+<<libraryInfo>>
 <<overWriteWarning>>
 </td>
 </tr>


### PR DESCRIPTION
# This PR does the following: 

 - Allows the user to re-activate "disabled" elements
 - `$:/StoryList` and `$:/HistoryList` are "prefixes" now. 
 - Every tiddler, that is part of the `UNSELECT_PREFIX_LIST` is default **unchecked**
 -  `$:/Import` is blocked

With TW 5.1.23 the "listed" tiddlers are completely removed from the import-tiddler. So they can't be reactivated anymore. The new import mechanism only disables them, so they can be activated if needed. 

# New Import tiddler

See:  https://github.com/Jermolene/TiddlyWiki5/pull/5479#issuecomment-847388102