### PR TITLE
sort plugins, themes and languages in Control Panel

### DIFF
--- a/core/ui/ControlPanel/Plugins.tid
+++ b/core/ui/ControlPanel/Plugins.tid
@@ -7,7 +7,8 @@ caption: {{$:/language/ControlPanel/Plugins/Caption}}
 \define plugin-table(type)
 <$set name="plugin-type" value="""$type$""">
 <$set name="qualified-state" value=<<qualify "$:/state/plugin-info">>>
-<$list filter="[!has[draft.of]plugin-type[$type$]sort[name]]" emptyMessage=<<lingo "Empty/Hint">> template="$:/core/ui/Components/plugin-info"/>
+<$list filter="[<__type__>match[plugin]then[$:/core]]" template="$:/core/ui/Components/plugin-info"/>
+<$list filter="[!has[draft.of]plugin-type[$type$]prefix[$:/$type$s/tiddlywiki]sort[name]] [!has[draft.of]plugin-type[$type$]!prefix[$:/$type$s/tiddlywiki]!title[$:/core]sort[name]]" emptyMessage=<<lingo "Empty/Hint">> template="$:/core/ui/Components/plugin-info"/>
 </$set>
 </$set>
 \end


### PR DESCRIPTION
This PR address the issue raised in discussion board!
See: https://github.com/Jermolene/TiddlyWiki5/discussions/5256

This PR does as below

- put the $:/core as first item in Plugins list in control panel
- it then lists **first the official plugins** [IMPORTANT]
- after official plugins it shows third party plugins
- it sorts plugins by name (unfortunately not all plugins have name! This PR did not touch this part)

@saqimtiaz I appreciate to have a look at the filter I used!