### PR TITLE
Pagescroller: use scrollContainer for scrolling

### DIFF
--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -65,7 +65,8 @@ Handle a scroll event hitting the page document
 PageScroller.prototype.scrollIntoView = function(element,callback) {
 	var self = this,
 		duration = $tw.utils.getAnimationDuration(),
-	    srcWindow = element ? element.ownerDocument.defaultView : window;
+		srcWindow = element ? element.ownerDocument.defaultView : window,
+		scrollContainer = $tw.utils.getScrollContainer(element);
 	// Now get ready to scroll the body
 	this.cancelScroll(srcWindow);
 	this.startTime = Date.now();
@@ -78,7 +79,7 @@ PageScroller.prototype.scrollIntoView = function(element,callback) {
 	// Get the client bounds of the element and adjust by the scroll position
 	var getBounds = function() {
 			var clientBounds = typeof callback === 'function' ? callback() : element.getBoundingClientRect(),
-				scrollPosition = $tw.utils.getScrollPosition(srcWindow);
+				scrollPosition = $tw.utils.getScrollPosition(scrollContainer);
 			return {
 				left: clientBounds.left + scrollPosition.x,
 				top: clientBounds.top + scrollPosition.y - offset,
@@ -110,11 +111,12 @@ PageScroller.prototype.scrollIntoView = function(element,callback) {
 				t = 1;
 			}
 			t = $tw.utils.slowInSlowOut(t);
-			var scrollPosition = $tw.utils.getScrollPosition(srcWindow),
+			var scrollPosition = $tw.utils.getScrollPosition(scrollContainer),
 				bounds = getBounds(),
 				endX = getEndPos(bounds.left,bounds.width,scrollPosition.x,srcWindow.innerWidth),
 				endY = getEndPos(bounds.top,bounds.height,scrollPosition.y,srcWindow.innerHeight);
-			srcWindow.scrollTo(scrollPosition.x + (endX - scrollPosition.x) * t,scrollPosition.y + (endY - scrollPosition.y) * t);
+			scrollContainer.scrollLeft = scrollPosition.x + (endX - scrollPosition.x) * t;
+			scrollContainer.scrollTop = scrollPosition.y + (endY - scrollPosition.y) * t;
 			if(t < 1) {
 				self.idRequestFrame = self.requestAnimationFrame.call(srcWindow,drawFrame);
 			}


### PR DESCRIPTION
This PR makes it possible, that elements within other scroll containers than the `window` can get scrolled into view by the pagescroller

Therefor it makes the `$tw.utils.getScrollContainer()` method more reliable and changes the `$tw.utils.getScrollPosition()` method to accept the scrollContainer as the only parameter and updates the `$tw.utils.getScrollPosition()` calls everywhere