### PR TITLE
Add syncer status hook and option to disable polling

### DIFF
--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -20,6 +20,7 @@ Syncer.prototype.titleIsAnonymous = "$:/status/IsAnonymous";
 Syncer.prototype.titleIsReadOnly = "$:/status/IsReadOnly";
 Syncer.prototype.titleUserName = "$:/status/UserName";
 Syncer.prototype.titleSyncFilter = "$:/config/SyncFilter";
+Syncer.prototype.titleSyncDisablePolling = "$:/status/SyncDisablePolling";
 Syncer.prototype.titleSyncPollingInterval = "$:/config/SyncPollingInterval";
 Syncer.prototype.titleSyncDisableLazyLoading = "$:/config/SyncDisableLazyLoading";
 Syncer.prototype.titleSavedNotification = "$:/language/Notifications/Save/Done";
@@ -89,7 +90,7 @@ function Syncer(options) {
 		if(filteredChanges.length > 0) {
 			self.processTaskQueue();
 		} else {
-			// Look for deletions of tiddlers we're already syncing	
+			// Look for deletions of tiddlers we're already syncing
 			var outstandingDeletion = false
 			$tw.utils.each(changes,function(change,title,object) {
 				if(change.deleted && $tw.utils.hop(self.tiddlerInfo,title)) {
@@ -121,7 +122,7 @@ function Syncer(options) {
 				self.login(username,password,function() {});
 			} else {
 				// No username and password, so we display a prompt
-				self.handleLoginEvent();				
+				self.handleLoginEvent();
 			}
 		});
 		$tw.rootWidget.addEventListener("tm-logout",function() {
@@ -138,7 +139,7 @@ function Syncer(options) {
 	if(!this.disableUI && this.wiki.getTiddlerText(this.titleSyncDisableLazyLoading) !== "yes") {
 		this.wiki.addEventListener("lazyLoad",function(title) {
 			self.handleLazyLoadEvent(title);
-		});		
+		});
 	}
 	// Get the login status
 	this.getStatus(function(err,isLoggedIn) {
@@ -173,8 +174,8 @@ Syncer.prototype.getTiddlerRevision = function(title) {
 	if(this.syncadaptor && this.syncadaptor.getTiddlerRevision) {
 		return this.syncadaptor.getTiddlerRevision(title);
 	} else {
-		return this.wiki.getTiddler(title).fields.revision;	
-	} 
+		return this.wiki.getTiddler(title).fields.revision;
+	}
 };
 
 /*
@@ -267,7 +268,7 @@ Syncer.prototype.getStatus = function(callback) {
 		// Mark us as not logged in
 		this.wiki.addTiddler({title: this.titleIsLoggedIn,text: "no"});
 		// Get login status
-		this.syncadaptor.getStatus(function(err,isLoggedIn,username,isReadOnly,isAnonymous) {
+		this.syncadaptor.getStatus(function(err,isLoggedIn,username,isReadOnly,isAnonymous,isPollingDisabled) {
 			if(err) {
 				self.logger.alert(err);
 			} else {
@@ -278,7 +279,11 @@ Syncer.prototype.getStatus = function(callback) {
 				if(isLoggedIn) {
 					self.wiki.addTiddler({title: self.titleUserName,text: username || ""});
 				}
+				if(isPollingDisabled) {
+					self.wiki.addTiddler({title: self.titleSyncDisablePolling, text: "yes"});
+				}
 			}
+			$tw.hooks.invokeHook("th-syncer-status-response",self,!err);
 			// Invoke the callback
 			if(callback) {
 				callback(err,isLoggedIn,username);
@@ -301,12 +306,15 @@ Syncer.prototype.syncFromServer = function() {
 			}
 		},
 		triggerNextSync = function() {
-			self.pollTimerId = setTimeout(function() {
-				self.pollTimerId = null;
-				self.syncFromServer.call(self);
-			},self.pollTimerInterval);
+			if(pollingEnabled) {
+				self.pollTimerId = setTimeout(function() {
+					self.pollTimerId = null;
+					self.syncFromServer.call(self);
+				},self.pollTimerInterval);
+			}
 		},
-		syncSystemFromServer = (self.wiki.getTiddlerText("$:/config/SyncSystemTiddlersFromServer") === "yes" ? true : false);
+		syncSystemFromServer = (self.wiki.getTiddlerText("$:/config/SyncSystemTiddlersFromServer") === "yes"),
+		pollingEnabled = (self.wiki.getTiddlerText(self.titleSyncDisablePolling) !== "yes");
 	if(this.syncadaptor && this.syncadaptor.getUpdatedTiddlers) {
 		this.logger.log("Retrieving updated tiddler list");
 		cancelNextSync();
@@ -329,7 +337,7 @@ Syncer.prototype.syncFromServer = function() {
 				});
 				if(updates.modifications.length > 0 || updates.deletions.length > 0) {
 					self.processTaskQueue();
-				}				
+				}
 			}
 		});
 	} else if(this.syncadaptor && this.syncadaptor.getSkinnyTiddlers) {
@@ -509,7 +517,7 @@ Syncer.prototype.processTaskQueue = function() {
 				} else {
 					self.updateDirtyStatus();
 					// Process the next task
-					self.processTaskQueue.call(self);					
+					self.processTaskQueue.call(self);
 				}
 			});
 		} else {
@@ -517,11 +525,11 @@ Syncer.prototype.processTaskQueue = function() {
 			this.updateDirtyStatus();
 			// And trigger a timeout if there is a pending task
 			if(task === true) {
-				this.triggerTimeout();				
+				this.triggerTimeout();
 			}
 		}
 	} else {
-		this.updateDirtyStatus();		
+		this.updateDirtyStatus();
 	}
 };
 
@@ -555,7 +563,7 @@ Syncer.prototype.chooseNextTask = function() {
 				isReadyToSave = !tiddlerInfo || !tiddlerInfo.timestampLastSaved || tiddlerInfo.timestampLastSaved < thresholdLastSaved;
 			if(hasChanged) {
 				if(isReadyToSave) {
-					return new SaveTiddlerTask(this,title); 					
+					return new SaveTiddlerTask(this,title);
 				} else {
 					havePending = true;
 				}

--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -268,7 +268,7 @@ Syncer.prototype.getStatus = function(callback) {
 		// Mark us as not logged in
 		this.wiki.addTiddler({title: this.titleIsLoggedIn,text: "no"});
 		// Get login status
-		this.syncadaptor.getStatus(function(err,isLoggedIn,username,isReadOnly,isAnonymous,isPollingDisabled) {
+		this.syncadaptor.getStatus(function(err,isLoggedIn,username,isReadOnly,isAnonymous) {
 			if(err) {
 				self.logger.alert(err);
 			} else {
@@ -278,9 +278,6 @@ Syncer.prototype.getStatus = function(callback) {
 				self.wiki.addTiddler({title: self.titleIsLoggedIn,text: isLoggedIn ? "yes" : "no"});
 				if(isLoggedIn) {
 					self.wiki.addTiddler({title: self.titleUserName,text: username || ""});
-				}
-				if(isPollingDisabled) {
-					self.wiki.addTiddler({title: self.titleSyncDisablePolling, text: "yes"});
 				}
 			}
 			$tw.hooks.invokeHook("th-syncer-status-response",self,!err);

--- a/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
+++ b/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
@@ -23,7 +23,6 @@ function TiddlyWebAdaptor(options) {
 	this.logger = new $tw.utils.Logger("TiddlyWebAdaptor");
 	this.isLoggedIn = false;
 	this.isReadOnly = false;
-	this.isPollingDisabled = false;
 }
 
 TiddlyWebAdaptor.prototype.name = "tiddlyweb";
@@ -92,15 +91,10 @@ TiddlyWebAdaptor.prototype.getStatus = function(callback) {
 				self.isLoggedIn = json.username !== "GUEST";
 				self.isReadOnly = !!json["read_only"];
 				self.isAnonymous = !!json.anonymous;
-
-				// set whether the syncer should be polling for changes
-				// this allows the syncer to still call for manual polls 
-				// when requested by the user
-				self.isPollingDisabled = false;
 			}
 			// Invoke the callback if present
 			if(callback) {
-				callback(null,self.isLoggedIn,json.username,self.isReadOnly,self.isAnonymous,self.isPollingDisabled);
+				callback(null,self.isLoggedIn,json.username,self.isReadOnly,self.isAnonymous);
 			}
 		}
 	});

--- a/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
+++ b/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
@@ -23,6 +23,7 @@ function TiddlyWebAdaptor(options) {
 	this.logger = new $tw.utils.Logger("TiddlyWebAdaptor");
 	this.isLoggedIn = false;
 	this.isReadOnly = false;
+	this.isPollingDisabled = false;
 }
 
 TiddlyWebAdaptor.prototype.name = "tiddlyweb";
@@ -91,10 +92,15 @@ TiddlyWebAdaptor.prototype.getStatus = function(callback) {
 				self.isLoggedIn = json.username !== "GUEST";
 				self.isReadOnly = !!json["read_only"];
 				self.isAnonymous = !!json.anonymous;
+
+				// set whether the syncer should be polling for changes
+				// this allows the syncer to still call for manual polls 
+				// when requested by the user
+				self.isPollingDisabled = false;
 			}
 			// Invoke the callback if present
 			if(callback) {
-				callback(null,self.isLoggedIn,json.username,self.isReadOnly,self.isAnonymous);
+				callback(null,self.isLoggedIn,json.username,self.isReadOnly,self.isAnonymous,self.isPollingDisabled);
 			}
 		}
 	});


### PR DESCRIPTION
This adds another variable to the status response which tells the syncer whether the sync adapter expects it to poll for changes. This is useful if the syncadaptor has some other mechanism to get changes from the server, but still allows a manual refresh to be triggered. If this argument is not passed or is false, the default behavior will still happen, so it's backward compatible. 

**Update:** I removed the status response variable from the getStatus callback but kept the status tiddler. The status tiddler is checked every time to determine whether to set a timeout to schedule the next sync, meaning if the tiddler gets unset, syncFromServer must be called once to restart polling. The tiddler may also be set to yes at any time and polling will stop after the next call to syncFromServer (including by polling). 

It also adds a hook to the syncer which fires after the status callback is processed so other plugins can handle the status accordingly. Because the syncer puts everything into the wiki, and also because many syncer instances could theoretically exist, I chose to pass the syncer itself as the hook argument. The listener can then verify that the instance matches `$tw.syncer`.

The main reason I only pass a boolean for success is partly to prevent memory leakage and partly because it's the syncer's job to handle that stuff and just doesn't make sense to pass that out. However, a failure could still indicate something depending on the syncadaptor in use so I include it as a boolean. 

If the syncadaptor wants to reference the syncer, it can listen for the hook and then check if `syncer.syncadaptor` equals itself.

This was originally discussed in #5853 and #5279.