### PR TITLE
Make ctrl-click in image-picker edit the image tiddler

### DIFF
--- a/core/ui/EditorToolbar/picture-dropdown.tid
+++ b/core/ui/EditorToolbar/picture-dropdown.tid
@@ -8,11 +8,24 @@ title: $:/core/ui/EditorToolbar/picture-dropdown
 
 <$macrocall $name="image-picker" actions="""
 
+<$list filter="[<modifier>!match[ctrl]]" variable="ignore">
+
 <$action-sendmessage
 	$message="tm-edit-text-operation"
 	$param="replace-selection"
 	text=<<replacement-text>>
 />
+
+</$list>
+
+<$list filter="[<modifier>match[ctrl]]" variable="ignore">
+
+<$action-sendmessage
+	$message="tm-edit-tiddler"
+	$param=<<imageTitle>>
+/>
+
+</$list>
 
 <$action-deletetiddler
 	$tiddler=<<dropdown-state>>

--- a/core/wiki/macros/image-picker.tid
+++ b/core/wiki/macros/image-picker.tid
@@ -5,8 +5,7 @@ title: $:/core/macros/image-picker
 type: text/vnd.tiddlywiki
 
 \define image-picker-thumbnail(actions)
-<$button tag="a" tooltip="""$(imageTitle)$""">
-$actions$
+<$button tag="a" tooltip="""$(imageTitle)$""" actions="""$actions$""">
 <$transclude tiddler=<<imageTitle>>/>
 </$button>
 \end


### PR DESCRIPTION
This PR makes <kbc>ctrl</kbd>-click open the image tiddler from the image-picker for editing