### PR TITLE
Do not add X-Requested-With header for simple requests

### DIFF
--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -34,6 +34,23 @@ exports.httpRequest = function(options) {
 			});
 			return result;
 		},
+		getHeader = function(targetHeader) {
+			return headers[targetHeader] || headers[targetHeader.toLowerCase()];
+		},
+		isSimpleRequest = function(type,headers) {
+			if(["GET","HEAD","POST"].indexOf(type) === -1) {
+				return false;
+			}
+			for(var header in headers) {
+				if(["accept","accept-language","content-language","content-type"].indexOf(header.toLowerCase()) === -1) {
+					return false;
+				}
+			}
+			if(hasHeader("Content-Type") && ["application/x-www-form-urlencoded","multipart/form-data","text/plain"].indexOf(getHeader["Content-Type"]) === -1) {
+				return false;
+			}
+			return true;	
+		},
 		returnProp = options.returnProp || "responseText",
 		request = new XMLHttpRequest(),
 		data = "",
@@ -76,7 +93,7 @@ exports.httpRequest = function(options) {
 	if(data && !hasHeader("Content-Type")) {
 		request.setRequestHeader("Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
 	}
-	if(!hasHeader("X-Requested-With")) {
+	if(!hasHeader("X-Requested-With") && !isSimpleRequest(type,headers)) {
 		request.setRequestHeader("X-Requested-With","TiddlyWiki");
 	}
 	try {

--- a/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
+++ b/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
@@ -114,6 +114,10 @@ TiddlyWebAdaptor.prototype.login = function(username,password,callback) {
 		},
 		callback: function(err) {
 			callback(err);
+		},
+		headers: {
+			"accept": "application/json",
+			"X-Requested-With": "TiddlyWiki"
 		}
 	};
 	this.logger.log("Logging in:",options);
@@ -132,6 +136,10 @@ TiddlyWebAdaptor.prototype.logout = function(callback) {
 		},
 		callback: function(err,data) {
 			callback(err);
+		},
+		headers: {
+			"accept": "application/json",
+			"X-Requested-With": "TiddlyWiki"
 		}
 	};
 	this.logger.log("Logging out:",options);


### PR DESCRIPTION
Fixes #4537 by not adding `X-Requested-With` header for [http requests that should not trigger a CORS preflight.](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests)

`$tw.utils.http()` currently always adds the `X-Requested-With` header to all requests, which in turn triggers an `OPTIONS` preflight even when it could be avoided. The changes herein modify the method so that the `X-Requested-With` header is only added for requests that would not satisfy the criteria for avoiding the CORS preflight.

The node.js server currently requires the `X-Requested-With` header for `POST` requests which with the above change would no longer have this header. `PUT` and `DELETE` requests have the same requirement but are unaffected by this change.

https://github.com/Jermolene/TiddlyWiki5/blob/82ec63e71118f9ee788972371f713579bae67530/core/modules/server/server.js#L242-L248

Rather than removing this requirement in the server, I have modified the tiddlyweb adaptor to manually add the `X-Requested-With` header for `POST` requests. 

The alternative would be to remove the requirement in the server for the `X-Requested-With `header for `POST` requests, which we probably do not want to do.