### PR TITLE
Add 401 and 403 error messages for put saver

### DIFF
--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -24,7 +24,6 @@ Encryption/RepeatPassword: Repeat password
 Encryption/PasswordNoMatch: Passwords do not match
 Encryption/SetPassword: Set password
 Error/Caption: Error
-Error/EditConflict: File changed on server
 Error/Filter: Filter error
 Error/FilterSyntax: Syntax error in filter expression
 Error/FilterRunPrefix: Filter Error: Unknown prefix for filter run
@@ -32,6 +31,9 @@ Error/IsFilterOperator: Filter Error: Unknown operand for the 'is' filter operat
 Error/FormatFilterOperator: Filter Error: Unknown suffix for the 'format' filter operator
 Error/LoadingPluginLibrary: Error loading plugin library
 Error/NetworkErrorAlert: `<h2>''Network Error''</h2>It looks like the connection to the server has been lost. This may indicate a problem with your network connection. Please attempt to restore network connectivity before continuing.<br><br>''Any unsaved changes will be automatically synchronised when connectivity is restored''.`
+Error/PutEditConflict: File changed on server
+Error/PutForbidden: Permission denied
+Error/PutUnauthorized: Authentication required
 Error/RecursiveTransclusion: Recursive transclusion error in transclude widget
 Error/RetrievingSkinny: Error retrieving skinny tiddler list
 Error/SavingToTWEdit: Error saving to TWEdit

