### PR TITLE
Fix slide animations if closing while opening

### DIFF
--- a/core/modules/utils/dom/animations/slide.js
+++ b/core/modules/utils/dom/animations/slide.js
@@ -23,7 +23,7 @@ function slideOpen(domNode,options) {
 		currPaddingTop = parseInt(computedStyle.paddingTop,10),
 		currHeight = domNode.offsetHeight;
 	// Reset the margin once the transition is over
-	setTimeout(function() {
+	var slideOpenTimeout = setTimeout(function() {
 		$tw.utils.setStyle(domNode,[
 			{transition: "none"},
 			{marginBottom: ""},
@@ -37,6 +37,9 @@ function slideOpen(domNode,options) {
 			options.callback();
 		}
 	},duration);
+	if(options.widget) {
+		options.widget.openTimeout = slideOpenTimeout;
+	}
 	// Set up the initial position of the element
 	$tw.utils.setStyle(domNode,[
 		{transition: "none"},
@@ -70,7 +73,7 @@ function slideClosed(domNode,options) {
 	var duration = options.duration || $tw.utils.getAnimationDuration(),
 		currHeight = domNode.offsetHeight;
 	// Clear the properties we've set when the animation is over
-	setTimeout(function() {
+	var slideCloseTimeout = setTimeout(function() {
 		$tw.utils.setStyle(domNode,[
 			{transition: "none"},
 			{marginBottom: ""},
@@ -84,6 +87,9 @@ function slideClosed(domNode,options) {
 			options.callback();
 		}
 	},duration);
+	if(options.widget) {
+		options.widget.closeTimeout = slideCloseTimeout;
+	}
 	// Set up the initial position of the element
 	$tw.utils.setStyle(domNode,[
 		{height: currHeight + "px"},

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -260,16 +260,18 @@ RevealWidget.prototype.updateState = function() {
 
 	}
 	if(this.isOpen) {
+		clearTimeout(this.closeTimeout);
 		domNode.removeAttribute("hidden");
-        $tw.anim.perform(this.openAnimation,domNode);
+        $tw.anim.perform(this.openAnimation,domNode,{widget: this});
 	} else {
+		clearTimeout(this.openTimeout);
 		$tw.anim.perform(this.closeAnimation,domNode,{callback: function() {
 			//make sure that the state hasn't changed during the close animation
 			self.readState()
 			if(!self.isOpen) {
 				domNode.setAttribute("hidden","true");
 			}
-		}});
+		},widget: this});
 	}
 };
 


### PR DESCRIPTION
To reproduce the problem:
- Go to https://tiddlywiki.com/prerelease
- Set the AnimationDuration to something high, like 4000
- open the info panel of a tiddler and click somewhere outside the opening info panel so that it closes while it opens
- see that when it should be closed, it reopens for a short time-period

The problem is, that the `setTimeout` of the `slideOpen` animation is still working
This PR clears the slide-open-timeout when a slideClose animation is started and vice versa