### PR TITLE
ViewSwitcher: use Button widget instead of LinkWidget

### DIFF
--- a/core/wiki/viewswitcher.tid
+++ b/core/wiki/viewswitcher.tid
@@ -7,7 +7,7 @@ $:/core/images/storyview-$(storyview)$
 <div class="tc-chooser tc-viewswitcher">
 <$list filter="[storyviews[]]" variable="storyview">
 <$set name="cls" filter="[<storyview>prefix{$:/view}]" value="tc-chooser-item tc-chosen" emptyValue="tc-chooser-item"><div class=<<cls>>>
-<$link to=<<storyview>>><$transclude tiddler=<<icon>>/><$text text=<<storyview>>/></$link>
+<$button tag="a" class="tc-tiddlylink tc-btn-invisible" to=<<storyview>>><$transclude tiddler=<<icon>>/><$text text=<<storyview>>/></$button>
 </div>
 </$set>
 </$list>


### PR DESCRIPTION
Fixes #5566 

Ran into this issue today. If missing links are disabled the switcher does not work since there are no corresponding tiddlers for each story view name. Using a `button` widget instead of a `link` widget resolves this.

@tiddlytweeter and @pmario an extra set of eyes to look this over would be appreciated.