### PR TITLE
prevent scroll-chaining in modals

### DIFF
--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -243,6 +243,7 @@ Modal.prototype.adjustPageClass = function() {
 	if(windowContainer) {
 		$tw.utils.toggleClass(windowContainer,"tc-modal-displayed",this.modalCount > 0);
 	}
+	$tw.utils.toggleClass(this.srcDocument.body,"tc-modal-prevent-scroll",this.modalCount > 0);
 };
 
 exports.Modal = Modal;

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -41,8 +41,6 @@ Modal.prototype.display = function(title,options) {
 	if(!tiddler) {
 		return;
 	}
-	// Make tiddler.fields available
-	this.tiddler = tiddler;
 	// Create the variables
 	var variables = $tw.utils.extend({
 			currentTiddler: title,

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -245,12 +245,7 @@ Modal.prototype.adjustPageClass = function() {
 	if(windowContainer) {
 		$tw.utils.toggleClass(windowContainer,"tc-modal-displayed",this.modalCount > 0);
 	}
-	if (this.tiddler.fields && this.tiddler.fields["prevent-scroll-chain"] === "yes") {
-		$tw.utils.toggleClass(this.srcDocument.body,"tc-modal-prevent-scroll",this.modalCount > 0);
-	} else if (this.modalCount === 0) {
-		// if the last modal didn't contain a prevent-scroll-chain field
-		$tw.utils.toggleClass(this.srcDocument.body,"tc-modal-prevent-scroll",false);
-	}
+	$tw.utils.toggleClass(this.srcDocument.body,"tc-modal-prevent-scroll",this.modalCount > 0);
 };
 
 exports.Modal = Modal;

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -247,6 +247,9 @@ Modal.prototype.adjustPageClass = function() {
 	}
 	if (this.tiddler.fields && this.tiddler.fields["prevent-scroll-chain"] === "yes") {
 		$tw.utils.toggleClass(this.srcDocument.body,"tc-modal-prevent-scroll",this.modalCount > 0);
+	} else if (this.modalCount === 0) {
+		// if the last modal didn't contain a prevent-scroll-chain field
+		$tw.utils.toggleClass(this.srcDocument.body,"tc-modal-prevent-scroll",false);
 	}
 };
 

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -41,6 +41,8 @@ Modal.prototype.display = function(title,options) {
 	if(!tiddler) {
 		return;
 	}
+	// Make tiddler.fields available
+	this.tiddler = tiddler;
 	// Create the variables
 	var variables = $tw.utils.extend({
 			currentTiddler: title,
@@ -243,7 +245,9 @@ Modal.prototype.adjustPageClass = function() {
 	if(windowContainer) {
 		$tw.utils.toggleClass(windowContainer,"tc-modal-displayed",this.modalCount > 0);
 	}
-	$tw.utils.toggleClass(this.srcDocument.body,"tc-modal-prevent-scroll",this.modalCount > 0);
+	if (this.tiddler.fields && this.tiddler.fields["prevent-scroll-chain"] === "yes") {
+		$tw.utils.toggleClass(this.srcDocument.body,"tc-modal-prevent-scroll",this.modalCount > 0);
+	}
 };
 
 exports.Modal = Modal;

--- a/core/ui/ControlPanel/Modals/AddPlugins.tid
+++ b/core/ui/ControlPanel/Modals/AddPlugins.tid
@@ -1,6 +1,5 @@
 title: $:/core/ui/ControlPanel/Modals/AddPlugins
 subtitle: {{$:/core/images/download-button}} {{$:/language/ControlPanel/Plugins/Add/Caption}}
-prevent-scroll-chain: yes
 
 \define install-plugin-actions()
 <$action-sendmessage $message="tm-load-plugin-from-library" url={{!!url}} title={{$(assetInfo)$!!original-title}}/>

--- a/core/ui/ControlPanel/Modals/AddPlugins.tid
+++ b/core/ui/ControlPanel/Modals/AddPlugins.tid
@@ -1,5 +1,6 @@
 title: $:/core/ui/ControlPanel/Modals/AddPlugins
 subtitle: {{$:/core/images/download-button}} {{$:/language/ControlPanel/Plugins/Add/Caption}}
+prevent-scroll-chain: yes
 
 \define install-plugin-actions()
 <$action-sendmessage $message="tm-load-plugin-from-library" url={{!!url}} title={{$(assetInfo)$!!original-title}}/>

--- a/editions/tw5.com/tiddlers/demonstrations/SampleWizard.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/SampleWizard.tid
@@ -1,7 +1,6 @@
 created: 20140912145537860
 footer: <$button message="tm-close-tiddler">Close</$button>
-modified: 20210621223203244
-prevent-scroll-chain: yes
+modified: 20210627054504823
 subtitle: I'm a modal wizard
 title: SampleWizard
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/demonstrations/SampleWizard.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/SampleWizard.tid
@@ -1,6 +1,7 @@
 created: 20140912145537860
 footer: <$button message="tm-close-tiddler">Close</$button>
-modified: 20140912145537861
+modified: 20210621223203244
+prevent-scroll-chain: yes
 subtitle: I'm a modal wizard
 title: SampleWizard
 type: text/vnd.tiddlywiki

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1932,7 +1932,6 @@ html body.tc-body.tc-single-tiddler-window {
 
 .tc-modal-body {
 	padding: 15px;
-	overscroll-behavior: contain;
 }
 
 .tc-modal-footer {
@@ -1943,6 +1942,9 @@ html body.tc-body.tc-single-tiddler-window {
 	border-top: 1px solid <<colour modal-footer-border>>;
 }
 
+.tc-modal-prevent-scroll {
+	overflow: hidden;
+}
 
 /*
 ** Centered modals

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1932,6 +1932,7 @@ html body.tc-body.tc-single-tiddler-window {
 
 .tc-modal-body {
 	padding: 15px;
+	overscroll-behavior: contain;
 }
 
 .tc-modal-footer {


### PR DESCRIPTION
This PR prevents the scroll-chaining, that usually happens to the main story-river if a list in a modal reaches the end, but the user keeps scrolling. 

This PR fixes: #5815 and #1558   ... (what a conincidence. See the swapped numbers ;)