### PR TITLE
Added counter-total variable to list widget

### DIFF
--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -135,6 +135,7 @@ ListWidget.prototype.makeItemTemplate = function(title,index) {
 		parseTreeNode.counterName = this.counterName;
 		parseTreeNode.isFirst = index === 0;
 		parseTreeNode.isLast = index === this.list.length - 1;
+		parseTreeNode.counterTotal = this.list.length;
 	}
 	return parseTreeNode;
 };
@@ -341,6 +342,7 @@ ListItemWidget.prototype.execute = function() {
 		this.setVariable(this.parseTreeNode.counterName,this.parseTreeNode.counter);
 		this.setVariable(this.parseTreeNode.counterName + "-first",this.parseTreeNode.isFirst ? "yes" : "no");
 		this.setVariable(this.parseTreeNode.counterName + "-last",this.parseTreeNode.isLast ? "yes" : "no");
+		this.setVariable(this.parseTreeNode.counterName + "-total",this.parseTreeNode.counterTotal.toString());
 	}
 	// Construct the child widgets
 	this.makeChildWidgets();

--- a/editions/tw5.com/tiddlers/widgets/ListWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ListWidget.tid
@@ -1,6 +1,6 @@
 caption: list
 created: 20131024141900000
-modified: 20210416175333981
+modified: 20210711122847337
 tags: Widgets Lists
 title: ListWidget
 type: text/vnd.tiddlywiki
@@ -91,10 +91,11 @@ The action of the list widget depends on the results of the filter combined with
 
 The optional `counter` attribute specifies the name of a variable to hold the 1-based numeric index of the current item in the list.
 
-Two additional variables are also set to indicate the first and last items in the list:
+Three additional variables are also set to indicate the first and last items in the list and the total number of items in the list:
 
 * `<counter-variable-name>-first` is set to `yes` for the first entry in the list, `no` for the others
 * `<counter-variable-name>-last` is set to `yes` for the last entry in the list, `no` for the others
+* `<counter-variable-name>-total` is set to the number of items in the list
 
 For example:
 
@@ -102,7 +103,7 @@ For example:
 ```
 <$list filter="[tag[About]sort[title]]" counter="counter">
 <div>
-<<counter>>: ''<$text text=<<currentTiddler>>/>'' (is first: <<counter-first>>, is last: <<counter-last>>)
+<<counter>> of <<counter-total>>: ''<$text text=<<currentTiddler>>/>'' (is first: <<counter-first>>, is last: <<counter-last>>)
 </div>
 </$list>
 ```
@@ -112,7 +113,7 @@ Displays as:
 <<<
 <$list filter="[tag[About]sort[title]]" counter="counter">
 <div>
-<<counter>>: ''<$text text=<<currentTiddler>>/>'' (is first: <<counter-first>>, is last: <<counter-last>>)
+<<counter>> of <<counter-total>>: ''<$text text=<<currentTiddler>>/>'' (is first: <<counter-first>>, is last: <<counter-last>>)
 </div>
 </$list>
 <<<


### PR DESCRIPTION
Fixes #5864

Adds a `<counter-variable-name>-total` variable when the List widget is used with the counter attribute.