### PR TITLE
Add test for event.event.target in rootwidget

### DIFF
--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -41,7 +41,7 @@ exports.startup = function() {
 	$tw.rootWidget.addEventListener("tm-focus-selector",function(event) {
 		var selector = event.param || "",
 			element,
-		    	doc = event.event ? event.event.target.ownerDocument : document;
+		    	doc = event.event && event.event.target ? event.event.target.ownerDocument : document;
 		try {
 			element = doc.querySelector(selector);
 		} catch(e) {


### PR DESCRIPTION
This PR adds a test for `event.event.target` being undefined in the tm-focus-selector listener