### PR TITLE
Add TiddlyHost saving info and revise TiddlySpot info

### DIFF
--- a/editions/tw5.com/tiddlers/saving/Saving on TiddlyHost.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TiddlyHost.tid
@@ -1,0 +1,17 @@
+caption: ~TiddlyHost
+color: #29B6F6
+community-author: Simon Baird
+created: 20210422191232572
+delivery: Service
+description: Online service for creating and hosting TiddlyWikis
+method: save
+modified: 20210423003921468
+tags: Android Chrome Firefox [[Internet Explorer]] Linux Mac Opera PHP Safari Saving Windows iOS Edge
+title: Saving on TiddlyHost
+type: text/vnd.tiddlywiki
+
+[img width=140 [https://github.com/simonbaird/tiddlyhost/raw/main/rails/app/assets/images/logo-800.png]]
+
+[[TiddlyHost.com|https://tiddlyhost.com/]] is a hosting service for TiddlyWiki created by Simon Baird. Once you sign up and confirm your email you can create "sites", (i.e. ~TiddlyWikis), with support for online saving. Sites can be private or public, and you can optionally list them on the taggable and searchable [[TiddlyHost Hub|https://tiddlyhost.com/hub]] where they'll be discoverable by others.
+
+Unlike [[TiddlySpot|Saving on TiddlySpot]], [[TiddlyHost|https://tiddlyhost.com]] is secure, open source, and has proper support for TiddlyWiki5. It also allows uploading existing ~TiddlyWiki files, supports TiddlyWikiClassic, and lets you claim ownership of your ~TiddlySpot sites. For more information see the [[FAQ|https://github.com/simonbaird/tiddlyhost/wiki/FAQ]] and the [[About|https://tiddlyhost.com/about]] page.

--- a/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
@@ -1,56 +1,46 @@
 caption: ~TiddlySpot
 color: #29B6F6
-community-author: Simon Baird and Daniel Baird
+community-author: Simon Baird & Daniel Baird
 created: 20130825213500000
 delivery: Service
-description: Free online service for hosting TiddlyWiki files
+description: Online TiddlyWiki hosting. (Deprecated in favour of TiddlyHost)
 method: save
-modified: 20200507202953380
+modified: 20210423004027196
 tags: Android Chrome Firefox [[Internet Explorer]] Linux Mac Opera PHP Safari Saving Windows iOS Edge
 title: Saving on TiddlySpot
 type: text/vnd.tiddlywiki
 
-[[TiddlySpot|http://tiddlyspot.com]] is a free hosting service for TiddlyWiki documents from Simon Baird and Daniel Baird.
+----
+<<.warning "''Please note: ~TiddlySpot is in maintenance mode and no longer allows new sites to be created. Instead of ~TiddlySpot you can now use [[TiddlyHost|Saving on TiddlyHost]], a new service from the creator of ~TiddlySpot.''">>
+----
+[img[https://raw.githubusercontent.com/simonbaird/tiddlyhost/main/rails/app/assets/images/tiddlyspot-banner-logo.png]]
 
-! Setting up a TiddlyWiki on ~TiddlySpot
-To set up a [[TiddlyWiki Classic|TiddlyWikiClassic]], you merely create a new wiki at http://tiddlyspot.com
+[[TiddlySpot.com|http://tiddlyspot.com]] is a hosting service for TiddlyWiki created in 2006 by Simon Baird and Daniel Baird.
 
-!!TiddlyWiki5 on ~TiddlySpot
-~TiddlyWiki5 also functions well on ~TiddlySpot but this version is not offered directly in the ~TiddlySpot set-up.
+In early 2021 it was superseded by [[TiddlyHost|Saving on TiddlyHost]], a new, secure, modern reimagining of ~TiddlySpot. Creating new sites on ~TiddlySpot is no longer supported, (though sites created in 2020 or earlier are still functional).
 
-The simplest way to create a new ~TiddlySpot with ~TiddlyWiki5 is probably through the community created site http://tiddlywiki5.tiddlyspot.com
+!! Security warning for ~TiddlySpot
 
-Alternatively, you can upload an existing ~TiddlyWiki5 document from your local disc to ~TiddlySpot by following these steps:
-
-# Sign up for a new wiki at http://tiddlyspot.com/, and remember the wiki name and password
-# Open your locally stored TiddlyWiki document in your browser
-# Fill in the ~TiddlySpot wikiname and password in ''Saving'' tab of the ''control panel'' <<.icon $:/core/images/options-button>>
-# Click the <<.icon $:/core/images/save-button>> ''save changes'' button. You should get a confirmation notification at the top right saying ''Saved wiki''. Saving can take several seconds if you're on a slow connection or working with a large wiki.
-# Navigate to your ~TiddlySpot URL at http://{wikiname}.tiddlyspot.com/
-
-Note that your password is sent unencrypted when using ~TiddlySpot. From http://faq.tiddlyspot.com/:
+Note that your password is sent unencrypted when using ~TiddlySpot. From the [[FAQ|http://faq.tiddlyspot.com/]]:
 
 <<<
 ''Is Tiddlyspot secure?''
 
-No. Tiddlyspot does not use SSL/https. Your password is sent in clear text when uploading and when authenticating to access a private site. This means that your Tiddlyspot is vulnerable to packet sniffing and your password could be discovered by a malicious third party. Also your data is transmitted unencrypted when you view your site, even if it is a private site. For this reason please don't put sensitive information such as banking details in your Tiddlyspot and don't use a password that you use for other high security sites.
+No. Tiddlyspot does not use SSL/https, so all ~Tiddlyspot web traffic is vulnerable to packet sniffing. This means your password and site data could be intercepted by a malicious third party. For this reason, please don't keep sensitive information in your ~TiddlySpot site, and don't use a password that you use for other web sites.
 <<<
 
-! Problems with saving on ~TiddlySpot
+!! Problems with saving on ~TiddlySpot
 
-In case you run into this error when uploading a new or freshly upgraded local TiddlyWiki to ~TiddlySpot :
+In case you run into this error when uploading a freshly upgraded local TiddlyWiki to ~TiddlySpot:
 
 <<<
-Error while saving:
-
-Error:NS_ERROR_DOM_BAD_URI: Access to restricted URI denied
+Error: NS_ERROR_DOM_BAD_URI: Access to restricted URI denied
 <<<
 
 The upgrade operation falls foul of a security restriction in Firefox. Until this can be resolved, we suggest using Chrome.
 
-*# Use Chrome to open the local TiddlyWiki document you want to upload to ~TiddlySpot and follow the steps 1 through 5 described above
-*# Once you've checked the ~TiddlySpot-hosted TiddlyWiki loads properly in Chrome, you should be able to access, edit and [[save using TiddlyFox|Saving with TiddlyFox]] again
-* After you've uploaded your local document once, further editing and saving of the online version hosted on ~TiddlySpot should work with any modern browser of your choice.
-** Don't forget to fill in the ~TiddlySpot wikiname and password in your ~TiddlySpot TiddlyWiki control panel for any new browser you want to use for saving changes
+* Use Chrome to open the local TiddlyWiki document you want to upload to ~TiddlySpot and follow the steps 1 through 5 described at [[Upgrading]].
+* Once you've checked the ~TiddlySpot-hosted TiddlyWiki loads properly in Chrome, you should be able to access, edit and [[save using TiddlyFox|Saving with TiddlyFox]] again.
+* After you've uploaded your local document once, further editing and saving of the online version hosted on ~TiddlySpot should work with any modern browser of your choice. (Don't forget to fill in the ~TiddlySpot password in your ~TiddlySpot TiddlyWiki control panel for any new browser you want to use for saving changes.)
 
-* //See also : [[Upgrading]]//
+//See also: [[Upgrading]]//


### PR DESCRIPTION
I updated the English text only. Will need some help with the
translations.

Summary:
- Mention that TiddlySpot is deprecated and doesn't allow site
  creation any more. Suggest using TiddlyHost instead.
- Remove obsolete intructions about creating TiddlySpot sites.
- Misc editing/rewording/tweaking of existing TiddlySpot info
  for tidiness and clarity.
- Add new information about saving on TiddlyHost.
- Add logos because why not..

Note: I usually prefer the non-camel case versions of Tiddlyspot and
Tiddlyhost, but decided to go with the CamelCase WikiWords here to
fit in with the existing conventions.