### PR TITLE
Improve import cancel warning

### DIFF
--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -3,8 +3,7 @@ title: $:/language/Import/
 Editor/Import/Heading: Import images and insert them into the editor.
 Imported/Hint: The following tiddlers were imported:
 Listing/Cancel/Caption: Cancel
-Listing/Cancel/Warning/1: Do you wish to cancel the import?
-Listing/Cancel/Warning/2: The tiddler "<$text text={{!!title}}/>" will be deleted
+Listing/Cancel/Warning: Do you wish to cancel the import?
 Listing/Hint: These tiddlers are ready to import:
 Listing/Import/Caption: Import
 Listing/Select/Caption: Select

--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -3,7 +3,8 @@ title: $:/language/Import/
 Editor/Import/Heading: Import images and insert them into the editor.
 Imported/Hint: The following tiddlers were imported:
 Listing/Cancel/Caption: Cancel
-Listing/Cancel/Warning: Do you wish to cancel importing? --- The tiddler "<$text text={{!!title}}/>" will be deleted
+Listing/Cancel/Warning/1: Do you wish to cancel the import?
+Listing/Cancel/Warning/2: The tiddler "<$text text={{!!title}}/>" will be deleted
 Listing/Hint: These tiddlers are ready to import:
 Listing/Import/Caption: Import
 Listing/Select/Caption: Select

--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -3,7 +3,7 @@ title: $:/language/Import/
 Editor/Import/Heading: Import images and insert them into the editor.
 Imported/Hint: The following tiddlers were imported:
 Listing/Cancel/Caption: Cancel
-Listing/Cancel/Warning: Do you wish to cancel importing? --- The tiddler "<$text text=<<title>>/>" will be deleted
+Listing/Cancel/Warning: Do you wish to cancel importing? --- The tiddler "<$text text={{!!title}}/>" will be deleted
 Listing/Hint: These tiddlers are ready to import:
 Listing/Import/Caption: Import
 Listing/Select/Caption: Select

--- a/core/language/en-GB/Import.multids
+++ b/core/language/en-GB/Import.multids
@@ -3,6 +3,7 @@ title: $:/language/Import/
 Editor/Import/Heading: Import images and insert them into the editor.
 Imported/Hint: The following tiddlers were imported:
 Listing/Cancel/Caption: Cancel
+Listing/Cancel/Warning: Do you wish to cancel importing? --- The tiddler "<$text text=<<title>>/>" will be deleted
 Listing/Hint: These tiddlers are ready to import:
 Listing/Import/Caption: Import
 Listing/Select/Caption: Select

--- a/core/ui/ViewTemplate/import.tid
+++ b/core/ui/ViewTemplate/import.tid
@@ -4,13 +4,10 @@ tags: $:/tags/ViewTemplate
 \define lingo-base() $:/language/Import/
 
 \define confirmCancel()
-<$wikify name="message" text="""{{||$:/language/Import/Listing/Cancel/Warning/1}}&nbsp;
-{{||$:/language/Import/Listing/Cancel/Warning/2}}""">
-<$action-confirm $message=<<message>> >
+<$action-confirm $message={{$:/language/Import/Listing/Cancel/Warning}} >
 <$action-deletetiddler $tiddler=<<currentTiddler>>/>
 <$action-sendmessage $message="tm-close-tiddler" title=<<currentTiddler>>/>
 </$action-confirm>
-</$wikify>
 \end
 
 \define buttons()

--- a/core/ui/ViewTemplate/import.tid
+++ b/core/ui/ViewTemplate/import.tid
@@ -4,7 +4,8 @@ tags: $:/tags/ViewTemplate
 \define lingo-base() $:/language/Import/
 
 \define confirmCancel()
-<$wikify name=message text={{$:/language/Import/Listing/Cancel/Warning}}>
+<$wikify name="message" text="""{{||$:/language/Import/Listing/Cancel/Warning/1}}&nbsp;
+{{||$:/language/Import/Listing/Cancel/Warning/2}}""">
 <$action-confirm $message=<<message>> >
 <$action-deletetiddler $tiddler=<<currentTiddler>>/>
 <$action-sendmessage $message="tm-close-tiddler" title=<<currentTiddler>>/>

--- a/core/ui/ViewTemplate/import.tid
+++ b/core/ui/ViewTemplate/import.tid
@@ -3,8 +3,17 @@ tags: $:/tags/ViewTemplate
 
 \define lingo-base() $:/language/Import/
 
+\define confirmCancel()
+<$wikify name=message text={{$:/language/Import/Listing/Cancel/Warning}}>
+<$action-confirm $message=<<message>> >
+<$action-deletetiddler $tiddler=<<currentTiddler>>/>
+<$action-sendmessage $message="tm-close-tiddler" title=<<currentTiddler>>/>
+</$action-confirm>
+</$wikify>
+\end
+
 \define buttons()
-<$button message="tm-delete-tiddler" param=<<currentTiddler>>><<lingo Listing/Cancel/Caption>></$button>
+<$button actions=<<confirmCancel>> ><<lingo Listing/Cancel/Caption>></$button>
 <$button message="tm-perform-import" param=<<currentTiddler>>><<lingo Listing/Import/Caption>></$button>
 <<lingo Listing/Preview>> <$select tiddler="$:/state/importpreviewtype" default="$:/core/ui/ImportPreviews/Text">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ImportPreview]!has[draft.of]]">


### PR DESCRIPTION
This PR fixes  #1219 "Change alert for when cancelling import" 

At the time when this issue was created we didn't have the `action-confirm` widget. The dialogue looks like this: 

![grafik](https://user-images.githubusercontent.com/374655/122690984-fd009580-d22c-11eb-837f-7f5a7dcb0138.png)
