### PR TITLE
Merge Client Tweak page into Control Panel

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -27,6 +27,12 @@ Basics/Tiddlers/Prompt: Number of tiddlers
 Basics/Title/Prompt: Title of this ~TiddlyWiki
 Basics/Username/Prompt: Username for signing edits
 Basics/Version/Prompt: ~TiddlyWiki version
+Client/Caption: Client Tweaks
+Client/Hint: Here you can customize the appearance of your client.
+Client/Tiddloid/Caption: Tiddloid
+Client/Tiddloid/Hint: These settings apply to the Tiddloid client.
+Client/Tiddloid/ApplyTheme/Description: Apply theme color to system bars
+Client/Tiddloid/HideToolbar/Description: Hide toolbar on loading complete
 EditorTypes/Caption: Editor Types
 EditorTypes/Editor/Caption: Editor
 EditorTypes/Hint: These tiddlers determine which editor is used to edit specific tiddler types.

--- a/core/ui/ControlPanel/Client.tid
+++ b/core/ui/ControlPanel/Client.tid
@@ -1,0 +1,9 @@
+caption: {{$:/language/ControlPanel/Client/Caption}}
+tags: $:/tags/ControlPanel/Appearance
+title: $:/core/ui/ControlPanel/Client
+
+\define lingo-base() $:/language/ControlPanel/Client/
+
+<<lingo Hint>>
+
+<<tabs "[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Appearance/Client]!has[draft.of]]">>

--- a/core/ui/ControlPanel/Client/Tiddloid.tid
+++ b/core/ui/ControlPanel/Client/Tiddloid.tid
@@ -1,0 +1,11 @@
+caption: {{$:/language/ControlPanel/Client/Tiddloid/Caption}}
+tags: $:/tags/ControlPanel/Appearance/Client
+title: $:/core/ui/ControlPanel/Client/Tiddloid
+
+\define lingo-base() $:/language/ControlPanel/Client/Tiddloid/
+
+<<lingo Hint>>
+
+<$checkbox tiddler="$:/config/Tiddloid/HideToolbar" field="text" checked="yes" unchecked="no" default="no"> <<lingo HideToolbar/Description>> </$checkbox>
+
+<$checkbox tiddler="$:/config/Tiddloid/ApplyTheme" field="text" checked="yes" unchecked="no" default="no"> <<lingo ApplyTheme/Description>> </$checkbox>

--- a/languages/de-DE/ControlPanel.multids
+++ b/languages/de-DE/ControlPanel.multids
@@ -25,6 +25,12 @@ Basics/Tiddlers/Prompt: Anzahl Tiddler
 Basics/Title/Prompt: Titel dieses ~TiddlyWikis
 Basics/Username/Prompt: Benutzersignatur zum Editieren
 Basics/Version/Prompt: ~TiddlyWiki Version
+Client/Caption: Client-Optimierungen
+Client/Hint: Hier können Sie das Erscheinungsbild Ihres Kunden anpassen.
+Client/Tiddloid/Caption: Tiddloid
+Client/Tiddloid/Hint: Diese Einstellungen gelten für den Tiddloid-Client.
+Client/Tiddloid/ApplyTheme/Description: Wenden Sie die Themenfarbe auf die Systemleisten an
+Client/Tiddloid/HideToolbar/Description: Ausblenden Symbolleiste auf der Ladevorgang abgeschlossen
 EditorTypes/Caption: Editor Typen
 EditorTypes/Editor/Caption: Editor
 EditorTypes/Hint: Diese Tiddler definieren, welcher Editor für bestimmte Tiddler Typen (MIME-Type) verwendet werden soll.

--- a/languages/es-ES/ControlPanel.multids
+++ b/languages/es-ES/ControlPanel.multids
@@ -21,6 +21,12 @@ Basics/Tiddlers/Prompt: Número de tiddlers
 Basics/Title/Prompt: Título de este ~TiddlyWiki:
 Basics/Username/Prompt: Nombre de usuario
 Basics/Version/Prompt: Versión de ~TiddlyWiki
+Client/Caption: Ajustes del cliente
+Client/Hint: Aquí puede personalizar la apariencia de su cliente.
+Client/Tiddloid/Caption: Tiddloid
+Client/Tiddloid/Hint: Esta configuración se aplica al cliente Tiddloid.
+Client/Tiddloid/ApplyTheme/Description: Aplicar el color del tema a las barras del sistema
+Client/Tiddloid/HideToolbar/Description: Ocultar barra de herramientas al completar la carga
 EditorTypes/Caption: Tipos de editor
 EditorTypes/Editor/Caption: Editor
 EditorTypes/Hint: Editores usados para ciertos tipos específicos de tiddler

--- a/languages/fr-FR/ControlPanel.multids
+++ b/languages/fr-FR/ControlPanel.multids
@@ -25,6 +25,12 @@ Basics/Tiddlers/Prompt: Nombre de tiddlers :
 Basics/Title/Prompt: Titre de ce ~TiddlyWiki :
 Basics/Username/Prompt: Signer les modifications avec ce nom d'utilisateur :
 Basics/Version/Prompt: Version de ~TiddlyWiki :
