### PR TITLE
Trigger actions when tiddlers change

### DIFF
--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -110,6 +110,12 @@ exports.startup = function() {
 			handlerMethod: "handleKeydownEvent"
 		}]);
 	}
+	// Kick off the tiddler-change manager
+	$tw.tiddlerChangeManager = new $tw.TiddlerChangeManager();
+	// Listen for changed tiddlers
+	$tw.wiki.addEventListener("change",function(changes) {
+		$tw.tiddlerChangeManager.handleChangedTiddlerEvent(changes);
+	});
 	// Clear outstanding tiddler store change events to avoid an unnecessary refresh cycle at startup
 	$tw.wiki.clearTiddlerEventQueue();
 	// Find a working syncadaptor

--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -70,14 +70,6 @@ exports.startup = function() {
 	if($tw.node) {
 		$tw.rootWidget.invokeActionsByTag("$:/tags/StartupAction/Node");
 	}
-	// Kick off the tiddler-change manager
-	$tw.tiddlerChangeManager = new $tw.TiddlerChangeManager();
-	// Listen for changed tiddlers
-	if($tw.browser) {
-		$tw.wiki.addEventListener("change",function(changes) {
-			$tw.tiddlerChangeManager.handleChangedTiddlerEvent(changes);
-		});
-	}
 	// Kick off the language manager and switcher
 	$tw.language = new $tw.Language();
 	$tw.languageSwitcher = new $tw.PluginSwitcher({
@@ -117,6 +109,14 @@ exports.startup = function() {
 			handlerObject: $tw.keyboardManager,
 			handlerMethod: "handleKeydownEvent"
 		}]);
+	}
+	// Kick off the tiddler-change manager
+	$tw.tiddlerChangeManager = new $tw.TiddlerChangeManager();
+	// Listen for changed tiddlers
+	if($tw.browser) {
+		$tw.wiki.addEventListener("change",function(changes) {
+			$tw.tiddlerChangeManager.handleChangedTiddlerEvent(changes);
+		});
 	}
 	// Clear outstanding tiddler store change events to avoid an unnecessary refresh cycle at startup
 	$tw.wiki.clearTiddlerEventQueue();

