### PR TITLE
Better detection of scroll container and use of it in pop.js storyview

### DIFF
--- a/core/modules/storyviews/pop.js
+++ b/core/modules/storyviews/pop.js
@@ -38,18 +38,19 @@ PopStoryView.prototype.insert = function(widget) {
 	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
+	var scrollContainer = $tw.utils.getScrollContainer(targetElement);
 	// Reset once the transition is over
 	setTimeout(function() {
 		$tw.utils.setStyle(targetElement,[
 			{transition: "none"},
 			{transform: "none"}
 		]);
-		$tw.utils.setStyle(widget.document.body,[
+		$tw.utils.setStyle(scrollContainer,[
 			{"overflow-x": ""}
 		]);
 	},duration);
 	// Prevent the page from overscrolling due to the zoom factor
-	$tw.utils.setStyle(widget.document.body,[
+	$tw.utils.setStyle(scrollContainer,[
 		{"overflow-x": "hidden"}
 	]);
 	// Set up the initial position of the element

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -66,13 +66,23 @@ exports.toggleClass = function(el,className,status) {
 
 /*
 Get the first parent element that has scrollbars or use the body as fallback.
+From https://stackoverflow.com/questions/35939886/find-first-scrollable-parent
 */
 exports.getScrollContainer = function(el) {
 	var doc = el.ownerDocument;
-	while(el.parentNode) {
-		el = el.parentNode;
-		if(el.scrollTop) {
-			return el;
+	var style = getComputedStyle(el);
+	var excludeStaticParent = style.position === "absolute";
+	var overflowRegex = includeHidden ? /(auto|scroll|hidden)/ : /(auto|scroll)/;
+	if(style.position === "fixed") {
+		return doc.body;
+	}
+	for(var parent=el;(parent = parent.parentElement);) {
+		style = getComputedStyle(parent);
+		if(excludeStaticParent && style.position === "static") {
+			continue;
+		}
+		if(overflowRegex.test(style.overflow + style.overflowY + style.overflowX)) {
+			return parent;
 		}
 	}
 	return doc.body;


### PR DESCRIPTION
This PR adds a better detection-method for the `scroll container` of a target Element.
It uses a solution proposed at https://stackoverflow.com/questions/35939886/find-first-scrollable-parent which is a pure JS port of the jQuery UI scrollParent method

In my tests this works more reliable

This PR also uses `$tw.utils.getScrollContainer(targetElement)` in the `pop storyview` to prevent overflowing of the scroll container in x-direction when the insert animation is done