### PR TITLE
Add test to storyviews if targetElement is null

### DIFF
--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -27,7 +27,7 @@ ClassicStoryView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	if(duration) {
@@ -43,7 +43,7 @@ ClassicStoryView.prototype.insert = function(widget) {
 	if(duration) {
 		var targetElement = widget.findFirstDomNode();
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
-		if(targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+		if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
 			return;
 		}
 		// Get the current height of the tiddler
@@ -83,7 +83,7 @@ ClassicStoryView.prototype.remove = function(widget) {
 				widget.removeChildDomNodes();
 			};
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
-		if(targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+		if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
 			removeElement();
 			return;
 		}

--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -27,7 +27,7 @@ ClassicStoryView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	if(duration) {
@@ -43,7 +43,7 @@ ClassicStoryView.prototype.insert = function(widget) {
 	if(duration) {
 		var targetElement = widget.findFirstDomNode();
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
-		if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+		if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 			return;
 		}
 		// Get the current height of the tiddler
@@ -83,7 +83,7 @@ ClassicStoryView.prototype.remove = function(widget) {
 				widget.removeChildDomNodes();
 			};
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
-		if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+		if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 			removeElement();
 			return;
 		}

--- a/core/modules/storyviews/pop.js
+++ b/core/modules/storyviews/pop.js
@@ -24,7 +24,7 @@ PopStoryView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Scroll the node into view
@@ -35,7 +35,7 @@ PopStoryView.prototype.insert = function(widget) {
 	var targetElement = widget.findFirstDomNode(),
 		duration = $tw.utils.getAnimationDuration();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Reset once the transition is over
@@ -77,7 +77,7 @@ PopStoryView.prototype.remove = function(widget) {
 			}
 		};
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
 		removeElement();
 		return;
 	}

--- a/core/modules/storyviews/pop.js
+++ b/core/modules/storyviews/pop.js
@@ -24,7 +24,7 @@ PopStoryView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Scroll the node into view
@@ -35,7 +35,7 @@ PopStoryView.prototype.insert = function(widget) {
 	var targetElement = widget.findFirstDomNode(),
 		duration = $tw.utils.getAnimationDuration();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Reset once the transition is over
@@ -77,7 +77,7 @@ PopStoryView.prototype.remove = function(widget) {
 			}
 		};
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 		removeElement();
 		return;
 	}

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -48,7 +48,7 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Make the new tiddler be position absolute and visible so that we can measure it
@@ -130,7 +130,7 @@ function findTitleDomNode(widget,targetClass) {
 ZoominListView.prototype.insert = function(widget) {
 	var targetElement = widget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Make the newly inserted node position absolute and hidden
@@ -147,7 +147,7 @@ ZoominListView.prototype.remove = function(widget) {
 			widget.removeChildDomNodes();
 		};
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
 		removeElement();
 		return;
 	}

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -48,7 +48,7 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Make the new tiddler be position absolute and visible so that we can measure it
@@ -130,7 +130,7 @@ function findTitleDomNode(widget,targetClass) {
 ZoominListView.prototype.insert = function(widget) {
 	var targetElement = widget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
 	// Make the newly inserted node position absolute and hidden
@@ -147,7 +147,7 @@ ZoominListView.prototype.remove = function(widget) {
 			widget.removeChildDomNodes();
 		};
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement === undefined || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 		removeElement();
 		return;
 	}


### PR DESCRIPTION
This PR tests if the `targetElement` is `null` in all of the three storyviews before testing for `targetElement.nodeType` which would cause a RSOD if `targetElement` is `null`

Fixes #5772