### PR TITLE
Plugins tab in control panel display tabs using filter instead of har…

### DIFF
--- a/core/ui/ControlPanel/Plugins.tid
+++ b/core/ui/ControlPanel/Plugins.tid
@@ -16,4 +16,4 @@ caption: {{$:/language/ControlPanel/Plugins/Caption}}
 
 <<lingo Installed/Hint>>
 
-<$macrocall $name="tabs" tabsList="[[$:/core/ui/ControlPanel/Plugins/Installed/Plugins]] [[$:/core/ui/ControlPanel/Plugins/Installed/Themes]] [[$:/core/ui/ControlPanel/Plugins/Installed/Languages]]" default="$:/core/ui/ControlPanel/Plugins/Installed/Plugins" explicitState="$:/state/tab--86143343"/>
+<$macrocall $name="tabs" tabsList="[all[tiddlers+shadows]tag[$:/tags/ControlPanel/Plugins]!has[draft.of]]" default="$:/core/ui/ControlPanel/Plugins/Installed/Plugins" explicitState="$:/state/tab--86143343"/>

--- a/core/ui/ControlPanel/Plugins/Installed/Languages.tid
+++ b/core/ui/ControlPanel/Plugins/Installed/Languages.tid
@@ -1,4 +1,5 @@
 title: $:/core/ui/ControlPanel/Plugins/Installed/Languages
+tags: $:/tags/ControlPanel/Plugins
 caption: {{$:/language/ControlPanel/Plugins/Languages/Caption}} (<$count filter="[!has[draft.of]plugin-type[language]]"/>)
 
 <<plugin-table language>>

--- a/core/ui/ControlPanel/Plugins/Installed/Plugins.tid
+++ b/core/ui/ControlPanel/Plugins/Installed/Plugins.tid
@@ -1,4 +1,5 @@
 title: $:/core/ui/ControlPanel/Plugins/Installed/Plugins
+tags: $:/tags/ControlPanel/Plugins
 caption: {{$:/language/ControlPanel/Plugins/Plugins/Caption}} (<$count filter="[!has[draft.of]plugin-type[plugin]]"/>)
 
 <<plugin-table plugin>>

--- a/core/ui/ControlPanel/Plugins/Installed/Themes.tid
+++ b/core/ui/ControlPanel/Plugins/Installed/Themes.tid
@@ -1,4 +1,5 @@
 title: $:/core/ui/ControlPanel/Plugins/Installed/Themes
+tags: $:/tags/ControlPanel/Plugins
 caption: {{$:/language/ControlPanel/Plugins/Themes/Caption}} (<$count filter="[!has[draft.of]plugin-type[theme]]"/>)
 
 <<plugin-table theme>>

--- a/core/wiki/tags/ControlPanelPlugins.tid
+++ b/core/wiki/tags/ControlPanelPlugins.tid
@@ -1,2 +1,2 @@
 title: $:/tags/ControlPanel/Plugins
-list: $:/core/ui/ControlPanel/Plugins/Installed/Plugins $:/core/ui/ControlPanel/Plugins/Installed/Themes $:/core/ui/ControlPanel/Plugins/Installed/Languages [[$:/core/ui/ControlPanel/Plugins/Installed]] [[$:/core/ui/ControlPanel/Plugins/Add]]
+list: $:/core/ui/ControlPanel/Plugins/Installed/Plugins $:/core/ui/ControlPanel/Plugins/Installed/Themes $:/core/ui/ControlPanel/Plugins/Installed/Languages

--- a/core/wiki/tags/ControlPanelPlugins.tid
+++ b/core/wiki/tags/ControlPanelPlugins.tid
@@ -1,2 +1,2 @@
 title: $:/tags/ControlPanel/Plugins
-list: [[$:/core/ui/ControlPanel/Plugins/Installed]] [[$:/core/ui/ControlPanel/Plugins/Add]]
+list: $:/core/ui/ControlPanel/Plugins/Installed/Plugins $:/core/ui/ControlPanel/Plugins/Installed/Themes $:/core/ui/ControlPanel/Plugins/Installed/Languages [[$:/core/ui/ControlPanel/Plugins/Installed]] [[$:/core/ui/ControlPanel/Plugins/Add]]

--- a/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_ControlPanel_Plugins.tid
+++ b/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_ControlPanel_Plugins.tid
@@ -1,0 +1,9 @@
+caption: $:/tags/ControlPanel/Plugins
+created: 20210807123106257
+description: marks elements to be placed under "Plugins" tab in Control Panel
+modified: 20210807123621182
+tags: SystemTags
+title: SystemTag: $:/tags/ControlPanel/Plugins
+type: text/vnd.tiddlywiki
+
+The [[system tag|SystemTags]] `$:/tags/ControlPanel/Plugins` marks elements to be placed under "Plugins" tab in [[$:/ControlPanel]]


### PR DESCRIPTION
Implement part of ideas in https://github.com/Jermolene/TiddlyWiki5/discussions/5462

This PR  uses filter to list plugins (themes, plugins, language)
This is the first step to let developer add their tab into plugin tab without touching the core tiddlers.
The current status is: a tabs macro with hardcoded list!
