### PR TITLE
fix some typos in the ViewTolbar button docs

### DIFF
--- a/editions/es-ES/tiddlers/Page_and_tiddler_layout_customisation.tid
+++ b/editions/es-ES/tiddlers/Page_and_tiddler_layout_customisation.tid
@@ -54,7 +54,7 @@ title="New tiddler"
 
 #* Asígnale la etiqueta <<.tag ~$:/tags/ViewToolbar]]>>
 
-# Hay que crear un tiddler que le diga a ~TiddlyWIki si el botón será o no visible en la barra. Llamémosle por ejemplo <<.tid "~$:/config/ViewToolbarButtons/Visibility/Receta"">>. Escribe `reveal` en el cuerpo y guárdalo.
+# Hay que crear un tiddler que le diga a ~TiddlyWIki si el botón será o no visible en la barra. Llamémosle por ejemplo <<.tid "~$:/config/ViewToolbarButtons/Visibility/Receta"">>. Escribe `show` en el cuerpo y guárdalo.
 
 # Habrá que posicionar el botón adecuadamente. Abre el tiddler <<.tid ~$:/tags/ViewToolbar>> e inserta el nombre de tu botón en el lugar adecuado del campo <<.field list>>.
 

--- a/editions/fr-FR/tiddlers/Page and tiddler layout customisation.tid
+++ b/editions/fr-FR/tiddlers/Page and tiddler layout customisation.tid
@@ -25,7 +25,7 @@ Imaginons que vous ayez un tiddler squelette appelé 'Modèle Recette', et que v
 
 # Pour illustrer votre bouton, si aucune des images du noyau (tiddlers shadow préfixés par $:/core/images/ ) n'est à votre convenance, vous devrez la créer ou en obtenir une au format SVG (par exemple, une de celles de http://flaticon.com), glissez-la dans votre fichier pour la transformer en tiddler, modifiez le tiddler et ajustez sa hauteur et sa largeur à 22px
 #Passons au tiddler contenant votre tiddler. Créez-le, titrez-le et ajoutez le code du bouton (voir le code ci-dessous par exemple, en l'adaptant à vos besoins si nécessaire) Étiquetez-le par [[$:/tags/ViewToolbar]]
-#Contrôlons la visibilité de votre tiddler dans la barre d'outil par la création d'un tiddler à titrer [[$:/config/ViewToolbarButtons/Visibility/Recette]]. Saisissez `reveal`dans la zone texte et sauvegardez.
+#Contrôlons la visibilité de votre tiddler dans la barre d'outil par la création d'un tiddler à titrer [[$:/config/ViewToolbarButtons/Visibility/Recette]]. Saisissez `show`dans la zone texte et sauvegardez.
 #Enfin, positionnons le bouton proprement. Ouvrez le tiddler $:/tags/ViewToolbar et insérez le titre de votre tiddler bouton (cf. titre étape précédente) dans le champ field au bon endroit.
 
 ```

--- a/editions/tw5.com/tiddlers/concepts/ShadowTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/ShadowTiddlers.tid
@@ -1,3 +1,6 @@
+title: ShadowTiddlers
+tags: Concepts
+
 \define actions()
 <$action-setfield $tiddler="$:/state/tab/moresidebar-1850697562" $field="text" $value="$:/core/ui/MoreSideBar/Shadows"/>
 <$action-setfield $tiddler="$:/state/tab/sidebar--595412856" $field="text" $value="$:/core/ui/SideBar/More"/>

--- a/editions/tw5.com/tiddlers/customising/Page and tiddler layout customisation.tid
+++ b/editions/tw5.com/tiddlers/customising/Page and tiddler layout customisation.tid
@@ -26,7 +26,7 @@ Let's say you have a skeleton tiddler called 'Recipe template', and you want to 
 
 # You will want an image for your button. If none of the core images (shadow tiddlers with the prefix $:/core/images/) work for you, then you will need to create or acquire an SVG image (for example, one of the images at http://flaticon.com), drag it into your file so that it becomes a tiddler, edit the tiddler and adjust the height and width to 22px
 # You will want to create the tiddler that contains your tiddler. Create it, title it, and add the button code (see the code at the bottom of this tiddler for an example, with hints where you will need to adapt it). Tag it [[$:/tags/ViewToolbar]]
-# You will need to create a tiddler that tells TiddlyWiki whether your button should be visible in the toolbar or hidden. Let's title it [[$:/config/ViewToolbarButtons/Visibility/Recipe]]. Type `reveal` into the text area, and save.
+# You will need to create a tiddler that tells TiddlyWiki whether your button should be visible in the toolbar or hidden. Let's title it [[$:/config/ViewToolbarButtons/Visibility/Recipe]]. Type `show` into the text area, and save. If you want to hide it, type `hide` into the text area and save. The button will also be accessable from the ''ControlPanel : Appearance : Toolbars : ViewToolbar'' tab
 # You will want to position the button properly. Open the tiddler $:/tags/ViewToolbar and insert your button tiddler's title in the appropriate place in the list field.
 
 ```


### PR DESCRIPTION
This PR fixes a type in the ViewTemplate toolbar buttons docs. Since the configuration text is English I could fix all languages that contain the issue.