### PR TITLE
Remove stray characters in example of :map prefix

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
@@ -8,7 +8,7 @@ Replace the input titles with the caption field if it exists, otherwise preserve
 
 <<.operator-example 1 "[tag[Widgets]] :map[get[caption]else{!!title}]">>
 
-<<.tip "The above example is equivalent to `[tag[Widgets]] :map[get[{!!caption}!is[blank]else{!!title}]`. Note that referencing a field as a text reference such as `{!!caption}` returns an empty string for a non-existent or empty caption field. Therefore a check for `is[blank]` is needed before the `else` operator">>
+<<.tip "The above example is equivalent to `[tag[Widgets]] :map[{!!caption}!is[blank]else{!!title}]`. Note that referencing a field as a text reference such as `{!!caption}` returns an empty string for a non-existent or empty caption field. Therefore a check for `is[blank]` is needed before the `else` operator">>
 
 
 For each title in a shopping list, calculate the total cost of purchasing each item:


### PR DESCRIPTION
Nitpick fix in the new prerelease documentation – an extra, invalid `get[` is included in the alternative example, presumably due to a copy-paste error.