### PR TITLE
i18n(Tiddlyweb) setup basic translation support and translate two labels

### DIFF
--- a/plugins/tiddlywiki/tiddlyweb/i18n.multids
+++ b/plugins/tiddlywiki/tiddlyweb/i18n.multids
@@ -1,0 +1,4 @@
+title: $:/config/plugins/tiddlywiki/tiddlyweb/language/
+
+ServerStatus: Server status
+ServerStatus/Description: Status of synchronisation with server

--- a/plugins/tiddlywiki/tiddlyweb/save-wiki-button.tid
+++ b/plugins/tiddlywiki/tiddlyweb/save-wiki-button.tid
@@ -1,19 +1,19 @@
 title: $:/core/ui/Buttons/save-wiki
 tags: $:/tags/PageControls
-caption: {{$:/plugins/tiddlywiki/tiddlyweb/icon/cloud}} Server status
-description: Status of synchronisation with server
+caption: {{$:/plugins/tiddlywiki/tiddlyweb/icon/cloud}} {{$:/config/plugins/tiddlywiki/tiddlyweb/language/ServerStatus}}
+description: {{$:/config/plugins/tiddlywiki/tiddlyweb/language/ServerStatus/Description}}
 
 \whitespace trim
 \define config-title()
 $:/config/PageControlButtons/Visibility/$(listItem)$
 \end
-<$button popup=<<qualify "$:/state/popup/save-wiki">> tooltip="Status of synchronisation with server" aria-label="Server status" class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
+<$button popup=<<qualify "$:/state/popup/save-wiki">> tooltip={{$:/config/plugins/tiddlywiki/tiddlyweb/language/ServerStatus/Description}} aria-label={{$:/config/plugins/tiddlywiki/tiddlyweb/language/ServerStatus}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
 <span class="tc-dirty-indicator">
 <$list filter="[<tv-config-toolbar-icons>match[yes]]">
 {{$:/plugins/tiddlywiki/tiddlyweb/icon/cloud}}
 </$list>
 <$list filter="[<tv-config-toolbar-text>match[yes]]">
-<span class="tc-btn-text"><$text text="Server status"/></span>
+<span class="tc-btn-text"><$text text={{$:/config/plugins/tiddlywiki/tiddlyweb/language/ServerStatus}}/></span>
 </$list>
 </span>
 </$button>


### PR DESCRIPTION
I'm not sure this is the correct way to translate a plugin. I added a "translation string" multitiddler and used the values to translate the button and hint. Then I added a similar file to the es-ES plugin with the translation, reloaded and it worked.

But, if there is a better or "correct" way to translate plugins, let me know and I will try to adapt.

Note, I did look at the other plugins but couldn't find anything useful.