### PR TITLE
Fixes getStatus error alerts

### DIFF
--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -269,7 +269,7 @@ Syncer.prototype.getStatus = function(callback) {
 		// Get login status
 		this.syncadaptor.getStatus(function(err,isLoggedIn,username,isReadOnly,isAnonymous) {
 			if(err) {
-				self.logger.alert(err);
+				self.displayError("Get Status Error",err);
 			} else {
 				// Set the various status tiddlers
 				self.wiki.addTiddler({title: self.titleIsReadOnly,text: isReadOnly ? "yes" : "no"});


### PR DESCRIPTION
All other connections errors lookup the localized Connection Error message and displays it in an alert. This aligns the getStatus function with that standard.