### PR TITLE
Add custom macro editor for KaTeX plugin

### DIFF
--- a/plugins/tiddlywiki/katex/config.tid
+++ b/plugins/tiddlywiki/katex/config.tid
@@ -1,0 +1,13 @@
+title: $:/plugins/tiddlywiki/katex/config
+
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/katex/config]!has[draft.of]]">
+
+<div>
+
+!! <$link><$transclude field="caption"/></$link>
+
+<$transclude>
+
+</div>
+
+</$list>

--- a/plugins/tiddlywiki/katex/config.tid
+++ b/plugins/tiddlywiki/katex/config.tid
@@ -1,6 +1,6 @@
 title: $:/plugins/tiddlywiki/katex/config
 
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/katex/config]!has[draft.of]]">
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/KaTeX/Config]!has[draft.of]]">
 
 <div>
 

--- a/plugins/tiddlywiki/katex/config.tid
+++ b/plugins/tiddlywiki/katex/config.tid
@@ -1,5 +1,7 @@
 title: $:/plugins/tiddlywiki/katex/config
 
+<div class="tc-control-panel">
+
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/KaTeX/Config]!has[draft.of]]">
 
 <div>
@@ -11,3 +13,5 @@ title: $:/plugins/tiddlywiki/katex/config
 </div>
 
 </$list>
+
+</div>

--- a/plugins/tiddlywiki/katex/plugin.info
+++ b/plugins/tiddlywiki/katex/plugin.info
@@ -2,6 +2,6 @@
 	"title": "$:/plugins/tiddlywiki/katex",
 	"name": "KaTeX",
 	"description": "KaTeX library for mathematical typography",
-	"list": "readme usage",
+	"list": "readme usage config",
 	"library-version": "v0.12.0"
 }

--- a/plugins/tiddlywiki/katex/ui/config/macro.tid
+++ b/plugins/tiddlywiki/katex/ui/config/macro.tid
@@ -1,0 +1,60 @@
+title: $:/plugins/tiddlywiki/katex/ui/config/macro
+tags: $:/tags/katex/config
+caption: Custom macro editor
+
+\define katex-escape(text)
+<$set filter="[[$text$]search-replace:g:regexp[(?<!\\)#(\d)],[\#_$1]]">
+<$latex text=<<currentTiddler>>/>
+</$set>
+\end
+
+Note that the macros are loaded on startup, so please refresh the page when new macros are added (or deleted).
+
+<table>
+<tr>
+<th>Macro</th>
+<th>Command</th>
+<th>Preview</th>
+<th></th>
+</tr>
+
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/katex/macro]!has[draft.of]sort[macro]]">
+<tr>
+<td><tt>{{!!macro}}</tt></td>
+<td><tt>{{!!text}}</tt></td>
+<td><$macrocall $name=katex-escape text={{!!text}}/></td>
+<td>
+<$button>
+<$action-navigate $to={{!!title}}/>
+{{$:/core/images/folder}}
+</$button>
+<$button>
+<$action-deletetiddler $tiddler={{!!title}}/>
+{{$:/core/images/delete-button}}
+</$button>
+</td>
+</tr>
+</$list>
+
+<tr>
+<td><$edit-text tiddler="$:/state/katex-new-macro" tag="input" default=""/></td>
+<td><$edit-text tiddler="$:/state/katex-new-command" tag="input" default=""/></td>
+<td></td>
+<td><$button>
+<$action-createtiddler $basetitle="$:/plugins/tiddlywiki/katex/macros/macro" tags="$:/tags/katex/macro" macro={{$:/state/katex-new-macro}} text={{$:/state/katex-new-command}}/>
+{{$:/language/EditTemplate/Fields/Add/Button}}
+</$button></td>
+</tr>
+</table>
+
+<details>
+<summary>Usage</summary>
+<ul>
+<li>
+You can add entries like `\ZZ`, `\mathbb{Z}`, which will render as <$latex text="\mathbb{Z}"/>.
+</li>
+<li>
+An entry mapping `\dd` to `\frac{d#1}{d#2}` will create a macro with two arguments; `\dd{f}{x}` will then render as <$latex text="\frac{df}{dx}"/>. The arguments should only appear in the command and not the macro itself.
+</li>
+</ul>
+</details>

