### PR TITLE
Two typo fixups related to surplus tilde chars

### DIFF
--- a/editions/tw5.com/tiddlers/community/resources/TW5-firebase TiddlyWiki5 for Google Firebase by Peter Neumark.tid
+++ b/editions/tw5.com/tiddlers/community/resources/TW5-firebase TiddlyWiki5 for Google Firebase by Peter Neumark.tid
@@ -1,4 +1,4 @@
-caption: ~TW5-firebase
+caption: TW5-firebase
 color: #FFEB3B
 community-author: Peter Neumark
 created: 20210115121027582

--- a/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
@@ -26,7 +26,7 @@ Note that your password is sent unencrypted when using ~TiddlySpot. From the [[F
 <<<
 ''Is Tiddlyspot secure?''
 
-No. Tiddlyspot does not use SSL/https, so all ~Tiddlyspot web traffic is vulnerable to packet sniffing. This means your password and site data could be intercepted by a malicious third party. For this reason, please don't keep sensitive information in your ~TiddlySpot site, and don't use a password that you use for other web sites.
+No. Tiddlyspot does not use SSL/https, so all ~TiddlySpot web traffic is vulnerable to packet sniffing. This means your password and site data could be intercepted by a malicious third party. For this reason, please don't keep sensitive information in your ~TiddlySpot site, and don't use a password that you use for other web sites.
 <<<
 
 !! Problems with saving on ~TiddlySpot


### PR DESCRIPTION
One is a typo I missed in the previous commit.

The other is a similar but unrelated fix I noticed while looking at
the savers list at https://tiddlywiki.com/#GettingStarted