### PR TITLE
CodeMirror: include reference to edit widget

### DIFF
--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -109,6 +109,7 @@ function CodeMirrorEngine(options) {
 	if(this.widget.editTabIndex) {
 		config["tabindex"] = this.widget.editTabIndex;
 	}
+	config.editWidget = this.widget;
 	// Create the CodeMirror instance
 	this.cm = window.CodeMirror(function(cmDomNode) {
 		// Note that this is a synchronous callback that is called before the constructor returns


### PR DESCRIPTION
Pass a reference to the edit widget to the CodeMirror instance. This is helpful for CodeMirror addons that need to render widgets or get variable values from the edit widget.