--- a/plugins/tiddlywiki/katex/ui/config/macro.tid
+++ b/plugins/tiddlywiki/katex/ui/config/macro.tid
@@ -10,6 +10,15 @@ caption: Custom macro editor
 </$vars>
 \end
 
+\define katex-create-macro()
+<$vars t={{$:/state/katex-new-macro}}>
+<$list filter="[<t>addprefix[$:/plugins/tiddlywiki/katex/macros/]]">
+<$action-setfield $tiddler="$:/state/katex-new-macro-location" text=<<currentTiddler>>/>
+</$list>
+</$vars>
+<$action-createtiddler $basetitle={{$:/state/katex-new-macro-location}} tags="$:/tags/KaTeX/Macro" type="text/plain" caption={{$:/state/katex-new-macro}} text={{$:/state/katex-new-command}}/>
+\end
+
 <table>
 <tr>
 <th>Macro</th>
@@ -18,9 +27,9 @@ caption: Custom macro editor
 <th></th>
 </tr>
 
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/KaTeX/Macro]!has[draft.of]sort[macro]]">
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/KaTeX/Macro]!has[draft.of]sort[caption]]">
 <tr>
-<td><tt><$text text={{!!macro}}/></tt></td>
+<td><tt><$text text={{!!caption}}/></tt></td>
 <td><tt><$text text={{!!text}}/></tt></td>
 <td><<katex-escape {{!!text}}>></td>
 <td>
@@ -40,8 +49,7 @@ caption: Custom macro editor
 <td><$edit-text tiddler="$:/state/katex-new-macro" tag="input" default=""/></td>
 <td><$edit-text tiddler="$:/state/katex-new-command" tag="input" default=""/></td>
 <td><<katex-escape {{$:/state/katex-new-command}}>></td>
-<td><$button>
-<$action-createtiddler $basetitle="$:/plugins/tiddlywiki/katex/macros/macro" tags="$:/tags/KaTeX/Macro" type="text/plain" macro={{$:/state/katex-new-macro}} text={{$:/state/katex-new-command}}/>
+<td><$button actions=<<katex-create-macro>>>
 {{$:/language/EditTemplate/Fields/Add/Button}}
 </$button></td>
 </tr>

--- a/plugins/tiddlywiki/katex/ui/config/macro.tid
+++ b/plugins/tiddlywiki/katex/ui/config/macro.tid
@@ -30,7 +30,7 @@ caption: Custom macro editor
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/KaTeX/Macro]!has[draft.of]sort[caption]]">
 <tr>
 <td><tt><$text text={{!!caption}}/></tt></td>
-<td><tt><$text text={{!!text}}/></tt></td>
+<td><$edit-text tiddler=<<currentTiddler>> tag="input" default=""/></td>
 <td><<katex-escape {{!!text}}>></td>
 <td>
 <$button class="tc-btn-invisible tc-btn-dropdown">
@@ -45,6 +45,9 @@ caption: Custom macro editor
 </tr>
 </$list>
 
+<tr>
+<td colspan="4" align="left">Add a new macro</td>
+</tr>
 <tr>
 <td><$edit-text tiddler="$:/state/katex-new-macro" tag="input" default=""/></td>
 <td><$edit-text tiddler="$:/state/katex-new-command" tag="input" default=""/></td>

--- a/plugins/tiddlywiki/katex/ui/config/macro.tid
+++ b/plugins/tiddlywiki/katex/ui/config/macro.tid
@@ -1,5 +1,5 @@
 title: $:/plugins/tiddlywiki/katex/ui/config/macro
-tags: $:/tags/katex/config
+tags: $:/tags/KaTeX/Config
 caption: Custom macro editor
 
 \define katex-escape(text)
@@ -18,7 +18,7 @@ caption: Custom macro editor
 <th></th>
 </tr>
 
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/katex/macro]!has[draft.of]sort[macro]]">
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/KaTeX/Macro]!has[draft.of]sort[macro]]">
 <tr>
 <td><tt><$text text={{!!macro}}/></tt></td>
 <td><tt><$text text={{!!text}}/></tt></td>
@@ -41,7 +41,7 @@ caption: Custom macro editor
 <td><$edit-text tiddler="$:/state/katex-new-command" tag="input" default=""/></td>
 <td><<katex-escape {{$:/state/katex-new-command}}>></td>
 <td><$button>
