### PR TITLE
Bug fixes for Eventcatcher (FF and IE)

### DIFF
--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -22,6 +22,10 @@ exports.domContains = function(a,b) {
 		!!(a.compareDocumentPosition(b) & 16);
 };
 
+exports.domMatchesSelector = function(node,selector) {
+	return node.matches ? node.matches(selector) : node.msMatchesSelector(selector);
+};
+
 exports.removeChildren = function(node) {
 	while(node.hasChildNodes()) {
 		node.removeChild(node.firstChild);

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -47,38 +47,42 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 		domNode.addEventListener(type,function(event) {
 			var selector = self.getAttribute("selector"),
 				actions = self.getAttribute("actions-"+type),
+				stopPropagation = self.getAttribute("stopPropagation","onaction"),
 				selectedNode = event.target,
 				selectedNodeRect,
 				catcherNodeRect,
 				variables = {};
-			if(selector) {
+			if(selector && selectedNode instanceof Element) {
 				// Search ancestors for a node that matches the selector
-				while(!selectedNode.matches(selector) && selectedNode !== domNode) {
+				while(!$tw.utils.domMatchesSelector(selectedNode,selector) && selectedNode !== domNode) {
 					selectedNode = selectedNode.parentNode;
 				}
 				// If we found one, copy the attributes as variables, otherwise exit
-				if(selectedNode.matches(selector)) {
-					$tw.utils.each(selectedNode.attributes,function(attribute) {
-						variables["dom-" + attribute.name] = attribute.value.toString();
-					});
-					//Add a variable with a popup coordinate string for the selected node
-					variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
-					
-					//Add variables for offset of selected node
-					variables["tv-selectednode-posx"] = selectedNode.offsetLeft.toString();
-					variables["tv-selectednode-posy"] = selectedNode.offsetTop.toString();
-					variables["tv-selectednode-width"] = selectedNode.offsetWidth.toString();
-					variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
+				if($tw.utils.domMatchesSelector(selectedNode,selector)) {
+					// Only set up variables if we have actions to invoke
+					if(actions) {
+						$tw.utils.each(selectedNode.attributes,function(attribute) {
+							variables["dom-" + attribute.name] = attribute.value.toString();
+						});
+						//Add a variable with a popup coordinate string for the selected node
+						variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
 
-					//Add variables for event X and Y position relative to selected node
-					selectedNodeRect = selectedNode.getBoundingClientRect();				
-					variables["event-fromselected-posx"] = (event.clientX - selectedNodeRect.left).toString();
-					variables["event-fromselected-posy"] = (event.clientY - selectedNodeRect.top).toString();
+						//Add variables for offset of selected node
+						variables["tv-selectednode-posx"] = selectedNode.offsetLeft.toString();
+						variables["tv-selectednode-posy"] = selectedNode.offsetTop.toString();
+						variables["tv-selectednode-width"] = selectedNode.offsetWidth.toString();
+						variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
 
-					//Add variables for event X and Y position relative to event catcher node
-					catcherNodeRect = self.domNode.getBoundingClientRect();
-					variables["event-fromcatcher-posx"] = (event.clientX - catcherNodeRect.left).toString();
-					variables["event-fromcatcher-posy"] = (event.clientY - catcherNodeRect.top).toString();
+						//Add variables for event X and Y position relative to selected node
+						selectedNodeRect = selectedNode.getBoundingClientRect();
+						variables["event-fromselected-posx"] = (event.clientX - selectedNodeRect.left).toString();
+						variables["event-fromselected-posy"] = (event.clientY - selectedNodeRect.top).toString();
+
+						//Add variables for event X and Y position relative to event catcher node
+						catcherNodeRect = self.domNode.getBoundingClientRect();
+						variables["event-fromcatcher-posx"] = (event.clientX - catcherNodeRect.left).toString();
+						variables["event-fromcatcher-posy"] = (event.clientY - catcherNodeRect.top).toString();
+					}
 				} else {
 					return false;
 				}
@@ -106,6 +110,8 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 					variables["event-detail"] = event.detail.toString();
 				}
 				self.invokeActionString(actions,self,event,variables);
+			}
+			if((actions && stopPropagation === "onaction") || stopPropagation === "always") {
 				event.preventDefault();
 				event.stopPropagation();
 				return true;

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -47,7 +47,6 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 		domNode.addEventListener(type,function(event) {
 			var selector = self.getAttribute("selector"),
 				actions = self.getAttribute("actions-"+type),
-				stopPropagation = self.getAttribute("stopPropagation","onaction"),
 				selectedNode = event.target,
 				selectedNodeRect,
 				catcherNodeRect,
@@ -59,30 +58,27 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 				}
 				// If we found one, copy the attributes as variables, otherwise exit
 				if($tw.utils.domMatchesSelector(selectedNode,selector)) {
-					// Only set up variables if we have actions to invoke
-					if(actions) {
-						$tw.utils.each(selectedNode.attributes,function(attribute) {
-							variables["dom-" + attribute.name] = attribute.value.toString();
-						});
-						//Add a variable with a popup coordinate string for the selected node
-						variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
+					$tw.utils.each(selectedNode.attributes,function(attribute) {
+						variables["dom-" + attribute.name] = attribute.value.toString();
+					});
+					//Add a variable with a popup coordinate string for the selected node
+					variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
+					
+					//Add variables for offset of selected node
+					variables["tv-selectednode-posx"] = selectedNode.offsetLeft.toString();
+					variables["tv-selectednode-posy"] = selectedNode.offsetTop.toString();
+					variables["tv-selectednode-width"] = selectedNode.offsetWidth.toString();
+					variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
 
-						//Add variables for offset of selected node
-						variables["tv-selectednode-posx"] = selectedNode.offsetLeft.toString();
-						variables["tv-selectednode-posy"] = selectedNode.offsetTop.toString();
-						variables["tv-selectednode-width"] = selectedNode.offsetWidth.toString();
-						variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
+					//Add variables for event X and Y position relative to selected node
+					selectedNodeRect = selectedNode.getBoundingClientRect();				
+					variables["event-fromselected-posx"] = (event.clientX - selectedNodeRect.left).toString();
+					variables["event-fromselected-posy"] = (event.clientY - selectedNodeRect.top).toString();
 
-						//Add variables for event X and Y position relative to selected node
-						selectedNodeRect = selectedNode.getBoundingClientRect();
-						variables["event-fromselected-posx"] = (event.clientX - selectedNodeRect.left).toString();
-						variables["event-fromselected-posy"] = (event.clientY - selectedNodeRect.top).toString();
-
-						//Add variables for event X and Y position relative to event catcher node
-						catcherNodeRect = self.domNode.getBoundingClientRect();
-						variables["event-fromcatcher-posx"] = (event.clientX - catcherNodeRect.left).toString();
-						variables["event-fromcatcher-posy"] = (event.clientY - catcherNodeRect.top).toString();
-					}
+					//Add variables for event X and Y position relative to event catcher node
+					catcherNodeRect = self.domNode.getBoundingClientRect();
+					variables["event-fromcatcher-posx"] = (event.clientX - catcherNodeRect.left).toString();
+					variables["event-fromcatcher-posy"] = (event.clientY - catcherNodeRect.top).toString();
 				} else {
 					return false;
 				}
@@ -110,8 +106,6 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 					variables["event-detail"] = event.detail.toString();
 				}
 				self.invokeActionString(actions,self,event,variables);
-			}
-			if((actions && stopPropagation === "onaction") || stopPropagation === "always") {
 				event.preventDefault();
 				event.stopPropagation();
 				return true;


### PR DESCRIPTION
These are targeted bug fixes for FF and IE.

On IE, `<$eventcatcher>` causes a red error screen as soon as an event is trapped. This is because IE does not support the `matches()` method but has its own equivalent `msMatchesSelector()` method. A utils method `domMatchesSelector()` has been introduced.

In FF there is a quirk where some events (such as `dragenter` and `dragleave`) can be fired for text nodes (nodeType 3) which are not proper Elements and therefore checking their attributes throws an error. To resolve this, a check for `instanceof Element` has been added.