### PR TITLE
Make plugin-info states system tiddlers

### DIFF
--- a/core/ui/Components/plugin-info.tid
+++ b/core/ui/Components/plugin-info.tid
@@ -3,7 +3,7 @@ title: $:/core/ui/Components/plugin-info
 \define lingo-base() $:/language/ControlPanel/Plugins/
 
 \define popup-state-macro()
-$(qualified-state)$-$(currentTiddler)$
+$:/state$(qualified-state)$-$(currentTiddler)$
 \end
 
 \define tabs-state-macro()


### PR DESCRIPTION
When we currently open the `plugin-info` of the `$:/core/ui/Components/plugin-info` tiddler (and plugins that use it as a template) an annoying state tiddler gets created that shows up under the `Recent` tab. The states of the `$:/core/ui/Components/plugin-info` aren't prefixed with `$:/state`

This PR solves this problem with an easy fix