### PR TITLE
Fix the EditTabIndex value applied to DomNodes which was '1\n'

### DIFF
--- a/core/wiki/config/EditTabIndex.tid
+++ b/core/wiki/config/EditTabIndex.tid
@@ -1,3 +1,2 @@
 title: $:/config/EditTabIndex
-
-1
+text: 1


### PR DESCRIPTION
This PR fixes the EditTabIndex applied to the input domNodes that use `$:/config/EditTabIndex`
Til now that tabindex was `1\n' even if that didn't cause problems