### PR TITLE
Keyboard widget: provide variable for shortcut descriptor to actions.

### DIFF
--- a/core/modules/keyboard.js
+++ b/core/modules/keyboard.js
@@ -179,7 +179,7 @@ Key descriptors have the following format:
 	ctrl+enter
 	ctrl+shift+alt+A
 */
-KeyboardManager.prototype.parseKeyDescriptor = function(keyDescriptor) {
+KeyboardManager.prototype.parseKeyDescriptor = function(keyDescriptor,options) {
 	var components = keyDescriptor.split(/\+|\-/),
 		info = {
 			keyCode: 0,
@@ -205,6 +205,9 @@ KeyboardManager.prototype.parseKeyDescriptor = function(keyDescriptor) {
 		if(this.namedKeys[s]) {
 			info.keyCode = this.namedKeys[s];
 		}
+	}
+	if(options.keyDescriptor) {
+		info.keyDescriptor = options.keyDescriptor;
 	}
 	if(info.keyCode) {
 		return info;
@@ -237,6 +240,7 @@ KeyboardManager.prototype.parseKeyDescriptors = function(keyDescriptors,options)
 					lookupName = function(configName) {
 						var keyDescriptors = wiki.getTiddlerText("$:/config/" + configName + "/" + name);
 						if(keyDescriptors) {
+							options.keyDescriptor = keyDescriptor;
 							result.push.apply(result,self.parseKeyDescriptors(keyDescriptors,options));
 						}
 					};
@@ -245,7 +249,7 @@ KeyboardManager.prototype.parseKeyDescriptors = function(keyDescriptors,options)
 				});
 			}
 		} else {
-			result.push(self.parseKeyDescriptor(keyDescriptor));
+			result.push(self.parseKeyDescriptor(keyDescriptor,options));
 		}
 	});
 	return result;
@@ -276,12 +280,16 @@ KeyboardManager.prototype.checkKeyDescriptor = function(event,keyInfo) {
 };
 
 KeyboardManager.prototype.checkKeyDescriptors = function(event,keyInfoArray) {
+	return (this.getMatchingKeyDescriptor(event,keyInfoArray) !== null);
+};
+
+KeyboardManager.prototype.getMatchingKeyDescriptor = function(event,keyInfoArray) {
 	for(var t=0; t<keyInfoArray.length; t++) {
 		if(this.checkKeyDescriptor(event,keyInfoArray[t])) {
-			return true;
+			return keyInfoArray[t];
 		}
 	}
-	return false;
+	return null;
 };
 
 KeyboardManager.prototype.getEventModifierKeyDescriptor = function(event) {

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -54,7 +54,8 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 };
 
 KeyboardWidget.prototype.handleChangeEvent = function(event) {
-	if($tw.keyboardManager.checkKeyDescriptors(event,this.keyInfoArray)) {
+	var keyInfo = $tw.keyboardManager.getMatchingKeyDescriptor(event,this.keyInfoArray);
+	if(keyInfo) {
 		var handled = this.invokeActions(this,event);
 		if(this.actions) {
 			var variables = {
@@ -62,6 +63,9 @@ KeyboardWidget.prototype.handleChangeEvent = function(event) {
 					"event-code": event.code,
 					"modifier": $tw.keyboardManager.getEventModifierKeyDescriptor(event)
 				};
+			if(keyInfo.keyDescriptor) {
+				variables["event-key-descriptor"] = keyInfo.keyDescriptor;
+			}
 			this.invokeActionString(this.actions,this,event,variables);
 		}
 		this.dispatchMessage(event);

--- a/editions/tw5.com/tiddlers/widgets/KeyboardWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/KeyboardWidget.tid
@@ -1,7 +1,7 @@
 caption: keyboard
 created: 20140302192136805
 list: [[Keyboard Codes]] [[Key Codes (Example)]] [[Key Codes (Example 1)]] [[Possible Keys (Example 2)]]
-modified: 20210525102143381
+modified: 20210612101618855
 tags: Widgets
 title: KeyboardWidget
 type: text/vnd.tiddlywiki
@@ -30,6 +30,7 @@ The content of the `<$keyboard>` widget is rendered normally. The keyboard short
 |!Variables |!Description |
 |`event-key` |The <<.var event-key>> variable contains the character, if possible. eg: `1`. You can experiment with some settings at: [[Key Codes (Example)]] |
 |`event-code` |The <<.var event-code>> variable contains a character description. eg:  `Digit1` instead of `1`. Or `Space` instead of an empty string ` `, which is hard to see|
+|`event-key-descriptor` |The <<.var event-key-descriptor>> variable is available if the keyboard event captured was configured using a [[keyboard shortcut descriptor|Keyboard Shortcut Descriptor]] of the form `((my-shortcut))` which references a configuration tiddler. |
 |`modifier` |The [[modifier Variable]] contains the Modifier Key held during the event (can be <kbd>normal</kbd>, <kbd>ctrl</kbd>, <kbd>shift</kbd>, <kbd>alt</kbd> or combinations thereof) |
 
 ! Key Strings


### PR DESCRIPTION
This PR extends the keyboard widget to provide an additional variable `event-key-descriptor` to the actions it invokes.

This makes it possible for a single keyboard widget to handle multiple keyboard shortcuts configured with key descriptors to be handled within a single block of actions.

`KeyboardManager.prototype.checkKeyDescriptor` has been refactored to use a new method `getMatchingKeyDescriptor`, which can also be used independently to get the `keyInfo` matching a given event. This change is backwards compatible.

Docs have been updated with the new variable.

