### PR TITLE
New text operation insert-text

### DIFF
--- a/core/modules/editor/operations/text/insert-text.js
+++ b/core/modules/editor/operations/text/insert-text.js
@@ -1,0 +1,23 @@
+/*\
+title: $:/core/modules/editor/operations/text/insert-text.js
+type: application/javascript
+module-type: texteditoroperation
+
+Text editor operation insert text at the caret position. If there is a selection it is replaced.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports["insert-text"] = function(event,operation) {
+	operation.replacement = event.paramObject.text;
+	operation.cutStart = operation.selStart;
+	operation.cutEnd = operation.selEnd;
+	operation.newSelStart = operation.selStart + operation.replacement.length;
+	operation.newSelEnd = operation.newSelStart;
+};
+
+})();

--- a/core/ui/EditorToolbar/file-import.tid
+++ b/core/ui/EditorToolbar/file-import.tid
@@ -16,7 +16,7 @@ condition: [<targetTiddler>!has[type]] [<targetTiddler>type[text/vnd.tiddlywiki]
 <$list filter="[<importTitle>links[]] :reduce[get[type]prefix[image]then<replacement-text-image>else<replacement-text-file>search-replace[$title$],<currentTiddler>addprefix<accumulator>]" variable="imageTitle">
 <$action-sendmessage
 	$message="tm-edit-text-operation"
-	$param="replace-selection"
+	$param="insert-text"
 	text=<<imageTitle>>
 />
 </$list>

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-text-operation.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-text-operation.tid
@@ -136,6 +136,7 @@ At this point the following text operations have been implemented:
 |<<.def "wrap-selection">>|<<wrapSelectionDescription>> |
 |<<.def "save-selection">>|<<saveSelectionDescription>> |
 |<<.def "make-link">>|<<makeLinkDescription>> |
+|<<.def "insert-text">>|<<insertTextDescription>>|
 
 
 !Example

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-text-operation.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-edit-text-operation.tid
@@ -1,6 +1,6 @@
 caption: tm-edit-text-operation
 created: 20160424211339792
-modified: 20180630073432471
+modified: 20210520053923011
 tags: Messages
 title: WidgetMessage: tm-edit-text-operation
 type: text/vnd.tiddlywiki
@@ -93,6 +93,27 @@ Saves the text of the current //selection// into the provided <<.param "tiddler"
 </div>
 \end
 
+\define makeLinkDescription()
+<div>
+
+Creates a wiki text link to the tiddler specified in <<.param "text">>. If there is a selection, it is used as the text of the link. 
+
+|!Name |!Description |
+|text |Tiddler title to which the link will be created |
+
+</div>
+\end
+
+\define insertTextDescription()
+<div>
+
+Inserts the text specified in <<.param "text">> at the caret position. If there is a selection, it is replaced. 
+
+|!Name |!Description |
+|text |Text to be inserted |
+
+</div>
+\end
 
 A `tm-edit-text-operation` invokes one of the available operations on a __surrounding__ text editor. Therefore the message has to be dispatched within the editor in order for it to catch it. The following properties on the `event` object are required:
 
@@ -114,6 +135,7 @@ At this point the following text operations have been implemented:
 |<<.def "wrap-lines">>|<<wrapLinesDescription>> |
 |<<.def "wrap-selection">>|<<wrapSelectionDescription>> |
 |<<.def "save-selection">>|<<saveSelectionDescription>> |
+|<<.def "make-link">>|<<makeLinkDescription>> |
 
 
 !Example


### PR DESCRIPTION
This PR adds a new text operation `insert-text` that can be used to insert the literal text specified in the param `text` at the caret position. If there is a selection, it is replaced.

Currently the only way to do something similar is to use `replace-selection` which results in a selection after the replacement. This is not always desirable. 

The new text operation `insert-text` has been used in this PR for the new feature for importing images via dropping in the editor. Previously, this resulted in the inserted image transclusion text being selected, which isn't consistent with using the editor tool for inserting a tiddler link for example. Now this behaviour is consistent.

Documentation is included.