### PR TITLE
Transclude widget: refresh selectively when needed

### DIFF
--- a/core/modules/widgets/transclude.js
+++ b/core/modules/widgets/transclude.js
@@ -101,51 +101,8 @@ TranscludeWidget.prototype.makeRecursionMarker = function() {
 };
 
 TranscludeWidget.prototype.parserNeedsRefresh = function() {
-	var parserInfo = this.getParserInfo();
-	return (parserInfo.sourceText === undefined || parserInfo.sourceText !== this.sourceText || parserInfo.parserType !== this.parserType)
-};
-
-/*
-Returns the same source and parserType for the widget to be transcluded as wiki.parseTextReference
-*/
-TranscludeWidget.prototype.getParserInfo = function() {
-	var tiddler,
-		field = this.transcludeField,
-		parserInfo = {
-			sourceText : null,
-			parserType : "text/vnd.tiddlywiki"
-		};
-	// Always trigger a refresh for parsers that don't have a source attribute by returning undefined for sourceText
-	if(this.sourceText === undefined) {
-		parserInfo.sourceText = undefined;
-		parserInfo.parserType = undefined;
-		return parserInfo;
-	}
-	if(this.transcludeSubTiddler) {
-		tiddler = this.wiki.getSubTiddler(this.transcludeTitle,this.transcludeSubTiddler);
-	} else {
-		tiddler = this.wiki.getTiddler(this.transcludeTitle);
-	}
-	if(field === "text" || (!field && !this.transcludeIndex)) {
-		if(tiddler && tiddler.fields) {
-			parserInfo.sourceText = tiddler.fields.text || "";
-			if(tiddler.fields.type) {
-				parserInfo.parserType = tiddler.fields.type;
-			}
-		}
-	} else if(field) {
-		if(field === "title") {
-			parserInfo.sourceText = this.transcludeTitle;
-		} else if(tiddler && tiddler.fields) {
-			parserInfo.sourceText = tiddler.fields[field] ? tiddler.fields[field].toString() : null;
-		}
-	} else if(this.transcludeIndex) {
-		parserInfo.sourceText = this.wiki.extractTiddlerDataItem(tiddler,this.transcludeIndex,null);
-	}
-	if(parserInfo.sourceText === null) {
-		parserInfo.parserType = null;
-	}
-	return parserInfo;
+	var parserInfo = this.wiki.getTextReferenceParserInfo(this.transcludeTitle,this.transcludeField,this.transcludeIndex,{subTiddler:this.transcludeSubTiddler});
+	return (this.sourceText === undefined || parserInfo.sourceText !== this.sourceText || parserInfo.parserType !== this.parserType)
 };
 
 /*

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -936,6 +936,25 @@ exports.parseTiddler = function(title,options) {
 		}) : null;
 };
 
+exports.parseTextReference = function(title,field,index,options) {
+	var tiddler,
+		text,
+		parserInfo;
+	if(!options.subTiddler) {
+		tiddler = this.getTiddler(title);
+		if(field === "text" || (!field && !index)) {
+			this.getTiddlerText(title); // Force the tiddler to be lazily loaded
+			return this.parseTiddler(title,options);
+		}
+	} 
+	parserInfo = this.getTextReferenceParserInfo(title,field,index,options);
+	if(parserInfo.sourceText !== null) {
+		return this.parseText(parserInfo.parserType,parserInfo.sourceText,options);
+	} else {
+		return null;
+	}
+};
+
 exports.getTextReferenceParserInfo = function(title,field,index,options) {
 	var tiddler,
 		parserInfo = {
@@ -969,25 +988,6 @@ exports.getTextReferenceParserInfo = function(title,field,index,options) {
 	}
 	return parserInfo;
 }
-
-exports.parseTextReference = function(title,field,index,options) {
-	var tiddler,
-		text,
-		parserInfo;
-	if(!options.subTiddler) {
-		tiddler = this.getTiddler(title);
-		if(field === "text" || (!field && !index)) {
-			this.getTiddlerText(title); // Force the tiddler to be lazily loaded
-			return this.parseTiddler(title,options);
-		}
-	} 
-	parserInfo = this.getTextReferenceParserInfo(title,field,index,options);
-	if(parserInfo.sourceText !== null) {
-		return this.parseText(parserInfo.parserType,parserInfo.sourceText,options);
-	} else {
-		return null;
-	}
-};
 
 /*
 Make a widget tree for a parse tree

--- a/editions/test/tiddlers/tests/test-parsetextreference.js
+++ b/editions/test/tiddlers/tests/test-parsetextreference.js
@@ -3,7 +3,7 @@ title: test-parsetextreference.js
 type: application/javascript
 tags: [[$:/tags/test-spec]]
 
-Tests for equivalency between source attribute in parser returned from wiki.parseTextReference and TranscludeWidget.prototype.getParserInfo
+Tests for source attribute in parser returned from wiki.parseTextReference
 
 \*/
 (function(){
@@ -116,55 +116,6 @@ describe("Wiki.parseTextReference tests", function() {
 		expect(parseAndGetSource("$:/ShadowPlugin","text",null,"MyMissingTiddler")).toEqual(null);
 		// Plain text tiddler
 		expect(parseAndGetSource("TiddlerNine")).toEqual(undefined);
-	});
-
-	var widget = require("$:/core/modules/widgets/widget.js");
-	
-	function createWidgetNode(parseTreeNode,wiki) {
-		return new widget.widget(parseTreeNode,{
-			wiki: wiki,
-			document: $tw.fakeDocument
-		});
-	}
-
-	function renderWidgetNode(widgetNode) {
-		$tw.fakeDocument.setSequenceNumber(0);
-		var wrapper = $tw.fakeDocument.createElement("div");
-		widgetNode.render(wrapper,null);
-		return wrapper;
-	}
-
-	function createTranscludeWidget(tiddler,field,index,subTiddler) {
-		var parseTreeNode = {type: "widget", children: [
-								{type: "transclude", attributes: {
-										"tiddler": {type: "string", value: tiddler},
-										"field": {type: "string", value: field},
-										"index": {type: "string", value: index},
-										"subtiddler": {type: "string", value: subTiddler}
-									}}
-							]};
-		var widgetNode = createWidgetNode(parseTreeNode,wiki);
-		var wrapper = renderWidgetNode(widgetNode);
-		return widgetNode.children[0];		
-	}
-
-	// Compare source attribute from wiki.parseTextReference to source attribute from TranscludeWidget.getParserInfo()
-	function compareSource(tiddler,field,index,subTiddler) {
-		expect(createTranscludeWidget(tiddler,field,index,subTiddler).getParserInfo().sourceText).toEqual(parseAndGetSource(tiddler,field,index,subTiddler));
-	}
-	
-	it("should return same source from wiki.parseTextReference and TranscludeWidget.getParserInfo()",function(){
-		compareSource("TiddlerOne"),
-		compareSource("TiddlerOne","text");
-		compareSource("$:/TiddlerTwo");
-		compareSource("TiddlerOne","authors");
-		compareSource("MissingTiddler");
-		compareSource("MissingTiddler","missing-field");
-		compareSource("Tiddler One","missing-field");
-		compareSource("Tiddler Three",null,"oct");
-		compareSource("TiddlerFour");
-		compareSource("$:/ShadowPlugin","text",null,"Tiddler8");
-		compareSource("TiddlerNine");
 	});
 
 });

