### PR TITLE
Focus-Preservation over refresh cycles II

### DIFF
--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -70,6 +70,10 @@ PageTemplate/Description: the default ~TiddlyWiki layout
 PageTemplate/Name: Default ~PageTemplate
 PluginReloadWarning: Please save {{$:/core/ui/Buttons/save-wiki}} and reload {{$:/core/ui/Buttons/refresh}} to allow changes to ~JavaScript plugins to take effect
 RecentChanges/DateFormat: DDth MMM YYYY
+Shortcuts/CloseFocusTiddler/Hint: Close the focused tiddler
+Shortcuts/EditFocusTiddler/Hint: Edit the focused tiddler
+Shortcuts/FocusNextTiddler/Hint: Focus the next tiddler in the ~StoryRiver
+Shortcuts/FocusPreviousTiddler/Hint: Focus the previous tiddler in the ~StoryRiver
 Shortcuts/Input/AdvancedSearch/Hint: Open the ~AdvancedSearch panel from within the sidebar search field
 Shortcuts/Input/Accept/Hint: Accept the selected item
 Shortcuts/Input/AcceptVariant/Hint: Accept the selected item (variant)

--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -86,10 +86,12 @@ function FramedEngine(options) {
 		{name: "click",handlerObject: this,handlerMethod: "handleClickEvent"},
 		{name: "input",handlerObject: this,handlerMethod: "handleInputEvent"},
 		{name: "keydown",handlerObject: this.widget,handlerMethod: "handleKeydownEvent"},
-		{name: "focus",handlerObject: this,handlerMethod: "handleFocusEvent"}
+		{name: "focus",handlerObject: this,handlerMethod: "handleFocusEvent"},
+		{name: "blur",handlerObject: this, handlerMethod: "handleBlurEvent"}
 	]);
 	// Insert the element into the DOM
 	this.iframeDoc.body.appendChild(this.domNode);
+	this.widget.domNodes.push(this.domNode);
 }
 
 /*
@@ -105,6 +107,25 @@ FramedEngine.prototype.copyStyles = function() {
 	// In Chrome setting -webkit-text-fill-color overrides the placeholder text colour
 	this.domNode.style["-webkit-text-fill-color"] = "currentcolor";
 };
+
+/*
+Get an object containing the selectionStart and selectionEnd values
+*/
+FramedEngine.prototype.getSelectionRange = function() {
+	return {
+		selectionStart: this.domNode.selectionStart,
+		selectionEnd: this.domNode.selectionEnd
+	}
+};
+
+/*
+Set the selection-range
+*/
+FramedEngine.prototype.setSelectionRange = function(selectionStart,selectionEnd) {
+	this.domNode.selectionStart = selectionStart;
+	this.domNode.selectionEnd = selectionEnd;
+};
+
 
 /*
 Set the text of the engine if it doesn't currently have focus
@@ -171,6 +192,20 @@ Handle a focus event
 FramedEngine.prototype.handleFocusEvent = function(event) {
 	if(this.widget.editCancelPopups) {
 		$tw.popup.cancel(0);	
+	}
+	var currentTiddler = this.widget.document.querySelector('[data-tiddler-title="' + CSS.escape(this.widget.editTitle) + '"].tc-tiddler-frame');
+	if(currentTiddler) {
+		$tw.utils.addClass(currentTiddler,"tc-focused");
+	}
+};
+
+/*
+Handle a blur event
+*/
+FramedEngine.prototype.handleBlurEvent = function(event) {
+	var currentTiddler = this.widget.document.querySelector('[data-tiddler-title="' + CSS.escape(this.widget.editTitle) + '"].tc-tiddler-frame');
+	if(currentTiddler) {
+		$tw.utils.removeClass(currentTiddler,"tc-focused");
 	}
 };
 

