### PR TITLE
markdown: Don't emit paragraph tags when a paragraph is "tight".

### DIFF
--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -94,7 +94,14 @@ function convertNodes(remarkableTree, isStartOfInline) {
 		var currentNode = remarkableTree[i];
 		switch (currentNode.type) {
 		case "paragraph_open":
-			i = wrappedElement("p", i, currentNode.level, "paragraph_close", remarkableTree);
+			// If the paragraph is a "tight" layout paragraph, don't wrap children in a <p> tag.
+			if (currentNode.tight) {
+				i = withChildren(i, currentNode.level, "paragraph_close", remarkableTree, function(children) {
+					out.push(...children);
+				});
+			} else {
+				i = wrappedElement("p", i, currentNode.level, "paragraph_close", remarkableTree);
+			}
 			break;
 
 		case "heading_open":

--- a/plugins/tiddlywiki/markdown/wrapper.js
+++ b/plugins/tiddlywiki/markdown/wrapper.js
@@ -97,7 +97,7 @@ function convertNodes(remarkableTree, isStartOfInline) {
 			// If the paragraph is a "tight" layout paragraph, don't wrap children in a <p> tag.
 			if (currentNode.tight) {
 				i = withChildren(i, currentNode.level, "paragraph_close", remarkableTree, function(children) {
-					out.push(...children);
+					Array.prototype.push.apply(out, children);
 				});
 			} else {
 				i = wrappedElement("p", i, currentNode.level, "paragraph_close", remarkableTree);


### PR DESCRIPTION
Motivation: Since the upgrade to remarkable.js (#3876), lists are rendered as
HTML like this:

```
<ul>
  <li><p>One</p></li>
  <li><p>Two</p></li>
  <li><p>Three</p></li>
</ul>
```

<img width="578" alt="Screen Shot 2021-07-03 at 2 43 01 PM" src="https://user-images.githubusercontent.com/26527/124371637-a5085c80-dc38-11eb-99cf-64efae2944a7.png">

The paragraph nodes insert blocks that break the visual flow of the list and are
unexpected e.g. compared to WikiText markup's rendering of a bulleted list.

Solution: remarkable.js annotates certain paragraph nodes as "tight", and in the
bulleted list case, the paragraph nodes wrapping the text of each list item are
marked tight.

remarkable uses the tight property to [elide paragraph tags in its
renderer](https://github.com/jonschlinkert/remarkable/blob/58b6945f203ca7a0bb5a0785df90a3a6a8b9e59c/lib/rules.js#L136-L142).

This change implements the equivalent logic in TiddlyWiki's markdown rendering:
If a paragraph is marked tight, then we elide the `<p>` tag wrapping its children.

With this PR:

<img width="717" alt="Screen Shot 2021-07-03 at 10 36 44 PM" src="https://user-images.githubusercontent.com/26527/124371648-b81b2c80-dc38-11eb-8001-a534215b020a.png">
