### PR TITLE
freelinks - performance improvement

### DIFF
--- a/plugins/tiddlywiki/freelinks/text.js
+++ b/plugins/tiddlywiki/freelinks/text.js
@@ -77,9 +77,10 @@ TextNodeWidget.prototype.execute = function() {
 					}
 				}),
 				titles = [],
-				reparts = [];
+				reparts = [],
+				isCC = new RegExp("^" + $tw.config.textPrimitives.unWikiLink + "?" + $tw.config.textPrimitives.wikiLink,"mg");
 			$tw.utils.each(sortedTitles,function(title) {
-				if(title.substring(0,3) !== "$:/") {
+				if ((title.substring(0,3) !== "$:/") && (title.match(isCC) === null)) {
 					titles.push(title);
 					reparts.push("(\\b" + $tw.utils.escapeRegExp(title) + "\\b)");
 				}
@@ -120,10 +121,10 @@ TextNodeWidget.prototype.execute = function() {
 						childParseTree[index] = {
 							type: "plain-text",
 							text: text.substring(matchEnd)
-						};					
+						};
 					}
 				}
-			} while(match && childParseTree[childParseTree.length - 1].type === "plain-text");			
+			} while(match && childParseTree[childParseTree.length - 1].type === "plain-text");
 		}
 	}
 	// Make the child widgets
@@ -158,7 +159,7 @@ TextNodeWidget.prototype.refresh = function(changedTiddlers) {
 		this.refreshSelf();
 		return true;
 	} else {
-		return false;	
+		return false;
 	}
 };
 


### PR DESCRIPTION
This PR removes all CamelCase checks from the freelink logic. 

 - CamelCase has its own parser. So freelinks shouldn't deal with it. 
 - Especially since the CameCase parser is already done when freelinks starts
 - IMO freelinks can be "freed" from that work ;)

This allows us to reduce the `reparts` length from 1339 to about 950 for tiddlywiki.com which imo is huge. Since the regexp is used about 1400 times if 30 tiddlers are open.

I did the following test. 

 - Install freelinks plugin
 - Disable it 
 - Open 30 tiddlers from the Recent tab
 - Enabled freelinks
 - Enabled Pereformance Instrumentation
 - Save - Reload
 - Inspect
 - Switch tabs between Recent and Contents

I was able to reduce the time needed to check all open tiddlers from about 1.9 seconds to about 1.2 seconds. Using FF latest Windows 10 Pro.