### PR TITLE
Make the insert- and remove-animations of storyviews work in new windows

### DIFF
--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -43,7 +43,7 @@ ClassicStoryView.prototype.insert = function(widget) {
 	if(duration) {
 		var targetElement = widget.findFirstDomNode();
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
-		if(!(targetElement instanceof Element)) {
+		if(targetElement.nodeType === Node.TEXT_NODE) {
 			return;
 		}
 		// Get the current height of the tiddler
@@ -83,7 +83,7 @@ ClassicStoryView.prototype.remove = function(widget) {
 				widget.removeChildDomNodes();
 			};
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
-		if(!(targetElement instanceof Element)) {
+		if(targetElement.nodeType === Node.TEXT_NODE) {
 			removeElement();
 			return;
 		}

--- a/core/modules/storyviews/pop.js
+++ b/core/modules/storyviews/pop.js
@@ -35,7 +35,7 @@ PopStoryView.prototype.insert = function(widget) {
 	var targetElement = widget.findFirstDomNode(),
 		duration = $tw.utils.getAnimationDuration();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!(targetElement instanceof Element)) {
+	if(targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Reset once the transition is over
@@ -77,7 +77,7 @@ PopStoryView.prototype.remove = function(widget) {
 			}
 		};
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!(targetElement instanceof Element)) {
+	if(targetElement.nodeType === Node.TEXT_NODE) {
 		removeElement();
 		return;
 	}

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -130,7 +130,7 @@ function findTitleDomNode(widget,targetClass) {
 ZoominListView.prototype.insert = function(widget) {
 	var targetElement = widget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!(targetElement instanceof Element)) {
+	if(targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Make the newly inserted node position absolute and hidden
@@ -147,7 +147,7 @@ ZoominListView.prototype.remove = function(widget) {
 			widget.removeChildDomNodes();
 		};
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!(targetElement instanceof Element)) {
+	if(targetElement.nodeType === Node.TEXT_NODE) {
 		removeElement();
 		return;
 	}


### PR DESCRIPTION
This PR makes the insert- and remove-animations of domNodes work in new windows, too, where `!(targetElement instanceOf Element)` fails