### PR TITLE
Update MessageCatcher to simplify and unify syntax

### DIFF
--- a/core/modules/widgets/messagecatcher.js
+++ b/core/modules/widgets/messagecatcher.js
@@ -63,9 +63,7 @@ MessageCatcherWidget.prototype.render = function(parent,nextSibling) {
 			);
 		}
 	}
-	// Add the main event handler
-	addEventHandler(this.getAttribute("type"),this.getAttribute("actions"));
-	// Add any other event handlers
+	// Add  event handlers
 	$tw.utils.each(this.attributes,function(value,key) {
 		if(key.charAt(0) === "$") {
 			addEventHandler(key.slice(1),value);

--- a/editions/tw5.com/tiddlers/widgets/MessageCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/MessageCatcherWidget.tid
@@ -1,5 +1,5 @@
 created: 20210309133636211
-modified: 20210309133636211
+modified: 20210711171232457
 tags: Widgets
 title: MessageCatcherWidget
 type: text/vnd.tiddlywiki
@@ -15,9 +15,7 @@ The message catcher widget traps [[messages|Messages]] dispatched within its chi
 The content of the `<$messagecatcher>` widget is displayed normally.
 
 |!Attribute |!Description |
-|type |Name of the message be trapped, for example "tm-scroll" or "tm-navigate" |
-|actions |Action string to be invoked when a matching message is trapped |
-|//{any attributes starting with $}// |Each attribute name (excluding the $) specifies the name of a message, and the value specifies the action string to be invoked  |
+|//{any attributes starting with $}// |Each attribute name (excluding the $) specifies the name of a message, and the value specifies the action string to be invoked. For example `$tm-navigate=<<navigateActions>>`  |
 
 ! Variables
 
@@ -35,7 +33,7 @@ The message catcher widget
 <$action-log/>
 \end
 
-<$messagecatcher type="tm-navigate" actions=<<actions>>>
+<$messagecatcher $tm-navigate=<<actions>>>
 
 Click on [[this link]] to fire an action. See the browser JavaScript console for the output
 


### PR DESCRIPTION
This PR removes the `type` and `actions` attribute for `$messagecatcher` resulting in a more consistent and easier to remember syntax, as [previously discussed](https://github.com/Jermolene/TiddlyWiki5/commit/f87b3bfcdba79b6ad198af286bd827c61044891f#commitcomment-53032635).