### PR TITLE
Fix color string lookup that can potentiallly crash TW

### DIFF
--- a/core/modules/utils/dom/csscolorparser.js
+++ b/core/modules/utils/dom/csscolorparser.js
@@ -133,7 +133,7 @@ function parseCSSColor(css_str) {
   var str = css_str.replace(/ /g, '').toLowerCase();
 
   // Color keywords (and transparent) lookup.
-  if (str in kCSSColorTable) return kCSSColorTable[str].slice();  // dup.
+  if (kCSSColorTable.hasOwnProperty(str)) return kCSSColorTable[str].slice();  // dup.
 
   // #abc and #abc123 syntax.
   if (str[0] === '#') {


### PR DESCRIPTION
I was working on a color filter and during testing, I accidentally pulled in all the tiddler titles in the wiki. Just so happened, I have a tiddler titled "Constructor", and the filter execution crashed with error "kCSSColorTable[str].slice is not a function".

So I replaced "in" operator with "hasOwnProperty()" in the color string lookup section of the code.