### PR TITLE
Let's make TiddlyWiki lazy!!!

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1207,6 +1207,9 @@ $tw.Wiki = function(options) {
 			callback(tiddlers[title],title);
 		}
 	};
+	// This .iterable is attached to each tiddler traversing method. It's
+	// required to maintain backward compatibility with old method(callback)
+	// functions people might pass to wiki.filterTiddlers as source.
 	this.each.iterable = true;
 
 	// Get an array of all shadow tiddler titles

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -337,6 +337,13 @@ exports.compileFilter = function(filterString) {
 	});
 };
 
+/**For backward compatibility.
+ * Some plugins may still call filterTiddlers and pass a method as a source.
+ * That method won't be able to manage both the callback(tiddler,title)
+ * style and the lazy iterable style, so we've got to wrap it.
+ * Methods passed with .iterable = true will be recognized as true
+ * tiddler iterators.
+ */
 function updateDeprecatedSource(source) {
 	return function(callback) {
 		var titles = [],

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -323,6 +323,8 @@ exports.compileFilter = function(filterString) {
 			source = self.each;
 		} else if(typeof source === "object") { // Array or hashmap
 			source = self.makeTiddlerIterator(source);
+		} else if(!source.iterable) { // Deprecated method. Wrap it.
+			source = updateDeprecatedSource(source);
 		}
 		if(!widget) {
 			widget = $tw.rootWidget;
@@ -333,6 +335,21 @@ exports.compileFilter = function(filterString) {
 		});
 		return results.toArray();
 	});
+};
+
+function updateDeprecatedSource(source) {
+	return function(callback) {
+		var titles = [],
+			ptr = 0;
+		if (callback === undefined) {
+			source(function(tiddler,title) {
+				titles.push(title);
+			});
+			return new $tw.utils.Iterator(function() { return titles[ptr++]; });
+		} else {
+			source(callback);
+		}
+	};
 };
 
 })();

--- a/core/modules/filters/getindex.js
+++ b/core/modules/filters/getindex.js
@@ -16,17 +16,40 @@ returns the value at a given index of datatiddlers
 Export our filter function
 */
 exports.getindex = function(source,operator,options) {
-	var data,title,results = [];
-	if(operator.operand){
-		source(function(tiddler,title) {
-			title = tiddler ? tiddler.fields.title : title;
-			data = options.wiki.extractTiddlerDataItem(tiddler,operator.operand);
-			if(data) {
-				results.push(data);
+	var iter;
+	if(operator.operand) {
+		iter = source();
+		return options.wiki.makeTiddlerIterator(function() {
+			var next, data;
+			while((next = iter.next()).done == false) {
+				var tiddler = options.wiki.getTiddler(next.value);
+				data = options.wiki.extractTiddlerDataItem(tiddler,operator.operand);
+				if (data) {
+					return data;
+				}
+			}
+			return undefined;
+		});
+	}
+	return [];
+};
+
+/*
+exports.getindex = function(source,operator,options) {
+	var iter;
+	if(operator.operand) {
+		return options.wiki.makeTiddlerIteratorFromGenerator(function*() {
+			for (var title of source()) {
+				var tiddler = options.wiki.getTiddler(title),
+					data = options.wiki.extractTiddlerDataItem(tiddler,operator.operand);
+				if (data) {
+					yield data;
+				}
 			}
 		});
 	}
-	return results;
+	return [];
 };
+*/
 
 })();

--- a/core/modules/filters/getindex.js
+++ b/core/modules/filters/getindex.js
@@ -34,7 +34,11 @@ exports.getindex = function(source,operator,options) {
 	return [];
 };
 
-/*
+// LOOK HERE
+/* This is what the getindex would look like if it used for..of and yield.
+ * It's... not that much better, which is why I'm not sure maintaining
+ * forward-compatibility is a great idea.
+ *
 exports.getindex = function(source,operator,options) {
 	var iter;
 	if(operator.operand) {

--- a/core/modules/filters/prefix.js
+++ b/core/modules/filters/prefix.js
@@ -29,17 +29,4 @@ exports.prefix = function(source,operator,options) {
 	});
 };
 
-/*
-exports.prefix = function(source,operator,options) {
-	var expected = (operator.prefix === "!");
-	return options.wiki.makeTiddlerIteratorFromGenerator(function*() {
-		for (var title of source) {
-			if((pair.value.substr(0,operator.operand.length) !== operator.operand) === expected) {
-				yield title;
-			}
-		}
-	});
-};
-*/
-
 })();

