### PR TITLE
fix whitespace in themes

### DIFF
--- a/themes/tiddlywiki/starlight/styles.tid
+++ b/themes/tiddlywiki/starlight/styles.tid
@@ -8,17 +8,17 @@ Placeholder for a more thorough refinement of Snow White
 */
 
 @font-face {
-  font-family: "Arvo";
-  font-style: normal;
-  font-weight: 400;
-  src: local("Arvo"), url(<<datauri "$:/themes/tiddlywiki/starlight/arvo.woff">>) format("woff");
+	font-family: "Arvo";
+	font-style: normal;
+	font-weight: 400;
+	src: local("Arvo"), url(<<datauri "$:/themes/tiddlywiki/starlight/arvo.woff">>) format("woff");
 }
 
 html body, .tc-sidebar-scrollable-backdrop {
 	font-family: "Arvo", "Times";
-  background: url(<<datauri "$:/themes/tiddlywiki/starlight/ltbg.jpg">>);
+	background: url(<<datauri "$:/themes/tiddlywiki/starlight/ltbg.jpg">>);
 }
 
 .tc-page-controls svg {
-  <<filter "drop-shadow(1px 1px 2px rgba(255,255,255,0.9))">>
+	<<filter "drop-shadow(1px 1px 2px rgba(255,255,255,0.9))">>
 }

