### PR TITLE
Docs for macro parameters in filter operands

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Parameter.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Parameter.tid
@@ -1,5 +1,5 @@
 created: 20150220152540000
-modified: 20201103110920722
+modified: 20210629215024053
 tags: [[Filter Syntax]]
 title: Filter Parameter
 type: text/vnd.tiddlywiki
@@ -24,7 +24,8 @@ The parameter to a [[filter operator|Filter Operators]] can be:
 :: The parameter is the text indicated by the [[text reference|TextReference]] whose name appears between the curly brackets, i.e. a [[field|TiddlerFields]] of a specified tiddler, or the value of a property of a specified [[data tiddler|DataTiddlers]].
 : <<.def variable>>
 :: `<like this>`
-:: The parameter is the current value of the [[variable|Variables]] whose name appears between the angle brackets. Macro parameters are <<.em not>> supported.
+:: The parameter is the current value of the [[variable|Variables]] whose name appears between the angle brackets. Macro parameters are <<.em not>> supported up to and including ~TiddlyWiki v5.1.23.
+::<<.from-version "5.2.0">> Literal macro parameters are supported. For example: `[<now [UTC]YYYY0MM0DD0hh0mm0ssXXX>]`.
 
 <<.from-version "5.1.23">> Filter operators support multiple parameters which are separated by a ` , ` character.
 

--- a/editions/tw5.com/tiddlers/macros/NowMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/NowMacro.tid
@@ -1,6 +1,6 @@
 caption: now
 created: 20141008141616791
-modified: 20170630223406157
+modified: 20210629215024061
 tags: Macros [[Core Macros]]
 title: now Macro
 type: text/vnd.tiddlywiki
@@ -15,6 +15,8 @@ The value doesn't update automatically, like a ticking clock. It updates wheneve
 : A string specifying the desired [[format|DateFormat]], defaulting to `0hh:0mm, DDth MMM YYYY`
 
 ''Note'': The format string `[UTC]YYYY0MM0DD0hh0mm0ssXXX` will return a date string representing the UTC time-stamp as it is used in the ~TiddlyWiki `created` and `modified` time-stamp fields.
+
+<<.from-version 5.2.0>><<.tip "You can now pass literal parameters to the `now` macro in filters. For example, this filter will return all tiddlers created today: `[all[tiddlers]] :filter[get[created]format:date[YYYY0MM0DD]match<now YYYY0MM0DD>]`">>
 
 
 <<.macro-examples "now">>


### PR DESCRIPTION
I've used the term "literal parameters" to refer to parameters that are not variables or text references. Is there a different term we use for this in formal documentation? "String" felt too developer-centric and I wasn't sure if "hard" parameters would be understood.