### PR TITLE
Pagescroller: use scrollContainer for scrolling. + Scrollposition store/restore

### DIFF
--- a/core/modules/startup/render.js
+++ b/core/modules/startup/render.js
@@ -70,11 +70,19 @@ exports.startup = function() {
 	var deferredChanges = Object.create(null),
 		timerId;
 	function refresh() {
+		var scrollableElements = $tw.utils.getScrollableElements(document);
+		var scrollPositions = [];
+		for(var i=0; i<scrollableElements.length; i++) {
+			scrollPositions.push($tw.utils.getScrollPosition(scrollableElements[i]));
+		}
 		// Process the refresh
 		$tw.hooks.invokeHook("th-page-refreshing");
 		$tw.pageWidgetNode.refresh(deferredChanges);
 		deferredChanges = Object.create(null);
 		$tw.hooks.invokeHook("th-page-refreshed");
+		for(var k=0; k<scrollableElements.length; k++) {
+			$tw.utils.setScrollPosition(scrollableElements[k],scrollPositions[k]);
+		}
 	}
 	// Add the change event handler
 	$tw.wiki.addEventListener("change",$tw.perf.report("mainRefresh",function(changes) {

--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -73,10 +73,18 @@ exports.startup = function() {
 		widgetNode.render(srcDocument.body,srcDocument.body.firstChild);
 		// Function to handle refreshes
 		refreshHandler = function(changes) {
+			var scrollableElements = $tw.utils.getScrollableElements(document);
+			var scrollPositions = [];
+			for(var i=0; i<scrollableElements.length; i++) {
+				scrollPositions.push($tw.utils.getScrollPosition(scrollableElements[i]));
+			}
 			if(styleWidgetNode.refresh(changes,styleContainer,null)) {
 				styleElement.innerHTML = styleContainer.textContent;
 			}
 			widgetNode.refresh(changes);
+			for(var k=0; k<scrollableElements.length; k++) {
+				$tw.utils.setScrollPosition(scrollableElements[k],scrollPositions[k]);
+			}
 		};
 		$tw.wiki.addEventListener("change",refreshHandler);
 		// Listen for keyboard shortcuts

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -64,18 +64,52 @@ exports.toggleClass = function(el,className,status) {
 	}
 };
 
-/*
-Get the first parent element that has scrollbars or use the body as fallback.
-*/
-exports.getScrollContainer = function(el) {
-	var doc = el.ownerDocument;
-	while(el.parentNode) {
-		el = el.parentNode;
-		if(el.scrollTop) {
-			return el;
+exports.getScrollableElements = function(doc) {
+	var elements = doc.querySelectorAll("*"),
+		scrollers = [];
+	for(var i=0; i<elements.length; i++) {
+		var scrollContainer = $tw.utils.getScrollContainer(elements[i]);
+		if(scrollers.indexOf(scrollContainer) === -1) {
+			scrollers.push(scrollContainer);
 		}
 	}
-	return doc.body;
+	return scrollers;
+};
+
+/*
+Get the first parent element that has scrollbars or use the body as fallback.
+From https://stackoverflow.com/questions/35939886/find-first-scrollable-parent/42543908#42543908
+*/
+exports.getScrollContainer = function(el,includeHidden) {
+	var doc = el.ownerDocument;
+	var style = getComputedStyle(el);
+	var excludeStaticParent = style.position === "absolute";
+	var overflowRegex = includeHidden ? /(auto|scroll|hidden)/ : /(auto|scroll)/;
+	if(style.position === "fixed") {
+		if("scrollingElement" in doc) {
+			return doc.scrollingElement;
+		}
+		if(navigator.userAgent.indexOf("WebKit") !== -1) {
+			return doc.body;
+		}
+		return doc.documentElement;
+	}
+	for(var parent=el; parent=parent.parentElement; ) {
+		style = getComputedStyle(parent);
+		if(excludeStaticParent && style.position === "static") {
+			continue;
+		}
+		if(overflowRegex.test(style.overflow + style.overflowY + style.overflowX)) {
+			return parent;
+		}
+	}
+	if("scrollingElement" in doc) {
+		return doc.scrollingElement;
+	}
+	if(navigator.userAgent.indexOf("WebKit") !== -1) {
+		return doc.body;
+	}
+	return doc.documentElement;
 };
 
 /*
@@ -86,12 +120,21 @@ Returns:
 		y: vertical scroll position in pixels
 	}
 */
-exports.getScrollPosition = function(srcWindow) {
-	var scrollWindow = srcWindow || window;
-	if("scrollX" in scrollWindow) {
-		return {x: scrollWindow.scrollX, y: scrollWindow.scrollY};
+exports.getScrollPosition = function(scrollContainer) {
+	if("scrollX" in scrollContainer) {
+		return {x: scrollContainer.scrollX, y: scrollContainer.scrollY};
 	} else {
-		return {x: scrollWindow.document.documentElement.scrollLeft, y: scrollWindow.document.documentElement.scrollTop};
+		return {x: scrollContainer.scrollLeft, y: scrollContainer.scrollTop};
+	}
+};
+
+exports.setScrollPosition = function(scrollContainer,scrollPosition) {
+	if("scrollX" in scrollContainer) {
+		scrollContainer.scrollX = scrollPosition.x;
+		scrollContainer.scrollY = scrollPosition.y;
+	} else {
+		scrollContainer.scrollLeft = scrollPosition.x;
+		scrollContainer.scrollTop = scrollPosition.y;
 	}
 };
 

--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -65,7 +65,8 @@ Handle a scroll event hitting the page document
 PageScroller.prototype.scrollIntoView = function(element,callback) {
 	var self = this,
 		duration = $tw.utils.getAnimationDuration(),
-	    srcWindow = element ? element.ownerDocument.defaultView : window;
+		srcWindow = element ? element.ownerDocument.defaultView : window,
+		scrollContainer = $tw.utils.getScrollContainer(element);
 	// Now get ready to scroll the body
 	this.cancelScroll(srcWindow);
 	this.startTime = Date.now();
@@ -78,7 +79,7 @@ PageScroller.prototype.scrollIntoView = function(element,callback) {
 	// Get the client bounds of the element and adjust by the scroll position
 	var getBounds = function() {
 			var clientBounds = typeof callback === 'function' ? callback() : element.getBoundingClientRect(),
-				scrollPosition = $tw.utils.getScrollPosition(srcWindow);
+				scrollPosition = $tw.utils.getScrollPosition(scrollContainer);
 			return {
 				left: clientBounds.left + scrollPosition.x,
 				top: clientBounds.top + scrollPosition.y - offset,
@@ -110,11 +111,12 @@ PageScroller.prototype.scrollIntoView = function(element,callback) {
 				t = 1;
 			}
 			t = $tw.utils.slowInSlowOut(t);
-			var scrollPosition = $tw.utils.getScrollPosition(srcWindow),
+			var scrollPosition = $tw.utils.getScrollPosition(scrollContainer),
 				bounds = getBounds(),
 				endX = getEndPos(bounds.left,bounds.width,scrollPosition.x,srcWindow.innerWidth),
 				endY = getEndPos(bounds.top,bounds.height,scrollPosition.y,srcWindow.innerHeight);
-			srcWindow.scrollTo(scrollPosition.x + (endX - scrollPosition.x) * t,scrollPosition.y + (endY - scrollPosition.y) * t);
+			scrollContainer.scrollLeft = scrollPosition.x + (endX - scrollPosition.x) * t;
+			scrollContainer.scrollTop = scrollPosition.y + (endY - scrollPosition.y) * t;
 			if(t < 1) {
 				self.idRequestFrame = self.requestAnimationFrame.call(srcWindow,drawFrame);
 			}


### PR DESCRIPTION
render.js and windows.js: store and restore scroll positions of all scrollable elements after a page refresh cycle

This PR does the following:

- In the pagescroller `scrollIntoView` method it detects the `scrollContainer` of the target element using `$tw.utils.getScrollContainer(element)` and scrolls that `scrollContainer` instead of using `window.scrollTo`. This approach is more flexible
- In `render.js` and `windows.js` it detects all scrollable elements before a refresh cycle and gets their scroll positions
- After a refresh, all scroll positions are restored

