### PR TITLE
Fix #5760 - tm-focus-selector doesn't work in new windows

### DIFF
--- a/core/modules/keyboard.js
+++ b/core/modules/keyboard.js
@@ -324,7 +324,7 @@ KeyboardManager.prototype.handleKeydownEvent = function(event) {
 	if(key !== undefined) {
 		event.preventDefault();
 		event.stopPropagation();
-		$tw.rootWidget.invokeActionString(action,$tw.rootWidget);
+		$tw.rootWidget.invokeActionString(action,$tw.rootWidget,event);
 		return true;
 	}
 	return false;

--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -40,9 +40,10 @@ exports.startup = function() {
 	// Install the tm-focus-selector message
 	$tw.rootWidget.addEventListener("tm-focus-selector",function(event) {
 		var selector = event.param || "",
-			element;
+			element,
+		    	doc = event.event ? event.event.target.ownerDocument : document;
 		try {
-			element = document.querySelector(selector);
+			element = doc.querySelector(selector);
 		} catch(e) {
 			console.log("Error in selector: ",selector)
 		}


### PR DESCRIPTION
This PR fixes #5760

- in keyboard.js we now pass the original event to `invokeActionString`
- in rootWidget.js we now use event.event.target.ownerDocument or document as fallback if event.event is undefined