### PR TITLE
Make editor-preview open on a per-tiddler basis

### DIFF
--- a/core/ui/EditTemplate/body.tid
+++ b/core/ui/EditTemplate/body.tid
@@ -10,6 +10,8 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 <$action-popup $state=<<importState>> $coords="(0,0,0,0)" $floating="yes"/>
 \end
 
+\define edit-preview-state() $:/state/showeditpreview/$(storyTiddler)$
+
 <$list filter="[all[current]has[_canonical_uri]]">
 
 <div class="tc-message-box">
@@ -26,7 +28,7 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 
 <$list filter="[all[current]!has[_canonical_uri]]">
 <$vars importTitle=<<qualify $:/ImportImage>> importState=<<qualify $:/state/ImportImage>> >
-<$dropzone importTitle=<<importTitle>> autoOpenOnImport="no" contentTypesFilter={{$:/config/Editor/ImportContentTypesFilter}} class="tc-dropzone-editor" enable={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}} filesOnly="yes" actions=<<importFileActions>> ><$reveal state="$:/state/showeditpreview" type="match" text="yes">
+<$dropzone importTitle=<<importTitle>> autoOpenOnImport="no" contentTypesFilter={{$:/config/Editor/ImportContentTypesFilter}} class="tc-dropzone-editor" enable={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}} filesOnly="yes" actions=<<importFileActions>> ><$reveal stateTitle=<<edit-preview-state>> type="match" text="yes">
 <div class="tc-tiddler-preview">
 
 <$transclude tiddler="$:/core/ui/EditTemplate/body/editor" mode="inline"/>
@@ -44,7 +46,7 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 </div>
 </$reveal>
 
-<$reveal state="$:/state/showeditpreview" type="nomatch" text="yes">
+<$reveal stateTitle=<<edit-preview-state>> type="nomatch" text="yes">
 
 <$transclude tiddler="$:/core/ui/EditTemplate/body/editor" mode="inline"/>
 

--- a/core/ui/EditorToolbar/preview.tid
+++ b/core/ui/EditorToolbar/preview.tid
@@ -8,11 +8,11 @@ condition: [<targetTiddler>]
 button-classes: tc-text-editor-toolbar-item-start-group
 shortcuts: ((preview))
 
-<$reveal state="$:/state/showeditpreview" type="match" text="yes" tag="span">
+<$reveal state=<<edit-preview-state>> type="match" text="yes" tag="span">
 {{$:/core/images/preview-open}}
-<$action-setfield $tiddler="$:/state/showeditpreview" $value="no"/>
+<$action-setfield $tiddler=<<edit-preview-state>> $value="no"/>
 </$reveal>
-<$reveal state="$:/state/showeditpreview" type="nomatch" text="yes" tag="span">
+<$reveal state=<<edit-preview-state>> type="nomatch" text="yes" tag="span">
 {{$:/core/images/preview-closed}}
-<$action-setfield $tiddler="$:/state/showeditpreview" $value="yes"/>
+<$action-setfield $tiddler=<<edit-preview-state>> $value="yes"/>
 </$reveal>


### PR DESCRIPTION
This PR makes the editor preview open on a per-tiddler basis
That means that the preview toggle toggles the preview for the current tiddler only, not for all open tiddlers
This reduces the pretty heavy refreshing of all open tiddler-editors if there are many open in the story river