--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -113,9 +113,11 @@ exports.startup = function() {
 	// Kick off the tiddler-change manager
 	$tw.tiddlerChangeManager = new $tw.TiddlerChangeManager();
 	// Listen for changed tiddlers
-	$tw.wiki.addEventListener("change",function(changes) {
-		$tw.tiddlerChangeManager.handleChangedTiddlerEvent(changes);
-	});
+	if($tw.browser) {
+		$tw.wiki.addEventListener("change",function(changes) {
+			$tw.tiddlerChangeManager.handleChangedTiddlerEvent(changes);
+		});
+	}
 	// Clear outstanding tiddler store change events to avoid an unnecessary refresh cycle at startup
 	$tw.wiki.clearTiddlerEventQueue();
 	// Find a working syncadaptor

--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -70,6 +70,14 @@ exports.startup = function() {
 	if($tw.node) {
 		$tw.rootWidget.invokeActionsByTag("$:/tags/StartupAction/Node");
 	}
+	// Kick off the tiddler-change manager
+	$tw.tiddlerChangeManager = new $tw.TiddlerChangeManager();
+	// Listen for changed tiddlers
+	if($tw.browser) {
+		$tw.wiki.addEventListener("change",function(changes) {
+			$tw.tiddlerChangeManager.handleChangedTiddlerEvent(changes);
+		});
+	}
 	// Kick off the language manager and switcher
 	$tw.language = new $tw.Language();
 	$tw.languageSwitcher = new $tw.PluginSwitcher({
@@ -109,14 +117,6 @@ exports.startup = function() {
 			handlerObject: $tw.keyboardManager,
 			handlerMethod: "handleKeydownEvent"
 		}]);
-	}
-	// Kick off the tiddler-change manager
-	$tw.tiddlerChangeManager = new $tw.TiddlerChangeManager();
-	// Listen for changed tiddlers
-	if($tw.browser) {
-		$tw.wiki.addEventListener("change",function(changes) {
-			$tw.tiddlerChangeManager.handleChangedTiddlerEvent(changes);
-		});
 	}
 	// Clear outstanding tiddler store change events to avoid an unnecessary refresh cycle at startup
 	$tw.wiki.clearTiddlerEventQueue();

--- a/core/modules/tiddler-change.js
+++ b/core/modules/tiddler-change.js
@@ -19,7 +19,7 @@ function TiddlerChangeManager(options) {
 	this.tiddlerActionList = [];
 	this.updateTiddlerChangeLists(this.getTiddlerList());
 	$tw.wiki.addEventListener("change",function(changes) {
-		self.handleShortcutChanges(changes);
+		self.handleTiddlerChanges(changes);
 	});
 }
 
@@ -52,27 +52,7 @@ TiddlerChangeManager.prototype.handleChangedTiddlerEvent = function(event) {
 	return false;
 };
 
-TiddlerChangeManager.prototype.detectNewShortcuts = function(changedTiddlers) {
-	var shortcutConfigTiddlers = [],
-		handled = false;
-	$tw.utils.each(this.lookupNames,function(platformDescriptor) {
-		var descriptorString = "$:/config/" + platformDescriptor + "/";
-		Object.keys(changedTiddlers).forEach(function(configTiddler) {
-			var configString = configTiddler.substr(0, configTiddler.lastIndexOf("/") + 1);
-			if(configString === descriptorString) {
-				shortcutConfigTiddlers.push(configTiddler);
-				handled = true;
-			}
-		});
-	});
-	if(handled) {
-		return $tw.utils.hopArray(changedTiddlers,shortcutConfigTiddlers);
-	} else {
-		return false;
-	}
-};
-
-TiddlerChangeManager.prototype.handleShortcutChanges = function(changedTiddlers) {
+TiddlerChangeManager.prototype.handleTiddlerChanges = function(changedTiddlers) {
 	var newList = this.getTiddlerList();
 	var hasChanged = $tw.utils.hopArray(changedTiddlers,this.actionTiddlers) ? true :
 		($tw.utils.hopArray(changedTiddlers,newList) ? true : false);

--- a/core/modules/tiddler-change.js
+++ b/core/modules/tiddler-change.js
@@ -2,9 +2,7 @@
 title: $:/core/modules/tiddler-change.js
 type: application/javascript
 module-type: global
-
 Tiddler change handling utilities
-
 \*/
 (function(){
 
@@ -13,39 +11,64 @@ Tiddler change handling utilities
 "use strict";
 
 function TiddlerChangeManager(options) {
-	var self = this;
+	var self = this,
 	options = options || "";
-	this.tiddlerChangeList = [],
-	this.tiddlerActionList = [];
-	this.updateTiddlerChangeLists(this.getTiddlerList());
+	this.tiddlerFilters = [],
+	this.tiddlerActions = [],
+	this.tiddlerFilterLists = [];
+	this.updateTiddlerFilterLists(this.getTiddlerList());
 	$tw.wiki.addEventListener("change",function(changes) {
 		self.handleTiddlerChanges(changes);
-	});
+	})
 }
 
 TiddlerChangeManager.prototype.getTiddlerList = function() {
 	return $tw.wiki.getTiddlersWithTag("$:/tags/TiddlerChangeAction");
 };
 
-TiddlerChangeManager.prototype.updateTiddlerChangeLists = function(tiddlerList) {
+TiddlerChangeManager.prototype.updateTiddlerFilterLists = function(tiddlerList) {
 	this.actionTiddlers = tiddlerList;
 	for(var i=0; i<tiddlerList.length; i++) {
 		var title = tiddlerList[i],
 			tiddlerFields = $tw.wiki.getTiddler(title).fields;
-		this.tiddlerChangeList[i] = tiddlerFields["change-tiddler"] !== undefined ? tiddlerFields["change-tiddler"] : undefined;
-		this.tiddlerActionList[i] = tiddlerFields.text;
+		this.tiddlerFilters[i] = tiddlerFields["tiddler-filter"] !== undefined ? tiddlerFields["tiddler-filter"] : undefined;
+		this.tiddlerActions[i] = tiddlerFields.text;
+		this.tiddlerFilterLists[i] = $tw.wiki.filterTiddlers(this.tiddlerChangeList[i]);
 	}
+};
+
+TiddlerChangeManager.prototype.isEqual = function(a,b) {
+	if(a === b) {
+		return true;
+	}
+	if(a == null || b == null) {
+		return false;
+	}
+	if(a.length !== b.length) {
+		return false;
+	}
+
+	for(var i=0; i<a.length; ++i) {
+		if(a[i] !== b[i]) {
+			return false;
+		}
+	}
+	return true;
 };
 
 TiddlerChangeManager.prototype.handleChangedTiddlerEvent = function(event) {
 	var actions = [];
 	for(var i=0; i<this.actionTiddlers.length; i++) {
-		if(this.tiddlerChangeList[i] !== undefined && $tw.utils.hop(event,this.tiddlerChangeList[i])) {
-			actions.push = this.tiddlerActionList[i];
+		var tiddlerListBefore = this.tiddlerFilterLists[i];
+		var tiddlerListNow = $tw.wiki.filterTiddlers(this.tiddlerFilters[i]);
+		if(!this.isEqual(tiddlerListNow,tiddlerListBefore)) {
+			actions.push(this.tiddlerActions[i]);
+			this.tiddlerFilterLists[i] = tiddlerListNow;
 		}
 	}
 	for(i=0; i<actions.length; i++) {
 		$tw.rootWidget.invokeActionString(actions[i],$tw.rootWidget);
+		console.log("ACTION INVOKED");
 	}
 	return true;
 };
@@ -56,7 +79,7 @@ TiddlerChangeManager.prototype.handleTiddlerChanges = function(changedTiddlers) 
 		($tw.utils.hopArray(changedTiddlers,newList) ? true : false);
 	// Re-cache tiddlers if something changed
 	if(hasChanged) {
-		this.updateTiddlerChangeLists(newList);
+		this.updateTiddlerFilterLists(newList);
 	}
 };
 

--- a/core/modules/tiddler-change.js
+++ b/core/modules/tiddler-change.js
@@ -38,18 +38,16 @@ TiddlerChangeManager.prototype.updateTiddlerChangeLists = function(tiddlerList) 
 };
 
 TiddlerChangeManager.prototype.handleChangedTiddlerEvent = function(event) {
-	var action;
+	var actions = [];
 	for(var i=0; i<this.actionTiddlers.length; i++) {
 		if(this.tiddlerChangeList[i] !== undefined && $tw.utils.hop(event,this.tiddlerChangeList[i])) {
-			action = this.tiddlerActionList[i];
-			break;
+			actions.push = this.tiddlerActionList[i];
 		}
 	}
-	if(action !== undefined) {
-		$tw.rootWidget.invokeActionString(action,$tw.rootWidget);
-		return true;
+	for(i=0; i<actions.length; i++) {
+		$tw.rootWidget.invokeActionString(actions[i],$tw.rootWidget);
 	}
-	return false;
+	return true;
 };
 
 TiddlerChangeManager.prototype.handleTiddlerChanges = function(changedTiddlers) {

--- a/core/modules/tiddler-change.js
+++ b/core/modules/tiddler-change.js
@@ -33,7 +33,7 @@ TiddlerChangeManager.prototype.updateTiddlerFilterLists = function(tiddlerList) 
 			tiddlerFields = $tw.wiki.getTiddler(title).fields;
 		this.tiddlerFilters[i] = tiddlerFields["tiddler-filter"] !== undefined ? tiddlerFields["tiddler-filter"] : undefined;
 		this.tiddlerActions[i] = tiddlerFields.text;
-		this.tiddlerFilterLists[i] = $tw.wiki.filterTiddlers(this.tiddlerChangeList[i]);
+		this.tiddlerFilterLists[i] = $tw.wiki.filterTiddlers(this.tiddlerFilters[i]);
 	}
 };
 

--- a/core/modules/tiddler-change.js
+++ b/core/modules/tiddler-change.js
@@ -68,7 +68,6 @@ TiddlerChangeManager.prototype.handleChangedTiddlerEvent = function(event) {
 	}
 	for(i=0; i<actions.length; i++) {
 		$tw.rootWidget.invokeActionString(actions[i],$tw.rootWidget);
-		console.log("ACTION INVOKED");
 	}
 	return true;
 };

--- a/core/modules/tiddler-change.js
+++ b/core/modules/tiddler-change.js
@@ -1,0 +1,87 @@
+/*\
+title: $:/core/modules/tiddler-change.js
+type: application/javascript
+module-type: global
+
+Tiddler change handling utilities
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+function TiddlerChangeManager(options) {
+	var self = this;
+	options = options || "";
+	this.tiddlerChangeList = [],
+	this.tiddlerActionList = [];
+	this.updateTiddlerChangeLists(this.getTiddlerList());
+	$tw.wiki.addEventListener("change",function(changes) {
+		self.handleShortcutChanges(changes);
+	});
+}
+
+TiddlerChangeManager.prototype.getTiddlerList = function() {
+	return $tw.wiki.getTiddlersWithTag("$:/tags/TiddlerChangeAction");
+};
+
+TiddlerChangeManager.prototype.updateTiddlerChangeLists = function(tiddlerList) {
+	this.actionTiddlers = tiddlerList;
+	for(var i=0; i<tiddlerList.length; i++) {
+		var title = tiddlerList[i],
+			tiddlerFields = $tw.wiki.getTiddler(title).fields;
+		this.tiddlerChangeList[i] = tiddlerFields["change-tiddler"] !== undefined ? tiddlerFields["change-tiddler"] : undefined;
+		this.tiddlerActionList[i] = tiddlerFields.text;
+	}
+};
+
+TiddlerChangeManager.prototype.handleChangedTiddlerEvent = function(event) {
+	var action;
+	for(var i=0; i<this.actionTiddlers.length; i++) {
+		if(this.tiddlerChangeList[i] !== undefined && $tw.utils.hop(event,this.tiddlerChangeList[i])) {
+			action = this.tiddlerActionList[i];
+			break;
+		}
+	}
+	if(action !== undefined) {
+		$tw.rootWidget.invokeActionString(action,$tw.rootWidget);
+		return true;
+	}
+	return false;
+};
+
+TiddlerChangeManager.prototype.detectNewShortcuts = function(changedTiddlers) {
+	var shortcutConfigTiddlers = [],
+		handled = false;
+	$tw.utils.each(this.lookupNames,function(platformDescriptor) {
+		var descriptorString = "$:/config/" + platformDescriptor + "/";
+		Object.keys(changedTiddlers).forEach(function(configTiddler) {
+			var configString = configTiddler.substr(0, configTiddler.lastIndexOf("/") + 1);
+			if(configString === descriptorString) {
+				shortcutConfigTiddlers.push(configTiddler);
+				handled = true;
+			}
+		});
+	});
+	if(handled) {
+		return $tw.utils.hopArray(changedTiddlers,shortcutConfigTiddlers);
+	} else {
+		return false;
+	}
+};
+
+TiddlerChangeManager.prototype.handleShortcutChanges = function(changedTiddlers) {
+	var newList = this.getTiddlerList();
+	var hasChanged = $tw.utils.hopArray(changedTiddlers,this.actionTiddlers) ? true :
+		($tw.utils.hopArray(changedTiddlers,newList) ? true : false);
+	// Re-cache tiddlers if something changed
+	if(hasChanged) {
+		this.updateTiddlerChangeLists(newList);
+	}
+};
+
+exports.TiddlerChangeManager = TiddlerChangeManager;
+
+})();


### PR DESCRIPTION
This PR allows to trigger actions when a specified tiddler changes

- We create a tiddler tagged `$:/tags/TiddlerChangeAction`
- The text field contains the action to be invoked
- The `change-tiddler` field contains the title of the tiddler that must change in order for the actions to be invoked

Sometimes tiddlers may change automatically, like the tiddler `$:/info/darkmode` and it would be suitable to invoke an action if they change

I also have in mind adding a mechanism like the one that detects dark mode, which detects if the window-width is lower than `$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint` ... but I'll have to ask @Jermolene if that's doable