### PR TITLE
Extend Dropzone widget

### DIFF
--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -114,12 +114,11 @@ DropZoneWidget.prototype.handleDragEndEvent = function(event) {
 
 DropZoneWidget.prototype.filterByMimeTypes = function(tiddlerFieldsArray) {
 	var filteredTypes,
-		filtered =[],
+		filtered = [],
 		types = [];
 	$tw.utils.each(tiddlerFieldsArray,function(tiddlerFields) {
 		types.push(tiddlerFields.type);
 	});
-
 	filteredTypes = this.wiki.filterTiddlers(this.mimeTypesFilter,this,this.wiki.makeTiddlerIterator(types));
 	$tw.utils.each(tiddlerFieldsArray,function(tiddlerFields) {
 		if(filteredTypes.indexOf(tiddlerFields.type) !== -1) {

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -114,6 +114,9 @@ DropZoneWidget.prototype.handleDropEvent  = function(event) {
 	var self = this,
 		readFileCallback = function(tiddlerFieldsArray) {
 			self.dispatchEvent({type: "tm-import-tiddlers", param: JSON.stringify(tiddlerFieldsArray), autoOpenOnImport: self.autoOpenOnImport, importTitle: self.importTitle});
+			if(self.actions) {
+				self.invokeActionString(self.actions,self,event,{importTitle: self.importTitle});
+			}
 		};
 	this.leaveDrag(event);
 	// Check for being over a TEXTAREA or INPUT
@@ -150,6 +153,9 @@ DropZoneWidget.prototype.handlePasteEvent  = function(event) {
 	var self = this,
 		readFileCallback = function(tiddlerFieldsArray) {
 			self.dispatchEvent({type: "tm-import-tiddlers", param: JSON.stringify(tiddlerFieldsArray), autoOpenOnImport: self.autoOpenOnImport, importTitle: self.importTitle});
+			if(self.actions) {
+				self.invokeActionString(self.actions,self,event,{importTitle: self.importTitle});
+			}
 		};
 	// Let the browser handle it if we're in a textarea or input box
 	if(["TEXTAREA","INPUT"].indexOf(event.target.tagName) == -1 && !event.target.isContentEditable) {
@@ -194,7 +200,8 @@ DropZoneWidget.prototype.execute = function() {
 	this.dropzoneDeserializer = this.getAttribute("deserializer");
 	this.dropzoneEnable = (this.getAttribute("enable") || "yes") === "yes";
 	this.autoOpenOnImport = this.getAttribute("autoOpenOnImport");
-	this.importTitle = this.getAttribute("importTitle");
+	this.importTitle = this.getAttribute("importTitle","$:/Import");
+	this.actions = this.getAttribute("actions");
 	// Make child widgets
 	this.makeChildWidgets();
 };

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -112,14 +112,14 @@ DropZoneWidget.prototype.handleDragEndEvent = function(event) {
 	$tw.utils.removeClass(this.domNodes[0],"tc-dragover");
 };
 
-DropZoneWidget.prototype.filterByMimeTypes = function(tiddlerFieldsArray) {
+DropZoneWidget.prototype.filterByContentTypes = function(tiddlerFieldsArray) {
 	var filteredTypes,
 		filtered = [],
 		types = [];
 	$tw.utils.each(tiddlerFieldsArray,function(tiddlerFields) {
 		types.push(tiddlerFields.type);
 	});
-	filteredTypes = this.wiki.filterTiddlers(this.mimeTypesFilter,this,this.wiki.makeTiddlerIterator(types));
+	filteredTypes = this.wiki.filterTiddlers(this.contentTypesFilter,this,this.wiki.makeTiddlerIterator(types));
 	$tw.utils.each(tiddlerFieldsArray,function(tiddlerFields) {
 		if(filteredTypes.indexOf(tiddlerFields.type) !== -1) {
 			filtered.push(tiddlerFields);
@@ -129,8 +129,8 @@ DropZoneWidget.prototype.filterByMimeTypes = function(tiddlerFieldsArray) {
 };
 
 DropZoneWidget.prototype.readFileCallback = function(tiddlerFieldsArray) {
-	if(this.mimeTypesFilter) {
-		tiddlerFieldsArray = this.filterByMimeTypes(tiddlerFieldsArray);
+	if(this.contentTypesFilter) {
+		tiddlerFieldsArray = this.filterByContentTypes(tiddlerFieldsArray);
 	}
 	if(tiddlerFieldsArray.length) {
 		this.dispatchEvent({type: "tm-import-tiddlers", param: JSON.stringify(tiddlerFieldsArray), autoOpenOnImport: this.autoOpenOnImport, importTitle: this.importTitle});
@@ -226,7 +226,7 @@ DropZoneWidget.prototype.execute = function() {
 	this.autoOpenOnImport = this.getAttribute("autoOpenOnImport");
 	this.importTitle = this.getAttribute("importTitle",IMPORT_TITLE);
 	this.actions = this.getAttribute("actions");
-	this.mimeTypesFilter = this.getAttribute("mimeTypesFilter");
+	this.contentTypesFilter = this.getAttribute("contentTypesFilter");
 	// Make child widgets
 	this.makeChildWidgets();
 };

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -113,28 +113,24 @@ DropZoneWidget.prototype.handleDragEndEvent = function(event) {
 };
 
 DropZoneWidget.prototype.filterByMimeTypes = function(tiddlerFieldsArray) {
-	var filterFn,
-		filtered = [],
-		self = this,
-		checkMimeType = function(mimeType) {
-			return (self.mimeTypes.indexOf(mimeType) !== -1);
-		},
-		checkMimeTypePrefix = function(mimeType) {
-			return (mimeType.indexOf(self.mimeTypesPrefix) === 0);
-		};
+	var filteredTypes,
+		filtered =[],
+		types = [];
+	$tw.utils.each(tiddlerFieldsArray,function(tiddlerFields) {
+		types.push(tiddlerFields.type);
+	});
 
-	filterFn = this.mimeTypes.length ? checkMimeType : checkMimeTypePrefix;
-
-	for(var i=0; i<tiddlerFieldsArray.length; i++) {
-		if(filterFn(tiddlerFieldsArray[i].type)) {
-			filtered.push(tiddlerFieldsArray[i]);
+	filteredTypes = this.wiki.filterTiddlers(this.mimeTypesFilter,this,this.wiki.makeTiddlerIterator(types));
+	$tw.utils.each(tiddlerFieldsArray,function(tiddlerFields) {
+		if(filteredTypes.indexOf(tiddlerFields.type) !== -1) {
+			filtered.push(tiddlerFields);
 		}
-	}
+	});
 	return filtered;
 };
 
 DropZoneWidget.prototype.readFileCallback = function(tiddlerFieldsArray) {
-	if(this.mimeTypes.length || this.mimeTypesPrefix) {
+	if(this.mimeTypesFilter) {
 		tiddlerFieldsArray = this.filterByMimeTypes(tiddlerFieldsArray);
 	}
 	if(tiddlerFieldsArray.length) {
@@ -231,9 +227,7 @@ DropZoneWidget.prototype.execute = function() {
 	this.autoOpenOnImport = this.getAttribute("autoOpenOnImport");
 	this.importTitle = this.getAttribute("importTitle",IMPORT_TITLE);
 	this.actions = this.getAttribute("actions");
-	var mimeTypes = this.getAttribute("mimeTypes");
-	this.mimeTypes = mimeTypes ? mimeTypes.split(" ") : [];
-	this.mimeTypesPrefix = this.getAttribute("mimeTypesPrefix");
+	this.mimeTypesFilter = this.getAttribute("mimeTypesFilter");
 	// Make child widgets
 	this.makeChildWidgets();
 };

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -237,7 +237,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 DropZoneWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.enable || changedAttributes.autoOpenOnImport || changedAttributes.importTitle || changedAttributes.deserializer || changedAttributes.class) {
+	if($tw.utils.count(changedAttributes) > 0) {
 		this.refreshSelf();
 		return true;
 	}

--- a/editions/tw5.com/tiddlers/widgets/DropzoneWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DropzoneWidget.tid
@@ -1,6 +1,6 @@
 caption: dropzone
 created: 20131024141900000
-modified: 20200403103224328
+modified: 20210410062410660
 tags: Widgets
 title: DropzoneWidget
 type: text/vnd.tiddlywiki
@@ -16,9 +16,13 @@ It sends a [[WidgetMessage: tm-import-tiddlers]] carrying a JSON representation 
 |!Attribute |!Description |
 |deserializer |<<.from-version "5.1.15">> Optional name of deserializer to be used (by default the deserializer is derived from the file extension) |
 |enable |<<.from-version "5.1.22">> Optional value "no" to disable the dropzone functionality (defaults to "yes") |
-|class |<<.from-version "5.1.22">> Optional CSS class to be assigned to the dropzone (defaults to "tc-drag-over") |
+|class |<<.from-version "5.1.22">> Optional CSS class to be assigned to the DOM node created by the dropzone (defaults to "tc-dropzone") |
 |autoOpenOnImport |<<.from-version "5.1.23">> Optional value "no" or "yes" that can override tv-auto-open-on-import |
-|importTitle|<<.from-version "5.1.23">> optional tiddler title to use for import process instead of ~$:/Import |
+|importTitle|<<.from-version "5.1.23">> Optional tiddler title to use for import process instead of ~$:/Import |
+|actions|<<.from-version "5.1.24">> Optional actions string to be invoked after the `tm-import-tiddlers` message has been sent. The variable `importTitle` provides the title of the tiddler used for the import process. |
+|contentTypesFilter |<<.from-version "5.1.24">> Optional filter that specifies the [[content types|ContentType]] accepted by the dropzone. |
+
+<<.tip """Use the `prefix` filter operator to easily accept multiple related content types. For example this filter will accept all image content types: `[prefix[image/]]`""">>
 
 The list of available deserializers can be inspected by executing `Object.keys($tw.Wiki.tiddlerDeserializerModules).sort().join("\n")` in the browser JavaScript console.
 


### PR DESCRIPTION
This PR extends the `<$dropzone>` widget to:

- optionally invoke actions after the `tm-import-tiddlers` message has been sent. This allows triggering an alternative UX and workflow to the default import process.
- specify an optional `contentTypesFilter` which determines which content types are accepted by the dropzone. (note that the parameter is intentionally named for consistency with existing documentation https://tiddlywiki.com/#ContentType rather than introducing the term mimeType for end-users). Using a filter offers flexibility such as using the following for all image types: `[prefix[image/]]`.

Note that the `filterByContentTypes` method does the filtering just before calling `tm-import-tiddlers`. Filtering here instead of earlier in the event handling allows:
- a consistent and unified handling of drop and paste events by the same method.
- removes the need to handle browser inconsistencies in the information provided in the drop and paste events.
- allows the logic in our deserializers to attempt to correctly identify the content types in the payload.
- prevents the default browser behaviour regardless of mimeType, such as replacing the TW file with the dropped content or opening the content in a new tab, which is otherwise disruptive to the user experience.