### PR TITLE
Focus-Preservation over refresh cycles III

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -86,7 +86,8 @@ function FramedEngine(options) {
 		{name: "click",handlerObject: this,handlerMethod: "handleClickEvent"},
 		{name: "input",handlerObject: this,handlerMethod: "handleInputEvent"},
 		{name: "keydown",handlerObject: this.widget,handlerMethod: "handleKeydownEvent"},
-		{name: "focus",handlerObject: this,handlerMethod: "handleFocusEvent"}
+		{name: "focus",handlerObject: this,handlerMethod: "handleFocusEvent"},
+		{name: "blur",handlerObject: this, handlerMethod: "handleBlurEvent"}
 	]);
 	// Add drag and drop event listeners if fileDrop is enabled
 	if(this.widget.isFileDropEnabled) {
@@ -102,6 +103,7 @@ function FramedEngine(options) {
 	}
 	// Insert the element into the DOM
 	this.iframeDoc.body.appendChild(this.domNode);
+	this.widget.domNodes.push(this.domNode);
 }
 
 /*
@@ -116,6 +118,24 @@ FramedEngine.prototype.copyStyles = function() {
 	this.domNode.style.margin = "0";
 	// In Chrome setting -webkit-text-fill-color overrides the placeholder text colour
 	this.domNode.style["-webkit-text-fill-color"] = "currentcolor";
+};
+
+/*
+Get an object containing the selectionStart and selectionEnd values
+*/
+FramedEngine.prototype.getSelectionRange = function() {
+	return {
+		selectionStart: this.domNode.selectionStart,
+		selectionEnd: this.domNode.selectionEnd
+	}
+};
+
+/*
+Set the selection-range
+*/
+FramedEngine.prototype.setSelectionRange = function(selectionStart,selectionEnd) {
+	this.domNode.selectionStart = selectionStart;
+	this.domNode.selectionEnd = selectionEnd;
 };
 
 /*
@@ -183,6 +203,17 @@ Handle a focus event
 FramedEngine.prototype.handleFocusEvent = function(event) {
 	if(this.widget.editCancelPopups) {
 		$tw.popup.cancel(0);
+	}
+	var currentTiddler = this.widget.document.querySelector('[data-tiddler-title="' + CSS.escape(this.widget.editTitle) + '"].tc-tiddler-frame');
+	if(currentTiddler) {
+		$tw.utils.addClass(currentTiddler,"tc-focused");
+	}
+};
+
+FramedEngine.prototype.handleBlurEvent = function(event) {
+	var currentTiddler = this.widget.document.querySelector('[data-tiddler-title="' + CSS.escape(this.widget.editTitle) + '"].tc-tiddler-frame');
+	if(currentTiddler) {
+		$tw.utils.removeClass(currentTiddler,"tc-focused");
 	}
 };
 

--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -69,6 +69,24 @@ function SimpleEngine(options) {
 }
 
 /*
+Get an object containing the selectionStart and selectionEnd values
+*/
+SimpleEngine.prototype.getSelectionRange = function() {
+	return {
+		selectionStart: this.domNode.selectionStart,
+		selectionEnd: this.domNode.selectionEnd
+	}
+};
+
+/*
+Set the selection-range
+*/
+SimpleEngine.prototype.setSelectionRange = function(selectionStart,selectionEnd) {
+	this.domNode.selectionStart = selectionStart;
+	this.domNode.selectionEnd = selectionEnd;
+};
+
+/*
 Set the text of the engine if it doesn't currently have focus
 */
 SimpleEngine.prototype.setText = function(text,type) {

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -72,6 +72,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		this.engine.fixHeight();
 		// Focus if required
 		if(this.editFocus === "true" || this.editFocus === "yes") {
+			$tw.focusManager.interceptFocusPreservation = true;
 			this.engine.focus();
 		}
 		// Add widget message listeners

--- a/core/modules/focus.js
+++ b/core/modules/focus.js
@@ -1,0 +1,223 @@
+/*\
+title: $:/core/modules/focus.js
+type: application/javascript
+module-type: global
+
+Focus handling utilities
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+function FocusManager(options) {
+	var options = options || "";
+	this.interceptFocusPreservation = false;
+}
+
+FocusManager.prototype.findChildDomNode = function(startingDomNode,domNode) {
+	for(var domNodeIndex=0; domNodeIndex<startingDomNode.childNodes.length; domNodeIndex++) {
+		if(startingDomNode.childNodes[domNodeIndex] === domNode) {
+			return startingDomNode.childNodes[domNodeIndex];
+		}
+	}
+	for(var childIndex=0; childIndex<startingDomNode.childNodes.length; childIndex++) {
+		var result = this.findChildDomNode(startingDomNode.childNodes[childIndex],domNode);
+		if(result) {
+			return result;
+		}
+	}
+	return null;
+};
+
+FocusManager.prototype.findWidgetOwningDomNode = function(widget,domNode) {
+	for(var domNodeIndex=0; domNodeIndex<widget.domNodes.length; domNodeIndex++) {
+		if(widget.domNodes[domNodeIndex] === domNode) {
+			return widget;
+		}
+	}
+	for(var childIndex=0; childIndex<widget.children.length; childIndex++) {
+		var result = this.findWidgetOwningDomNode(widget.children[childIndex],domNode);
+		if(result) {
+			return result;
+		}
+	}
+	for(domNodeIndex=0; domNodeIndex<widget.domNodes.length; domNodeIndex++) {
+		var childDomNode = this.findChildDomNode(widget.domNodes[domNodeIndex],domNode);
+		if(childDomNode) {
+			return widget;
+		}
+	}
+	return null;
+};
+
+FocusManager.prototype.getRenderTreeFootprint = function(widget,domNode) {
+	var footprint = [];
+	while(widget.domNodes.indexOf(domNode) === -1) {
+		var domNodeIndex = Array.prototype.indexOf.call(domNode.parentNode.children,domNode);
+		footprint.push(domNodeIndex);
+		domNode = domNode.parentNode;
+	}
+	if(widget.domNodes.indexOf(domNode) > -1) {
+		footprint.push(widget.domNodes.indexOf(domNode));
+	}
+	return footprint.reverse();
+};
+
+FocusManager.prototype.getWidgetTreeFootprint = function(widget) {
+	var node = widget,
+		footprint = [];
+	while(node) {
+		if(node.parentWidget && node.parentWidget.children && node.parentWidget.children.indexOf(node) !== -1) {
+			footprint.push(node.parentWidget.children.indexOf(node));
+		}
+		node = node.parentWidget;
+	}
+	return footprint.reverse();
+};
+
+FocusManager.prototype.getFocusWidgetInfo = function(rootWidget,domNode) {
+	// Get the widget owning the currently focused Dom Node
+	var focusWidget = this.findWidgetOwningDomNode(rootWidget,domNode),
+		renderTreeFootprint,
+		widgetTreeFootprint,
+		widgetQualifier,
+		widgetInfo = {};
+	// Collect information about our widget
+	if(focusWidget) {
+		widgetInfo.renderTreeFootprint = this.getRenderTreeFootprint(focusWidget,domNode);
+		widgetInfo.widgetTreeFootprint = this.getWidgetTreeFootprint(focusWidget);
+		widgetInfo.widgetQualifier = focusWidget.getStateQualifier() + "_" + focusWidget.generateWidgetTreeFootprint();
+		if(focusWidget.engine && focusWidget.engine.getSelectionRange) {
+			var selections = focusWidget.engine.getSelectionRange();
+			widgetInfo.selectionStart = selections.selectionStart;
+			widgetInfo.selectionEnd = selections.selectionEnd;
+		}
+	}
+	return widgetInfo;
+};
+
+FocusManager.prototype.findWidgetByQualifier = function(qualifier,widget) {
+	if(qualifier) {
+		for(var widgetIndex=0; widgetIndex < widget.children.length; widgetIndex++) {
+			var childWidget = widget.children[widgetIndex];
+			var childWidgetQualifier = childWidget.getStateQualifier() + "_" + childWidget.generateWidgetTreeFootprint();
+			if(childWidgetQualifier === qualifier) {
+				return widget.children[widgetIndex];
+			}
+		}
+		for(var childIndex=0; childIndex<widget.children.length; childIndex++) {
+			var result = this.findWidgetByQualifier(qualifier,widget.children[childIndex]);
+			if(result) {
+				return result;
+			}
+		}
+	}
+	return null;
+};
+
+FocusManager.prototype.findWidgetByRenderTreeFootprint = function(widgetTreeFootprint,rootWidget) {
+	var index,
+		count = 0,
+		widget = rootWidget,
+		lastFoundWidget;
+	if(widgetTreeFootprint) {
+		while(count < widgetTreeFootprint.length) {
+			index = widgetTreeFootprint[count],
+			lastFoundWidget = widget;
+			if(widget && widget.children) {
+				widget = widget.children[index];
+			}
+			if(widget === undefined) {
+				break;
+			}
+			count++;
+		}
+		if(widget) {
+			return widget;
+		} else if(lastFoundWidget) {
+			return lastFoundWidget;
+		}
+	}
+	return null;
+};
+
+FocusManager.prototype.findWidgetByFootprint = function(rootWidget,widgetInfo) {
+	var widget = this.findWidgetByQualifier(widgetInfo.widgetQualifier,rootWidget);
+	if(!widget) {
+		widget = this.findWidgetByRenderTreeFootprint(widgetInfo.widgetTreeFootprint,rootWidget);
+	}
+	return widget;
+};
+
+FocusManager.prototype.findParentWidgetWithDomNodes = function(widget) {
+	while(widget) {
+		widget = widget.parentWidget;
+		if(widget.domNodes.length > 0 && widget.domNodes[0].childNodes[0] &&
+			widget.domNodes[0].childNodes[0].getAttribute && widget.domNodes[0].childNodes[0].getAttribute("hidden") !== "true" &&
+			widget.domNodes[0].childNodes[0].nodeType !== Node.TEXT_NODE &&
+			widget.domNodes[0].childNodes[0].focus) {
+			return widget.domNodes[0].childNodes[0];
+		}
+	}
+	return null;
+};
+
+FocusManager.prototype.restoreFocus = function(rootWidget,widgetInfo) {
+	var widget = this.findWidgetByFootprint(rootWidget,widgetInfo);
+	if(widget) {
+		if(!this.interceptFocusPreservation) {
+			var footprint = widgetInfo.renderTreeFootprint,
+				counter = 0,
+				domNode = widget.domNodes[footprint[0]],
+				foundDomNode;
+			while(domNode) {
+				counter++;
+				foundDomNode = domNode;
+				domNode = domNode.childNodes[footprint[counter]];
+			}
+			// If we haven't found a Dom Node
+			if(foundDomNode === undefined) {
+				foundDomNode = this.findParentWidgetWithDomNodes(widget);
+			}
+			// If the Dom Node is hidden
+			if(foundDomNode && foundDomNode.getAttribute && foundDomNode.getAttribute("hidden") === "true") {
+				while(foundDomNode && foundDomNode.getAttribute && foundDomNode.getAttribute("hidden") === "true") {
+					foundDomNode = this.findParentWidgetWithDomNodes(widget);
+				}
+			}
+			// If the DomNode is a Text Node, use the parent DomNode
+			if(foundDomNode && (foundDomNode.nodeType === Node.TEXT_NODE)) {
+				foundDomNode = foundDomNode.parentNode;
+			}
+			// If the Dom Node doesn't have the tabindex attribute set,
+			// detect if it's a focusable Dom Node
+			if(foundDomNode && foundDomNode.getAttribute && foundDomNode.getAttribute("tabindex") === null) {
+				var validTagNames = ["BUTTON","A","INPUT","TEXTAREA"];
+				while((foundDomNode.getAttribute && foundDomNode.getAttribute("tabindex") === null) && (foundDomNode && foundDomNode.tagName && validTagNames.indexOf(foundDomNode.tagName.toUpperCase()) === -1)) {
+					if(foundDomNode.tagName && foundDomNode.tagName.toUpperCase() === "SPAN" && foundDomNode.childNodes[0]) {
+						foundDomNode = foundDomNode.childNodes[0];
+					} else {
+						foundDomNode = foundDomNode.parentNode;
+					}
+				}
+			}
+			// Set an eventual selection-range
+			if(foundDomNode && widget.engine && widget.engine.setSelectionRange) {
+				widget.engine.setSelectionRange(widgetInfo.selectionStart,widgetInfo.selectionEnd);
+			}
+			// Now focus the DomNode
+			if(foundDomNode && foundDomNode.focus) {
+				foundDomNode.focus({preventScroll: true});
+			}
+		} else {
+			this.interceptFocusPreservation = false;
+		}
+	}
+};
+
+exports.FocusManager = FocusManager;
+
+})();

--- a/core/modules/startup/render.js
+++ b/core/modules/startup/render.js
@@ -70,11 +70,23 @@ exports.startup = function() {
 	var deferredChanges = Object.create(null),
 		timerId;
 	function refresh() {
+		// Save the scroll position
+		var scrollX = window.scrollX,
+			scrollY = window.scrollY;
+		// Get the currently focused Dom Node
+		var currentlyFocusedDomNode = document.activeElement.tagName.toUpperCase() !== "IFRAME" ? document.activeElement :
+			document.activeElement.contentWindow.document.activeElement;
+		// Generate the widget-info object
+		var focusWidgetInfo = $tw.focusManager.getFocusWidgetInfo($tw.rootWidget,currentlyFocusedDomNode);
 		// Process the refresh
 		$tw.hooks.invokeHook("th-page-refreshing");
 		$tw.pageWidgetNode.refresh(deferredChanges);
 		deferredChanges = Object.create(null);
 		$tw.hooks.invokeHook("th-page-refreshed");
+		// Restore the focus to a focusable Dom Node
+		$tw.focusManager.restoreFocus($tw.rootWidget,focusWidgetInfo);
+		// Restore the scroll position
+		window.scroll(scrollX,scrollY);
 	}
 	// Add the change event handler
 	$tw.wiki.addEventListener("change",$tw.perf.report("mainRefresh",function(changes) {

--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -110,6 +110,8 @@ exports.startup = function() {
 			handlerMethod: "handleKeydownEvent"
 		}]);
 	}
+	// Kick off the focus manager
+	$tw.focusManager = new $tw.FocusManager();
 	// Clear outstanding tiddler store change events to avoid an unnecessary refresh cycle at startup
 	$tw.wiki.clearTiddlerEventQueue();
 	// Find a working syncadaptor

--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -73,21 +73,35 @@ exports.startup = function() {
 		widgetNode.render(srcDocument.body,srcDocument.body.firstChild);
 		// Function to handle refreshes
 		refreshHandler = function(changes) {
+			// Save the scroll position
+			var scrollX = srcWindow.scrollX,
+				scrollY = srcWindow.scrollY;
+			// Get the currently focused Dom Node
+			var currentlyFocusedDomNode = srcDocument.activeElement.tagName.toUpperCase() !== "IFRAME" ? srcDocument.activeElement :
+				srcDocument.activeElement.contentWindow.document.activeElement;
+			// Generate the widget-info object
+			var focusWidgetInfo = $tw.focusManager.getFocusWidgetInfo(widgetNode,currentlyFocusedDomNode);
 			if(styleWidgetNode.refresh(changes,styleContainer,null)) {
 				styleElement.innerHTML = styleContainer.textContent;
 			}
 			widgetNode.refresh(changes);
+			// Restore the focus to a focusable Dom Node
+			$tw.focusManager.restoreFocus(widgetNode,focusWidgetInfo);
+			// Restore the scroll position
+			srcWindow.scroll(scrollX,scrollY);
 		};
 		$tw.wiki.addEventListener("change",refreshHandler);
 		// Listen for keyboard shortcuts
 		$tw.utils.addEventListeners(srcDocument,[{
 			name: "keydown",
 			handlerObject: $tw.keyboardManager,
-			handlerMethod: "handleKeydownEvent"
+			handlerMethod: "handleKeydownEvent",
+			document: srcDocument
 		}]);
 		srcWindow.document.documentElement.addEventListener("click",$tw.popup,true);
 		srcWindow.haveInitialisedWindow = true;
 	});
+	$tw.windows["rootWindow"] = window;
 	// Close open windows when unloading main window
 	$tw.addUnloadTask(function() {
 		$tw.utils.each($tw.windows,function(win) {

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -173,11 +173,25 @@ Modal.prototype.display = function(title,options) {
 		importPageMacros: true
 	});
 	footerWidgetNode.render(modalFooterButtons,null);
+	navigatorWidgetNode.children = [headerWidgetNode,bodyWidgetNode,footerWidgetNode];
 	// Set up the refresh handler
 	refreshHandler = function(changes) {
+		// Save the current scroll position
+		var scrollX = modalBody.scrollLeft,
+			scrollY = modalBody.scrollTop;
+		// Detect the currently focused domNode
+		var currentlyFocusedDomNode = self.srcDocument.activeElement.tagName.toUpperCase() !== "IFRAME" ? self.srcDocument.activeElement :
+			self.srcDocument.activeElement.contentWindow.document.activeElement;
+		// Generate the widget-info object
+		var focusWidgetInfo = $tw.focusManager.getFocusWidgetInfo(navigatorWidgetNode,currentlyFocusedDomNode);
 		headerWidgetNode.refresh(changes,modalHeader,null);
 		bodyWidgetNode.refresh(changes,modalBody,null);
 		footerWidgetNode.refresh(changes,modalFooterButtons,null);
+		// Restore the focus to a focusable Dom Node
+		$tw.focusManager.restoreFocus(navigatorWidgetNode,focusWidgetInfo);
+		// Restore the scroll position
+		modalBody.scrollLeft = scrollX;
+		modalBody.scrollTop = scrollY;
 	};
 	this.wiki.addEventListener("change",refreshHandler);
 	// Add the close event handler

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -46,6 +46,7 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 	$tw.utils.addEventListeners(domNode,[
 		{name: "keydown", handlerObject: this, handlerMethod: "handleChangeEvent"}
 	]);
+	this.assignMissingAttributes(domNode);
 	// Insert element
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -1,28 +1,51 @@
 title: $:/core/ui/EditTemplate
 
+\whitespace trim
+\define focus-tiddler-actions(afterOrBefore)
+<$set name="nextTiddler" value={{{ [list<tv-story-list>$afterOrBefore$<currentTiddler>] }}}>
+<$set name="cssEscapedTitle" value={{{ [<nextTiddler>escapecss[]] }}}>
+<$action-sendmessage $message="tm-focus-selector" $param=<<get-focus-selector>> preventScroll="true" interceptAutoFocus="true"/>
+<$action-navigate $to=<<nextTiddler>>/>
+</$set>
+</$set>
+\end
 \define delete-edittemplate-state-tiddlers() <$action-deletetiddler $filter="[<newFieldNameTiddler>] [<newFieldValueTiddler>] [<newFieldNameInputTiddler>] [<newFieldNameSelectionTiddler>] [<newTagNameTiddler>] [<newTagNameInputTiddler>] [<newTagNameSelectionTiddler>] [<typeInputTiddler>] [<typeSelectionTiddler>]"/>
 \define save-tiddler-actions()
 <$action-sendmessage $message="tm-add-tag" $param={{{ [<newTagNameTiddler>get[text]] }}}/>
 <$action-sendmessage $message="tm-add-field" $name={{{ [<newFieldNameTiddler>get[text]] }}} $value={{{ [<newFieldValueTiddler>get[text]] }}}/>
 <<delete-edittemplate-state-tiddlers>>
 <$action-sendmessage $message="tm-save-tiddler"/>
+<$set name="cssEscapedTitle" value={{{ [<currentTiddler>get[draft.title]] }}}>
+<$action-sendmessage $message="tm-focus-selector" $param=<<get-focus-selector>>/>
+</$set>
 \end
 \define cancel-delete-tiddler-actions(message)
+<$list filter="[[$message$]match[cancel]]" variable="ignore">
+<$list filter="[<currentTiddler>get[draft.of]!is[shadow]is[missing]]" variable="ignore">
+<<if-last-tiddler-actions>>
+</$list>
+</$list>
+<$list filter="[[$message$]match[delete]]" variable="ignore">
+<<if-last-tiddler-actions>>
+</$list>
 <<delete-edittemplate-state-tiddlers>>
 <$action-sendmessage $message="tm-$message$-tiddler"/>
 \end
-<div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ tc-tiddler-frame tc-tiddler-edit-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}>
-<$fieldmangler>
-<$vars storyTiddler=<<currentTiddler>> newTagNameTiddler=<<qualify "$:/temp/NewTagName">> newFieldNameTiddler=<<qualify "$:/temp/NewFieldName">> newFieldValueTiddler=<<qualify "$:/temp/NewFieldValue">> newFieldNameInputTiddler=<<qualify "$:/temp/NewFieldName/input">> newFieldNameSelectionTiddler=<<qualify "$:/temp/NewFieldName/selected-item">> newTagNameInputTiddler=<<qualify "$:/temp/NewTagName/input">> newTagNameSelectionTiddler=<<qualify "$:/temp/NewTagName/selected-item">> typeInputTiddler=<<qualify "$:/temp/Type/input">> typeSelectionTiddler=<<qualify "$:/temp/Type/selected-item">>>
+\whitespace trim
+<$keyboard key="((focus-previous-tiddler))" actions=<<focus-tiddler-actions "before">> tag="div" dom-data-tiddler-title=<<currentTiddler>> dom-data-tags={{!!tags}} class={{{ tc-tiddler-frame tc-tiddler-edit-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}>
 <$keyboard key="((cancel-edit-tiddler))" actions=<<cancel-delete-tiddler-actions "cancel">>>
 <$keyboard key="((save-tiddler))" actions=<<save-tiddler-actions>>>
+<$keyboard key="((focus-next-tiddler))" actions=<<focus-tiddler-actions "after">> tag="div" dom-data-focus-title=<<currentTiddler>> dom-tabindex={{$:/config/EditTabIndex}} class="tc-tiddler-pad-frame">
+<$fieldmangler>
+<$vars storyTiddler=<<currentTiddler>> newTagNameTiddler=<<qualify "$:/temp/NewTagName">> newFieldNameTiddler=<<qualify "$:/temp/NewFieldName">> newFieldValueTiddler=<<qualify "$:/temp/NewFieldValue">> newFieldNameInputTiddler=<<qualify "$:/temp/NewFieldName/input">> newFieldNameSelectionTiddler=<<qualify "$:/temp/NewFieldName/selected-item">> newTagNameInputTiddler=<<qualify "$:/temp/NewTagName/input">> newTagNameSelectionTiddler=<<qualify "$:/temp/NewTagName/selected-item">> typeInputTiddler=<<qualify "$:/temp/Type/input">> typeSelectionTiddler=<<qualify "$:/temp/Type/selected-item">>>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/EditTemplate]!has[draft.of]]" variable="listItem">
 <$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
 <$transclude tiddler=<<listItem>>/>
 </$set>
 </$list>
-</$keyboard>
-</$keyboard>
 </$vars>
 </$fieldmangler>
-</div>
+</$keyboard>
+</$keyboard>
+</$keyboard>
+</$keyboard>

--- a/core/ui/ViewTemplate.tid
+++ b/core/ui/ViewTemplate.tid
@@ -1,10 +1,43 @@
 title: $:/core/ui/ViewTemplate
 
+\whitespace trim
 \define folded-state()
 $:/state/folded/$(currentTiddler)$
 \end
-\define cancel-delete-tiddler-actions(message) <$action-sendmessage $message="tm-$message$-tiddler"/>
+\define focus-tiddler-actions(afterOrBefore)
+<$set name="nextTiddler" value={{{ [list<tv-story-list>$afterOrBefore$<currentTiddler>] }}}>
+<$set name="cssEscapedTitle" value={{{ [<nextTiddler>escapecss[]] }}}>
+<$action-navigate $to=<<nextTiddler>>/>
+<$action-sendmessage $message="tm-focus-selector" $param=<<get-focus-selector>> preventScroll="true"/>
+</$set>
+</$set>
+\end
+\define close-tiddler-actions()
+<<if-last-tiddler-actions>>
+<$action-sendmessage $message="tm-close-tiddler"/>
+\end
+\define cancel-delete-tiddler-actions(message)
+<$list filter="[[$message$]match[cancel]]" variable="ignore">
+<$list filter="[<currentTiddler>get[draft.of]!is[shadow]is[missing]]" variable="ignore">
+<<if-last-tiddler-actions>>
+</$list>
+</$list>
+<$list filter="[[$message$]match[delete]]" variable="ignore">
+<<if-last-tiddler-actions>>
+</$list>
+<$action-sendmessage $message="tm-$message$-tiddler"/>
+\end
 \import [all[shadows+tiddlers]tag[$:/tags/Macro/View]!has[draft.of]]
-<$vars storyTiddler=<<currentTiddler>> tiddlerInfoState=<<qualify "$:/state/popup/tiddler-info">>><div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ tc-tiddler-frame tc-tiddler-view-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[shadow]is[tiddler]then[tc-tiddler-overridden-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}><$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate]!has[draft.of]]" variable="listItem"><$transclude tiddler=<<listItem>>/></$list>
-</div>
+\whitespace trim
+<$keyboard key="((focus-previous-tiddler))" actions=<<focus-tiddler-actions "before">> tag="div" dom-data-tiddler-title=<<currentTiddler>> dom-data-tags={{!!tags}} class={{{ tc-tiddler-frame tc-tiddler-view-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[shadow]is[tiddler]then[tc-tiddler-overridden-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}>
+<$keyboard key="((edit-focus-tiddler))" actions="""<$action-sendmessage $message="tm-edit-tiddler"/>""">
+<$keyboard key="((close-focus-tiddler))" actions=<<close-tiddler-actions>>>
+<$keyboard key="((focus-next-tiddler))" actions=<<focus-tiddler-actions "after">> tag="div" dom-data-focus-title=<<currentTiddler>> dom-tabindex={{$:/config/EditTabIndex}} class="tc-tiddler-pad-frame">
+<$vars storyTiddler=<<currentTiddler>> tiddlerInfoState=<<qualify "$:/state/popup/tiddler-info">>>
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate]!has[draft.of]]" variable="listItem"><$transclude tiddler=<<listItem>>/>
+</$list>
 </$vars>
+</$keyboard>
+</$keyboard>
+</$keyboard>
+</$keyboard>

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -6,8 +6,12 @@ advanced-search-sidebar: {{$:/language/Shortcuts/Input/AdvancedSearch/Hint}}
 bold: {{$:/language/Buttons/Bold/Hint}}
 cancel-edit-tiddler: {{$:/language/Buttons/Cancel/Hint}}
 change-sidebar-layout: {{$:/language/Shortcuts/SidebarLayout/Hint}}
+close-focus-tiddler: {{$:/language/Shortcuts/FocusedTiddler/Close/Hint}}
 delete-field: {{$:/language/EditTemplate/Field/Remove/Hint}}
+edit-focus-tiddler: {{$:/language/Shortcuts/FocusedTiddler/Edit/Hint}}
 excise: {{$:/language/Buttons/Excise/Hint}}
+focus-next-tiddler: {{$:/language/Shortcuts/FocusedTiddler/Next/Hint}}
+focus-previous-tiddler: {{$:/language/Shortcuts/FocusedTiddler/Previous/Hint}}
 heading-1: {{$:/language/Buttons/Heading1/Hint}}
 heading-2: {{$:/language/Buttons/Heading2/Hint}}
 heading-3: {{$:/language/Buttons/Heading3/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts.multids
+++ b/core/wiki/config/shortcuts/shortcuts.multids
@@ -5,8 +5,12 @@ advanced-search: ctrl-shift-A
 advanced-search-sidebar: alt-Enter
 cancel-edit-tiddler: escape
 change-sidebar-layout: shift-alt-Down
+close-focus-tiddler: alt-C
 delete-field: shift-alt-D
+edit-focus-tiddler: alt-E
 excise: ctrl-E
+focus-next-tiddler: alt-Down
+focus-previous-tiddler: alt-Up
 sidebar-search: ctrl-shift-F
 heading-1: ctrl-1
 heading-2: ctrl-2

--- a/core/wiki/macros/templates.tid
+++ b/core/wiki/macros/templates.tid
@@ -1,0 +1,19 @@
+title: $:/core/macros/templates
+tags: $:/tags/Macro
+
+\define if-last-tiddler-actions()
+<$set name="lastTiddler" value={{{ [list<tv-story-list>last[]] }}}>
+<$list filter="[<currentTiddler>match<lastTiddler>]" variable="ignore">
+<$set name="nextTiddler" value={{{ [list<tv-story-list>before<currentTiddler>] }}}>
+<$set name="cssEscapedTitle" value={{{ [<nextTiddler>escapecss[]] }}}>
+<$action-sendmessage $message="tm-focus-selector" $param=<<get-focus-selector>> preventScroll="true"/>
+<$action-navigate $to=<<nextTiddler>>/>
+</$set>
+</$set>
+</$list>
+</$set>
+\end
+
+\define get-focus-selector()
+[data-tiddler-title="$(cssEscapedTitle)$"].tc-tiddler-frame [data-focus-title="$(cssEscapedTitle)$"]
+\end

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -168,6 +168,32 @@ function CodeMirrorEngine(options) {
 }
 
 /*
+Get an object containing the selectionStart and selectionEnd values
+*/
+CodeMirrorEngine.prototype.getSelectionRange = function() {
+	var selections = this.cm.listSelections(),
+		anchorPos,
+		headPos;
+	if(selections.length > 0) {
+		anchorPos = this.cm.indexFromPos(selections[0].anchor),
+		headPos = this.cm.indexFromPos(selections[0].head);
+	} else {
+		anchorPos = headPos = this.cm.indexFromPos(this.cm.getCursor());
+	}
+	return {
+		selectionStart: anchorPos,
+		selectionEnd: headPos
+	}
+};
+
+/*
+Set the selection-range
+*/
+CodeMirrorEngine.prototype.setSelectionRange = function(selectionStart,selectionEnd) {
+	this.cm.setSelection(this.cm.posFromIndex(selectionStart),this.cm.posFromIndex(selectionEnd));
+};
+
+/*
 Set the text of the engine if it doesn't currently have focus
 */
 CodeMirrorEngine.prototype.setText = function(text,type) {
@@ -198,7 +224,8 @@ Fix the height of textarea to fit content
 CodeMirrorEngine.prototype.fixHeight = function() {
 	if(this.widget.editAutoHeight) {
 		// Resize to fit
-		this.cm.setSize(null,null);
+		console.log("resizing to fit");
+		this.cm.setSize("100%","2.5em");
 	} else {
 		var fixedHeight = parseInt(this.widget.wiki.getTiddlerText(HEIGHT_VALUE_TITLE,"400px"),10);
 		fixedHeight = Math.max(fixedHeight,20);

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -333,6 +333,10 @@ table tfoot tr td {
 	height: 600px;
 }
 
+:root {
+	color-scheme: {{{ [{$:/palette}get[color-scheme]] }}};
+}
+
 /*
 ** Links
 */
@@ -1008,6 +1012,14 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	border: 1px solid <<colour tiddler-border>>;
 }
 
+.tc-story-river .tc-tiddler-frame:focus-within, .tc-story-river .tc-tiddler-frame:focus, .tc-story-river .tc-tiddler-frame.tc-focused {
+	border: 1px solid <<colour foreground>>;
+}
+
+.tc-story-river .tc-tiddler-frame, .tc-story-river .tc-tiddler-pad-frame {
+	outline: none;
+}
+
 {{$:/themes/tiddlywiki/vanilla/sticky}}
 
 .tc-tiddler-info {
@@ -1048,13 +1060,15 @@ button.tc-btn-invisible.tc-remove-tag-button {
 }
 
 .tc-view-field-value {
-	word-break: break-all;
 }
 
 @media (max-width: <<sidebarbreakpoint-minus-one>>) {
 	.tc-tiddler-frame {
-		padding: 14px 14px 14px 14px;
 		margin-bottom: .5em;
+	}
+
+	.tc-tiddler-pad-frame {
+		padding: 14px 14px 14px 14px;
 	}
 
 	.tc-tiddler-info {
@@ -1064,9 +1078,12 @@ button.tc-btn-invisible.tc-remove-tag-button {
 
 @media (min-width: <<sidebarbreakpoint>>) {
 	.tc-tiddler-frame {
-		padding: 28px 42px 42px 42px;
 		width: {{$:/themes/tiddlywiki/vanilla/metrics/tiddlerwidth}};
 		border-radius: 2px;
+	}
+
+	.tc-tiddler-pad-frame {
+		padding: 28px 42px 42px 42px;
 	}
 
 <<if-no-sidebar "


### PR DESCRIPTION
This PR preserves the focused domNode (the widget with the focused domNode) over refresh cycles
It also adds keyboard shortcuts for editing and closing the focused tiddler and navigating to the next/previous tiddler in the story river

This PR also includes something that adds `dom-` prefixed attributes to the keyboard widget. Something that should be addressed in another PR (and probably differently than I did) but it's needed in order for everything to work so here's my implementation of it

This should be considered a proof-of-concept PR and I hope to be able to discuss it here and to gather ideas