### PR TITLE
Fix #5537

### DIFF
--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -48,14 +48,21 @@ function Server(options) {
 	// Initialize Gzip compression
 	this.enableGzip = this.get("gzip") === "yes";
 	// Initialise authorization
-	var authorizedUserName = (this.get("username") && this.get("password")) ? this.get("username") : "(anon)";
+	var authorizedUserName;
+	if(this.get("username") && this.get("password")) {
+		authorizedUserName = this.get("username");
+	} else if(this.get("credentials")) {
+		authorizedUserName = "(authenticated)";
+	} else {
+		authorizedUserName = "(anon)";
+	}
 	this.authorizationPrincipals = {
 		readers: (this.get("readers") || authorizedUserName).split(",").map($tw.utils.trim),
 		writers: (this.get("writers") || authorizedUserName).split(",").map($tw.utils.trim)
 	}
 	// Load and initialise authenticators
 	$tw.modules.forEachModuleOfType("authenticator", function(title,authenticatorDefinition) {
-		// console.log("Loading server route " + title);
+		// console.log("Loading authenticator " + title);
 		self.addAuthenticator(authenticatorDefinition.AuthenticatorClass);
 	});
 	// Load route handlers


### PR DESCRIPTION
This PR implements the fix(es) proposed in issue #5537. For now, the most basic fix is simply to use `(authenticated)` as the default authorized username when only a credentials file is present.

If it seems appropriate, I can give a shot at adding a "role" (reader/writer) to the CSV credentials file. Please do not hesitate to suggest better approach as you see fit.