### PR TITLE
Correct DropzoneWidget docs

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/DropzoneWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DropzoneWidget.tid
@@ -16,7 +16,7 @@ It sends a [[WidgetMessage: tm-import-tiddlers]] carrying a JSON representation 
 |!Attribute |!Description |
 |deserializer |<<.from-version "5.1.15">> Optional name of deserializer to be used (by default the deserializer is derived from the file extension) |
 |enable |<<.from-version "5.1.22">> Optional value "no" to disable the dropzone functionality (defaults to "yes") |
-|class |<<.from-version "5.1.22">> Optional CSS class to be assigned to the dropzone (defaults to "tc-drag-over") |
+|class |<<.from-version "5.1.22">> Optional CSS class to be assigned to the DOM node created by the dropzone (defaults to "tc-dropzone") |
 |autoOpenOnImport |<<.from-version "5.1.23">> Optional value "no" or "yes" that can override tv-auto-open-on-import |
 |importTitle|<<.from-version "5.1.23">> optional tiddler title to use for import process instead of ~$:/Import |
 


### PR DESCRIPTION
@Jermolene It was somehow easier to create a new PR than target the previous one at the tiddlywiki-com branch.

This is a correction in existing docs and can go live immediately.