### PR TITLE
Update TiddlyWiki in the Sky for Dropbox.tid

### DIFF
--- a/editions/tw5.com/tiddlers/saving/TiddlyWiki in the Sky for Dropbox.tid
+++ b/editions/tw5.com/tiddlers/saving/TiddlyWiki in the Sky for Dropbox.tid
@@ -12,6 +12,6 @@ url: https://twcloud.github.io/tw5-dropbox/
 
 Originally built by Jeremy Ruston and now maintained by Arlen Beiler, TiddlyWiki Cloud (formerly known as TiddlyWiki in the Sky for Dropbox) is an online service that lets you edit TiddlyWiki documents directly in your own Dropbox using just a browser.
 
-It works with TiddlyWiki 5 and Classic.
+It works with TiddlyWiki 5. As for TiddlyWiki Classic, the mainstream loader does not work, and a newer loader may work.
 
 https://twcloud.github.io/


### PR DESCRIPTION
As [its site states](https://twcloud.github.io/):

> tw5-dropbox - This is the oldest and most dependable loader for TW5 files, but doesn’t support TiddlyWiki Classic files.
> dropbox - This is a newer loader which uses a different method to load files, but only seems to work on Chrome. Hardly anyone uses it, but you’re welcome to try it. It might work