--- a/editions/test/tiddlers/tests/test-parsetextreference.js
+++ b/editions/test/tiddlers/tests/test-parsetextreference.js
@@ -1,0 +1,172 @@
+/*\
+title: test-parsetextreference.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests for equivalency between source attribute in parser returned from wiki.parseTextReference and TranscludeWidget.prototype.getParserInfo
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+describe("Wiki.parseTextReference tests", function() {
+
+	// Create a wiki
+	var wiki = new $tw.Wiki();
+	wiki.addTiddler({
+		title: "TiddlerOne",
+		text: "The quick brown fox in $:/TiddlerTwo",
+		tags: ["one"],
+		authors: "Joe Bloggs",
+		modifier: "JoeBloggs",
+		modified: "201304152222"});
+	wiki.addTiddler({
+		title: "$:/TiddlerTwo",
+		tags: ["two"],
+		authors: "[[John Doe]]",
+		modifier: "John",
+		modified: "201304152211"});
+	wiki.addTiddler({
+		title: "Tiddler Three",
+		text: '{"oct":31,"nov":30,"dec":31}',
+		tags: ["one","two"],
+		type: "application/json",
+		modifier: "John",
+		modified: "201304162202"});
+	wiki.addTiddler({
+		title: "TiddlerFour",
+		text: "The quick brown fox in $:/TiddlerTwo",
+		tags: ["one"],
+		type: "text/vnd.tiddlywiki",
+		authors: "Joe Bloggs",
+		modifier: "JoeBloggs",
+		modified: "201304152222"});
+	// Add a plugin containing some shadow tiddlers
+	var shadowTiddlers = {
+		tiddlers: {
+			"$:/TiddlerFive": {
+				title: "$:/TiddlerFive",
+				text: "Everything in federation",
+				tags: ["two"]
+			},
+			"TiddlerSix": {
+				title: "TiddlerSix",
+				text: "Missing inaction from TiddlerOne",
+				filter: "[[one]] [[a a]] [subfilter{hasList!!list}]",
+				tags: []
+			},
+			"TiddlerSeventh": {
+				title: "TiddlerSeventh",
+				text: "",
+				list: "TiddlerOne [[Tiddler Three]] [[a fourth tiddler]] MissingTiddler",
+				tags: ["one"]
+			},
+			"Tiddler8": {
+				title: "Tiddler8",
+				text: "Tidd",
+				tags: ["one"],
+				"test-field": "JoeBloggs"
+			}
+		}
+	};
+	wiki.addTiddler({
+		title: "$:/ShadowPlugin",
+		text: JSON.stringify(shadowTiddlers),
+		"plugin-type": "plugin",
+		type: "application/json"});
+	wiki.addTiddler({
+		title: "TiddlerNine",
+		text: "this is plain text",
+		type: "text/plain"
+	});
+
+	// Define a parsing shortcut for souce attribute of parser returned by wiki.parseTextReference
+	var parseAndGetSource = function(title,field,index,subTiddler) {
+		var parser = wiki.parseTextReference(title,field,index,{subTiddler: subTiddler});
+		return parser ? parser.source : null;
+	};
+
+	it("should parse text references and return correct source attribute", function(){
+		// Existing tiddler with a text field, no field argument specified
+		expect(parseAndGetSource("TiddlerOne")).toEqual("The quick brown fox in $:/TiddlerTwo");
+		// Existing tiddler with a text field, field argument specified as text
+		expect(parseAndGetSource("TiddlerOne","text")).toEqual("The quick brown fox in $:/TiddlerTwo");
+		// Existing tiddler with no text field
+		expect(parseAndGetSource("$:/TiddlerTwo")).toEqual("");
+		// Existing tiddler, field argument specified as authors
+		expect(parseAndGetSource("TiddlerOne","authors")).toEqual("Joe Bloggs");
+		// Non-existent tiddler, no field argument
+		expect(parseAndGetSource("MissingTiddler")).toEqual(null);
+		// Non-existent tiddler, field argument
+		expect(parseAndGetSource("MissingTiddler","missing-field")).toEqual(null);
+		// Non-existent tiddler, index specified
+		expect(parseAndGetSource("MissingTiddler",null,"missing-index")).toEqual(null);
+		// Existing tiddler with non existent field
+		expect(parseAndGetSource("TiddlerOne","missing-field")).toEqual(null);
+		// Data tiddler with index specified
+		expect(parseAndGetSource("Tiddler Three",null,"oct")).toEqual("31");
+		// Existing tiddler with a text field, type set to vnd.tiddlywiki
+		expect(parseAndGetSource("TiddlerFour")).toEqual("The quick brown fox in $:/TiddlerTwo");
+		// Existing subtiddler of a plugin
+		expect(parseAndGetSource("$:/ShadowPlugin","text",null,"Tiddler8")).toEqual("Tidd");
+		// Non-existent subtiddler of a plugin
+		expect(parseAndGetSource("$:/ShadowPlugin","text",null,"MyMissingTiddler")).toEqual(null);
+		// Plain text tiddler
+		expect(parseAndGetSource("TiddlerNine")).toEqual(undefined);
+	});
+
+	var widget = require("$:/core/modules/widgets/widget.js");
+	
+	function createWidgetNode(parseTreeNode,wiki) {
+		return new widget.widget(parseTreeNode,{
+			wiki: wiki,
+			document: $tw.fakeDocument
+		});
+	}
+
+	function renderWidgetNode(widgetNode) {
+		$tw.fakeDocument.setSequenceNumber(0);
+		var wrapper = $tw.fakeDocument.createElement("div");
+		widgetNode.render(wrapper,null);
+		return wrapper;
+	}
+
+	function createTranscludeWidget(tiddler,field,index,subTiddler) {
+		var parseTreeNode = {type: "widget", children: [
+								{type: "transclude", attributes: {
+										"tiddler": {type: "string", value: tiddler},
+										"field": {type: "string", value: field},
+										"index": {type: "string", value: index},
+										"subtiddler": {type: "string", value: subTiddler}
+									}}
+							]};
+		var widgetNode = createWidgetNode(parseTreeNode,wiki);
+		var wrapper = renderWidgetNode(widgetNode);
+		return widgetNode.children[0];		
+	}
+
+	// Compare source attribute from wiki.parseTextReference to source attribute from TranscludeWidget.getParserInfo()
+	function compareSource(tiddler,field,index,subTiddler) {
+		expect(createTranscludeWidget(tiddler,field,index,subTiddler).getParserInfo().sourceText).toEqual(parseAndGetSource(tiddler,field,index,subTiddler));
+	}
+	
+	it("should return same source from wiki.parseTextReference and TranscludeWidget.getParserInfo()",function(){
+		compareSource("TiddlerOne"),
+		compareSource("TiddlerOne","text");
+		compareSource("$:/TiddlerTwo");
+		compareSource("TiddlerOne","authors");
+		compareSource("MissingTiddler");
+		compareSource("MissingTiddler","missing-field");
+		compareSource("Tiddler One","missing-field");
+		compareSource("Tiddler Three",null,"oct");
+		compareSource("TiddlerFour");
+		compareSource("$:/ShadowPlugin","text",null,"Tiddler8");
+		compareSource("TiddlerNine");
+	});
+
+});
+
+})();


### PR DESCRIPTION
Currently the `<$transclude>` widget calls `refreshSelf()` every time the transcluded tiddler changes. This means for instance that adding a tag to a tiddler results in every transclusion of its text field in the page template being re-rendered.

Instead `<$transclude/>` should only re-render when the source text or the parserType has changed.