### PR TITLE
Make stamp-dropdown items that are suffixed and prefixed ...

### DIFF
--- a/core/ui/EditorToolbar/stamp-dropdown-item-template.tid
+++ b/core/ui/EditorToolbar/stamp-dropdown-item-template.tid
@@ -4,7 +4,7 @@ title: $:/core/ui/EditorToolbar/StampDropdown/ItemTemplate
 
 <$list filter="[<modifier>!match[ctrl]]" variable="ignore">
 
-<$list filter="[<currentTiddler>addsuffix[/prefix]is[missing]removesuffix[/prefix]addsuffix[/suffix]is[missing]]" variable="ignore">
+<$list filter="[<currentTiddler>addsuffix[/prefix]!is[tiddler]!is[shadow]removesuffix[/prefix]addsuffix[/suffix]!is[tiddler]!is[shadow]]" variable="ignore">
 
 <$action-sendmessage
 	$message="tm-edit-text-operation"
@@ -15,7 +15,7 @@ title: $:/core/ui/EditorToolbar/StampDropdown/ItemTemplate
 </$list>
 
 
-<$list filter="[<currentTiddler>addsuffix[/prefix]is[missing]removesuffix[/prefix]addsuffix[/suffix]!is[missing]] [<currentTiddler>addsuffix[/prefix]!is[missing]removesuffix[/prefix]addsuffix[/suffix]is[missing]] [<currentTiddler>addsuffix[/prefix]!is[missing]removesuffix[/prefix]addsuffix[/suffix]!is[missing]]" variable="ignore">
+<$list filter="[<currentTiddler>addsuffix[/prefix]] [<currentTiddler>addsuffix[/suffix]] +[is[shadow]] :else[is[tiddler]] +[limit[1]]" variable="ignore">
 
 <$action-sendmessage
 	$message="tm-edit-text-operation"


### PR DESCRIPTION
... work for shadow tiddlers, too

This PR is about stamp-dropdown snippets where a snippet with the tag `$:/tags/TextEditor/Snippet` exists and one or both of the tiddlers with the same title as the snippet-tiddler but with the suffix `/prefix` and the suffix `/suffix` exitst

Before this PR this worked only for non-shadow tiddlers. Now it also works for shadow tiddlers