### PR TITLE
filter ops don't LinkedList to array anymore

### DIFF
--- a/core/modules/filters/all.js
+++ b/core/modules/filters/all.js
@@ -52,7 +52,7 @@ exports.all = function(source,operator,options) {
 			results.pushTop(subop(source,operator.prefix,options));
 		}
 	}
-	return results.toArray();
+	return results.tiddlerIterator(options.wiki);
 };
 
 })();

--- a/core/modules/filters/all.js
+++ b/core/modules/filters/all.js
@@ -52,7 +52,7 @@ exports.all = function(source,operator,options) {
 			results.pushTop(subop(source,operator.prefix,options));
 		}
 	}
-	return results.tiddlerIterator(options.wiki);
+	return results.makeTiddlerIterator(options.wiki);
 };
 
 })();

--- a/core/modules/filters/links.js
+++ b/core/modules/filters/links.js
@@ -20,7 +20,7 @@ exports.links = function(source,operator,options) {
 	source(function(tiddler,title) {
 		results.pushTop(options.wiki.getTiddlerLinks(title));
 	});
-	return results.tiddlerIterator(options.wiki);
+	return results.makeTiddlerIterator(options.wiki);
 };
 
 })();

--- a/core/modules/filters/links.js
+++ b/core/modules/filters/links.js
@@ -20,7 +20,7 @@ exports.links = function(source,operator,options) {
 	source(function(tiddler,title) {
 		results.pushTop(options.wiki.getTiddlerLinks(title));
 	});
-	return results.toArray();
+	return results.tiddlerIterator(options.wiki);
 };
 
 })();

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -95,6 +95,15 @@ LinkedList.prototype.toArray = function() {
 	return output;
 };
 
+LinkedList.prototype.tiddlerIterator = function(wiki) {
+	var self = this;
+	return function(callback) {
+		self.each(function(title) {
+			callback(wiki.getTiddler(title),title);
+		});
+	};
+};
+
 function _removeOne(list,value) {
 	var prevEntry = list.prev[value],
 		nextEntry = list.next[value],

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -95,7 +95,7 @@ LinkedList.prototype.toArray = function() {
 	return output;
 };
 
-LinkedList.prototype.tiddlerIterator = function(wiki) {
+LinkedList.prototype.makeTiddlerIterator = function(wiki) {
 	var self = this;
 	return function(callback) {
 		self.each(function(title) {


### PR DESCRIPTION
While investigating how to make filters lazy evaluators, I realized that filters don't have to return arrays. They can return methods that accept callbacks instead. So here's a little improvement to the way existing filters use LinkedList which removes the cloning of the LinkedList into an array before allowing the next filter step to use it.

Should be a little more time efficient, and a good deal more memory efficient.

Also, if people like my lazy filters, then this change makes transitioning easier.