### PR TITLE
Support for macro params in filter operands

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -53,7 +53,7 @@ function parseFilterOperation(operators,filterString,p) {
 				$tw.utils.each(subsuffix.split(","),function(entry) {
 					entry = $tw.utils.trim(entry);
 					if(entry) {
-						operator.suffixes[operator.suffixes.length - 1].push(entry);
+						operator.suffixes[operator.suffixes.length - 1].push(entry); 
 					}
 				});
 			});
@@ -305,7 +305,7 @@ exports.compileFilter = function(filterString) {
 					return filterRunPrefixes["and"](operationSubFunction, options);
 				case "~": // This operation is unioned into the result only if the main result so far is empty
 					return filterRunPrefixes["else"](operationSubFunction, options);
-				default: 
+				default:
 					if(operation.namedPrefix && filterRunPrefixes[operation.namedPrefix]) {
 						return filterRunPrefixes[operation.namedPrefix](operationSubFunction, options);
 					} else {

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -53,7 +53,7 @@ function parseFilterOperation(operators,filterString,p) {
 				$tw.utils.each(subsuffix.split(","),function(entry) {
 					entry = $tw.utils.trim(entry);
 					if(entry) {
-						operator.suffixes[operator.suffixes.length - 1].push(entry); 
+						operator.suffixes[operator.suffixes.length - 1].push(entry);
 					}
 				});
 			});
@@ -253,7 +253,8 @@ exports.compileFilter = function(filterString) {
 					if(operand.indirect) {
 						operand.value = self.getTextReference(operand.text,"",currTiddlerTitle);
 					} else if(operand.variable) {
-						operand.value = widget.getVariable(operand.text,{defaultValue: ""});
+						var varInfo = $tw.utils.parseFilterVariable(operand.text);
+						operand.value = widget.getVariable(varInfo.name,{params:varInfo.params,defaultValue: ""});
 					} else {
 						operand.value = operand.text;
 					}
@@ -304,7 +305,7 @@ exports.compileFilter = function(filterString) {
 					return filterRunPrefixes["and"](operationSubFunction, options);
 				case "~": // This operation is unioned into the result only if the main result so far is empty
 					return filterRunPrefixes["else"](operationSubFunction, options);
-				default: 
+				default:
 					if(operation.namedPrefix && filterRunPrefixes[operation.namedPrefix]) {
 						return filterRunPrefixes[operation.namedPrefix](operationSubFunction, options);
 					} else {

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -253,8 +253,8 @@ exports.compileFilter = function(filterString) {
 					if(operand.indirect) {
 						operand.value = self.getTextReference(operand.text,"",currTiddlerTitle);
 					} else if(operand.variable) {
-						var varInfo = $tw.utils.parseFilterVariable(operand.text);
-						operand.value = widget.getVariable(varInfo.name,{params:varInfo.params,defaultValue: ""});
+						var varTree = $tw.utils.parseFilterVariable(operand.text);
+						operand.value = widget.getVariable(varTree.name,{params:varTree.params,defaultValue: ""});
 					} else {
 						operand.value = operand.text;
 					}
@@ -305,7 +305,7 @@ exports.compileFilter = function(filterString) {
 					return filterRunPrefixes["and"](operationSubFunction, options);
 				case "~": // This operation is unioned into the result only if the main result so far is empty
 					return filterRunPrefixes["else"](operationSubFunction, options);
-				default:
+				default: 
 					if(operation.namedPrefix && filterRunPrefixes[operation.namedPrefix]) {
 						return filterRunPrefixes[operation.namedPrefix](operationSubFunction, options);
 					} else {

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -53,7 +53,7 @@ function parseFilterOperation(operators,filterString,p) {
 				$tw.utils.each(subsuffix.split(","),function(entry) {
 					entry = $tw.utils.trim(entry);
 					if(entry) {
-						operator.suffixes[operator.suffixes.length - 1].push(entry);
+						operator.suffixes[operator.suffixes.length - 1].push(entry); 
 					}
 				});
 			});

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -53,7 +53,7 @@ function parseFilterOperation(operators,filterString,p) {
 				$tw.utils.each(subsuffix.split(","),function(entry) {
 					entry = $tw.utils.trim(entry);
 					if(entry) {
-						operator.suffixes[operator.suffixes.length - 1].push(entry); 
+						operator.suffixes[operator.suffixes.length - 1].push(entry);
 					}
 				});
 			});
@@ -305,7 +305,7 @@ exports.compileFilter = function(filterString) {
 					return filterRunPrefixes["and"](operationSubFunction, options);
 				case "~": // This operation is unioned into the result only if the main result so far is empty
 					return filterRunPrefixes["else"](operationSubFunction, options);
-				default:
+				default: 
 					if(operation.namedPrefix && filterRunPrefixes[operation.namedPrefix]) {
 						return filterRunPrefixes[operation.namedPrefix](operationSubFunction, options);
 					} else {

--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -114,7 +114,7 @@ exports.parseStringLiteral = function(source,pos) {
 	var match = reString.exec(source);
 	if(match && match.index === pos) {
 		node.value = match[1] !== undefined ? match[1] :(
-			match[2] !== undefined ? match[2] : match[3] 
+			match[2] !== undefined ? match[2] : match[3]
 					);
 		node.end = pos + match[0].length;
 		return node;
@@ -206,6 +206,28 @@ exports.parseMacroInvocation = function(source,pos) {
 	// Update the end position
 	node.end = pos;
 	return node;
+};
+
+exports.parseFilterVariable = function(source) {
+	var name = "",
+		pos = 0,
+		params = [],
+		reName = /([^\s>"'=]+)/g;
+		// Get the variable name
+	var nameMatch = $tw.utils.parseTokenRegExp(source,pos,reName);
+	if(nameMatch) {
+		name = nameMatch.match[1];
+		pos = nameMatch.end;
+		// Process parameters
+		var parameter = $tw.utils.parseMacroParameter(source,pos);
+		while(parameter) {
+			params.push(parameter);
+			pos = parameter.end;
+			// Get the next parameter
+			parameter = $tw.utils.parseMacroParameter(source,pos);
+		}
+	}
+	return {name: name, params: params};
 };
 
 /*

--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -114,7 +114,7 @@ exports.parseStringLiteral = function(source,pos) {
 	var match = reString.exec(source);
 	if(match && match.index === pos) {
 		node.value = match[1] !== undefined ? match[1] :(
-			match[2] !== undefined ? match[2] : match[3]
+			match[2] !== undefined ? match[2] : match[3] 
 					);
 		node.end = pos + match[0].length;
 		return node;

--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -114,7 +114,7 @@ exports.parseStringLiteral = function(source,pos) {
 	var match = reString.exec(source);
 	if(match && match.index === pos) {
 		node.value = match[1] !== undefined ? match[1] :(
-			match[2] !== undefined ? match[2] : match[3]
+			match[2] !== undefined ? match[2] : match[3] 
 					);
 		node.end = pos + match[0].length;
 		return node;
@@ -221,7 +221,7 @@ exports.parseFilterVariable = function(source) {
 			params: [],
 		},
 		pos = 0,
-		reName = /([^\s>"'=]+)/g;
+		reName = /([^\s"']+)/g;
 	// If there is no whitespace or it is an empty string then there are no macro parameters
 	if(/^\S*$/.test(source)) {
 		node.name = source;

--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -213,7 +213,7 @@ exports.parseFilterVariable = function(source) {
 		pos = 0,
 		params = [],
 		reName = /([^\s>"'=]+)/g;
-		// Get the variable name
+	// Get the variable name
 	var nameMatch = $tw.utils.parseTokenRegExp(source,pos,reName);
 	if(nameMatch) {
 		name = nameMatch.match[1];

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -34,8 +34,8 @@ describe("Filter tests", function() {
 			[ { prefix : '', operators : [ { operator : 'search', suffix : ' , : ', suffixes : [ [  ], [  ] ], operands: [ { text:'operand' } ] } ] } ]
 		);
 	});
-
-
+	
+	
 	it("should parse multiple operands for operators", function() {
 		expect($tw.wiki.parseFilter("[search: , : [operand],[operand2]]")).toEqual(
 			[ { prefix : '', operators : [ { operator : 'search', suffix : ' , : ', suffixes : [ [  ], [  ] ], operands: [ { text:'operand' }, { text:'operand2' } ] } ] } ]
@@ -181,7 +181,7 @@ function runTests(wiki) {
 	it("should handle the enlist operator", function() {
 		expect(wiki.filterTiddlers("[enlist[one two three]addsuffix[!]]").join(",")).toBe("one!,two!,three!");
 	});
-
+	
 	it("should handle the enlist-input operator", function() {
 		expect(wiki.filterTiddlers("[[one two three]enlist-input[]]").join(",")).toBe("one,two,three");
 		expect(wiki.filterTiddlers("[[one two two three]enlist-input[]]").join(",")).toBe("one,two,three");
@@ -191,7 +191,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[[one two three]] [[four five six]] [[seven eight]] +[enlist-input[]]").join(",")).toBe("one,two,three,four,five,six,seven,eight");
 		expect(wiki.filterTiddlers("[[]] +[enlist-input[]]").join(",")).toBe("");
 	});
-
+	
 	it("should handle the then and else operators", function() {
 		expect(wiki.filterTiddlers("[modifier[JoeBloggs]then[Susi]]").join(",")).toBe("Susi");
 		expect(wiki.filterTiddlers("[!modifier[JoeBloggs]then[Susi]]").join(",")).toBe("Susi,Susi,Susi,Susi,Susi,Susi,Susi,Susi");
@@ -533,7 +533,7 @@ function runTests(wiki) {
 	});
 
 /* listops filters */
-
+	
 	it("should handle the allafter operator", function() {
 		expect(wiki.filterTiddlers("1 2 3 4 +[allafter[]]").join(",")).toBe("");
 		expect(wiki.filterTiddlers("1 2 3 4 +[allafter:include[]]").join(",")).toBe("");
@@ -569,7 +569,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("a b c +[append:1[d e]]").join(",")).toBe("a,b,c,d");
 		expect(wiki.filterTiddlers("a b c +[append{TiddlerSeventh!!list}]").join(",")).toBe("a,b,c,TiddlerOne,Tiddler Three,a fourth tiddler,MissingTiddler");
 		expect(wiki.filterTiddlers("a b c +[append:2{TiddlerSeventh!!list}]").join(",")).toBe("a,b,c,TiddlerOne,Tiddler Three");
-
+		
 		expect(wiki.filterTiddlers("a [[b c]] +[append{TiddlerSix!!filter}]").join(",")).toBe("a,b c,one,a a,[subfilter{hasList!!list}]");
 	});
 
@@ -582,11 +582,11 @@ function runTests(wiki) {
 		rootWidget.setVariable("myVar","c");
 		rootWidget.setVariable("tidTitle","e");
 		rootWidget.setVariable("tidList","one tid with spaces");
-
+		
 		expect(wiki.filterTiddlers("a b c d e f +[insertbefore:myVar[f]]",anchorWidget).join(",")).toBe("a,b,f,c,d,e");
 		expect(wiki.filterTiddlers("a b c d e f +[insertbefore:myVar<tidTitle>]",anchorWidget).join(",")).toBe("a,b,e,c,d,f");
 		expect(wiki.filterTiddlers("a b c d e f +[insertbefore:myVar[gg gg]]",anchorWidget).join(",")).toBe("a,b,gg gg,c,d,e,f");
-
+		
 		expect(wiki.filterTiddlers("a b c d e +[insertbefore:myVar<tidList>]",anchorWidget).join(",")).toBe("a,b,one tid with spaces,c,d,e");
 		expect(wiki.filterTiddlers("a b c d e f +[insertbefore:tidTitle{TiddlerOne!!tags}]",anchorWidget).join(",")).toBe("a,b,c,d,one,e,f");
 
@@ -608,7 +608,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("a b c +[prepend:3[ff gg]]").join(",")).toBe("ff,gg,a,b,c");
 		expect(wiki.filterTiddlers("a b c +[prepend:1[hh ii]]").join(",")).toBe("hh,a,b,c");
 		expect(wiki.filterTiddlers("a b c +[prepend:0[jj kk]]").join(",")).toBe("a,b,c");
-
+		
 		expect(wiki.filterTiddlers("a b c +[prepend:-0[ll mm]]").join(",")).toBe("a,b,c");
 		expect(wiki.filterTiddlers("a b c +[prepend:-1[nn oo pp qq]]").join(",")).toBe("nn,oo,pp,a,b,c");
 		expect(wiki.filterTiddlers("a b c +[prepend:-2[rr ss tt uu]]").join(",")).toBe("rr,ss,a,b,c");
@@ -651,19 +651,19 @@ function runTests(wiki) {
 
 		// this one is strange
 		expect(wiki.filterTiddlers("a b c ee +[putbefore:0[b]]").join(",")).toBe("a,a,b,c,ee");
-
+		
 		// b is not part of the list anymore, so it will be appended at the end ???
 		expect(wiki.filterTiddlers("a b c hh +[putbefore:3[b]]").join(",")).toBe("a,b,c,hh");
 		expect(wiki.filterTiddlers("a b c ii +[putbefore:4[b]]").join(",")).toBe("a,a,b,c,ii");
-
+		
 		// ????
 		expect(wiki.filterTiddlers("a b c ii +[putbefore:10[b]]").join(",")).toBe("a,a,b,c,ii");
-
+		
 		expect(wiki.filterTiddlers("a b c kk +[putbefore:-1[b]]").join(",")).toBe("a,b,c,kk");
 		expect(wiki.filterTiddlers("a b c ll +[putbefore:-2[b]]").join(",")).toBe("a,c,ll,b");
-
+		
 		expect(wiki.filterTiddlers("a b c mm +[putbefore:-3[b]]").join(",")).toBe("a,mm,b,c");
-
+		
 		expect(wiki.filterTiddlers("a b c nn +[putbefore:-10[b]]").join(",")).toBe("a,b,c,nn");
 	});
 
@@ -703,7 +703,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("a b c dd +[replace[a]]").join(",")).toBe("dd,b,c");
 		expect(wiki.filterTiddlers("a b c dd ee +[replace:2[a]]").join(",")).toBe("dd,ee,b,c");
 		expect(wiki.filterTiddlers("a b c dd ee +[replace:5[c]]").join(",")).toBe("a,b,a,b,c,dd,ee");
-
+		
 		// strange things happen.
 		expect(wiki.filterTiddlers("a b c dd ee +[replace:-1[c]]").join(",")).toBe("a,b,b,c,dd,ee");
 		expect(wiki.filterTiddlers("a b c dd ee +[replace:-2[c]]").join(",")).toBe("a,b,c,dd,ee");
@@ -762,7 +762,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[[TiddlerOne]] [[$:/TiddlerTwo]] [[Tiddler Three]] [[a fourth tiddler]] +[!sortsub:number<sort3>]",anchorWidget).join(",")).toBe("$:/TiddlerTwo,Tiddler Three,TiddlerOne,a fourth tiddler");
 		expect(wiki.filterTiddlers("a1 a10 a2 a3 b10 b3 b1 c9 c11 c1 +[sortsub:alphanumeric<sort4>]",anchorWidget).join(",")).toBe("a1,a2,a3,a10,b1,b3,b10,c1,c9,c11");
 	});
-
+	
 	it("should handle the toggle operator", function() {
 		expect(wiki.filterTiddlers("[[Tiddler Three]tags[]] +[toggle[one]]").join(",")).toBe("two");
 		expect(wiki.filterTiddlers("[[Tiddler Three]tags[]] -[[one]] +[toggle[one]]").join(",")).toBe("two,one");
@@ -785,9 +785,9 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[[Welcome to TiddlyWiki, a unique non-linear notebook.]search-replace[TiddlyWiki],{one}]",anchorWidget).join(",")).toBe("Welcome to This is the text of tiddler [[one]], a unique non-linear notebook.");
 		expect(wiki.filterTiddlers("[[Hello There]search-replace:g:regexp<myregexp>,[]]",anchorWidget).join(",")).toBe("Hll Thr");
 		expect(wiki.filterTiddlers("[[Hello There]search-replace::regexp<myregexp>,[]]",anchorWidget).join(",")).toBe("Hllo There");
-		expect(wiki.filterTiddlers("[[Hello There]search-replace:gi[H],[]]",anchorWidget).join(",")).toBe("ello Tere");
+		expect(wiki.filterTiddlers("[[Hello There]search-replace:gi[H],[]]",anchorWidget).join(",")).toBe("ello Tere");	
 	});
-
+	
 	it("should handle the pad operator", function() {
 	expect(wiki.filterTiddlers("[[2]pad[]]").join(",")).toBe("2");
 	expect(wiki.filterTiddlers("[[2]pad[0]]").join(",")).toBe("2");
@@ -808,11 +808,11 @@ function runTests(wiki) {
 	expect(wiki.filterTiddlers("'-25' +[escapecss[]]").join(",")).toBe("-\\32 5");
 	expect(wiki.filterTiddlers("'-' +[escapecss[]]").join(",")).toBe("\\-");
 	});
-
+	
 	it("should handle the format operator", function() {
 		expect(wiki.filterTiddlers("[[Hello There]] [[GettingStarted]] +[format:titlelist[]]").join(" ")).toBe("[[Hello There]] GettingStarted");
 		expect(wiki.filterTiddlers("[title[Hello There]] +[format:titlelist[]]").join(" ")).toBe("[[Hello There]]");
-		expect(wiki.filterTiddlers("[title[HelloThere]] +[format:titlelist[]]").join(" ")).toBe("HelloThere");
+		expect(wiki.filterTiddlers("[title[HelloThere]] +[format:titlelist[]]").join(" ")).toBe("HelloThere");		
 	});
 
 	it("should handle the deserializers operator", function() {
@@ -826,18 +826,18 @@ function runTests(wiki) {
 	});
 
 	it("should parse filter variable parameters", function(){
-		expect($tw.utils.parseFilterVariable("currentTiddler")).toEqual(
-			{ name: 'currentTiddler', params: [  ] }
-		);
-		expect($tw.utils.parseFilterVariable("now DDMM")).toEqual(
-			{ name: 'now', params: [{ type: 'macro-parameter', start: 3, value: 'DDMM', end: 8 }] }
-		);
-		expect($tw.utils.parseFilterVariable("now DDMM UTC")).toEqual(
-			{ name: 'now', params: [{ type: 'macro-parameter', start: 3, value: 'DDMM', end: 8 }, { type: 'macro-parameter', start: 8, value: 'UTC', end: 12 }] }
-		);
-		expect($tw.utils.parseFilterVariable("")).toEqual(
-			{ name: '', params: [] }
-		);
+	  expect($tw.utils.parseFilterVariable("currentTiddler")).toEqual(
+		{ name: 'currentTiddler', params: [  ] }
+	  );
+	  expect($tw.utils.parseFilterVariable("now DDMM")).toEqual(
+		{ name: 'now', params: [{ type: 'macro-parameter', start: 3, value: 'DDMM', end: 8 }] }
+	  );
+	  expect($tw.utils.parseFilterVariable("now DDMM UTC")).toEqual(
+		{ name: 'now', params: [{ type: 'macro-parameter', start: 3, value: 'DDMM', end: 8 }, { type: 'macro-parameter', start: 8, value: 'UTC', end: 12 }] }
+	  );
+	  expect($tw.utils.parseFilterVariable("")).toEqual(
+		{ name: '', params: [] }
+	  );
 	});
 
 }

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -847,6 +847,15 @@ function runTests(wiki) {
 	  expect($tw.utils.parseFilterVariable("nowformat:'DD MM'")).toEqual(
 		{ name: 'nowformat:', params: [{ type: 'macro-parameter', start: 10, value: 'DD MM', end: 17 }] }
 	  );
+	  expect($tw.utils.parseFilterVariable("now [UTC]YYYY0MM0DD0hh0mm0ssXXX")).toEqual(
+		{ name: 'now', params: [{ type: 'macro-parameter', start: 3, value: '[UTC]YYYY0MM0DD0hh0mm0ssXXX', end: 31 }] }
+	  );
+	  expect($tw.utils.parseFilterVariable("now '[UTC]YYYY0MM0DD0hh0mm0ssXXX'")).toEqual(
+		{ name: 'now', params: [{ type: 'macro-parameter', start: 3, value: '[UTC]YYYY0MM0DD0hh0mm0ssXXX', end: 33 }] }
+	  );
+	  expect($tw.utils.parseFilterVariable("now format:'[UTC]YYYY0MM0DD0hh0mm0ssXXX'")).toEqual(
+		{ name: 'now', params: [{ type: 'macro-parameter', start: 3, name:'format', value: '[UTC]YYYY0MM0DD0hh0mm0ssXXX', end: 40 }] }
+	  );
 	  expect($tw.utils.parseFilterVariable("")).toEqual(
 		{ name: '', params: [] }
 	  );

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -34,8 +34,8 @@ describe("Filter tests", function() {
 			[ { prefix : '', operators : [ { operator : 'search', suffix : ' , : ', suffixes : [ [  ], [  ] ], operands: [ { text:'operand' } ] } ] } ]
 		);
 	});
-	
-	
+
+
 	it("should parse multiple operands for operators", function() {
 		expect($tw.wiki.parseFilter("[search: , : [operand],[operand2]]")).toEqual(
 			[ { prefix : '', operators : [ { operator : 'search', suffix : ' , : ', suffixes : [ [  ], [  ] ], operands: [ { text:'operand' }, { text:'operand2' } ] } ] } ]
@@ -181,7 +181,7 @@ function runTests(wiki) {
 	it("should handle the enlist operator", function() {
 		expect(wiki.filterTiddlers("[enlist[one two three]addsuffix[!]]").join(",")).toBe("one!,two!,three!");
 	});
-	
+
 	it("should handle the enlist-input operator", function() {
 		expect(wiki.filterTiddlers("[[one two three]enlist-input[]]").join(",")).toBe("one,two,three");
 		expect(wiki.filterTiddlers("[[one two two three]enlist-input[]]").join(",")).toBe("one,two,three");
@@ -191,7 +191,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[[one two three]] [[four five six]] [[seven eight]] +[enlist-input[]]").join(",")).toBe("one,two,three,four,five,six,seven,eight");
 		expect(wiki.filterTiddlers("[[]] +[enlist-input[]]").join(",")).toBe("");
 	});
-	
+
 	it("should handle the then and else operators", function() {
 		expect(wiki.filterTiddlers("[modifier[JoeBloggs]then[Susi]]").join(",")).toBe("Susi");
 		expect(wiki.filterTiddlers("[!modifier[JoeBloggs]then[Susi]]").join(",")).toBe("Susi,Susi,Susi,Susi,Susi,Susi,Susi,Susi");
@@ -533,7 +533,7 @@ function runTests(wiki) {
 	});
 
 /* listops filters */
-	
+
 	it("should handle the allafter operator", function() {
 		expect(wiki.filterTiddlers("1 2 3 4 +[allafter[]]").join(",")).toBe("");
 		expect(wiki.filterTiddlers("1 2 3 4 +[allafter:include[]]").join(",")).toBe("");
@@ -569,7 +569,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("a b c +[append:1[d e]]").join(",")).toBe("a,b,c,d");
 		expect(wiki.filterTiddlers("a b c +[append{TiddlerSeventh!!list}]").join(",")).toBe("a,b,c,TiddlerOne,Tiddler Three,a fourth tiddler,MissingTiddler");
 		expect(wiki.filterTiddlers("a b c +[append:2{TiddlerSeventh!!list}]").join(",")).toBe("a,b,c,TiddlerOne,Tiddler Three");
-		
+
 		expect(wiki.filterTiddlers("a [[b c]] +[append{TiddlerSix!!filter}]").join(",")).toBe("a,b c,one,a a,[subfilter{hasList!!list}]");
 	});
 
@@ -582,11 +582,11 @@ function runTests(wiki) {
 		rootWidget.setVariable("myVar","c");
 		rootWidget.setVariable("tidTitle","e");
 		rootWidget.setVariable("tidList","one tid with spaces");
-		
+
 		expect(wiki.filterTiddlers("a b c d e f +[insertbefore:myVar[f]]",anchorWidget).join(",")).toBe("a,b,f,c,d,e");
 		expect(wiki.filterTiddlers("a b c d e f +[insertbefore:myVar<tidTitle>]",anchorWidget).join(",")).toBe("a,b,e,c,d,f");
 		expect(wiki.filterTiddlers("a b c d e f +[insertbefore:myVar[gg gg]]",anchorWidget).join(",")).toBe("a,b,gg gg,c,d,e,f");
-		
+
 		expect(wiki.filterTiddlers("a b c d e +[insertbefore:myVar<tidList>]",anchorWidget).join(",")).toBe("a,b,one tid with spaces,c,d,e");
 		expect(wiki.filterTiddlers("a b c d e f +[insertbefore:tidTitle{TiddlerOne!!tags}]",anchorWidget).join(",")).toBe("a,b,c,d,one,e,f");
 
@@ -608,7 +608,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("a b c +[prepend:3[ff gg]]").join(",")).toBe("ff,gg,a,b,c");
 		expect(wiki.filterTiddlers("a b c +[prepend:1[hh ii]]").join(",")).toBe("hh,a,b,c");
 		expect(wiki.filterTiddlers("a b c +[prepend:0[jj kk]]").join(",")).toBe("a,b,c");
-		
+
 		expect(wiki.filterTiddlers("a b c +[prepend:-0[ll mm]]").join(",")).toBe("a,b,c");
 		expect(wiki.filterTiddlers("a b c +[prepend:-1[nn oo pp qq]]").join(",")).toBe("nn,oo,pp,a,b,c");
 		expect(wiki.filterTiddlers("a b c +[prepend:-2[rr ss tt uu]]").join(",")).toBe("rr,ss,a,b,c");
@@ -651,19 +651,19 @@ function runTests(wiki) {
 
 		// this one is strange
 		expect(wiki.filterTiddlers("a b c ee +[putbefore:0[b]]").join(",")).toBe("a,a,b,c,ee");
-		
+
 		// b is not part of the list anymore, so it will be appended at the end ???
 		expect(wiki.filterTiddlers("a b c hh +[putbefore:3[b]]").join(",")).toBe("a,b,c,hh");
 		expect(wiki.filterTiddlers("a b c ii +[putbefore:4[b]]").join(",")).toBe("a,a,b,c,ii");
-		
+
 		// ????
 		expect(wiki.filterTiddlers("a b c ii +[putbefore:10[b]]").join(",")).toBe("a,a,b,c,ii");
-		
+
 		expect(wiki.filterTiddlers("a b c kk +[putbefore:-1[b]]").join(",")).toBe("a,b,c,kk");
 		expect(wiki.filterTiddlers("a b c ll +[putbefore:-2[b]]").join(",")).toBe("a,c,ll,b");
-		
+
 		expect(wiki.filterTiddlers("a b c mm +[putbefore:-3[b]]").join(",")).toBe("a,mm,b,c");
-		
+
 		expect(wiki.filterTiddlers("a b c nn +[putbefore:-10[b]]").join(",")).toBe("a,b,c,nn");
 	});
 
@@ -703,7 +703,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("a b c dd +[replace[a]]").join(",")).toBe("dd,b,c");
 		expect(wiki.filterTiddlers("a b c dd ee +[replace:2[a]]").join(",")).toBe("dd,ee,b,c");
 		expect(wiki.filterTiddlers("a b c dd ee +[replace:5[c]]").join(",")).toBe("a,b,a,b,c,dd,ee");
-		
+
 		// strange things happen.
 		expect(wiki.filterTiddlers("a b c dd ee +[replace:-1[c]]").join(",")).toBe("a,b,b,c,dd,ee");
 		expect(wiki.filterTiddlers("a b c dd ee +[replace:-2[c]]").join(",")).toBe("a,b,c,dd,ee");
@@ -762,7 +762,7 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[[TiddlerOne]] [[$:/TiddlerTwo]] [[Tiddler Three]] [[a fourth tiddler]] +[!sortsub:number<sort3>]",anchorWidget).join(",")).toBe("$:/TiddlerTwo,Tiddler Three,TiddlerOne,a fourth tiddler");
 		expect(wiki.filterTiddlers("a1 a10 a2 a3 b10 b3 b1 c9 c11 c1 +[sortsub:alphanumeric<sort4>]",anchorWidget).join(",")).toBe("a1,a2,a3,a10,b1,b3,b10,c1,c9,c11");
 	});
-	
+
 	it("should handle the toggle operator", function() {
 		expect(wiki.filterTiddlers("[[Tiddler Three]tags[]] +[toggle[one]]").join(",")).toBe("two");
 		expect(wiki.filterTiddlers("[[Tiddler Three]tags[]] -[[one]] +[toggle[one]]").join(",")).toBe("two,one");
@@ -785,9 +785,9 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[[Welcome to TiddlyWiki, a unique non-linear notebook.]search-replace[TiddlyWiki],{one}]",anchorWidget).join(",")).toBe("Welcome to This is the text of tiddler [[one]], a unique non-linear notebook.");
 		expect(wiki.filterTiddlers("[[Hello There]search-replace:g:regexp<myregexp>,[]]",anchorWidget).join(",")).toBe("Hll Thr");
 		expect(wiki.filterTiddlers("[[Hello There]search-replace::regexp<myregexp>,[]]",anchorWidget).join(",")).toBe("Hllo There");
-		expect(wiki.filterTiddlers("[[Hello There]search-replace:gi[H],[]]",anchorWidget).join(",")).toBe("ello Tere");	
+		expect(wiki.filterTiddlers("[[Hello There]search-replace:gi[H],[]]",anchorWidget).join(",")).toBe("ello Tere");
 	});
-	
+
 	it("should handle the pad operator", function() {
 	expect(wiki.filterTiddlers("[[2]pad[]]").join(",")).toBe("2");
 	expect(wiki.filterTiddlers("[[2]pad[0]]").join(",")).toBe("2");
@@ -808,21 +808,36 @@ function runTests(wiki) {
 	expect(wiki.filterTiddlers("'-25' +[escapecss[]]").join(",")).toBe("-\\32 5");
 	expect(wiki.filterTiddlers("'-' +[escapecss[]]").join(",")).toBe("\\-");
 	});
-	
+
 	it("should handle the format operator", function() {
 		expect(wiki.filterTiddlers("[[Hello There]] [[GettingStarted]] +[format:titlelist[]]").join(" ")).toBe("[[Hello There]] GettingStarted");
 		expect(wiki.filterTiddlers("[title[Hello There]] +[format:titlelist[]]").join(" ")).toBe("[[Hello There]]");
-		expect(wiki.filterTiddlers("[title[HelloThere]] +[format:titlelist[]]").join(" ")).toBe("HelloThere");		
+		expect(wiki.filterTiddlers("[title[HelloThere]] +[format:titlelist[]]").join(" ")).toBe("HelloThere");
 	});
 
 	it("should handle the deserializers operator", function() {
 	expect(wiki.filterTiddlers("[deserializers[]]").join(",")).toBe("application/javascript,application/json,application/x-tiddler,application/x-tiddler-html-div,application/x-tiddlers,text/css,text/html,text/plain");
 	});
-	
+
 	it("should handle the charcode operator", function() {
 		expect(wiki.filterTiddlers("[charcode[9]]").join(" ")).toBe(String.fromCharCode(9));
 		expect(wiki.filterTiddlers("[charcode[9],[10]]").join(" ")).toBe(String.fromCharCode(9) + String.fromCharCode(10));
 		expect(wiki.filterTiddlers("[charcode[]]").join(" ")).toBe("");
+	});
+
+	it("should parse filter variable parameters", function(){
+		expect($tw.utils.parseFilterVariable("currentTiddler")).toEqual(
+			{ name: 'currentTiddler', params: [  ] }
+		);
+		expect($tw.utils.parseFilterVariable("now DDMM")).toEqual(
+			{ name: 'now', params: [{ type: 'macro-parameter', start: 3, value: 'DDMM', end: 8 }] }
+		);
+		expect($tw.utils.parseFilterVariable("now DDMM UTC")).toEqual(
+			{ name: 'now', params: [{ type: 'macro-parameter', start: 3, value: 'DDMM', end: 8 }, { type: 'macro-parameter', start: 8, value: 'UTC', end: 12 }] }
+		);
+		expect($tw.utils.parseFilterVariable("")).toEqual(
+			{ name: '', params: [] }
+		);
 	});
 
 }

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -835,6 +835,18 @@ function runTests(wiki) {
 	  expect($tw.utils.parseFilterVariable("now DDMM UTC")).toEqual(
 		{ name: 'now', params: [{ type: 'macro-parameter', start: 3, value: 'DDMM', end: 8 }, { type: 'macro-parameter', start: 8, value: 'UTC', end: 12 }] }
 	  );
+	  expect($tw.utils.parseFilterVariable("now format:DDMM")).toEqual(
+		{ name: 'now', params: [{ type: 'macro-parameter', name:'format', start: 3, value: 'DDMM', end: 15 }] }	  	
+	  );
+	  expect($tw.utils.parseFilterVariable("now format:'DDMM'")).toEqual(
+		{ name: 'now', params: [{ type: 'macro-parameter', name:'format', start: 3, value: 'DDMM', end: 17 }] }	  	
+	  );
+	  expect($tw.utils.parseFilterVariable("nowformat:'DDMM'")).toEqual(
+		{ name: 'nowformat:\'DDMM\'', params: [] }
+	  );
+	  expect($tw.utils.parseFilterVariable("nowformat:'DD MM'")).toEqual(
+		{ name: 'nowformat:', params: [{ type: 'macro-parameter', start: 10, value: 'DD MM', end: 17 }] }
+	  );
 	  expect($tw.utils.parseFilterVariable("")).toEqual(
 		{ name: '', params: [] }
 	  );

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -818,7 +818,7 @@ function runTests(wiki) {
 	it("should handle the deserializers operator", function() {
 	expect(wiki.filterTiddlers("[deserializers[]]").join(",")).toBe("application/javascript,application/json,application/x-tiddler,application/x-tiddler-html-div,application/x-tiddlers,text/css,text/html,text/plain");
 	});
-
+	
 	it("should handle the charcode operator", function() {
 		expect(wiki.filterTiddlers("[charcode[9]]").join(" ")).toBe(String.fromCharCode(9));
 		expect(wiki.filterTiddlers("[charcode[9],[10]]").join(" ")).toBe(String.fromCharCode(9) + String.fromCharCode(10));


### PR DESCRIPTION
@Jermolene this adds support for macro parameters in filters as discussed in #5830. 

Salient changes:
- refactored `$tw.utils.parseMacroInvocation()` to create `$tw.utils.parseMacroParameters()` which can be re-used for parsing macro parameters.
  - We have existing tests for parsing macros that show this is change is backwards compatible. 
- Introduced `$tw.utils.parseFilterVariable()` for which I have added tests. 