--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -69,6 +69,25 @@ function SimpleEngine(options) {
 }
 
 /*
+Get an object containing the selectionStart and selectionEnd values
+*/
+SimpleEngine.prototype.getSelectionRange = function() {
+	return {
+		selectionStart: this.domNode.selectionStart,
+		selectionEnd: this.domNode.selectionEnd
+	}
+};
+
+/*
+Set the selection-range
+*/
+SimpleEngine.prototype.setSelectionRange = function(selectionStart,selectionEnd) {
+	this.domNode.selectionStart = selectionStart;
+	this.domNode.selectionEnd = selectionEnd;
+};
+
+
+/*
 Set the text of the engine if it doesn't currently have focus
 */
 SimpleEngine.prototype.setText = function(text,type) {

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -72,6 +72,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		this.engine.fixHeight();
 		// Focus if required
 		if(this.editFocus === "true" || this.editFocus === "yes") {
+			$tw.focusManager.interceptFocusPreservation = true;
 			this.engine.focus();
 		}
 		// Add widget message listeners

--- a/core/modules/focus.js
+++ b/core/modules/focus.js
@@ -1,0 +1,166 @@
+/*\
+title: $:/core/modules/focus.js
+type: application/javascript
+module-type: global
+
+Focus handling utilities
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+function FocusManager(options) {
+	var options = options || "";
+	this.interceptFocusPreservation = false;
+}
+
+FocusManager.prototype.findChildDomNode = function(startingDomNode,domNode) {
+	for(var domNodeIndex=0; domNodeIndex<startingDomNode.childNodes.length; domNodeIndex++) {
+		if(startingDomNode.childNodes[domNodeIndex] === domNode) {
+			return startingDomNode.childNodes[domNodeIndex];
+		}
+	}
+	for(var childIndex=0; childIndex<startingDomNode.childNodes.length; childIndex++) {
+		var result = this.findChildDomNode(startingDomNode.childNodes[childIndex],domNode);
+		if(result) {
+			return result;
+		}
+	}
+	return null;
+};
+
+FocusManager.prototype.findWidgetOwningDomNode = function(widget,domNode) {
+	for(var domNodeIndex=0; domNodeIndex<widget.domNodes.length; domNodeIndex++) {
+		if(widget.domNodes[domNodeIndex] === domNode) {
+			return widget;
+		}
+	}
+	for(var childIndex=0; childIndex<widget.children.length; childIndex++) {
+		var result = this.findWidgetOwningDomNode(widget.children[childIndex],domNode);
+		if(result) {
+			return result;
+		}
+	}
+	for(domNodeIndex=0; domNodeIndex<widget.domNodes.length; domNodeIndex++) {
+		var childDomNode = this.findChildDomNode(widget.domNodes[domNodeIndex],domNode);
+		if(childDomNode) {
+			return widget;
+		}
+	}
+	return null;
+};
+
+FocusManager.prototype.generateRenderTreeFootprint = function(widget,domNode) {
+	var footprint = [];
+	while(widget.domNodes.indexOf(domNode) === -1) {
+		var domNodeIndex = Array.prototype.indexOf.call(domNode.parentNode.children,domNode);
+		footprint.push(domNodeIndex);
+		domNode = domNode.parentNode;
+	}
+	if(widget.domNodes.indexOf(domNode) > -1) {
+		footprint.push(widget.domNodes.indexOf(domNode));
+	}
+	return footprint.reverse();
+};
+
+FocusManager.prototype.generateWidgetTreeFootprint = function(widget) {
+	var node = widget,
+		footprint = [];
+	while(node) {
+		if(node.parentWidget && node.parentWidget.children) {
+			footprint.push(node.parentWidget.children.indexOf(node));
+		}
+		node = node.parentWidget;
+	}
+	return footprint.reverse();
+};
+
+FocusManager.prototype.findWidgetByQualifier = function(qualifier,widget) {
+	for(var widgetIndex=0; widgetIndex<widget.children.length; widgetIndex++) {
+		var childWidget = widget.children[widgetIndex];
+		var childWidgetQualifier = childWidget.getStateQualifier() + "_" + childWidget.generateWidgetTreeFootprint();
+		if(childWidgetQualifier === qualifier) {
+			return widget.children[widgetIndex];
+		}
+	}
+	for(var childIndex=0; childIndex<widget.children.length; childIndex++) {
+		var result = this.findWidgetByQualifier(qualifier,widget.children[childIndex]);
+		if(result) {
+			return result;
+		}
+	}	
+	return null;
+};
+
+FocusManager.prototype.findWidgetByRenderTreeFootprint = function(footprint,startingWidget) {
+	var index,
+		count = 0,
+		widget = startingWidget,
+		lastFoundWidget;
+	while(count < footprint.length) {
+		index = footprint[count],
+		lastFoundWidget = widget;
+		if(widget && widget.children) {
+			widget = widget.children[index];
+		}
+		if(widget === undefined) {
+			break;
+		}
+		count++;
+	}
+	if(widget) {
+		return widget;
+	} else if(lastFoundWidget) {
+		return lastFoundWidget;
+	}
+	return null;
+};
+
+FocusManager.prototype.findWidgetByFootprint = function(footprint,startingWidget,widgetQualifier) {
+	var widget = this.findWidgetByQualifier(widgetQualifier,startingWidget);
+	if(!widget) {
+		widget = this.findWidgetByRenderTreeFootprint(footprint,startingWidget);
+	}
+	return widget;
+};
+
+FocusManager.prototype.findParentWidgetWithDomNodes = function(widget) {
+	while(widget) {
+		widget = widget.parentWidget;
+		if(widget.domNodes.length > 0 && widget.domNodes[0].getAttribute("hidden") !== "true" &&
+			widget.domNodes[0].nodeType !== Node.TEXT_NODE && widget.domNodes[0].focus) {
+			return widget.domNodes[0].childNodes[0];
+		}
+	}
+};
+
+FocusManager.prototype.focusWidget = function(widget,footprint,widgetInfo) {
+	if(!this.interceptFocusPreservation) {
+		var counter = 0,
+			savedDomNode,
+			domNode = widget.domNodes[footprint[0]];
+		while(domNode) {
+			counter++;
+			savedDomNode = domNode;
+			domNode = domNode.childNodes[footprint[counter]];
+		}
+		if((savedDomNode && savedDomNode.getAttribute && savedDomNode.getAttribute("hidden") === "true") || (savedDomNode === undefined)) {
+			savedDomNode = this.findParentWidgetWithDomNodes(widget);
+		}
+		if(savedDomNode && savedDomNode.focus) {
+			savedDomNode.focus({preventScroll: true});
+		}
+		if(widgetInfo.selectionStart && widgetInfo.selectionEnd && widget.engine && widget.engine.setSelectionRange) {
+			widget.engine.setSelectionRange(widgetInfo.selectionStart,widgetInfo.selectionEnd);
+		}
+	} else {
+		this.interceptFocusPreservation = false;
+	}
+};
+
+exports.FocusManager = FocusManager;
+
+})();

--- a/core/modules/startup/render.js
+++ b/core/modules/startup/render.js
@@ -70,11 +70,38 @@ exports.startup = function() {
 	var deferredChanges = Object.create(null),
 		timerId;
 	function refresh() {
+		// Detect the currently focused domNode
+		var currentlyFocusedDomNode = document.activeElement.tagName !== "IFRAME" ? document.activeElement : document.activeElement.contentWindow.document.activeElement;
+		// Find the widget owning the currently focused domNode
+		var focusWidget = $tw.focusManager.findWidgetOwningDomNode($tw.rootWidget,currentlyFocusedDomNode);
+		var renderTreeFootprint;
+		if(focusWidget) {
+			renderTreeFootprint = $tw.focusManager.generateRenderTreeFootprint(focusWidget,currentlyFocusedDomNode);
+		}
+		var widgetTreeFootprint,
+			widgetQualifier,
+			widgetInfo = {};
+		if(focusWidget) {
+			widgetTreeFootprint = $tw.focusManager.generateWidgetTreeFootprint(focusWidget);
+			widgetQualifier = focusWidget.getStateQualifier() + "_" + focusWidget.generateWidgetTreeFootprint();
+			if(focusWidget.engine && focusWidget.engine.getSelectionRange) {
+				var selections = focusWidget.engine.getSelectionRange();
+				widgetInfo.selectionStart = selections.selectionStart,
+				widgetInfo.selectionEnd = selections.selectionEnd;
+			}
+		}
 		// Process the refresh
 		$tw.hooks.invokeHook("th-page-refreshing");
 		$tw.pageWidgetNode.refresh(deferredChanges);
 		deferredChanges = Object.create(null);
 		$tw.hooks.invokeHook("th-page-refreshed");
+		var refreshedWidget;
+		if(widgetTreeFootprint) {
+			refreshedWidget = $tw.focusManager.findWidgetByFootprint(widgetTreeFootprint,$tw.rootWidget,widgetQualifier);
+		}
+		if(refreshedWidget) {
+			$tw.focusManager.focusWidget(refreshedWidget,renderTreeFootprint,widgetInfo);
+		}
 	}
 	// Add the change event handler
 	$tw.wiki.addEventListener("change",$tw.perf.report("mainRefresh",function(changes) {

--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -110,6 +110,8 @@ exports.startup = function() {
 			handlerMethod: "handleKeydownEvent"
 		}]);
 	}
+	// Kick off the focus manager
+	$tw.focusManager = new $tw.FocusManager();
 	// Clear outstanding tiddler store change events to avoid an unnecessary refresh cycle at startup
 	$tw.wiki.clearTiddlerEventQueue();
 	// Find a working syncadaptor

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -234,6 +234,36 @@ Widget.prototype.hasVariable = function(name,value) {
 	}
 	return false;
 };
+	
+	/*
+Find the widget, walking up the widget-tree, that has a different transclusion variable than the current widget
+*/
+Widget.prototype.findParentTransclusionWidget = function() {
+	var node = this;
+	var transclusionVariable = this.getVariable("transclusion");
+	while(node && node.getVariable("transclusion") === transclusionVariable) {
+		node = node.parentWidget;
+	}
+	return (node !== this) ? node : null;
+};
+
+/*
+Generate the "transclusion-footprint" of the current widget in the widget-tree up to the next widget that changes the transclusion variable
+*/
+Widget.prototype.generateWidgetTreeFootprint = function() {
+	var parentTransclusionWidget = this.findParentTransclusionWidget(),
+	    node = this,
+	    footprint = node.parentWidget.children.indexOf(node);
+	while(node) {
+		node = node.parentWidget;
+		if(node === parentTransclusionWidget) {
+			break;
+		} else if(node.parentWidget && node.parentWidget.children) {
+			footprint = footprint + "-" + node.parentWidget.children.indexOf(node);
+		}
+	}
+	return footprint;
+};
 
 /*
 Construct a qualifying string based on a hash of concatenating the values of a given variable in the parent chain

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -1,5 +1,16 @@
 title: $:/core/ui/EditTemplate
 
+\define get-focus-selector()
+[data-tiddler-title="$(cssEscapedTitle)$"].tc-tiddler-frame
+\end
+\define focus-tiddler-actions(afterOrBefore)
+<$set name="nextTiddler" value={{{ [list<tv-story-list>$afterOrBefore$<currentTiddler>] }}}>
+<$set name="cssEscapedTitle" value={{{ [<nextTiddler>escapecss[]] }}}>
+<$action-navigate $to=<<nextTiddler>>/>
+<$action-sendmessage $message="tm-focus-selector" $param=<<get-focus-selector>> preventScroll="true"/>
+</$set>
+</$set>
+\end
 \define delete-edittemplate-state-tiddlers() <$action-deletetiddler $filter="[<newFieldNameTiddler>] [<newFieldValueTiddler>] [<newFieldNameInputTiddler>] [<newFieldNameSelectionTiddler>] [<newTagNameTiddler>] [<newTagNameInputTiddler>] [<newTagNameSelectionTiddler>] [<typeInputTiddler>] [<typeSelectionTiddler>]"/>
 \define save-tiddler-actions()
 <$action-sendmessage $message="tm-add-tag" $param={{{ [<newTagNameTiddler>get[text]] }}}/>
@@ -11,18 +22,22 @@ title: $:/core/ui/EditTemplate
 <<delete-edittemplate-state-tiddlers>>
 <$action-sendmessage $message="tm-$message$-tiddler"/>
 \end
-<div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ tc-tiddler-frame tc-tiddler-edit-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}>
-<$fieldmangler>
-<$vars storyTiddler=<<currentTiddler>> newTagNameTiddler=<<qualify "$:/temp/NewTagName">> newFieldNameTiddler=<<qualify "$:/temp/NewFieldName">> newFieldValueTiddler=<<qualify "$:/temp/NewFieldValue">> newFieldNameInputTiddler=<<qualify "$:/temp/NewFieldName/input">> newFieldNameSelectionTiddler=<<qualify "$:/temp/NewFieldName/selected-item">> newTagNameInputTiddler=<<qualify "$:/temp/NewTagName/input">> newTagNameSelectionTiddler=<<qualify "$:/temp/NewTagName/selected-item">> typeInputTiddler=<<qualify "$:/temp/Type/input">> typeSelectionTiddler=<<qualify "$:/temp/Type/selected-item">>>
+<$keyboard key="((focus-next-tiddler))" actions=<<focus-tiddler-actions "after">>>
+<$keyboard key="((focus-previous-tiddler))" actions=<<focus-tiddler-actions "before">>>
 <$keyboard key="((cancel-edit-tiddler))" actions=<<cancel-delete-tiddler-actions "cancel">>>
 <$keyboard key="((save-tiddler))" actions=<<save-tiddler-actions>>>
+<div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ tc-tiddler-frame tc-tiddler-edit-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}} tabindex={{$:/config/EditTabIndex}}>
+<$fieldmangler>
+<$vars storyTiddler=<<currentTiddler>> newTagNameTiddler=<<qualify "$:/temp/NewTagName">> newFieldNameTiddler=<<qualify "$:/temp/NewFieldName">> newFieldValueTiddler=<<qualify "$:/temp/NewFieldValue">> newFieldNameInputTiddler=<<qualify "$:/temp/NewFieldName/input">> newFieldNameSelectionTiddler=<<qualify "$:/temp/NewFieldName/selected-item">> newTagNameInputTiddler=<<qualify "$:/temp/NewTagName/input">> newTagNameSelectionTiddler=<<qualify "$:/temp/NewTagName/selected-item">> typeInputTiddler=<<qualify "$:/temp/Type/input">> typeSelectionTiddler=<<qualify "$:/temp/Type/selected-item">>>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/EditTemplate]!has[draft.of]]" variable="listItem">
 <$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
 <$transclude tiddler=<<listItem>>/>
 </$set>
 </$list>
-</$keyboard>
-</$keyboard>
 </$vars>
 </$fieldmangler>
 </div>
+</$keyboard>
+</$keyboard>
+</$keyboard>
+</$keyboard>

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -22,7 +22,7 @@ title: $:/core/ui/EditTemplate
 <<delete-edittemplate-state-tiddlers>>
 <$action-sendmessage $message="tm-$message$-tiddler"/>
 \end
-<$keyboard key="((focus-next-tiddler))" actions=<<focus-tiddler-actions "after">>>
+<$keyboard key="((focus-next-tiddler))" actions=<<focus-tiddler-actions "after">> tag="div">
 <$keyboard key="((focus-previous-tiddler))" actions=<<focus-tiddler-actions "before">>>
 <$keyboard key="((cancel-edit-tiddler))" actions=<<cancel-delete-tiddler-actions "cancel">>>
 <$keyboard key="((save-tiddler))" actions=<<save-tiddler-actions>>>

--- a/core/ui/ViewTemplate.tid
+++ b/core/ui/ViewTemplate.tid
@@ -15,7 +15,7 @@ $:/state/folded/$(currentTiddler)$
 \define cancel-delete-tiddler-actions(message) <$action-sendmessage $message="tm-$message$-tiddler"/>
 \import [all[shadows+tiddlers]tag[$:/tags/Macro/View]!has[draft.of]]
 <$vars storyTiddler=<<currentTiddler>> tiddlerInfoState=<<qualify "$:/state/popup/tiddler-info">>>
-<$keyboard key="((focus-next-tiddler))" actions=<<focus-tiddler-actions "after">>>
+<$keyboard key="((focus-next-tiddler))" actions=<<focus-tiddler-actions "after">> tag="div">
 <$keyboard key="((focus-previous-tiddler))" actions=<<focus-tiddler-actions "before">>>
 <$keyboard key="((edit-focus-tiddler))" actions="""<$action-sendmessage $message="tm-edit-tiddler"/>""">
 <$keyboard key="((close-focus-tiddler))" actions="""<$action-sendmessage $message="tm-close-tiddler"/>""">

--- a/core/ui/ViewTemplate.tid
+++ b/core/ui/ViewTemplate.tid
@@ -3,8 +3,29 @@ title: $:/core/ui/ViewTemplate
 \define folded-state()
 $:/state/folded/$(currentTiddler)$
 \end
+\define get-focus-selector() [data-tiddler-title="$(cssEscapedTitle)$"].tc-tiddler-frame
+\define focus-tiddler-actions(afterOrBefore)
+<$set name="nextTiddler" value={{{ [list<tv-story-list>$afterOrBefore$<currentTiddler>] }}}>
+<$set name="cssEscapedTitle" value={{{ [<nextTiddler>escapecss[]] }}}>
+<$action-navigate $to=<<nextTiddler>>/>
+<$action-sendmessage $message="tm-focus-selector" $param=<<get-focus-selector>> preventScroll="true"/>
+</$set>
+</$set>
+\end
 \define cancel-delete-tiddler-actions(message) <$action-sendmessage $message="tm-$message$-tiddler"/>
 \import [all[shadows+tiddlers]tag[$:/tags/Macro/View]!has[draft.of]]
-<$vars storyTiddler=<<currentTiddler>> tiddlerInfoState=<<qualify "$:/state/popup/tiddler-info">>><div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ tc-tiddler-frame tc-tiddler-view-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[shadow]is[tiddler]then[tc-tiddler-overridden-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}><$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate]!has[draft.of]]" variable="listItem"><$transclude tiddler=<<listItem>>/></$list>
+<$vars storyTiddler=<<currentTiddler>> tiddlerInfoState=<<qualify "$:/state/popup/tiddler-info">>>
+<$keyboard key="((focus-next-tiddler))" actions=<<focus-tiddler-actions "after">>>
+<$keyboard key="((focus-previous-tiddler))" actions=<<focus-tiddler-actions "before">>>
+<$keyboard key="((edit-focus-tiddler))" actions="""<$action-sendmessage $message="tm-edit-tiddler"/>""">
+<$keyboard key="((close-focus-tiddler))" actions="""<$action-sendmessage $message="tm-close-tiddler"/>""">
+<div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ tc-tiddler-frame tc-tiddler-view-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[shadow]is[tiddler]then[tc-tiddler-overridden-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}} tabindex={{$:/config/EditTabIndex}}>
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate]!has[draft.of]]" variable="listItem">
+<$transclude tiddler=<<listItem>>/>
+</$list>
 </div>
+</$keyboard>
+</$keyboard>
+</$keyboard>
+</$keyboard>
 </$vars>

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -6,8 +6,12 @@ advanced-search-sidebar: {{$:/language/Shortcuts/Input/AdvancedSearch/Hint}}
 bold: {{$:/language/Buttons/Bold/Hint}}
 cancel-edit-tiddler: {{$:/language/Buttons/Cancel/Hint}}
 change-sidebar-layout: {{$:/language/Shortcuts/SidebarLayout/Hint}}
+close-focus-tiddler: {{$:/language/Shortcuts/CloseFocusTiddler/Hint}}
 delete-field: {{$:/language/EditTemplate/Field/Remove/Hint}}
+edit-focus-tiddler: {{$:/language/Shortcuts/EditFocusTiddler/Hint}}
 excise: {{$:/language/Buttons/Excise/Hint}}
+focus-next-tiddler: {{$:/language/Shortcuts/FocusNextTiddler/Hint}}
+focus-previous-tiddler: {{$:/language/Shortcuts/FocusPreviousTiddler/Hint}}
 heading-1: {{$:/language/Buttons/Heading1/Hint}}
 heading-2: {{$:/language/Buttons/Heading2/Hint}}
 heading-3: {{$:/language/Buttons/Heading3/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -5,8 +5,12 @@ advanced-search: ctrl-shift-A
 advanced-search-sidebar: alt-Enter
 cancel-edit-tiddler: escape
 change-sidebar-layout: shift-alt-Down
+close-focus-tiddler: alt-C
 delete-field: shift-alt-D
+edit-focus-tiddler: alt-E
 excise: ctrl-E
+focus-next-tiddler: alt-Down
+focus-previous-tiddler: alt-Up
 sidebar-search: ctrl-shift-F
 heading-1: ctrl-1
 heading-2: ctrl-2

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -139,6 +139,33 @@ function CodeMirrorEngine(options) {
 }
 
 /*
+Get an object containing the selectionStart and selectionEnd values
+*/
+CodeMirrorEngine.prototype.getSelectionRange = function() {
+	var selections = this.cm.listSelections(),
+	    anchorPos,
+	    headPos;
+	if(selections.length > 0) {
+		anchorPos = this.cm.indexFromPos(selections[0].anchor),
+		headPos = this.cm.indexFromPos(selections[0].head);
+	} else {
+		anchorPos = headPos = this.cm.indexFromPos(this.cm.getCursor());
+	}
+	return {
+		selectionStart: anchorPos,
+		selectionEnd: headPos
+	}
+};
+
+/*
+Set the selection-range
+*/
+CodeMirrorEngine.prototype.setSelectionRange = function(selectionStart,selectionEnd) {
+	this.cm.setSelection(this.cm.posFromIndex(selectionStart),this.cm.posFromIndex(selectionEnd));
+};
+
+
+/*
 Set the text of the engine if it doesn't currently have focus
 */
 CodeMirrorEngine.prototype.setText = function(text,type) {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1003,6 +1003,15 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	border: 1px solid <<colour tiddler-border>>;
 }
 
+.tc-story-river .tc-tiddler-frame:focus-within, .tc-story-river .tc-tiddler-frame:focus, .tc-story-river .tc-tiddler-frame.tc-focused {
+	border: 1px solid <<colour foreground>>;
+}
+
+.tc-story-river .tc-tiddler-frame {
+	outline: none;
+}
+
+
 {{$:/themes/tiddlywiki/vanilla/sticky}}
 
 .tc-tiddler-info {


### PR DESCRIPTION
This PR preserves the widget owning the domNode that has focus over refresh cycles.
With this PR, we're able to focus a tiddler (for example) by clicking it, then moving focus to another tiddler using a keyboard shortcut, editing the focused tiddler using a keyboard shortcut and so on

This is a draft PR for discussions and should replace #5414 but I don't want to close that PR yet