### PR TITLE
fakedom to use text encoder for html text

### DIFF
--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -235,7 +235,7 @@ Object.defineProperty(TW_Element.prototype, "innerHTML", {
 				if(node instanceof TW_Element) {
 					b.push(node.outerHTML);
 				} else if(node instanceof TW_TextNode) {
-					b.push($tw.utils.htmlEncode(node.textContent));
+					b.push($tw.utils.htmlTextEncode(node.textContent));
 				}
 			});
 			return b.join("");


### PR DESCRIPTION
The fakedom can use the htmlTextEncode when encoding text content.  This makes transcludes and ViewWidgets a little more efficient. It no longer unnecessarily escapes " into &amp;quot;

Since TiddlyWiki is moving to a JSON store for tiddlers, this doesn't cause any savings to the file size, but it does for anyone using transclusion to generate files (like me).