### PR TITLE
Docs for new system tag $:/tags/EditorTools

### DIFF
--- a/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_EditorTools.tid
+++ b/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_EditorTools.tid
@@ -1,0 +1,9 @@
+caption: $:/tags/EditorTools
+created: 20210519160245560
+description: marks the edit mode tiddler toolbar for non-button elements.
+modified: 20210519160509587
+tags: SystemTags
+title: SystemTag: $:/tags/EditorTools
+type: text/vnd.tiddlywiki
+
+The [[system tag|SystemTags]]  `$:/tags/EditorTools` can be used to include non-button UI elements in the edit mode tiddler toolbar. For buttons see [[SystemTag: $:/tags/EditToolbar]].


### PR DESCRIPTION
Documentation only. This tiddler was left out from yesterday's commit in #5699 for the new feature for importing images in the editor.