+Client/Caption: Ajustements du client
+Client/Hint: Ici, vous pouvez personnaliser l'apparence de votre client.
+Client/Tiddloid/Caption: Tiddloid
+Client/Tiddloid/Hint: Ces paramètres s'appliquent au client Tiddloid.
+Client/Tiddloid/ApplyTheme/Description: Appliquer la couleur du thème aux barres système
+Client/Tiddloid/HideToolbar/Description: Masquer la barre d'outils une fois le chargement terminé
 EditorTypes/Caption: Types d'éditeur
 EditorTypes/Editor/Caption: Éditeur
 EditorTypes/Hint: Ces tiddlers déterminent l'éditeur à utiliser pour éditer tel ou tel type de tiddler.

--- a/languages/ja-JP/ControlPanel.multids
+++ b/languages/ja-JP/ControlPanel.multids
@@ -21,6 +21,12 @@ Basics/Tiddlers/Prompt: tiddler 数:
 Basics/Title/Prompt: この ~TiddlyWiki のタイトル:
 Basics/Username/Prompt: 編集者として表示するユーザ名:
 Basics/Version/Prompt: ~TiddlyWiki バージョン:
+Client/Caption: クライアントの調整
+Client/Hint: ここでは、クライアントの外観をカスタマイズできます。
+Client/Tiddloid/Caption: Tiddloid
+Client/Tiddloid/Hint: これらの設定はTiddloidクライアントに適用されます。
+Client/Tiddloid/ApplyTheme/Description: システムバーにテーマカラーを適用する
+Client/Tiddloid/HideToolbar/Description: 読み込み完了時にツールバーを非表示
 EditorTypes/Caption: エディタ
 EditorTypes/Editor/Caption: エディタ
 EditorTypes/Hint: tiddlerの種類と、それを編集するエディタの関係です。

--- a/languages/ko-KR/ControlPanel.multids
+++ b/languages/ko-KR/ControlPanel.multids
@@ -21,6 +21,12 @@ Basics/Tiddlers/Prompt: 티들러 수:
 Basics/Title/Prompt: 이 티들리위키의 제목:
 Basics/Username/Prompt: 편집에 서명하기 위한 사용자 이름:
 Basics/Version/Prompt: 티들리위키 버전:
+Client/Caption: 클라이언트 비틀기
+Client/Hint: 여기에서 클라이언트의 모양을 사용자 지정할 수 있습니다.
+Client/Tiddloid/Caption: Tiddloid
+Client/Tiddloid/Hint: 이러한 설정은 Tiddloid 클라이언트에 적용됩니다.
+Client/Tiddloid/ApplyTheme/Description: 시스템 표시 줄에 테마 색상 적용
+Client/Tiddloid/HideToolbar/Description: 로딩 완료시 툴바 숨기기
 EditorTypes/Caption: 편집기 형식
 EditorTypes/Editor/Caption: 편집기
 EditorTypes/Hint: 이 티들러는 특정 티들러 형식을 편집하는 데 사용하는 편집기를 결정합니다.

--- a/languages/zh-Hans/ControlPanel.multids
+++ b/languages/zh-Hans/ControlPanel.multids
@@ -27,6 +27,12 @@ Basics/Tiddlers/Prompt: 一般条目数量
 Basics/Title/Prompt: 标题
 Basics/Username/Prompt: 编辑者署名
 Basics/Version/Prompt: ~TiddlyWiki 版本
+Client/Caption: 客户端设置
+Client/Hint: 设置客户端程序的外观。
+Client/Tiddloid/Caption: Tiddloid
+Client/Tiddloid/Hint: 这此设置适用于Android Tiddloid客户端。
+Client/Tiddloid/ApplyTheme/Description: 应用主题色到系统栏
+Client/Tiddloid/HideToolbar/Description: 加载完成后隐藏标题栏
 EditorTypes/Caption: 编辑器类型
 EditorTypes/Editor/Caption: 编辑器
 EditorTypes/Hint: 这些条目决定使用哪个编辑器来编辑特定条目类型。

--- a/languages/zh-Hant/ControlPanel.multids
+++ b/languages/zh-Hant/ControlPanel.multids
@@ -27,6 +27,12 @@ Basics/Tiddlers/Prompt: 一般條目數量
 Basics/Title/Prompt: 標題
 Basics/Username/Prompt: 編輯者署名
 Basics/Version/Prompt: ~TiddlyWiki 版本
+Client/Caption: 客戶端調整
+Client/Hint: 您可以在此處自定義客戶端的外觀。
+Client/Tiddloid/Caption: Tiddloid
+Client/Tiddloid/Hint: 這些設置適用於Tiddloid客戶端。
+Client/Tiddloid/ApplyTheme/Description: 將主題顏色應用於系統欄
+Client/Tiddloid/HideToolbar/Description: 加載完成後隱藏工具欄
 EditorTypes/Caption: 編輯器類型
 EditorTypes/Editor/Caption: 編輯器
 EditorTypes/Hint: 這些條目決定使用哪個編輯器來編輯特定條目類型。


### PR DESCRIPTION
Once I saw [this issue](https://github.com/donmor/TiddloidLite/issues/6) and decided to make new versions of Tiddloid/Lite. To make configurations easy, I created this PR for a tweak page in Control Panel, and now a wiki that properly configured looks like this:
![Screenshot_1617682448](https://user-images.githubusercontent.com/29735136/113657945-a4ac0400-96d1-11eb-9e6e-39ffee4f9f2d.png)
![Screenshot_1617682555](https://user-images.githubusercontent.com/29735136/113658703-18024580-96d3-11eb-93e7-6eeb9daf0e4e.png)


