### PR TITLE
Fixed refresh bug with radio widget

### DIFF
--- a/core/modules/widgets/radio.js
+++ b/core/modules/widgets/radio.js
@@ -122,6 +122,7 @@ RadioWidget.prototype.refresh = function(changedTiddlers) {
 		return true;
 	} else if(changedTiddlers[this.radioTitle]) {
 		this.inputDomNode.checked = this.getValue() === this.radioValue;
+		$tw.utils.toggleClass(this.labelDomNode,"tc-radio-selected",this.inputDomNode.checked);
 		return this.refreshChildren(changedTiddlers);
 	} else {
 		return this.refreshChildren(changedTiddlers);


### PR DESCRIPTION
Fixed refresh bug with radio widget where the `tc-radio-selected` class is not correctly updated in 5.2.0
Fixes #6040 