-<$action-createtiddler $basetitle="$:/plugins/tiddlywiki/katex/macros/macro" tags="$:/tags/katex/macro" type="text/plain" macro={{$:/state/katex-new-macro}} text={{$:/state/katex-new-command}}/>
+<$action-createtiddler $basetitle="$:/plugins/tiddlywiki/katex/macros/macro" tags="$:/tags/KaTeX/Macro" type="text/plain" macro={{$:/state/katex-new-macro}} text={{$:/state/katex-new-command}}/>
 {{$:/language/EditTemplate/Fields/Add/Button}}
 </$button></td>
 </tr>

--- a/plugins/tiddlywiki/katex/ui/config/macro.tid
+++ b/plugins/tiddlywiki/katex/ui/config/macro.tid
@@ -2,12 +2,6 @@ title: $:/plugins/tiddlywiki/katex/ui/config/macro
 tags: $:/tags/katex/config
 caption: Custom macro editor
 
-\define katex-escape(text)
-<$list filter="[[$text$]search-replace:g:regexp[(?<!\\)#(\d)],[\#_$1]]">
-<$latex text=<<currentTiddler>>/>
-</$list>
-\end
-
 Note that the macros are loaded on startup, so please refresh the page when new macros are added (or deleted).
 
 <table>
@@ -20,9 +14,15 @@ Note that the macros are loaded on startup, so please refresh the page when new 
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/katex/macro]!has[draft.of]sort[macro]]">
 <tr>
-<td><tt>{{!!macro}}</tt></td>
-<td><tt>{{!!text}}</tt></td>
-<td><$macrocall $name=katex-escape text={{!!text}}/></td>
+<td><tt><$text text={{!!macro}}/></tt></td>
+<td><tt><$text text={{!!text}}/></tt></td>
+<td>
+<$vars t={{!!text}}>
+<$list filter="[<t>search-replace:g:regexp[(?<!\\)#(\d)],[{\#_$1}]]">
+<$latex text=<<currentTiddler>>/>
+</$list>
+</$vars>
+</td>
 <td>
 <$button>
 <$action-navigate $to={{!!title}}/>
@@ -41,7 +41,7 @@ Note that the macros are loaded on startup, so please refresh the page when new 
 <td><$edit-text tiddler="$:/state/katex-new-command" tag="input" default=""/></td>
 <td></td>
 <td><$button>
-<$action-createtiddler $basetitle="$:/plugins/tiddlywiki/katex/macros/macro" tags="$:/tags/katex/macro" macro={{$:/state/katex-new-macro}} text={{$:/state/katex-new-command}}/>
+<$action-createtiddler $basetitle="$:/plugins/tiddlywiki/katex/macros/macro" tags="$:/tags/katex/macro" type="text/plain" macro={{$:/state/katex-new-macro}} text={{$:/state/katex-new-command}}/>
 {{$:/language/EditTemplate/Fields/Add/Button}}
 </$button></td>
 </tr>

--- a/plugins/tiddlywiki/katex/ui/config/macro.tid
+++ b/plugins/tiddlywiki/katex/ui/config/macro.tid
@@ -4,19 +4,44 @@ caption: Custom macro editor
 
 \define katex-escape(text)
 <$vars t=$text$>
