### PR TITLE
EditTemplate: Improve warning 'Already exists'

### DIFF
--- a/core/ui/EditTemplate/title.tid
+++ b/core/ui/EditTemplate/title.tid
@@ -23,7 +23,7 @@ tags: $:/tags/EditTemplate
 
 <div class="tc-message-box">
 
-{{$:/core/images/warning}} {{$:/language/EditTemplate/Title/Exists/Prompt}}
+{{$:/core/images/warning}} {{$:/language/EditTemplate/Title/Exists/Prompt}}: <$link to={{!!draft.title}} />
 
 </div>
 


### PR DESCRIPTION
Add a link to the existing tiddler when the warning _Target tiddler already exists_ is displayed in EditTemplate. The warning is displayed when title conflict emerges.