### PR TITLE
Fixed super minor issue with import pragma

### DIFF
--- a/core/modules/parsers/wikiparser/rules/import.js
+++ b/core/modules/parsers/wikiparser/rules/import.js
@@ -36,7 +36,7 @@ exports.parse = function() {
 	// Move past the pragma invocation
 	this.parser.pos = this.matchRegExp.lastIndex;
 	// Parse the filter terminated by a line break
-	var reMatch = /(.*)(\r?\n)|$/mg;
+	var reMatch = /(.*)(?:$|\r?\n)/mg;
 	reMatch.lastIndex = this.parser.pos;
 	var match = reMatch.exec(this.parser.source);
 	this.parser.pos = reMatch.lastIndex;

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -585,6 +585,19 @@ describe("Widget module", function() {
 		expect(wrapper.innerHTML).toBe("<p>Don't forget me.</p>");
 	});
 
+	/** Special case. \import should parse correctly, even if it's
+	 *  the only line in the tiddler. Technically doesn't cause a
+	 *  visual difference, but may affect plugins if it doesn't.
+	 */
+	it("should work when import pragma is standalone", function() {
+		var wiki = new $tw.Wiki();
+		var text = "\\import [prefix[XXX]]";
+		var parseTreeNode = parseText(text,wiki);
+		// Test the resulting parse tree node, since there is no
+		// rendering which may expose a problem.
+		expect(parseTreeNode.children[0].attributes.filter.value).toBe('[prefix[XXX]]');
+	});
+
 	/** This test reproduces issue #4504.
 	 *
 	 * The importvariable widget was creating redundant copies into


### PR DESCRIPTION
When import pragma is alone in a text body...

```
\import something
```

...with no newline following it, then the filter doesn't get added to the parseTreeNode. I realize that this bug doesn't cause any issues for end users, but it may cause trouble for some plugins (*cough* Relink).