-<$list filter="[<t>search-replace:g:regexp[(?<!\\)#(\d)],[{\#_$1}]]">
-<$latex text=<<currentTiddler>>/>
-</$list>
+<$latex text={{{[<t>search-replace:g:regexp[(?<!\\)#(\d)],[{\#_$1}]]}}}>
 </$vars>
 \end
 
 \define katex-create-macro()
-<$vars t={{$:/temp/katex/new-macro-name}}>
-<$list filter="[<t>addprefix[$:/plugins/tiddlywiki/katex/macros/]]">
-<$action-setfield $tiddler="$:/temp/katex/new-macro-location" text=<<currentTiddler>>/>
-</$list>
+<$vars loc={{$:/temp/katex/new-macro-name}}>
+<$action-createtiddler $basetitle={{{[<loc>addprefix[$:/plugins/tiddlywiki/katex/macros/]]}}} tags="$:/tags/KaTeX/Macro" type="text/plain" caption={{$:/temp/katex/new-macro-name}} text={{$:/temp/katex/new-macro-command}} $overwrite=yes/>
 </$vars>
-<$action-createtiddler $basetitle={{$:/temp/katex/new-macro-location}} tags="$:/tags/KaTeX/Macro" type="text/plain" caption={{$:/temp/katex/new-macro-name}} text={{$:/temp/katex/new-macro-command}}/>
+\end
+
+\define katex-edit-cell()
+<$reveal state="$:/temp/katex/edit-macro" type=match text={{!!title}}>
+<$edit-text tiddler=<<currentTiddler>> tag="input" default=""/>
+</$reveal>
+\end
+
+\define katex-view-cell()
+<$reveal state="$:/temp/katex/edit-macro" type=nomatch text={{!!title}}>
+<tt><$view field=text/></tt>
+</$reveal>
+\end
+
+\define katex-edit-macro-button()
+<$reveal state="$:/temp/katex/edit-macro" type=nomatch text={{!!title}}>
+<$button class="tc-btn-invisible tc-btn-dropdown">
+<$action-setfield $tiddler="$:/temp/katex/edit-macro" text={{!!title}}/>
+{{$:/core/images/edit-button}}
+</$button>
+</$reveal>
+\end
+
+\define katex-save-macro-button()
+<$reveal state="$:/temp/katex/edit-macro" type=match text={{!!title}}>
+<$button class="tc-btn-invisible tc-btn-dropdown">
+<$action-deletetiddler $tiddler="$:/temp/katex/edit-macro"/>
+{{$:/core/images/done-button}}
+</$button>
+</$reveal>
 \end
 
 <table>
@@ -30,13 +55,11 @@ caption: Custom macro editor
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/KaTeX/Macro]!has[draft.of]sort[caption]]">
 <tr>
 <td><tt><$text text={{!!caption}}/></tt></td>
-<td><$edit-text tiddler=<<currentTiddler>> tag="input" default=""/></td>
+<td><<katex-edit-cell>><<katex-view-cell>></td>
 <td><<katex-escape {{!!text}}>></td>
 <td>
-<$button class="tc-btn-invisible tc-btn-dropdown">
-<$action-navigate $to={{!!title}}/>
-{{$:/core/images/folder}}
-</$button>
+<<katex-edit-macro-button>>
+<<katex-save-macro-button>>
 <$button class="tc-btn-invisible tc-btn-dropdown">
 <$action-deletetiddler $tiddler={{!!title}}/>
 {{$:/core/images/delete-button}}
@@ -56,8 +79,45 @@ caption: Custom macro editor
 {{$:/language/EditTemplate/Fields/Add/Button}}
 </$button></td>
 </tr>
+
+<tr><td colspan="4" align="left">
+<details>
+<summary>Import</summary>
+<$edit-text tiddler="$:/temp/katex/import-macro" tag="textarea" default="" class="tc-edit-texteditor" placeholder="You can type commands like \def\ZZ{\mathbb{Z}} and import them automatically."/>
+
+<$vars macros={{$:/temp/katex/import-macro}} sep="%.*\n|\n+" re="^\\g?def([^{]*){(.*)}.*">
+
+<$button>
+<$list filter="[<macros>splitregexp<sep>regexp<re>]" variable=line>
+<$vars m={{{[<line>search-replace:g:regexp<re>,[$1]]}}} c={{{[<line>search-replace:g:regexp<re>,[$2]]}}}>
+<$action-createtiddler $basetitle={{{[<m>addprefix[$:/plugins/tiddlywiki/katex/macros/]]}}} tags="$:/tags/KaTeX/Macro" type="text/plain" caption=<<m>> text=<<c>> $overwrite=yes/>
+</$vars>
+</$list>
+Import
+</$button>
+<$button>
+<$action-setfield $tiddler="$:/temp/katex/import-macro" text=""/>
+Clear
+</$button>
+
+''Preview''
+<table>
+<$list filter="[<macros>splitregexp<sep>regexp<re>]" variable=line>
+<$vars m={{{[<line>search-replace:g:regexp<re>,[$1]]}}} c={{{[<line>search-replace:g:regexp<re>,[$2]]}}}>
+<tr>
+<td><tt><<m>></tt></td>
+<td><tt><<c>></tt></td>
+<td><$macrocall $name=katex-escape text="<<c>>"/></td></tr>
+</$vars>
+</$list>
 </table>
 
+</$vars>
+</details>
+</td>
+</tr>
+
+<tr><td colspan="4" align="left">
 <details>
 <summary>Usage</summary>
 <ul>
@@ -72,3 +132,6 @@ Note that the macros defined here have higher priority than those defined using 
 </li>
 </ul>
 </details>
+</td>
+</tr>
+</table>

--- a/plugins/tiddlywiki/katex/ui/config/macro.tid
+++ b/plugins/tiddlywiki/katex/ui/config/macro.tid
@@ -3,9 +3,9 @@ tags: $:/tags/katex/config
 caption: Custom macro editor
 
 \define katex-escape(text)
-<$set filter="[[$text$]search-replace:g:regexp[(?<!\\)#(\d)],[\#_$1]]">
+<$list filter="[[$text$]search-replace:g:regexp[(?<!\\)#(\d)],[\#_$1]]">
 <$latex text=<<currentTiddler>>/>
-</$set>
+</$list>
 \end
 
 Note that the macros are loaded on startup, so please refresh the page when new macros are added (or deleted).

--- a/plugins/tiddlywiki/katex/ui/config/macro.tid
+++ b/plugins/tiddlywiki/katex/ui/config/macro.tid
@@ -11,12 +11,12 @@ caption: Custom macro editor
 \end
 
 \define katex-create-macro()
-<$vars t={{$:/state/katex-new-macro}}>
+<$vars t={{$:/temp/katex/new-macro-name}}>
 <$list filter="[<t>addprefix[$:/plugins/tiddlywiki/katex/macros/]]">
-<$action-setfield $tiddler="$:/state/katex-new-macro-location" text=<<currentTiddler>>/>
+<$action-setfield $tiddler="$:/temp/katex/new-macro-location" text=<<currentTiddler>>/>
 </$list>
 </$vars>
-<$action-createtiddler $basetitle={{$:/state/katex-new-macro-location}} tags="$:/tags/KaTeX/Macro" type="text/plain" caption={{$:/state/katex-new-macro}} text={{$:/state/katex-new-command}}/>
+<$action-createtiddler $basetitle={{$:/temp/katex/new-macro-location}} tags="$:/tags/KaTeX/Macro" type="text/plain" caption={{$:/temp/katex/new-macro-name}} text={{$:/temp/katex/new-macro-command}}/>
 \end
 
 <table>
@@ -49,9 +49,9 @@ caption: Custom macro editor
 <td colspan="4" align="left">Add a new macro</td>
 </tr>
 <tr>
-<td><$edit-text tiddler="$:/state/katex-new-macro" tag="input" default=""/></td>
-<td><$edit-text tiddler="$:/state/katex-new-command" tag="input" default=""/></td>
-<td><<katex-escape {{$:/state/katex-new-command}}>></td>
+<td><$edit-text tiddler="$:/temp/katex/new-macro-name" tag="input" default=""/></td>
+<td><$edit-text tiddler="$:/temp/katex/new-macro-command" tag="input" default=""/></td>
+<td><<katex-escape {{$:/temp/katex/new-macro-command}}>></td>
 <td><$button actions=<<katex-create-macro>>>
 {{$:/language/EditTemplate/Fields/Add/Button}}
 </$button></td>

--- a/plugins/tiddlywiki/katex/ui/config/macro.tid
+++ b/plugins/tiddlywiki/katex/ui/config/macro.tid
@@ -2,7 +2,13 @@ title: $:/plugins/tiddlywiki/katex/ui/config/macro
 tags: $:/tags/katex/config
 caption: Custom macro editor
 
-Note that the macros are loaded on startup, so please refresh the page when new macros are added (or deleted).
+\define katex-escape(text)
+<$vars t=$text$>
+<$list filter="[<t>search-replace:g:regexp[(?<!\\)#(\d)],[{\#_$1}]]">
+<$latex text=<<currentTiddler>>/>
+</$list>
+</$vars>
+\end
 
 <table>
 <tr>
@@ -16,19 +22,13 @@ Note that the macros are loaded on startup, so please refresh the page when new 
 <tr>
 <td><tt><$text text={{!!macro}}/></tt></td>
 <td><tt><$text text={{!!text}}/></tt></td>
+<td><<katex-escape {{!!text}}>></td>
 <td>
-<$vars t={{!!text}}>
-<$list filter="[<t>search-replace:g:regexp[(?<!\\)#(\d)],[{\#_$1}]]">
-<$latex text=<<currentTiddler>>/>
-</$list>
-</$vars>
-</td>
-<td>
-<$button>
+<$button class="tc-btn-invisible tc-btn-dropdown">
 <$action-navigate $to={{!!title}}/>
 {{$:/core/images/folder}}
 </$button>
-<$button>
+<$button class="tc-btn-invisible tc-btn-dropdown">
 <$action-deletetiddler $tiddler={{!!title}}/>
 {{$:/core/images/delete-button}}
 </$button>
@@ -39,7 +39,7 @@ Note that the macros are loaded on startup, so please refresh the page when new 
 <tr>
 <td><$edit-text tiddler="$:/state/katex-new-macro" tag="input" default=""/></td>
 <td><$edit-text tiddler="$:/state/katex-new-command" tag="input" default=""/></td>
-<td></td>
+<td><<katex-escape {{$:/state/katex-new-command}}>></td>
 <td><$button>
 <$action-createtiddler $basetitle="$:/plugins/tiddlywiki/katex/macros/macro" tags="$:/tags/katex/macro" type="text/plain" macro={{$:/state/katex-new-macro}} text={{$:/state/katex-new-command}}/>
 {{$:/language/EditTemplate/Fields/Add/Button}}
@@ -54,7 +54,10 @@ Note that the macros are loaded on startup, so please refresh the page when new 
 You can add entries like `\ZZ`, `\mathbb{Z}`, which will render as <$latex text="\mathbb{Z}"/>.
 </li>
 <li>
-An entry mapping `\dd` to `\frac{d#1}{d#2}` will create a macro with two arguments; `\dd{f}{x}` will then render as <$latex text="\frac{df}{dx}"/>. The arguments should only appear in the command and not the macro itself.
+An entry mapping `\dd#1#2` to `\frac{d#1}{d#2}` will create a macro with two arguments; `\dd{f}{x}` will then render as <$latex text="\frac{df}{dx}"/>.
+</li>
+<li>
+Note that the macros defined here have higher priority than those defined using `\gdef`. Also, deleted macros will continue to exist until a full refresh.
 </li>
 </ul>
 </details>

--- a/plugins/tiddlywiki/katex/wrapper.js
+++ b/plugins/tiddlywiki/katex/wrapper.js
@@ -16,6 +16,16 @@ var katex = require("$:/plugins/tiddlywiki/katex/katex.min.js"),
     chemParse = require("$:/plugins/tiddlywiki/katex/mhchem.min.js"),
 	Widget = require("$:/core/modules/widgets/widget.js").widget;
 
+katex.macros = {};
+(function() {
+	var tid, m, v;
+	for (const t of $tw.wiki.getTiddlersWithTag("$:/tags/katex/macro")) {
+		tid = $tw.wiki.getTiddler(t);
+		m = tid.fields["macro"];
+		v = tid.fields["text"];
+		katex.macros[m] = v;
+	};
+})();
 var KaTeXWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
@@ -38,7 +48,7 @@ KaTeXWidget.prototype.render = function(parent,nextSibling) {
 	var displayMode = this.getAttribute("displayMode",this.parseTreeNode.displayMode || "false") === "true";
 	// Render it into a span
 	var span = this.document.createElement("span"),
-		options = {throwOnError: false, displayMode: displayMode};
+		options = {throwOnError: false, displayMode: displayMode, macros: katex.macros};
 	try {
 		if(!this.document.isTiddlyWikiFakeDom) {
 			katex.render(text,span,options);

--- a/plugins/tiddlywiki/katex/wrapper.js
+++ b/plugins/tiddlywiki/katex/wrapper.js
@@ -24,7 +24,7 @@ katex.updateMacros = function() {
 	for (var i=0; i < tiddlers.length; i++) {
 		tid = $tw.wiki.getTiddler(tiddlers[i]);
 		try {
-			macro = tid.fields["macro"];
+			macro = tid.fields["caption"];
 			macro = macro.replace(regex, "");
 			cmd = tid.fields["text"];
 			katex.macros[macro] = cmd;

--- a/plugins/tiddlywiki/katex/wrapper.js
+++ b/plugins/tiddlywiki/katex/wrapper.js
@@ -18,10 +18,11 @@ var katex = require("$:/plugins/tiddlywiki/katex/katex.min.js"),
 
 katex.macros = {};
 katex.updateMacros = function() {
-	var tid, macro, cmd;
-	const regex = /#\d/g; // Remove the arguments like #1#2
-	for (const t of $tw.wiki.getTiddlersWithTag("$:/tags/katex/macro")) {
-		tid = $tw.wiki.getTiddler(t);
+	var tiddlers = $tw.wiki.getTiddlersWithTag("$:/tags/katex/macro"),
+		regex = /#\d/g, // Remove the arguments like #1#2
+		tid, macro, cmd;
+	for (var i=0; i < tiddlers.length; i++) {
+		tid = $tw.wiki.getTiddler(tiddlers[i]);
 		macro = tid.fields["macro"];
 		macro = macro.replace(regex, "");
 		cmd = tid.fields["text"];

--- a/plugins/tiddlywiki/katex/wrapper.js
+++ b/plugins/tiddlywiki/katex/wrapper.js
@@ -23,10 +23,13 @@ katex.updateMacros = function() {
 		tid, macro, cmd;
 	for (var i=0; i < tiddlers.length; i++) {
 		tid = $tw.wiki.getTiddler(tiddlers[i]);
-		macro = tid.fields["macro"];
-		macro = macro.replace(regex, "");
-		cmd = tid.fields["text"];
-		katex.macros[macro] = cmd;
+		try {
+			macro = tid.fields["macro"];
+			macro = macro.replace(regex, "");
+			cmd = tid.fields["text"];
+			katex.macros[macro] = cmd;
+		} catch(ex) {// Catch the bad ones
+		};
 	};
 };
 

--- a/plugins/tiddlywiki/katex/wrapper.js
+++ b/plugins/tiddlywiki/katex/wrapper.js
@@ -17,15 +17,18 @@ var katex = require("$:/plugins/tiddlywiki/katex/katex.min.js"),
 	Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 katex.macros = {};
-(function() {
-	var tid, m, v;
+katex.updateMacros = function() {
+	var tid, macro, cmd;
+	const regex = /#\d/g; // Remove the arguments like #1#2
 	for (const t of $tw.wiki.getTiddlersWithTag("$:/tags/katex/macro")) {
 		tid = $tw.wiki.getTiddler(t);
-		m = tid.fields["macro"];
-		v = tid.fields["text"];
-		katex.macros[m] = v;
+		macro = tid.fields["macro"];
+		macro = macro.replace(regex, "");
+		cmd = tid.fields["text"];
+		katex.macros[macro] = cmd;
 	};
-})();
+};
+
 var KaTeXWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
@@ -46,6 +49,7 @@ KaTeXWidget.prototype.render = function(parent,nextSibling) {
 	// Get the source text
 	var text = this.getAttribute("text",this.parseTreeNode.text || "");
 	var displayMode = this.getAttribute("displayMode",this.parseTreeNode.displayMode || "false") === "true";
+	katex.updateMacros();
 	// Render it into a span
 	var span = this.document.createElement("span"),
 		options = {throwOnError: false, displayMode: displayMode, macros: katex.macros};

--- a/plugins/tiddlywiki/katex/wrapper.js
+++ b/plugins/tiddlywiki/katex/wrapper.js
@@ -18,7 +18,7 @@ var katex = require("$:/plugins/tiddlywiki/katex/katex.min.js"),
 
 katex.macros = {};
 katex.updateMacros = function() {
-	var tiddlers = $tw.wiki.getTiddlersWithTag("$:/tags/katex/macro"),
+	var tiddlers = $tw.wiki.getTiddlersWithTag("$:/tags/KaTeX/Macro"),
 		regex = /#\d/g, // Remove the arguments like #1#2
 		tid, macro, cmd;
 	for (var i=0; i < tiddlers.length; i++) {


### PR DESCRIPTION
...as requested in https://github.com/Jermolene/TiddlyWiki5/issues/4375, with a nice UI :)

![katex](https://user-images.githubusercontent.com/69371221/128250172-9d43ba86-e0e4-4fef-ad04-c44327907200.png)

**Update.** Added a few tweaks: no need to refresh for new macros now, and macros with arguments can be added with `#` (`\dd#1#2` in the above example).