### PR TITLE
Add tc-small-gap-right to tag-pills in tags editTemplate

### DIFF
--- a/core/ui/EditTemplate/tags.tid
+++ b/core/ui/EditTemplate/tags.tid
@@ -14,7 +14,7 @@ color:$(foregroundColor)$;
 \define tag-body-inner(colour,fallbackTarget,colourA,colourB,icon,tagField:"tags")
 \whitespace trim
 <$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
-<span style=<<tag-styles>> class="tc-tag-label tc-tag-list-item">
+<span style=<<tag-styles>> class="tc-tag-label tc-tag-list-item tc-small-gap-right">
 <$transclude tiddler="""$icon$"""/><$view field="title" format="text" />
 <$button class="tc-btn-invisible tc-remove-tag-button" style=<<tag-styles>>><$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="-[{!!title}]"/>{{$:/core/images/close-button}}</$button>
 </span>


### PR DESCRIPTION
This PR makes the tag-pills in the tags EditTemplate look like the tag-pills in the ViewTemplate, with a small gap between one tag and the other