### PR TITLE
Make Stamp-Dropdown sortable by Drag&Drop

### DIFF
--- a/core/ui/EditorToolbar/stamp-dropdown-item-template.tid
+++ b/core/ui/EditorToolbar/stamp-dropdown-item-template.tid
@@ -2,6 +2,8 @@ title: $:/core/ui/EditorToolbar/StampDropdown/ItemTemplate
 
 <$linkcatcher actions="""
 
+<$list filter="[<modifier>!match[ctrl]]" variable="ignore">
+
 <$list filter="[<currentTiddler>addsuffix[/prefix]is[missing]removesuffix[/prefix]addsuffix[/suffix]is[missing]]" variable="ignore">
 
 <$action-sendmessage
@@ -21,6 +23,14 @@ title: $:/core/ui/EditorToolbar/StampDropdown/ItemTemplate
 	prefix={{{ [<currentTiddler>addsuffix[/prefix]get[text]] }}}
   suffix={{{ [<currentTiddler>addsuffix[/suffix]get[text]] }}}
 />
+
+</$list>
+
+</$list>
+
+<$list filter="[<modifier>match[ctrl]]" variable="ignore">
+
+<$action-sendmessage $message="tm-edit-tiddler"/>
 
 </$list>
 

--- a/core/ui/EditorToolbar/stamp-dropdown-item-template.tid
+++ b/core/ui/EditorToolbar/stamp-dropdown-item-template.tid
@@ -1,0 +1,43 @@
+title: $:/core/ui/EditorToolbar/StampDropdown/ItemTemplate
+
+<$linkcatcher actions="""
+
+<$list filter="[<currentTiddler>addsuffix[/prefix]is[missing]removesuffix[/prefix]addsuffix[/suffix]is[missing]]" variable="ignore">
+
+<$action-sendmessage
+	$message="tm-edit-text-operation"
+	$param="replace-selection"
+	text={{{ [<currentTiddler>get[text]] }}}
+/>
+
+</$list>
+
+
+<$list filter="[<currentTiddler>addsuffix[/prefix]is[missing]removesuffix[/prefix]addsuffix[/suffix]!is[missing]] [<currentTiddler>addsuffix[/prefix]!is[missing]removesuffix[/prefix]addsuffix[/suffix]is[missing]] [<currentTiddler>addsuffix[/prefix]!is[missing]removesuffix[/prefix]addsuffix[/suffix]!is[missing]]" variable="ignore">
+
+<$action-sendmessage
+	$message="tm-edit-text-operation"
+	$param="wrap-selection"
+	prefix={{{ [<currentTiddler>addsuffix[/prefix]get[text]] }}}
+  suffix={{{ [<currentTiddler>addsuffix[/suffix]get[text]] }}}
+/>
+
+</$list>
+
+<$action-deletetiddler
+	$tiddler=<<dropdown-state>>
+/>
+
+""">
+
+<$link>
+
+<$transclude tiddler=<<currentTiddler>> field="caption" mode="inline">
+
+<$view tiddler=<<currentTiddler>> field="title" />
+
+</$transclude>
+
+</$link>
+
+</$linkcatcher>

--- a/core/ui/EditorToolbar/stamp-dropdown-item-template.tid
+++ b/core/ui/EditorToolbar/stamp-dropdown-item-template.tid
@@ -40,7 +40,7 @@ title: $:/core/ui/EditorToolbar/StampDropdown/ItemTemplate
 
 """>
 
-<$link>
+<$link tooltip={{{ [<currentTiddler>get[description]] }}}>
 
 <$transclude tiddler=<<currentTiddler>> field="caption" mode="inline">
 

--- a/core/ui/EditorToolbar/stamp-dropdown.tid
+++ b/core/ui/EditorToolbar/stamp-dropdown.tid
@@ -1,48 +1,6 @@
 title: $:/core/ui/EditorToolbar/stamp-dropdown
 
