### PR TITLE
Add `m` flag for multiline matches to search-replace filter operator

### DIFF
--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -119,7 +119,7 @@ exports["search-replace"] = function(source,operator,options) {
 	var results = [],
 		suffixes = operator.suffixes || [],
 		flagSuffix = (suffixes[0] ? (suffixes[0][0] || "") : ""),
-		flags = (flagSuffix.indexOf("g") !== -1 ? "g" : "") + (flagSuffix.indexOf("i") !== -1 ? "i" : ""),
+		flags = (flagSuffix.indexOf("g") !== -1 ? "g" : "") + (flagSuffix.indexOf("i") !== -1 ? "i" : "") + (flagSuffix.indexOf("m") !== -1 ? "m" : ""),
 		isRegExp = (suffixes[1] && suffixes[1][0] === "regexp") ? true : false,
 		searchTerm,
 		regExp;

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -779,7 +779,8 @@ function runTests(wiki) {
 		var anchorWidget = rootWidget.children[0];
 		rootWidget.setVariable("var1","different");
 		rootWidget.setVariable("myregexp1","e|o");
-		rootWidget.setVariable("myregexp2","^(?!Unlike).*$");
+		rootWidget.setVariable("myregexp2","^Unlike ");
+		rootWidget.setVariable("myregexp3","^(?!Unlike).*$");
 		rootWidget.setVariable("name","(\w+)\s(\w+)");
 		expect(wiki.filterTiddlers("[[Welcome to TiddlyWiki, a unique non-linear webpage.]search-replace[webpage],[notebook]]").join(",")).toBe("Welcome to TiddlyWiki, a unique non-linear notebook.");
 		expect(wiki.filterTiddlers("[[Welcome to TiddlyWiki, a unique non-linear notebook.]search-replace[unique],<var1>]",anchorWidget).join(",")).toBe("Welcome to TiddlyWiki, a different non-linear notebook.");
@@ -787,8 +788,9 @@ function runTests(wiki) {
 		expect(wiki.filterTiddlers("[[Hello There]search-replace:g:regexp<myregexp1>,[]]",anchorWidget).join(",")).toBe("Hll Thr");
 		expect(wiki.filterTiddlers("[[Hello There]search-replace::regexp<myregexp1>,[]]",anchorWidget).join(",")).toBe("Hllo There");
 		expect(wiki.filterTiddlers("[[Hello There]search-replace:gi[H],[]]",anchorWidget).join(",")).toBe("ello Tere");
-		expect(wiki.filterTiddlers("[[Unlike conventional online services, TiddlyWiki lets you choose where to keep your data]search-replace:gm[c],[C]]",anchorWidget).join(",")).toBe("Unlike Conventional online serviCes, TiddlyWiki lets you Choose where to keep your data");
-		expect(wiki.filterTiddlers("[[Hello There\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\nguaranteeing that in the decades to come you will still be able to use the notes you take today.]search-replace:gm:regexp<myregexp2>,[]]",anchorWidget).join(",")).toBe("\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\n");
+		expect(wiki.filterTiddlers("[[Unlike conventional online services, TiddlyWiki lets you choose where to keep your data\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data]search-replace:g:regexp<myregexp2>,[]]",anchorWidget).join(",")).toBe("conventional online services, TiddlyWiki lets you choose where to keep your data\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data");
+		expect(wiki.filterTiddlers("[[Unlike conventional online services, TiddlyWiki lets you choose where to keep your data\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data]search-replace:gm:regexp<myregexp2>,[]]",anchorWidget).join(",")).toBe("conventional online services, TiddlyWiki lets you choose where to keep your data\nconventional online services, TiddlyWiki lets you choose where to keep your data\nconventional online services, TiddlyWiki lets you choose where to keep your data\nconventional online services, TiddlyWiki lets you choose where to keep your data");
+		expect(wiki.filterTiddlers("[[Hello There\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\nguaranteeing that in the decades to come you will still be able to use the notes you take today.]search-replace:gm:regexp<myregexp3>,[]]",anchorWidget).join(",")).toBe("\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\n");
 	});
 	
 	it("should handle the pad operator", function() {

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -779,7 +779,7 @@ function runTests(wiki) {
 		var anchorWidget = rootWidget.children[0];
 		rootWidget.setVariable("var1","different");
 		rootWidget.setVariable("myregexp1","e|o");
-		rootWidget.setVariable("myregexp2","^(?!^Unlike.*\n).*");
+		rootWidget.setVariable("myregexp2","^(?!Unlike).*$");
 		rootWidget.setVariable("name","(\w+)\s(\w+)");
 		expect(wiki.filterTiddlers("[[Welcome to TiddlyWiki, a unique non-linear webpage.]search-replace[webpage],[notebook]]").join(",")).toBe("Welcome to TiddlyWiki, a unique non-linear notebook.");
 		expect(wiki.filterTiddlers("[[Welcome to TiddlyWiki, a unique non-linear notebook.]search-replace[unique],<var1>]",anchorWidget).join(",")).toBe("Welcome to TiddlyWiki, a different non-linear notebook.");

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -778,14 +778,17 @@ function runTests(wiki) {
 		rootWidget.makeChildWidgets();
 		var anchorWidget = rootWidget.children[0];
 		rootWidget.setVariable("var1","different");
-		rootWidget.setVariable("myregexp","e|o");
+		rootWidget.setVariable("myregexp1","e|o");
+		rootWidget.setVariable("myregexp2","^(?!^Unlike.*\n).*");
 		rootWidget.setVariable("name","(\w+)\s(\w+)");
 		expect(wiki.filterTiddlers("[[Welcome to TiddlyWiki, a unique non-linear webpage.]search-replace[webpage],[notebook]]").join(",")).toBe("Welcome to TiddlyWiki, a unique non-linear notebook.");
 		expect(wiki.filterTiddlers("[[Welcome to TiddlyWiki, a unique non-linear notebook.]search-replace[unique],<var1>]",anchorWidget).join(",")).toBe("Welcome to TiddlyWiki, a different non-linear notebook.");
 		expect(wiki.filterTiddlers("[[Welcome to TiddlyWiki, a unique non-linear notebook.]search-replace[TiddlyWiki],{one}]",anchorWidget).join(",")).toBe("Welcome to This is the text of tiddler [[one]], a unique non-linear notebook.");
-		expect(wiki.filterTiddlers("[[Hello There]search-replace:g:regexp<myregexp>,[]]",anchorWidget).join(",")).toBe("Hll Thr");
-		expect(wiki.filterTiddlers("[[Hello There]search-replace::regexp<myregexp>,[]]",anchorWidget).join(",")).toBe("Hllo There");
-		expect(wiki.filterTiddlers("[[Hello There]search-replace:gi[H],[]]",anchorWidget).join(",")).toBe("ello Tere");	
+		expect(wiki.filterTiddlers("[[Hello There]search-replace:g:regexp<myregexp1>,[]]",anchorWidget).join(",")).toBe("Hll Thr");
+		expect(wiki.filterTiddlers("[[Hello There]search-replace::regexp<myregexp1>,[]]",anchorWidget).join(",")).toBe("Hllo There");
+		expect(wiki.filterTiddlers("[[Hello There]search-replace:gi[H],[]]",anchorWidget).join(",")).toBe("ello Tere");
+		expect(wiki.filterTiddlers("[[Unlike conventional online services, TiddlyWiki lets you choose where to keep your data]search-replace:gm[c],[C]]",anchorWidget).join(",")).toBe("Unlike Conventional online serviCes, TiddlyWiki lets you Choose where to keep your data");
+		expect(wiki.filterTiddlers("[[Hello There\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\nguaranteeing that in the decades to come you will still be able to use the notes you take today.]search-replace:gm:regexp<myregexp2>,[]]",anchorWidget).join(",")).toBe("\nUnlike conventional online services, TiddlyWiki lets you choose where to keep your data\n");
 	});
 	
 	it("should handle the pad operator", function() {

--- a/editions/tw5.com/tiddlers/filters/examples/search-replace Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/search-replace Operator (Examples).tid
@@ -6,6 +6,8 @@ type: text/vnd.tiddlywiki
 
 \define myregexp() e|o
 
+\define myregexp2() ^(?!Unlike).*$
+
 \define names() (\w+)\s(\w+)
 
 Replace one string with another:
@@ -22,5 +24,9 @@ Replace all matches of a string irrespective of case:
 You can also use regular expression capture groups in the replacement string:
 `\define names() (\w+)\s(\w+)`
 <<.operator-example 4 """[[John Smith]search-replace::regexp<names>,[$2,$1]]""" >>
+
+To replace everything but a match using a regular expression and the ''multiline'' (m) flag:
+`\define myregexp2() ^(?!Unlike).*$`
+<<.operator-example 5 """[[Hello There]get[text]search-replace:gm:regexp<myregexp2>,[]]""">>
 
 {{How to remove stop words}}

--- a/editions/tw5.com/tiddlers/filters/examples/search-replace Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/search-replace Operator (Examples).tid
@@ -27,6 +27,6 @@ You can also use regular expression capture groups in the replacement string:
 
 To replace everything but a match using a regular expression and the ''multiline'' (m) flag:
 `\define myregexp2() ^(?!Unlike).*$`
-<<.operator-example 5 """[[Hello There]get[text]search-replace:gm:regexp<myregexp2>,[]]""">>
+<<.operator-example 5 """[[HelloThere]get[text]search-replace:gm:regexp<myregexp2>,[]]""">>
 
 {{How to remove stop words}}

--- a/editions/tw5.com/tiddlers/filters/search-replace Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/search-replace Operator.tid
@@ -18,7 +18,7 @@ The <<.op search-replace>> operator uses an extended syntax that allows for mult
 [search-replace:<flag list>:<regexp-mode>[<search-term>],[<replacement>]]
 ```
 
-* ''flag-list'': ''g'' for global mode to replace all matches, ''i'' for case-insensitive mode, "gi" for both. (optional)
+* ''flag-list'': ''g'' for global mode to replace all matches, ''i'' for case-insensitive mode, ''m'' for multiline mode, "gim" for all. (optional)
 * ''regexp-mode'': ''regexp'' to treat the first parameter as a regular expression (optional).
 * ''search-term'': string or regular expression that should be replaced
 * ''replacement'': string that should replace the search-term


### PR DESCRIPTION
This PR adds the multiline flag to the search-replace operator
It also updates documentation and adds two tests