--- a/core/modules/savers/put.js
+++ b/core/modules/savers/put.js
@@ -89,9 +89,12 @@ PutSaver.prototype.save = function(text,method,callback) {
 			if(err) {
 				// response is textual: "XMLHttpRequest error code: 412"
 				var status = Number(err.substring(err.indexOf(':') + 2, err.length))
-				if(status === 412) { // edit conflict
-					var message = $tw.language.getString("Error/EditConflict");
-					callback(message);
+				if(status === 412) { // file changed on server
+					callback($tw.language.getString("Error/PutEditConflict"));
+				} else if(status === 401) { // authentication required
+					callback($tw.language.getString("Error/PutUnauthorized"));
+				} else if(status === 403) { // permission denied
+					callback($tw.language.getString("Error/PutForbidden"));
 				} else {
 					callback(err); // fail
 				}

--- a/languages/ar-PS/Misc.multids
+++ b/languages/ar-PS/Misc.multids
@@ -24,7 +24,6 @@ Encryption/RepeatPassword: كرر/ي كلمة السر
 Encryption/SetPassword: ضبط كلمة السر
 Encryption/Username: اسم المستخدم
 Error/Caption: خطأ
-Error/EditConflict: تم تغيير الملف على الخادم
 Error/Filter: خطأ في التصفية
 Error/FilterSyntax: خطأ في بناء الجملة في تعبير عامل التصفية
 Error/IsFilterOperator: خطأ في التصفية: معامل غير معروف لعامل التصفية 'is'
@@ -32,6 +31,7 @@ Error/IsFilterOperator: خطأ في التصفية: معامل غير معروف
 Error/LoadingPluginLibrary: خطأ في تحميل مكتبة المكونات الإضافية
 
 Error/NetworkErrorAlert: `<h2>''خطأ في الشبكة''</h2> يبدو أن الاتصال بالخادم قد انقطع. قد يشير هذا إلى وجود مشكلة في اتصال الشبكة. يرجى محاولة استعادة اتصال الشبكة قبل المتابعة. <br> <br> '' ستتم مزامنة أي تغييرات غير محفوظة تلقائيًا عند استعادة الاتصال ''.
+Error/PutEditConflict: تم تغيير الملف على الخادم
 Error/WhileSaving: حدث خطأ أثناء الحفظ
 
 InternalJavaScriptError/Hint: حسنا، هذا أمر محرج. من المستحسن إعادة تشغيل تدلي ويكي عن طريق إنعاش المتصفح الخاص بك

--- a/languages/ca-ES/Misc.multids
+++ b/languages/ca-ES/Misc.multids
@@ -22,12 +22,12 @@ Encryption/RepeatPassword: Repetiu la contrasenya
 Encryption/SetPassword: Indiqueu la contrasenya
 Encryption/Username: Usuari
 Error/Caption: S'ha produït un error
-Error/EditConflict: El fitxer ha canviat al servidor
 Error/Filter: S'ha produït un error del filtre
 Error/FilterSyntax: S'ha produït un error de sintaxi en l'expressió del filtre
 Error/IsFilterOperator: S'ha produït un error del filtre: operant desconegut per a l’operador de filtre "is"
 Error/LoadingPluginLibrary: S'ha produït un error en carregar la biblioteca del connector
 Error/NetworkErrorAlert: `<h2>''Error de la xarxa''</h2>Sembla que s'ha perdut la connexió amb el servidor. Això pot indicar un problema amb la vostra connexió de la xarxa. Intenteu restaurar la connectivitat de xarxa abans de continuar.<br><br>' Qualsevol canvi no guardat es sincronitzarà automàticament quan es restableixi la connectivitat''.'
+Error/PutEditConflict: El fitxer ha canviat al servidor
 Error/RecursiveTransclusion: S'ha produït un error de transclusió recursiva en el widget de transclusió
 Error/RetrievingSkinny: S'ha produït un error en recuperar la llista de tiddler parcials
 Error/SavingToTWEdit: S'ha produït un error en desar a TWEdit

--- a/languages/de-DE/Misc.multids
+++ b/languages/de-DE/Misc.multids
@@ -24,7 +24,6 @@ Encryption/RepeatPassword: Passwort wiederholen
 Encryption/PasswordNoMatch: Passwörter stimmen nicht überein
 Encryption/SetPassword: Passwort setzen
 Error/Caption: Fehler
-Error/EditConflict: Datei auf Server verändert
 Error/Filter: Filter Fehler
 Error/FilterSyntax: Syntax Fehler im Filter-Ausdruck
 Error/FilterRunPrefix: Filter Fehler: Unbekanntes Prefix für Filter lauf
@@ -32,6 +31,7 @@ Error/IsFilterOperator: Filter Fehler: Unbekannter Operand für den 'is' Filter 
 Error/FormatFilterOperator: Filter Fehler: Unbekannter Operand für den 'format' Filter Operator
 Error/LoadingPluginLibrary: Fehler beim Laden der "plugin library"
 Error/NetworkErrorAlert: `<h2>''Netzwerk Fehler''</h2>Es scheint, die Verbindung zum Server ist ausgefallen. Das weist auf Probleme mit der Netzwerkverbindung hin. Bitte versuchen Sie die Verbingung wider herzustellen, bevor Sie weitermachen.<br><br>''Nicht gespeicherte Änderungen werden automatich synchronisiert, sobald die Verbindung wider hergestellt ist.
+Error/PutEditConflict: Datei auf Server verändert
 Error/RecursiveTransclusion: Recursive Transclusion: Fehler im "transclude widget"
 Error/RetrievingSkinny: Fehler beim Empfangen einer "skinny" Tiddler Liste
 Error/SavingToTWEdit: Fehler beim Speichern mit "TWEdit"

--- a/languages/el-GR/Misc.multids
+++ b/languages/el-GR/Misc.multids
@@ -22,11 +22,11 @@ Encryption/RepeatPassword: Επαναλάβατε το συνθηματικό
 Encryption/SetPassword: Ορίστε το συνθηματικό
 Encryption/Username: Όνομα χρήστη
 Error/Caption: Σφάλμα
-Error/EditConflict: Το αρχείο στον εξυπηρετητή είναι διαφορετικό
 Error/Filter: Σφάλμα φίλτρου
 Error/FilterSyntax: Συντακτικό σφάλμα στην έκφραση του φίλτρου
 Error/IsFilterOperator: Σφάλμα φίλτρου: Άγνωστος τελεστέος για τον τελεστή φίλτρου 'is'
 Error/LoadingPluginLibrary: Σφάλμα κατά την φόρτωση της βιβλιοθήκης του πρόσθετου
+Error/PutEditConflict: Το αρχείο στον εξυπηρετητή είναι διαφορετικό
 Error/RecursiveTransclusion: Σφάλμα αναδρομής σε transclusion στο transclude widget
 Error/RetrievingSkinny: Σφάλμα κατά την ανάκληση της skinny tiddler λίστας
 Error/SavingToTWEdit: Σφάλμα κατά την αποθήκευση στο TWEdit

--- a/languages/fa-IR/Misc.multids
+++ b/languages/fa-IR/Misc.multids
@@ -22,11 +22,11 @@ Encryption/RepeatPassword: تکرار رمز
 Encryption/SetPassword: تعیین رمز
 Encryption/Username: نام کاربری
 Error/Caption: خطا
-Error/EditConflict: فایل در سرور عوض شد
 Error/Filter: خطای فیلتر
 Error/FilterSyntax: در نحوه‌ی بیان فیلتر خطای نحوی وجود داشت
 Error/IsFilterOperator: خطای فیلتر: عملکرد ناشناخته‌ای برای عملگر 'is' مشخص شده
 Error/LoadingPluginLibrary: خطا در بارگزاری کتاب‌خانه افزونه
+Error/PutEditConflict: فایل در سرور عوض شد
 Error/RecursiveTransclusion: Recursive transclusion error in transclude widget
 Error/RetrievingSkinny: طا در دریافت لیست‌های تیدلر لاغر
 Error/SavingToTWEdit: خطا در ذخیره در TWEdit

--- a/languages/fr-FR/Misc.multids
+++ b/languages/fr-FR/Misc.multids
@@ -23,7 +23,6 @@ Encryption/RepeatPassword: Répéter le mot de passe
 Encryption/PasswordNoMatch: Les mots de passe ne correspondent pas
 Encryption/SetPassword: Définir ce mot de passe 
 Error/Caption: Erreur
-Error/EditConflict: Le fichier a changé sur le serveur
 Error/Filter: Erreur de filtre
 Error/FilterSyntax: Erreur de syntaxe dans l'expression du filtre
 Error/FilterRunPrefix: Erreur de filtre : Préfixe de run inconnu pour le filtre
@@ -31,6 +30,7 @@ Error/IsFilterOperator: Erreur de filtre : Opérande inconnu pour l'opérateur d
 Error/FormatFilterOperator: Erreur de filtre : Suffixe inconnu pour l'opérateur de filtre 'format'
 Error/LoadingPluginLibrary: Erreur lors du chargement de la bibliothèque de plugins
 Error/NetworkErrorAlert: `<h2>''Erreur Réseau''</h2>Il semble que la connexion au serveur soit perdue. Cela peut indiquer un problème avec votre connexion réseau. Essayez de rétablir la connectivité du réseau avant de continuer.<br><br>''Toute modification non enregistrée sera automatiquement synchronisée lorsque la connectivité sera rétablie''.`
+Error/PutEditConflict: Le fichier a changé sur le serveur
 Error/RecursiveTransclusion: Erreur dans le widget //transclude// : transclusion récursive
 Error/RetrievingSkinny: Erreur pendant la récupération de la liste des tiddlers partiels
 Error/SavingToTWEdit: Erreur lors de l'enregistrement vers TWEdit

--- a/languages/nl-NL/Misc.multids
+++ b/languages/nl-NL/Misc.multids
@@ -23,7 +23,6 @@ Encryption/RepeatPassword: Herhaal wachtwoord
 Encryption/SetPassword: Vul wachtwoord in
 Encryption/Username: Gebruikersnaam
 Error/Caption: Fout
-Error/EditConflict: Bestand gewijzigd op server
 Error/Filter: Filterfout
 Error/FilterRunPrefix: Filterfout: Onbekend voorvoegsel voor filter 'run'
 Error/FilterSyntax: Syntaxfout in filter expressie
@@ -31,6 +30,7 @@ Error/FormatFilterOperator: Filterfout: Onbekend achtervoegsel voor de 'format' 
 Error/IsFilterOperator: Filterfout: Onbekende operand voor het 'is' filter
 Error/LoadingPluginLibrary: Fout bij laden van de pluginbibliotheek
 Error/NetworkErrorAlert: `<h2>''Network fout''</h2>De verbinding met de server lijkt verbroken. Mogelijk een probleem met de netwerkverbinding. Herstel de netwerkverbinding voordat verder wordt gegaan.<br><br>''Niet opgeslagen veranderingen worden gesynchroniseerd als de verbinding hersteld is''.`
+Error/PutEditConflict: Bestand gewijzigd op server
 Error/RecursiveTransclusion: Recursieve transclusiefout in 'transclude' widget
 Error/RetrievingSkinny: Fout bij ophalen van de 'skinny' tiddlerlijst
 Error/SavingToTWEdit: Fout bij opslaan naar TWEdit

--- a/languages/pt-PT/Misc.multids
+++ b/languages/pt-PT/Misc.multids
@@ -23,11 +23,11 @@ Encryption/RepeatPassword: Repetir palavra passe
 Encryption/SetPassword: Definir palavra passe
 Encryption/Username: Nome de utilizador
 Error/Caption: Erro
-Error/EditConflict: File changed on server
 Error/Filter: Erro de filtro
 Error/FilterSyntax: Erro de sintaxe na expressão do filtro
 Error/IsFilterOperator: Erro de Filtro: Operando desconhecido para o operador de filtro 'is'
 Error/LoadingPluginLibrary: Erro ao carregar a biblioteca de extensões
+Error/PutEditConflict: File changed on server
 Error/RecursiveTransclusion: Erro de transclusão recursiva na widget de transclusão
 Error/RetrievingSkinny: Erro ao obter a lista simples de tiddlers
 Error/SavingToTWEdit: Erro ao gravar em TWEdit

--- a/languages/sl-SI/Misc.multids
+++ b/languages/sl-SI/Misc.multids
@@ -22,11 +22,11 @@ Encryption/RepeatPassword: Ponovite geslo
 Encryption/SetPassword: Nastavite geslo
 Encryption/Username: Uporabniško ime
 Error/Caption: Napaka
-Error/EditConflict: Datoteka je spremenjena na strežniku
 Error/Filter: Filter napaka
 Error/FilterSyntax: Sintaktična napaka v izrazu filtra
 Error/IsFilterOperator: Filter napaka: neznan operand za 'is' operator filtra
 Error/LoadingPluginLibrary: Napaka pri nalaganju knjižnice vtičnikov
+Error/PutEditConflict: Datoteka je spremenjena na strežniku
 Error/RecursiveTransclusion: Rekurzivna napaka transkluzije v "transclude widget"
 Error/RetrievingSkinny: Napaka pri pridobivanju "skinny" seznama tiddlerjev
 Error/SavingToTWEdit: Napaka pri shranjevanju v TWEdit

--- a/languages/zh-Hans/Misc.multids
+++ b/languages/zh-Hans/Misc.multids
@@ -24,7 +24,6 @@ Encryption/RepeatPassword: 重复输入密码
 Encryption/PasswordNoMatch: 密码不匹配
 Encryption/SetPassword: 设定密码
 Error/Caption: 错误
-Error/EditConflict: 服务器上的文件已更改
 Error/Filter: 筛选器错误
 Error/FilterRunPrefix: 筛选器错误：筛选器 run 的未知首码
 Error/FilterSyntax: 筛选器运算式中的语法错误
@@ -32,6 +31,7 @@ Error/FormatFilterOperator: 筛选器错误：`format` 筛选器运算符的未�
 Error/IsFilterOperator: 筛选器错误︰'is' 筛选器运算符的未知操作数
 Error/LoadingPluginLibrary: 加载插件程式库时，发生错误
 Error/NetworkErrorAlert: `<h2>''网络错误''</h2>与服务器的连缐似乎已中断。这可能表示您的网络连缐有问题。请尝试恢复网路连缐才能继续。<br><br>''恢复连缐时，所有未保存的更改，将自动同步''。`
+Error/PutEditConflict: 服务器上的文件已更改
 Error/RecursiveTransclusion: 于 transclude 小部件中的递回嵌入错误
 Error/RetrievingSkinny: 简要条目清单撷取错误
 Error/SavingToTWEdit: 保存到 TWEdit 时，发生错误

--- a/languages/zh-Hant/Misc.multids
+++ b/languages/zh-Hant/Misc.multids
@@ -24,7 +24,6 @@ Encryption/RepeatPassword: 重複輸入密碼
 Encryption/PasswordNoMatch: 密碼不匹配
 Encryption/SetPassword: 設定密碼
 Error/Caption: 錯誤
-Error/EditConflict: 伺服器上的檔案已更改
 Error/Filter: 篩選器錯誤
 Error/FilterRunPrefix: 篩選器錯誤：篩選器 run 的未知首碼
 Error/FilterSyntax: 篩選器運算式中的語法錯誤
@@ -32,6 +31,7 @@ Error/FormatFilterOperator: 篩選器錯誤：`format` 篩選器運算子的未�
 Error/IsFilterOperator: 篩選器錯誤︰'is' 篩選器運算子的未知運算元
 Error/LoadingPluginLibrary: 載入插件程式庫時，發生錯誤
 Error/NetworkErrorAlert: `<h2>''網路錯誤''</h2>與伺服器的連線似乎已中斷。這可能表示您的網路連線有問題。請嘗試恢復網路連線才能繼續。<br><br>''恢復連線時，所有未儲存的變更，將自動同步''。`
+Error/PutEditConflict: 伺服器上的檔案已更改
 Error/RecursiveTransclusion: 於 transclude 小工具中的遞迴嵌入錯誤
 Error/RetrievingSkinny: 簡要條目清單擷取錯誤
 Error/SavingToTWEdit: 儲存到 TWEdit 時，發生錯誤


### PR DESCRIPTION
Show the user a more useful message for the case where they're not
correctly authenticated and try to do a "put" save.

The context for this change is that I'm thinking about using the
put saver for TiddlyHost instead of the old upload saver, but it
should be generally useful.

Also includes a name change for the one existing error message. I
want to indicate these three messages are related, so I added the
"Put" prefix to make them appear next to each other in the language
files. (The Error/EditConflict string is used in just this one place
as far as I can tell.)