-\define toolbar-button-stamp-inner()
-<$button tag="a">
-
-<$list filter="[[$(snippetTitle)$]addsuffix[/prefix]is[missing]removesuffix[/prefix]addsuffix[/suffix]is[missing]]">
-
-<$action-sendmessage
-	$message="tm-edit-text-operation"
-	$param="replace-selection"
-	text={{$(snippetTitle)$}}
-/>
-
-</$list>
-
-
-<$list filter="[[$(snippetTitle)$]addsuffix[/prefix]is[missing]removesuffix[/prefix]addsuffix[/suffix]!is[missing]] [[$(snippetTitle)$]addsuffix[/prefix]!is[missing]removesuffix[/prefix]addsuffix[/suffix]is[missing]] [[$(snippetTitle)$]addsuffix[/prefix]!is[missing]removesuffix[/prefix]addsuffix[/suffix]!is[missing]]">
-
-<$action-sendmessage
-	$message="tm-edit-text-operation"
-	$param="wrap-selection"
-	prefix={{{ [[$(snippetTitle)$]addsuffix[/prefix]get[text]] }}}
-suffix={{{ [[$(snippetTitle)$]addsuffix[/suffix]get[text]] }}}
-/>
-
-</$list>
-
-<$action-deletetiddler
-	$tiddler=<<dropdown-state>>
-/>
-
-<$transclude tiddler=<<snippetTitle>> field="caption" mode="inline">
-
-<$view tiddler=<<snippetTitle>> field="title" />
-
-</$transclude>
-
-</$button>
-\end
-
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/TextEditor/Snippet]!has[draft.of]sort[caption]]" variable="snippetTitle">
-
-<<toolbar-button-stamp-inner>>
-
-</$list>
+<$macrocall $name="list-tagged-draggable" tag="$:/tags/TextEditor/Snippet" subFilter="!is[draft]" itemTemplate="$:/core/ui/EditorToolbar/StampDropdown/ItemTemplate"/>
 
 ----
 

--- a/core/ui/EditorToolbar/stamp.tid
+++ b/core/ui/EditorToolbar/stamp.tid
@@ -6,4 +6,5 @@ description: {{$:/language/Buttons/Stamp/Hint}}
 condition: [<targetTiddler>type[]] [<targetTiddler>get[type]prefix[text/]] [<targetTiddler>get[type]match[application/javascript]] [<targetTiddler>get[type]match[application/json]] [<targetTiddler>get[type]match[application/x-tiddler-dictionary]] [<targetTiddler>get[type]match[image/svg+xml]] +[first[]]
 shortcuts: ((stamp))
 dropdown: $:/core/ui/EditorToolbar/stamp-dropdown
+button-classes: tc-editortoolbar-stamp-button
 text:

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1321,6 +1321,15 @@ html body.tc-body.tc-single-tiddler-window {
 	padding: 0;
 }
 
+.tc-editor-toolbar button.tc-editortoolbar-stamp-button + .tc-popup .tc-drop-down > p {
+	margin: 0;
+	padding: 0;
+}
+
+.tc-text-editor-toolbar button.tc-editortoolbar-stamp-button + .tc-popup .tc-drop-down a.tc-tiddlylink {
+	font-weight: normal;
+}
+
 /*
 ** Adjustments for fluid-fixed mode
 */

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1326,7 +1326,7 @@ html body.tc-body.tc-single-tiddler-window {
 	padding: 0;
 }
 
-.tc-text-editor-toolbar button.tc-editortoolbar-stamp-button + .tc-popup .tc-drop-down a.tc-tiddlylink {
+.tc-editor-toolbar button.tc-editortoolbar-stamp-button + .tc-popup .tc-drop-down a.tc-tiddlylink {
 	font-weight: normal;
 }
 


### PR DESCRIPTION
This PR makes the Stamp-Dropdown items sortable by Drag&Drop
Therefor it uses the `list-tagged-draggable` macro and an additional `ItemTemplate`

This is very handy if a User has many Stamps and wants to order them by favourites