### PR TITLE
Fix: bug with List Widget counter-last variable

### DIFF
--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -236,6 +236,11 @@ ListWidget.prototype.handleListChanges = function(changedTiddlers) {
 					hasRefreshed = hasRefreshed || refreshed;
 				}
 			}
+			// If there are items to remove and we have not refreshed then recreate the item that will now be at the last position
+			if(!hasRefreshed && this.children.length > this.list.length) {
+				this.removeListItem(this.list.length-1);
+				this.insertListItem(this.list.length-1,this.list[this.list.length-1]);
+			}
 		} else {
 			// Cycle through the list, inserting and removing list items as needed
 			for(t=0; t<this.list.length; t++) {

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -465,6 +465,31 @@ describe("Widget module", function() {
 		expect(wrapper.children[0].children[13].sequenceNumber).toBe(43);
 		expect(wrapper.children[0].children[14].sequenceNumber).toBe(44);
 		expect(wrapper.children[0].children[15].sequenceNumber).toBe(45);
+		//Remove last tiddler
+		wiki.deleteTiddler("TiddlerTwo");
+		//Refresh
+		refreshWidgetNode(widgetNode,wrapper,["TiddlerTwo"]);
+		//Test the refreshing
+		expect(wrapper.innerHTML).toBe("<p>Jalapeno Peppers1yesnoLemon Squash2nonoJolly Old World3nonoSomething4noyes</p>");
+		// Test the sequence numbers in the DOM
+		expect(wrapper.sequenceNumber).toBe(0);
+		expect(wrapper.children[0].sequenceNumber).toBe(1);
+		expect(wrapper.children[0].children[0].sequenceNumber).toBe(18);
+		expect(wrapper.children[0].children[1].sequenceNumber).toBe(19);
+		expect(wrapper.children[0].children[2].sequenceNumber).toBe(20);
+		expect(wrapper.children[0].children[3].sequenceNumber).toBe(21);
+		expect(wrapper.children[0].children[4].sequenceNumber).toBe(22);
+		expect(wrapper.children[0].children[5].sequenceNumber).toBe(23);
+		expect(wrapper.children[0].children[6].sequenceNumber).toBe(24);
+		expect(wrapper.children[0].children[7].sequenceNumber).toBe(25);
+		expect(wrapper.children[0].children[8].sequenceNumber).toBe(26);
+		expect(wrapper.children[0].children[9].sequenceNumber).toBe(27);
+		expect(wrapper.children[0].children[10].sequenceNumber).toBe(28);
+		expect(wrapper.children[0].children[11].sequenceNumber).toBe(29);
+		expect(wrapper.children[0].children[12].sequenceNumber).toBe(50);
+		expect(wrapper.children[0].children[13].sequenceNumber).toBe(51);
+		expect(wrapper.children[0].children[14].sequenceNumber).toBe(52);
+		expect(wrapper.children[0].children[15].sequenceNumber).toBe(53);
 	});
 
 	it("should deal with the list widget followed by other widgets", function() {


### PR DESCRIPTION
This is a fix for a bug with the current implementation of the list widget when using the counter variable. If the last item is removed with no earlier changes in the list, then the `<counter-variable-name>-last` variable is not updated. I've added a test for this scenario.

An alternative approach would be to make the `-last` variable a separate attribute that has to be specified and only do the refreshing for it then. This would result in slightly better performance when a user wants a `counter` variable but not the `-last` variable. I am not convinced those marginal gains are significant enough to warrant going this route.

I am just entering a busy period expected to last ~ 3-4 weeks during which I wont have the opportunity to contribute to the core. So if we want to explore a different fix, depending on the timing of the 5.2.0 release, someone else may need to pick up the work on this.