### PR TITLE
Fix slide-open and slide-close animations

### DIFF
--- a/core/modules/utils/dom/animations/slide.js
+++ b/core/modules/utils/dom/animations/slide.js
@@ -23,7 +23,7 @@ function slideOpen(domNode,options) {
 		currPaddingTop = parseInt(computedStyle.paddingTop,10),
 		currHeight = domNode.offsetHeight;
 	// Reset the margin once the transition is over
-	setTimeout(function() {
+	var id = setTimeout(function() {
 		$tw.utils.setStyle(domNode,[
 			{transition: "none"},
 			{marginBottom: ""},
@@ -37,6 +37,7 @@ function slideOpen(domNode,options) {
 			options.callback();
 		}
 	},duration);
+	$tw.anim.animationId = id;
 	// Set up the initial position of the element
 	$tw.utils.setStyle(domNode,[
 		{transition: "none"},
@@ -70,7 +71,7 @@ function slideClosed(domNode,options) {
 	var duration = options.duration || $tw.utils.getAnimationDuration(),
 		currHeight = domNode.offsetHeight;
 	// Clear the properties we've set when the animation is over
-	setTimeout(function() {
+	var id = setTimeout(function() {
 		$tw.utils.setStyle(domNode,[
 			{transition: "none"},
 			{marginBottom: ""},
@@ -84,6 +85,7 @@ function slideClosed(domNode,options) {
 			options.callback();
 		}
 	},duration);
+	$tw.anim.animationId = id;
 	// Set up the initial position of the element
 	$tw.utils.setStyle(domNode,[
 		{height: currHeight + "px"},

--- a/core/modules/utils/dom/animator.js
+++ b/core/modules/utils/dom/animator.js
@@ -15,6 +15,7 @@ Orchestrates animations and transitions
 function Animator() {
 	// Get the registered animation modules
 	this.animations = {};
+	this.animationId = null;
 	$tw.modules.applyMethods("animation",this.animations);
 }
 
@@ -22,6 +23,10 @@ Animator.prototype.perform = function(type,domNode,options) {
 	options = options || {};
 	// Find an animation that can handle this type
 	var chosenAnimation;
+	if(this.animationId) {
+		domNode.ownerDocument.defaultView.clearTimeout(this.animationId);
+		this.animationId = null;
+	}
 	$tw.utils.each(this.animations,function(animation,name) {
 		if($tw.utils.hop(animation,type)) {
 			chosenAnimation = animation[type];


### PR DESCRIPTION
This PR tries a different approach than #5769 for fixing the slide-open and slide-close animations

The problem is (was) that the `setTimeout` call wasn't cleared when a new animation started while the other animation was still ongoing