### PR TITLE
Update link-widget refresh method

### DIFF
--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -207,7 +207,10 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 LinkWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.to || changedTiddlers[this.to] || changedAttributes["aria-label"] || changedAttributes.tooltip) {
+	var hideMissingLinks = (this.getVariable("tv-show-missing-links") || "yes") === "no";
+	if(changedAttributes.to || changedTiddlers[this.to] || changedAttributes["aria-label"] || changedAttributes.tooltip ||
+		changedAttributes["class"] || changedAttributes.tabindex || changedAttributes.draggable || changedAttributes.tag ||
+		hideMissingLinks !== this.hideMissingLinks) {
 		this.refreshSelf();
 		return true;
 	}


### PR DESCRIPTION
This PR updates the `<$link>` widgets refresh method
Maybe there's a reason it didn't refresh so often but I felt like it should refresh when those attributes change
