### PR TITLE
Dropzone: persistent dragover state fix

### DIFF
--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -70,7 +70,7 @@ DropZoneWidget.prototype.handleEvent = function(event) {
 		}
 	} else if(event.type === "dragleave") {
 		// Check if drag left the window
-		if (event.relatedTarget === null || event.relatedTarget.nodeName === "HTML") {
+		if (event.relatedTarget === null || (event.relatedTarget && event.relatedTarget.nodeName === "HTML")) {
 			this.resetState();
 		}
 	}

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -70,7 +70,7 @@ DropZoneWidget.prototype.handleEvent = function(event) {
 		}
 	} else if(event.type === "dragleave") {
 		// Check if drag left the window
-		if (event.relatedTarget === null || (event.relatedTarget && event.relatedTarget.nodeName === "HTML")) {
+		if(event.relatedTarget === null || (event.relatedTarget && event.relatedTarget.nodeName === "HTML")) {
 			this.resetState();
 		}
 	}

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -37,6 +37,7 @@ DropZoneWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	// Create element
 	var domNode = this.document.createElement("div");
+	this.domNode = domNode;
 	domNode.className = this.dropzoneClass || "tc-dropzone";
 	// Add event handlers
 	if(this.dropzoneEnable) {
@@ -47,10 +48,8 @@ DropZoneWidget.prototype.render = function(parent,nextSibling) {
 			{name: "drop", handlerObject: this, handlerMethod: "handleDropEvent"},
 			{name: "paste", handlerObject: this, handlerMethod: "handlePasteEvent"},
 			{name: "dragend", handlerObject: this, handlerMethod: "handleDragEndEvent"}
-		]);		
+		]);
 	}
-	domNode.addEventListener("click",function (event) {
-	},false);
 	// Insert element
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);
@@ -59,12 +58,46 @@ DropZoneWidget.prototype.render = function(parent,nextSibling) {
 	this.currentlyEntered = [];
 };
 