--- a/themes/tiddlywiki/tight/base.tid
+++ b/themes/tiddlywiki/tight/base.tid
@@ -82,17 +82,17 @@ tags: [[$:/tags/Stylesheet]]
 	}
 
 	html body.tc-body .tc-tiddler-frame .tc-tiddler-info {
-	    margin: 0 -13px 0 -13px;
+		margin: 0 -13px 0 -13px;
 	}
 
 	html body.tc-body .tc-tiddler-frame .tc-fold-banner {
-	    width: 13px;
-	    margin-left: -15px;
+		width: 13px;
+		margin-left: -15px;
 	}
 
 	html body.tc-body .tc-tiddler-frame .tc-unfold-banner {
-	    margin-left: -13px;
-	    margin-top: -4px;
+		margin-left: -13px;
+		margin-top: -4px;
 	}
 
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -76,7 +76,7 @@ $else$
 }
 
 input[type="search"] {
-  outline-offset: initial;
+	outline-offset: initial;
 }
 
 html button {
@@ -119,7 +119,7 @@ body.tc-body {
 <<if-background-attachment """
 
 body.tc-body {
-        background-color: transparent;
+	background-color: transparent;
 }
 
 """>>
@@ -182,7 +182,7 @@ blockquote.tc-big-quote {
 	margin-left: 50px;
 	margin-right: 50px;
 	padding: 10px;
-    border-radius: 8px;
+	border-radius: 8px;
 }
 
 blockquote.tc-big-quote cite:before {
@@ -198,8 +198,8 @@ blockquote.tc-big-quote:before {
 	margin-right: 0.25em;
 	vertical-align: -0.4em;
 	position: absolute;
-    left: -50px;
-    top: 42px;
+	left: -50px;
+	top: 42px;
 }
 
 blockquote.tc-big-quote:after {
@@ -211,8 +211,8 @@ blockquote.tc-big-quote:after {
 	margin-right: 0.25em;
 	vertical-align: -0.4em;
 	position: absolute;
-    right: -80px;
-    bottom: -20px;
+	right: -80px;
+	bottom: -20px;
 }
 
 dl dt {
@@ -234,7 +234,7 @@ input:not([type]) {
 }
 
 input[type="checkbox"] {
-  vertical-align: middle;
+	vertical-align: middle;
 }
 
 input[type="search"]::-webkit-search-decoration,
@@ -597,7 +597,7 @@ html body.tc-body .tc-btn-rounded:hover svg {
 }
 
 .tc-primary-btn {
- 	background: <<colour primary>>;
+	background: <<colour primary>>;
 }
 
 .tc-sidebar-lists input {
@@ -750,7 +750,7 @@ button.tc-untagged-label {
 .tc-tag-label svg, .tc-tag-label img {
 	height: 1em;
 	width: 1em;
-	margin-right: 3px; 
+	margin-right: 3px;
 	margin-bottom: 1px;
 	vertical-align: bottom;
 }
@@ -859,7 +859,7 @@ button.tc-btn-invisible.tc-remove-tag-button {
 }
 
 .tc-page-controls .tc-drop-down {
-  font-size: 1rem;
+	font-size: 1rem;
 }
 
 .tc-page-controls button {
@@ -1118,8 +1118,8 @@ button.tc-btn-invisible.tc-remove-tag-button {
 }
 
 .tc-tiddler-missing .tc-title {
-  font-style: italic;
-  font-weight: normal;
+	font-style: italic;
+	font-weight: normal;
 }
 
 .tc-tiddler-frame .tc-tiddler-controls {
@@ -1151,9 +1151,9 @@ button.tc-btn-invisible.tc-remove-tag-button {
 }
 
 .tc-search button svg, .tc-search a svg {
-    height: 1.2em;
-    width: 1.2em;
-    margin: 0 0.25em;
+	height: 1.2em;
+	width: 1.2em;
+	margin: 0 0.25em;
 }
 
 .tc-tiddler-controls button.tc-selected svg,
@@ -1369,39 +1369,39 @@ html body.tc-body.tc-single-tiddler-window {
 */
 
 .tc-page-controls svg.tc-image-new-button {
-  fill: <<colour toolbar-new-button>>;
+	fill: <<colour toolbar-new-button>>;
 }
 
 .tc-page-controls svg.tc-image-options-button {
-  fill: <<colour toolbar-options-button>>;
+	fill: <<colour toolbar-options-button>>;
 }
 
 .tc-page-controls svg.tc-image-save-button {
-  fill: <<colour toolbar-save-button>>;
+	fill: <<colour toolbar-save-button>>;
 }
 
 .tc-tiddler-controls button svg.tc-image-info-button {
-  fill: <<colour toolbar-info-button>>;
+	fill: <<colour toolbar-info-button>>;
 }
 
 .tc-tiddler-controls button svg.tc-image-edit-button {
-  fill: <<colour toolbar-edit-button>>;
+	fill: <<colour toolbar-edit-button>>;
 }
 
 .tc-tiddler-controls button svg.tc-image-close-button {
-  fill: <<colour toolbar-close-button>>;
+	fill: <<colour toolbar-close-button>>;
 }
 
 .tc-tiddler-controls button svg.tc-image-delete-button {
-  fill: <<colour toolbar-delete-button>>;
+	fill: <<colour toolbar-delete-button>>;
 }
 
 .tc-tiddler-controls button svg.tc-image-cancel-button {
-  fill: <<colour toolbar-cancel-button>>;
+	fill: <<colour toolbar-cancel-button>>;
 }
 
 .tc-tiddler-controls button svg.tc-image-done-button {
-  fill: <<colour toolbar-done-button>>;
+	fill: <<colour toolbar-done-button>>;
 }
 
 /*
@@ -1645,10 +1645,10 @@ html body.tc-body.tc-single-tiddler-window {
 
 .tc-drop-down .tc-tab-set .tc-tab-buttons button {
 	display: inline-block;
-    width: auto;
-    margin-bottom: 0px;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+	width: auto;
+	margin-bottom: 0px;
+	border-bottom-left-radius: 0;
+	border-bottom-right-radius: 0;
 }
 
 .tc-drop-down .tc-prompt {
@@ -2075,9 +2075,9 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-manager-list-item-heading {
-    display: block;
-    width: 100%;
-    text-align: left;	
+	display: block;
+	width: 100%;
+	text-align: left;
 	border-bottom: 1px solid <<colour muted-foreground>>;
 	padding: 3px;
 }
@@ -2099,22 +2099,22 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-manager-list-item-content-sidebar {
-    flex: 1 0;
-    background: <<colour tiddler-editor-background>>;
-    border-right: 0.5em solid <<colour muted-foreground>>;
-    border-bottom: 0.5em solid <<colour muted-foreground>>;
-    white-space: nowrap;
+	flex: 1 0;
+	background: <<colour tiddler-editor-background>>;
+	border-right: 0.5em solid <<colour muted-foreground>>;
+	border-bottom: 0.5em solid <<colour muted-foreground>>;
+	white-space: nowrap;
 }
 
 .tc-manager-list-item-content-item-heading {
 	display: block;
 	width: 100%;
 	text-align: left;
-    background: <<colour muted-foreground>>;
+	background: <<colour muted-foreground>>;
 	text-transform: uppercase;
 	font-size: 0.6em;
 	font-weight: bold;
-    padding: 0.5em 0 0.5em 0;
+	padding: 0.5em 0 0.5em 0;
 }
 
 .tc-manager-list-item-content-item-body {
@@ -2128,10 +2128,10 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-manager-list-item-content-tiddler {
-    flex: 3 1;
-    border-left: 0.5em solid <<colour muted-foreground>>;
-    border-right: 0.5em solid <<colour muted-foreground>>;
-    border-bottom: 0.5em solid <<colour muted-foreground>>;
+	flex: 3 1;
+	border-left: 0.5em solid <<colour muted-foreground>>;
+	border-right: 0.5em solid <<colour muted-foreground>>;
+	border-bottom: 0.5em solid <<colour muted-foreground>>;
 }
 
 .tc-manager-list-item-content-item-body > table {
@@ -2208,7 +2208,7 @@ html body.tc-body.tc-single-tiddler-window {
 	position: absolute;
 	top: 7px;
 	right: 7px;
-    line-height: 0;
+	line-height: 0;
 }
 
 .tc-alert-toolbar svg {
@@ -2218,8 +2218,8 @@ html body.tc-body.tc-single-tiddler-window {
 .tc-alert-subtitle {
 	color: <<colour alert-muted-foreground>>;
 	font-weight: bold;
-    font-size: 0.8em;
-    margin-bottom: 0.5em;
+	font-size: 0.8em;
+	margin-bottom: 0.5em;
 }
 
 .tc-alert-body > p {
@@ -2304,11 +2304,11 @@ html body.tc-body.tc-single-tiddler-window {
 	background-color: <<colour background>>;
 	margin: 0.5em 0 0.5em 0;
 	padding: 4px;
-    align-items: center;
+	align-items: center;
 }
 
 .tc-plugin-info-sub-plugins .tc-plugin-info {
-    margin: 0.5em;
+	margin: 0.5em;
 	background: <<colour background>>;
 }
 
@@ -2320,8 +2320,8 @@ html body.tc-body.tc-single-tiddler-window {
 	color: <<colour background>>;
 	background: <<colour foreground>>;
 	border-radius: 8px;
-    padding: 2px 7px;
-    font-size: 0.75em;
+	padding: 2px 7px;
+	font-size: 0.75em;
 }
 
 .tc-plugin-info-sub-plugins .tc-plugin-info-dropdown {
@@ -2351,7 +2351,7 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk > svg {
 }
 
 .tc-plugin-info-chunk {
-    margin: 2px;
+	margin: 2px;
 }
 
 .tc-plugin-info-chunk.tc-plugin-info-toggle {
@@ -2375,7 +2375,7 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk > svg {
 	line-height: 1.2;
 	flex-grow: 0;
 	flex-shrink: 0;
-    text-align: right;
+	text-align: right;
 }
 
 .tc-plugin-info-chunk.tc-plugin-info-description h1 {
@@ -2426,7 +2426,7 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk > svg {
 
 .tc-plugin-info-sub-plugins {
 	padding: 0.5em;
-    margin: 0 1em 1em 1em;
+	margin: 0 1em 1em 1em;
 	background: <<colour notification-background>>;
 }
 
@@ -2475,7 +2475,7 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk > svg {
 .tc-message-box svg {
 	width: 1em;
 	height: 1em;
-    vertical-align: text-bottom;
+	vertical-align: text-bottom;
 }
 
 /*
@@ -2861,10 +2861,10 @@ body.tc-dirty span.tc-dirty-indicator, body.tc-dirty span.tc-dirty-indicator svg
 }
 
 .tc-diff-tiddlers pre {
-    margin: 0;
-    padding: 0;
-    border: none;
-    background: none;
+	margin: 0;
+	padding: 0;
+	border: none;
+	background: none;
 }
 
 /*
@@ -2881,40 +2881,40 @@ body.tc-dirty span.tc-dirty-indicator, body.tc-dirty span.tc-dirty-indicator svg
 */
 
 .tc-tree div {
-    	padding-left: 14px;
+	padding-left: 14px;
 }
 
 .tc-tree ol {
-    	list-style-type: none;
-    	padding-left: 0;
-    	margin-top: 0;
+	list-style-type: none;
+	padding-left: 0;
+	margin-top: 0;
 }
 
 .tc-tree ol ol {
-    	padding-left: 1em;    
+	padding-left: 1em;
 }
 
-.tc-tree button { 
-    	color: #acacac;
+.tc-tree button {
+	color: #acacac;
 }
 
 .tc-tree svg {
-     	fill: #acacac;
+	fill: #acacac;
 }
 
 .tc-tree span svg {
-    	width: 1em;
-    	height: 1em;
-    	vertical-align: baseline;
+	width: 1em;
+	height: 1em;
+	vertical-align: baseline;
 }
 
 .tc-tree li span {
-    	color: lightgray;
+	color: lightgray;
 }
 
 select {
-        color: <<colour select-tag-foreground>>;
-        background: <<colour select-tag-background>>;
+	color: <<colour select-tag-foreground>>;
+	background: <<colour select-tag-background>>;
 }
 
 /*


### PR DESCRIPTION
This PR only contains fixes for leading and trailing whitespace. 

Please merge, so I can add the changes discussed here: https://groups.google.com/g/tiddlywiki/c/m0XycQ8DrI0/m/UgwTxCBEAgAJ

 - Zone 1, used when viewport width is below minimum side-by-side width:
   - Sidebar above content; both sidebar and content take up full viewport width (as presently).

 - Zone 2, used when viewport width is above minimum side-by-side width but below maximum story river width + fixed sidebar width:
   - Sidebar to right of content; sidebar consumes a configurable fixed width, and story river consumes all remaining available space (as in fluid-fixed presently).

 - Zone 3, used when viewport width exceeds maximum story river width + fixed sidebar width:
   - Sidebar to right of content; story river consumes a configurable maximum width, and sidebar consumes all remaining available space (as in fixed-fluid presently).