### PR TITLE
fix $tw.wiki.search options.invert init problem

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1242,7 +1242,7 @@ exports.search = function(text,options) {
 	var results = [],
 		source = options.source || this.each;
 	source(function(tiddler,title) {
-		if(searchTiddler(title) !== options.invert) {
+		if(searchTiddler(title) !== invert) {
 			results.push(title);
 		}
 	});


### PR DESCRIPTION
In line 1125 the `invert = !!options.invert;` variable is initialized. BUT it was never used. 

If the function is called from a plugin and `options.invert` is **missing** it is `undefined` which causes a problem with the search results. see line 1245

This PR fixes the problem because it uses the `invert` variable