### PR TITLE
Eventcatcher: bug fixes and new stopPropagation attribute

### DIFF
--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -22,6 +22,10 @@ exports.domContains = function(a,b) {
 		!!(a.compareDocumentPosition(b) & 16);
 };
 
+exports.domMatchesSelector = function(node,selector) {
+	return node.matches ? node.matches(selector) : node.msMatchesSelector(selector);
+};
+
 exports.removeChildren = function(node) {
 	while(node.hasChildNodes()) {
 		node.removeChild(node.firstChild);

--- a/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
@@ -1,5 +1,5 @@
 created: 20201123113532200
-modified: 20201202200719126
+modified: 20210520162813234
 tags: Widgets
 title: EventCatcherWidget
 type: text/vnd.tiddlywiki
@@ -30,6 +30,7 @@ The content of the `<$eventcatcher>` widget is displayed normally.
 |actions-* |Action strings to be invoked when a matching event is trapped. Each event is mapped to an action attribute name of the form <code>actions-<em>event</em></code> where <code><em>event</em></code> represents the type of the event. For example: `actions-click` or `actions-dblclick` |
 |tag |Optional. The HTML element the widget creates to capture the events, defaults to:<br>» `span` when parsed in inline-mode<br>» `div` when parsed in block-mode |
 |class |Optional. A CSS class name (or names) to be assigned to the widget HTML element |
+|stopPropagation |<<.from-version "5.1.24">> Optional. Set to "always" to always stop event propagation even if there are no corresponding actions to invoke, "never" to never stop event propagation, or the default value "onaction" with which event propagation is only stopped if there are corresponding actions that are invoked. |
 
 ! Variables
 


### PR DESCRIPTION
This PR addresses three issues in `<$eventcatcher>`:

1. IE bug fix: `<$eventcatcher>` causes a red error screen as soon as an event is trapped. This is because IE does not support the `matches()` method but has its own equivalent `msMatchesSelector()` method. A utils method `domMatchesSelector()` has been introduced.

2. FireFox bug fix: there is a quirk where some events (such as `dragenter` and `dragleave`) can be fired for text nodes (nodeType 3) which are not proper Elements and therefore checking their attributes throws an error. All events originating from text nodes are now treated as originating from their parentNode.

3. Introduced a new `stopPropagation` attribute which fixes #5684 and allows greater control over handling of event propagation. The 3 possible values are:
  - `onaction` (default) which stops event propagation if there are actions to invoke.
  - `never` - never stop event propagation
  - `always` - always stops event propagation even if no actions have been specified.

Documentation has also been updated.