### PR TITLE
Fix #5980 - TiddlyWiki has a tiddler with garbled fields

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/ShadowTiddlers.tid
+++ b/editions/tw5.com/tiddlers/concepts/ShadowTiddlers.tid
@@ -1,3 +1,6 @@
+title: ShadowTiddlers
+tags: Concepts
+
 \define actions()
 <$action-setfield $tiddler="$:/state/tab/moresidebar-1850697562" $field="text" $value="$:/core/ui/MoreSideBar/Shadows"/>
 <$action-setfield $tiddler="$:/state/tab/sidebar--595412856" $field="text" $value="$:/core/ui/SideBar/More"/>


### PR DESCRIPTION
The `title` and `tags` fields were missing for the tiddler `ShadowTiddlers`