### PR TITLE
Revise the TiddlySpot Saver settings form

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -123,12 +123,12 @@ Saving/TiddlySpot/BackupDir: Backup Directory
 Saving/TiddlySpot/ControlPanel: ~TiddlySpot Control Panel
 Saving/TiddlySpot/Backups: Backups
 Saving/TiddlySpot/Caption: ~TiddlySpot Saver
-Saving/TiddlySpot/Description: These settings are only used when saving to http://tiddlyspot.com or a compatible remote server
+Saving/TiddlySpot/Description: These settings are only used when saving to [[TiddlySpot|http://tiddlyspot.com]], [[TiddlyHost|https://tiddlyhost.com]], or a compatible remote server. See [[here|https://github.com/simonbaird/tiddlyhost/wiki/TiddlySpot-Saver-configuration-for-Tiddlyhost-and-Tiddlyspot]] for information on ~TiddlySpot and ~TiddlyHost saving configuration.
 Saving/TiddlySpot/Filename: Upload Filename
 Saving/TiddlySpot/Heading: ~TiddlySpot
 Saving/TiddlySpot/Hint: //The server URL defaults to `http://<wikiname>.tiddlyspot.com/store.cgi` and can be changed to use a custom server address, e.g. `http://example.com/store.php`.//
 Saving/TiddlySpot/Password: Password
-Saving/TiddlySpot/ReadOnly: The ~TiddlySpot service is currently only available in read-only form. Please see http://tiddlyspot.com/ for the latest details. The ~TiddlySpot saver can still be used to save to compatible servers.
+Saving/TiddlySpot/ReadOnly: Note that [[TiddlySpot|http://tiddlyspot.com]] no longer allows the creation of new sites. For new sites you can use [[TiddlyHost|https://tiddlyhost.com]], a new hosting service which replaces ~TiddlySpot.
 Saving/TiddlySpot/ServerURL: Server URL
 Saving/TiddlySpot/UploadDir: Upload Directory
 Saving/TiddlySpot/UserName: Wiki Name

--- a/core/ui/ControlPanel/Saving/TiddlySpot.tid
+++ b/core/ui/ControlPanel/Saving/TiddlySpot.tid
@@ -30,8 +30,6 @@ http://$(userName)$.tiddlyspot.com/$path$/
 
 |<<lingo UserName>> |<$edit-text tiddler="$:/UploadName" default="" tag="input"/> |
 |<<lingo Password>> |<$password name="upload"/> |
-|<<lingo Backups>> |<<siteLink backup>> |
-|<<lingo ControlPanel>> |<<siteLink controlpanel>> |
 
 ''<<lingo Advanced/Heading>>''
 


### PR DESCRIPTION
Mention TiddlyHost and link to some documentation on the
configuration options.

Also remove the TiddlySpot control panel and backups links since
they no longer work.

Notes:
* The last three fields are no use for TiddlySpot or TiddlyHost, but
  it's possible that someone, somewhere is still using the old
  store.php from Bidix's UploadPlugin, and would miss them if they
  were removed.

  I'd be happy to remove them in a future PR, if it's decided they
  can be retired.

  (If they were removed, I could delete the last row here:)
  https://github.com/simonbaird/tiddlyhost/wiki/TiddlySpot-Saver-configuration-for-Tiddlyhost-and-Tiddlyspot

* It's still called "TiddlySpot Saver" which I think is fine for
  now. TiddlyHost might use a different saving method in future
  so keep the old name seems best.