### PR TITLE
removed pushtop from untagged filter

### DIFF
--- a/core/modules/filters/untagged.js
+++ b/core/modules/filters/untagged.js
@@ -16,20 +16,13 @@ Filter operator returning all the selected tiddlers that are untagged
 Export our filter function
 */
 exports.untagged = function(source,operator,options) {
-	var results = [];
-	if(operator.prefix === "!") {
-		source(function(tiddler,title) {
-			if(tiddler && $tw.utils.isArray(tiddler.fields.tags) && tiddler.fields.tags.length > 0) {
-				$tw.utils.pushTop(results,title);
-			}
-		});
-	} else {
-		source(function(tiddler,title) {
-			if(!tiddler || !tiddler.hasField("tags") || ($tw.utils.isArray(tiddler.fields.tags) && tiddler.fields.tags.length === 0)) {
-				$tw.utils.pushTop(results,title);
-			}
-		});
-	}
+	var results = [],
+		expected = (operator.prefix === "!");
+	source(function(tiddler,title) {
+		if((tiddler && $tw.utils.isArray(tiddler.fields.tags) && tiddler.fields.tags.length > 0) === expected) {
+			results.push(title);
+		}
+	});
 	return results;
 };
 


### PR DESCRIPTION
I'm back to implementing the LinkedList into all the filters that use pushTop. I was going to start with [untagged[]], when I had the question:

Why on earth is [untagged[]] using pushtop? Nothing in the documentation indicates that it does. No filters that are like it do (such as tag, field, prefix, etc...). It seems to me that it should just be using push, because in the RARE occurrence that someone passes a source with duplicates to [untagged[]], it shouldn't be [untagged[]]'s responsibility to remove those duplicates. It seems to me like it's more like a bug than a feature. Who would want [untagged[]] doing that?

Anyway, here are the performance specs: Filtering with 30,000 input tiddlers on Chrome.

Using pushtop: 1685 ms
Just using push: 37 ms