+// Handler for transient event listeners added when the dropzone has an active drag in progress
+DropZoneWidget.prototype.handleEvent = function(event) {
+	if(event.type === "click") {
+		if(this.currentlyEntered.length) {
+			this.resetState();
+		}
+	} else if(event.type === "dragenter") {
+		if(event.target && event.target !== this.domNode && !$tw.utils.domContains(this.domNode,event.target)) {
+			this.resetState();
+		}
+	} else if(event.type === "dragleave") {
+		// Check if drag left the window
+		if (event.relatedTarget === null || event.relatedTarget.nodeName === "HTML") {
+			this.resetState();
+		}
+	}
+};
+
+// Reset the state of the dropzone after a drag has ended
+DropZoneWidget.prototype.resetState = function() {
+	$tw.utils.removeClass(this.domNode,"tc-dragover");
+	this.currentlyEntered = [];
+	this.document.body.removeEventListener("click",this,true);
+	this.document.body.removeEventListener("dragenter",this,true);
+	this.document.body.removeEventListener("dragleave",this,true);	
+	this.dragInProgress = false;
+};
+
 DropZoneWidget.prototype.enterDrag = function(event) {
 	if(this.currentlyEntered.indexOf(event.target) === -1) {
 		this.currentlyEntered.push(event.target);
 	}
-	// If we're entering for the first time we need to apply highlighting
-	$tw.utils.addClass(this.domNodes[0],"tc-dragover");
+	if(!this.dragInProgress) {
+		this.dragInProgress = true;
+		// If we're entering for the first time we need to apply highlighting
+		$tw.utils.addClass(this.domNodes[0],"tc-dragover");	
+		this.document.body.addEventListener("click",this,true);
+		this.document.body.addEventListener("dragenter",this,true);
+		this.document.body.addEventListener("dragleave",this,true);
+	}
 };
 
 DropZoneWidget.prototype.leaveDrag = function(event) {
@@ -74,12 +107,11 @@ DropZoneWidget.prototype.leaveDrag = function(event) {
 	}
 	// Remove highlighting if we're leaving externally
 	if(this.currentlyEntered.length === 0) {
-		$tw.utils.removeClass(this.domNodes[0],"tc-dragover");
+		this.resetState();
 	}
 };
 
 DropZoneWidget.prototype.handleDragEnterEvent  = function(event) {
-	// Check for this window being the source of the drag
 	if($tw.dragInProgress) {
 		return false;
 	}
@@ -109,7 +141,7 @@ DropZoneWidget.prototype.handleDragLeaveEvent  = function(event) {
 };
 
 DropZoneWidget.prototype.handleDragEndEvent = function(event) {
-	$tw.utils.removeClass(this.domNodes[0],"tc-dragover");
+	this.resetState();
 };
 
 DropZoneWidget.prototype.filterByContentTypes = function(tiddlerFieldsArray) {
@@ -117,7 +149,7 @@ DropZoneWidget.prototype.filterByContentTypes = function(tiddlerFieldsArray) {
 		filtered = [],
 		types = [];
 	$tw.utils.each(tiddlerFieldsArray,function(tiddlerFields) {
-		types.push(tiddlerFields.type);
+		types.push(tiddlerFields.type || "");
 	});
 	filteredTypes = this.wiki.filterTiddlers(this.contentTypesFilter,this,this.wiki.makeTiddlerIterator(types));
 	$tw.utils.each(tiddlerFieldsArray,function(tiddlerFields) {
@@ -157,7 +189,7 @@ DropZoneWidget.prototype.handleDropEvent  = function(event) {
 	var self = this,
 		dataTransfer = event.dataTransfer;
 	// Remove highlighting
-	$tw.utils.removeClass(this.domNodes[0],"tc-dragover");
+	this.resetState();
 	// Import any files in the drop
 	var numFiles = 0;
 	if(dataTransfer.files) {


### PR DESCRIPTION
This is a quick draft PR with a proposal for how to resolve the issues described in #5616 where the `dragover` state incorrectly persists in `<$dropzone>`. If we are amenable to this approach I will clean this up for merging.

**Summary of the problem:**
The `dragover` state incorrectly persists whenever the dragged object leaves the dropzone DOM node and the count of entered/exited nodes in `currentlyEntered` is inaccurate and not 0. The underlying reason is that the `dragleave` and `dragenter` events do not always fire for all DOM nodes, particularly in Firefox.

After quite extensive research and having tried a fair few things, I have finally identified an approach that can resolve this issue.

**Proposed workaround:**
- The first time `dragenter` fires within the dropzone, we attach `dragenter`, `dragleave` and `click` listeners to the `document.body`.
- In this `dragenter` listener, we check the `event.target` to see if it is a descendant of the dropzone DOM node. If it is not we know the drag has moved outside the dropzone, we reset the state of the dropzone, which includes removing the event listeners we had attached. This relies on the fact that whenever the drag leaves the dropzone a `dragenter` is fired on a DOM node outside the dropzone.
- This however doesn't cover the scenario where the dropzone covers nearly the entire viewport and the dragged file leaves the browser window. For this we check in the `dragleave` listener on `document.body` if the `relatedTarget` is null. If so, the drag has left the window and we can reset the state of the dropzone.
- There is a `resetState()` method in the widget that is called for all scenarios where the drag has concluded in the dropzone. This method removes the dragover class, sets `currentlyEntered` to an empty array and removes the extra event listeners that were added.
- The above accounts for all cases where the dragover state can incorrectly persist apart from using the <kbd>Escape</kbd> key to cancel the drag event in webkit browsers. This does not fire a dragend or dragleave event. As mitigation towards this, we have the `click` event listener which resets the dropzone.

I do not think there is an alternative fix that would not involve listening for events on the entire document. The extra event listeners are only present for the duration of the drag.

With this approach we could actually rewrite the entire dropzone widget and remove the need for tracking DOM nodes entered and left in `currentlyEntered[]`. However, the existing solution is more semantically correct and we are only having issues due to the HTML5 drag and drop spec being flawed and the browser implementations inconsistent. Therefore I would be in favour of adding these additional checks to the existing implementation as in the code in this PR. This will make it easier to remove this additional code once the browser implementation gets cleaned up (one can hope!).

Thoughts @Jermolene? 
