### PR TITLE
CurrentTiddler variable consistency in subfilters and prefixes

### DIFF
--- a/core/modules/filterrunprefixes/filter.js
+++ b/core/modules/filterrunprefixes/filter.js
@@ -17,10 +17,21 @@ exports.filter = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		if(results.length > 0) {
 			var resultsToRemove = [];
-			results.each(function(result) {
-				var filtered = operationSubFunction(options.wiki.makeTiddlerIterator([result]),widget);
+			results.each(function(title) {
+				var filtered = operationSubFunction(options.wiki.makeTiddlerIterator([title]),{
+					getVariable: function(name) {
+						switch(name) {
+							case "currentTiddler":
+								return "" + title;
+							case "outerCurrentTiddler":
+								return widget.getVariable("currentTiddler");
+							default:
+								return widget.getVariable(name);
+						}
+					}
+				});
 				if(filtered.length === 0) {
-					resultsToRemove.push(result);
+					resultsToRemove.push(title);
 				}
 			});
 			results.remove(resultsToRemove);

--- a/core/modules/filterrunprefixes/filter.js
+++ b/core/modules/filterrunprefixes/filter.js
@@ -23,7 +23,7 @@ exports.filter = function(operationSubFunction,options) {
 						switch(name) {
 							case "currentTiddler":
 								return "" + title;
-							case "outerCurrentTiddler":
+							case "..currentTiddler":
 								return widget.getVariable("currentTiddler");
 							default:
 								return widget.getVariable(name);

--- a/core/modules/filterrunprefixes/reduce.js
+++ b/core/modules/filterrunprefixes/reduce.js
@@ -23,7 +23,7 @@ exports.reduce = function(operationSubFunction,options) {
 						switch(name) {
 							case "currentTiddler":
 								return "" + title;
-							case "outerCurrentTiddler":
+							case "..currentTiddler":
 								return widget.getVariable("currentTiddler");
 							case "accumulator":
 								return "" + accumulator;

--- a/core/modules/filterrunprefixes/reduce.js
+++ b/core/modules/filterrunprefixes/reduce.js
@@ -19,23 +19,25 @@ exports.reduce = function(operationSubFunction,options) {
 			var index = 0;
 			results.each(function(title) {
 				var list = operationSubFunction(options.wiki.makeTiddlerIterator([title]),{
-						getVariable: function(name) {
-							switch(name) {
-								case "currentTiddler":
-									return "" + title;
-								case "accumulator":
-									return "" + accumulator;
-								case "index":
-									return "" + index;
-								case "revIndex":
-									return "" +  (results.length - 1 - index);
-								case "length":
-									return "" + results.length;
-								default:
-									return widget.getVariable(name);
-							}
+					getVariable: function(name) {
+						switch(name) {
+							case "currentTiddler":
+								return "" + title;
+							case "outerCurrentTiddler":
+								return widget.getVariable("currentTiddler");
+							case "accumulator":
+								return "" + accumulator;
+							case "index":
+								return "" + index;
+							case "revIndex":
+								return "" +  (results.length - 1 - index);
+							case "length":
+								return "" + results.length;
+							default:
+								return widget.getVariable(name);
 						}
-					});
+					}
+				});
 				if(list.length > 0) {
 					accumulator = "" + list[0];
 				}

--- a/core/modules/filterrunprefixes/sort.js
+++ b/core/modules/filterrunprefixes/sort.js
@@ -26,15 +26,17 @@ exports.sort = function(operationSubFunction,options) {
 				compareFn;	
 			results.each(function(title) {
 				var key = operationSubFunction(options.wiki.makeTiddlerIterator([title]),{
-						getVariable: function(name) {
-							switch(name) {
-								case "currentTiddler":
-									return "" + title;
-								default:
-									return widget.getVariable(name);
-							}
+					getVariable: function(name) {
+						switch(name) {
+							case "currentTiddler":
+								return "" + title;
+							case "outerCurrentTiddler":
+								return widget.getVariable("currentTiddler");
+							default:
+								return widget.getVariable(name);
 						}
-					});
+					}
+				});
 				sortKeys.push(key[0] || "");
 			});
 			results.clear();

--- a/core/modules/filterrunprefixes/sort.js
+++ b/core/modules/filterrunprefixes/sort.js
@@ -30,7 +30,7 @@ exports.sort = function(operationSubFunction,options) {
 						switch(name) {
 							case "currentTiddler":
 								return "" + title;
-							case "outerCurrentTiddler":
+							case "..currentTiddler":
 								return widget.getVariable("currentTiddler");
 							default:
 								return widget.getVariable(name);

--- a/core/modules/filters/filter.js
+++ b/core/modules/filters/filter.js
@@ -25,7 +25,7 @@ exports.filter = function(source,operator,options) {
 					switch(name) {
 						case "currentTiddler":
 							return "" + title;
-						case "outerCurrentTiddler":
+						case "..currentTiddler":
 							return options.widget.getVariable("currentTiddler");
 						default:
 							return options.widget.getVariable(name);

--- a/core/modules/filters/filter.js
+++ b/core/modules/filters/filter.js
@@ -20,7 +20,18 @@ exports.filter = function(source,operator,options) {
 		results = [],
 		target = operator.prefix !== "!";
 	source(function(tiddler,title) {
-		var list = filterFn.call(options.wiki,options.wiki.makeTiddlerIterator([title]),options.widget);
+		var list = filterFn.call(options.wiki,options.wiki.makeTiddlerIterator([title]),{
+				getVariable: function(name) {
+					switch(name) {
+						case "currentTiddler":
+							return "" + title;
+						case "outerCurrentTiddler":
+							return options.widget.getVariable("currentTiddler");
+						default:
+							return options.widget.getVariable(name);
+					}
+				}
+			});
 		if((list.length > 0) === target) {
 			results.push(title);
 		}

--- a/core/modules/filters/reduce.js
+++ b/core/modules/filters/reduce.js
@@ -31,7 +31,7 @@ exports.reduce = function(source,operator,options) {
 					switch(name) {
 						case "currentTiddler":
 							return "" + title;
-						case "outerCurrentTiddler":
+						case "..currentTiddler":
 							return options.widget.getVariable("currentTiddler");
 						case "accumulator":
 							return "" + accumulator;

--- a/core/modules/filters/reduce.js
+++ b/core/modules/filters/reduce.js
@@ -31,6 +31,8 @@ exports.reduce = function(source,operator,options) {
 					switch(name) {
 						case "currentTiddler":
 							return "" + title;
+						case "outerCurrentTiddler":
+							return options.widget.getVariable("currentTiddler");
 						case "accumulator":
 							return "" + accumulator;
 						case "index":

--- a/core/modules/filters/sortsub.js
+++ b/core/modules/filters/sortsub.js
@@ -30,7 +30,7 @@ exports.sortsub = function(source,operator,options) {
 				switch(name) {
 					case "currentTiddler":
 						return "" + title;
-					case "outerCurrentTiddler":
+					case "..currentTiddler":
 						return options.widget.getVariable("currentTiddler");
 					default:
 						return options.widget.getVariable(name);

--- a/core/modules/filters/sortsub.js
+++ b/core/modules/filters/sortsub.js
@@ -27,10 +27,13 @@ exports.sortsub = function(source,operator,options) {
 			iterator(options.wiki.getTiddler(title),title);
 		},{
 			getVariable: function(name) {
-				if(name === "currentTiddler") {
-					return title;
-				} else {
-					return options.widget.getVariable(name);
+				switch(name) {
+					case "currentTiddler":
+						return "" + title;
+					case "outerCurrentTiddler":
+						return options.widget.getVariable("currentTiddler");
+					default:
+						return options.widget.getVariable(name);
 				}
 			}
 		});

--- a/editions/tw5.com/tiddlers/filters/filter.tid
+++ b/editions/tw5.com/tiddlers/filters/filter.tid
@@ -1,6 +1,6 @@
 caption: filter
 created: 20200929174420821
-modified: 20210517140705058
+modified: 20210522162551921
 op-input: a [[selection of titles|Title Selection]] passed as input to the filter
 op-neg-input: a [[selection of titles|Title Selection]] passed as input to the filter
 op-neg-output: those input titles that <<.em "do not">> pass the filter  <<.place S>>
@@ -28,7 +28,7 @@ Simple filter operations can be concatenated together directly (eg `[tag[HelloTh
 </$vars>
 ```
 
-Note that within the subfilter, the "currentTiddler" variable is set to the title of the tiddler being processed. The value of currentTiddler outside the subfilter is available in the variable "outerCurrentTiddler". <<.from-version "5.1.24">>
+Note that within the subfilter, the "currentTiddler" variable is set to the title of the tiddler being processed. The value of currentTiddler outside the subfilter is available in the variable "..currentTiddler". <<.from-version "5.1.24">>
 
 <<.tip "Compare with the similar [[subfilter|subfilter Operator]] operator which runs a subfilter and directly returns the results">>
 

--- a/editions/tw5.com/tiddlers/filters/filter.tid
+++ b/editions/tw5.com/tiddlers/filters/filter.tid
@@ -1,6 +1,6 @@
 caption: filter
 created: 20200929174420821
-modified: 20201027185144953
+modified: 20210517140705058
 op-input: a [[selection of titles|Title Selection]] passed as input to the filter
 op-neg-input: a [[selection of titles|Title Selection]] passed as input to the filter
 op-neg-output: those input titles that <<.em "do not">> pass the filter  <<.place S>>
@@ -27,6 +27,8 @@ Simple filter operations can be concatenated together directly (eg `[tag[HelloTh
 </$list>
 </$vars>
 ```
+
+Note that within the subfilter, the "currentTiddler" variable is set to the title of the tiddler being processed. The value of currentTiddler outside the subfilter is available in the variable "outerCurrentTiddler". <<.from-version "5.1.24">>
 
 <<.tip "Compare with the similar [[subfilter|subfilter Operator]] operator which runs a subfilter and directly returns the results">>
 

--- a/editions/tw5.com/tiddlers/filters/reduce.tid
+++ b/editions/tw5.com/tiddlers/filters/reduce.tid
@@ -1,6 +1,6 @@
 caption: reduce
 created: 20201004154131193
-modified: 20210517140651758
+modified: 20210522162536854
 op-input: a [[selection of titles|Title Selection]] passed as input to the filter
 op-output: the final result of running the subfilter <<.place S>>
 op-parameter: a [[filter expression|Filter Expression]]. Optional second parameter for initial value for accumulator
@@ -18,7 +18,7 @@ The following variables are available within the subfilter:
 
 * ''accumulator'' - the result of the previous subfilter run
 * ''currentTiddler'' - the input title
-* ''outerCurrentTiddler'' - the value of the variable `currentTiddler` outside the subfilter. <<.from-version "5.1.24">>
+* ''..currentTiddler'' - the value of the variable `currentTiddler` outside the subfilter. <<.from-version "5.1.24">>
 * ''index'' - the numeric index of the current list item (with zero being the first item in the list)
 * ''revIndex'' - the reverse numeric index of the current list item (with zero being the last item in the list)
 * ''length'' - the total length of the input list

--- a/editions/tw5.com/tiddlers/filters/reduce.tid
+++ b/editions/tw5.com/tiddlers/filters/reduce.tid
@@ -1,6 +1,6 @@
 caption: reduce
 created: 20201004154131193
-modified: 20201208185109549
+modified: 20210517140651758
 op-input: a [[selection of titles|Title Selection]] passed as input to the filter
 op-output: the final result of running the subfilter <<.place S>>
 op-parameter: a [[filter expression|Filter Expression]]. Optional second parameter for initial value for accumulator
@@ -18,6 +18,7 @@ The following variables are available within the subfilter:
 
 * ''accumulator'' - the result of the previous subfilter run
 * ''currentTiddler'' - the input title
+* ''outerCurrentTiddler'' - the value of the variable `currentTiddler` outside the subfilter. <<.from-version "5.1.24">>
 * ''index'' - the numeric index of the current list item (with zero being the first item in the list)
 * ''revIndex'' - the reverse numeric index of the current list item (with zero being the last item in the list)
 * ''length'' - the total length of the input list

--- a/editions/tw5.com/tiddlers/filters/sortsub Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/sortsub Operator.tid
@@ -1,6 +1,6 @@
 caption: sortsub
 created: 20200424160155182
-modified: 20210517140643256
+modified: 20210522162521222
 op-input: a [[selection of titles|Title Selection]]
 op-neg-output: the input, sorted into reverse order by the result of evaluating subfilter <<.param S>>
 op-output: the input, sorted into ascending order by the result of evaluating subfilter <<.param S>>
@@ -17,7 +17,7 @@ Each item in the list of input titles is passed to the subfilter in turn. The su
 
 Note that within the subfilter, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits subfilters like `[{!!value}divide{!!cost}]` to be used for computation. 
 
-The value of currentTiddler outside the subfilter is available in the variable "outerCurrentTiddler". <<.from-version "5.1.24">>
+The value of currentTiddler outside the subfilter is available in the variable "..currentTiddler". <<.from-version "5.1.24">>
 
 The suffix <<.place T>> determines how the items are compared and can be:
 

--- a/editions/tw5.com/tiddlers/filters/sortsub Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/sortsub Operator.tid
@@ -1,6 +1,6 @@
 caption: sortsub
 created: 20200424160155182
-modified: 20210428152533501
+modified: 20210517140643256
 op-input: a [[selection of titles|Title Selection]]
 op-neg-output: the input, sorted into reverse order by the result of evaluating subfilter <<.param S>>
 op-output: the input, sorted into ascending order by the result of evaluating subfilter <<.param S>>
@@ -15,7 +15,9 @@ type: text/vnd.tiddlywiki
 
 Each item in the list of input titles is passed to the subfilter in turn. The subfilter transforms the input titles into the form needed for sorting. For example, the subfilter `[length[]]` transforms each input title in the number representing its length, and thus sorts the input titles according to their length.
 
-Note that within the subfilter, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits subfilters like `[{!!value}divide{!!cost}]` to be used for computation.
+Note that within the subfilter, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits subfilters like `[{!!value}divide{!!cost}]` to be used for computation. 
+
+The value of currentTiddler outside the subfilter is available in the variable "outerCurrentTiddler". <<.from-version "5.1.24">>
 
 The suffix <<.place T>> determines how the items are compared and can be:
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
@@ -1,5 +1,5 @@
 created: 20150124182421000
-modified: 20210428084144231
+modified: 20210517140609511
 tags: [[Filter Syntax]]
 title: Filter Expression
 type: text/vnd.tiddlywiki
@@ -32,6 +32,8 @@ If a run has:
 <<.tip "Compare named filter run prefix `:filter` with [[filter Operator]] which applies a subfilter to every input title, removing the titles that return an empty result from the subfilter">>
 
 <<.tip "Compare named filter run prefix `:reduce` with [[reduce Operator]] which is used to used to flatten a list of items down to a single item by repeatedly applying a subfilter.">> 
+
+<<.tip """Within the filter runs prefixed with `:reduce`, `:sort` and `:filter`, the "currentTiddler" variable is set to the title of the tiddler being processed. The value of currentTiddler outside the subfilter is available in the variable "outerCurrentTiddler".<<.from-version "5.1.24">>""" >>
 
 In technical / logical terms:
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
@@ -1,5 +1,5 @@
 created: 20150124182421000
-modified: 20210517140609511
+modified: 20210522162642994
 tags: [[Filter Syntax]]
 title: Filter Expression
 type: text/vnd.tiddlywiki
@@ -33,7 +33,7 @@ If a run has:
 
 <<.tip "Compare named filter run prefix `:reduce` with [[reduce Operator]] which is used to used to flatten a list of items down to a single item by repeatedly applying a subfilter.">> 
 
-<<.tip """Within the filter runs prefixed with `:reduce`, `:sort` and `:filter`, the "currentTiddler" variable is set to the title of the tiddler being processed. The value of currentTiddler outside the subfilter is available in the variable "outerCurrentTiddler".<<.from-version "5.1.24">>""" >>
+<<.tip """Within the filter runs prefixed with `:reduce`, `:sort` and `:filter`, the "currentTiddler" variable is set to the title of the tiddler being processed. The value of currentTiddler outside the subfilter is available in the variable "..currentTiddler".<<.from-version "5.1.24">>""" >>
 
 In technical / logical terms:
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix.tid
@@ -1,5 +1,5 @@
 created: 20210428083929749
-modified: 20210517140629838
+modified: 20210522162628946
 tags: [[Filter Syntax]] [[Filter Run Prefix]]
 title: Sort Filter Run Prefix
 type: text/vnd.tiddlywiki
@@ -13,7 +13,7 @@ type: text/vnd.tiddlywiki
 
 Each input title from previous runs is passed to this run in turn. The filter run transforms the input titles into the form needed for sorting. For example, the filter run `[length[]]` transforms each input title in to the number representing its length, and thus sorts the input titles according to their length.
 
-Note that within the filter run, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits filter runs like `:sort:number[{!!value}divide{!!cost}]` to be used for computation. The value of currentTiddler outside the run is available in the variable "outerCurrentTiddler".
+Note that within the filter run, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits filter runs like `:sort:number[{!!value}divide{!!cost}]` to be used for computation. The value of currentTiddler outside the run is available in the variable "..currentTiddler".
 
 The `:sort` filter run prefix uses an extended syntax that allows for multiple suffixes, some of which are required:
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix.tid
@@ -1,5 +1,5 @@
 created: 20210428083929749
-modified: 20210428140713422
+modified: 20210517140629838
 tags: [[Filter Syntax]] [[Filter Run Prefix]]
 title: Sort Filter Run Prefix
 type: text/vnd.tiddlywiki
@@ -13,7 +13,7 @@ type: text/vnd.tiddlywiki
 
 Each input title from previous runs is passed to this run in turn. The filter run transforms the input titles into the form needed for sorting. For example, the filter run `[length[]]` transforms each input title in to the number representing its length, and thus sorts the input titles according to their length.
 
-Note that within the filter run, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits filter runs like `:sort:number[{!!value}divide{!!cost}]` to be used for computation.
+Note that within the filter run, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits filter runs like `:sort:number[{!!value}divide{!!cost}]` to be used for computation. The value of currentTiddler outside the run is available in the variable "outerCurrentTiddler".
 
 The `:sort` filter run prefix uses an extended syntax that allows for multiple suffixes, some of which are required:
 


### PR DESCRIPTION
Fixes #5683 

This PR makes the value of currentTiddler consistent in filters operators that implement subfilters which are invoked once for each input title, as well as their corresponding filter run prefix equivalents.

Documentation has also been updated.