--- a/core/modules/filters/prefix.js
+++ b/core/modules/filters/prefix.js
@@ -16,21 +16,30 @@ Filter operator for checking if a title starts with a prefix
 Export our filter function
 */
 exports.prefix = function(source,operator,options) {
-	var results = [];
-	if(operator.prefix === "!") {
-		source(function(tiddler,title) {
-			if(title.substr(0,operator.operand.length) !== operator.operand) {
-				results.push(title);
+	var expected = (operator.prefix === "!"),
+		iter = source();
+	return options.wiki.makeTiddlerIterator(function() {
+		var pair;
+		while ((pair = iter.next()).done == false) {
+			if((pair.value.substr(0,operator.operand.length) !== operator.operand) === expected) {
+				return pair.value;
 			}
-		});
-	} else {
-		source(function(tiddler,title) {
-			if(title.substr(0,operator.operand.length) === operator.operand) {
-				results.push(title);
-			}
-		});
-	}
-	return results;
+		}
+		return undefined;
+	});
 };
+
+/*
+exports.prefix = function(source,operator,options) {
+	var expected = (operator.prefix === "!");
+	return options.wiki.makeTiddlerIteratorFromGenerator(function*() {
+		for (var title of source) {
+			if((pair.value.substr(0,operator.operand.length) !== operator.operand) === expected) {
+				yield title;
+			}
+		}
+	});
+};
+*/
 
 })();

--- a/core/modules/utils/iterator.js
+++ b/core/modules/utils/iterator.js
@@ -8,6 +8,9 @@ compatible with ECMA 2015's yield statements and generator functions.
 
 Objects returned by next() are {value: value, done: false}, but the next method
 returned by this need only return a string or null.
+
+If we decide not to be forward-compatible with for..of and yield, then we
+can scrap this and just pass around iterator methods instead.
 \*/
 
 function Iterator(next) {

--- a/core/modules/utils/iterator.js
+++ b/core/modules/utils/iterator.js
@@ -1,0 +1,38 @@
+/*\
+module-type: utils
+title: $:/core/modules/utils/iterator.js
+type: application/javascript
+
+This iterator can be used for lazy evaluation. It's designed to be forward
+compatible with ECMA 2015's yield statements and generator functions.
+
+Objects returned by next() are {value: value, done: false}, but the next method
+returned by this need only return a string or null.
+\*/
+
+function Iterator(next) {
+	this.method = next;
+};
+
+Iterator.prototype.next = function() {
+	var value = this.method();
+	if (value !== undefined) {
+		return { value: value, done: false };
+	} else {
+		return { done: true };
+	}
+};
+
+Iterator.prototype.return = function(value) {
+	this.method = function() { return undefined; };
+	return { value: value, done: true };
+};
+
+Iterator.prototype.throw = function(exception) { throw exception; };
+
+// This provides compatibility with yield and for...of
+if ((typeof(Symbol) !== "undefined") && Symbol.iterator) {
+	Iterator.prototype[Symbol.iterator] = function() { return this; };
+}
+
+exports.Iterator = Iterator;

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -339,6 +339,12 @@ exports.countTiddlers = function(excludeTag) {
 	return $tw.utils.count(tiddlers);
 };
 
+/**This creates a tiddler iterator from a function*() method, which is an
+ * ECMA 2015 feature. Basically, the only people who would use this are
+ * people writing plugins who don't care about backward compatibility.
+ * If we decide not to be forward-compatible with for..of and yield, then
+ * this function can be removed.
+ */
 exports.makeTiddlerIteratorFromGenerator = function(generator) {
 	var self = this,
 		generator = function(callback) {


### PR DESCRIPTION
I know this is the feature no one asked for, but hear me out. I was blown away when I first got into TiddlyWiki development when I found out that its filters, which would lend themselves so wonderfully to lazy evaluation, actually accumulate full arrays of intermediate results between every single operation. I wanted to see if it was even possible to make it lazy now with so much backward compatibility necessary, and... actually it was pretty easy.

Check out my implementation. It's not meant for merging, but more for people to see. If people don't want to go this direction, I understand, but it's super nifty, you guys!

## tiddler iterating wikimethods
The first major change was taking wiki's methods `each`, `eachShadow`, `eachShadowAndTiddlers`, and `eachTiddlerAndShadows` and making them lazy while maintaining their existing use. If you call them and supply a callback method, they call that callback method like usual. If you don't supply a callback, they return an iterator. Boom. Done.

The super cool way I have it implemented right now makes these iterators forward compatible with ES6's `for...of` syntax, so you can do this...
```javascript
for(var title of $tw.wiki.each()) {
   // do stuff. Or don't. Finish, or break. Up to you.
}
```
Of course, TiddlyWiki doesn't allow `for...of`, but plugin developers don't have to concern themselves with supporting those people using those CRT screen Dell computers at their church to design their websites. We wouldn't _have_ to keep support for `for...of`, and if we don't, some of my code simplifies down.

To keep support, right now, $tw.wiki.each() et al are returning an iterator that returns `{value: title, done: false}` if there's a value and `{value: undefined, done: true}` for End-Of-Stream. BUT since our tiddler titles are always defined, and since filters never allow non-string values, we could have the simpler `title` on value, and `undefined` for End-Of-Stream.

## Filters

Filters don't have to change at all. This upgrade is fully backward compatible. However, we obviously don't get much benefit from this if I don't refactor the existing filters. Currently, I've only implemented `prefix` and `getindex`, because they both make good use cases.

There are several types of filters that won't get much benefit from this, and that's the ones that use pushTop. (I freakin hate that method). But many other filters do, especially ones like `[first[]]` and such.

Anyway, let me know what you guys think. Anyone interested in this? Should it maintain forward-compatibility or go with the slightly simpler form where it just passes around iterator methods? Check out the new code too. I littered it with heavy comments explaining stuff (that I'd take out before merge).