### PR TITLE
katex-plugin: fix #6041 add automatic numbering reset to KaTex style-sheet

### DIFF
--- a/plugins/tiddlywiki/katex/styles.tid
+++ b/plugins/tiddlywiki/katex/styles.tid
@@ -13,7 +13,7 @@ tags: [[$:/tags/Stylesheet]]
     text-rendering: auto;
 }
 
-/* Reset Automatic Numbering on a per tiddler body basis */
+/* Reset Automatic Numbering on a per tiddler basis */
 
 .tc-tiddler-frame {
 	counter-reset: katexEqnNo;

--- a/plugins/tiddlywiki/katex/styles.tid
+++ b/plugins/tiddlywiki/katex/styles.tid
@@ -13,10 +13,16 @@ tags: [[$:/tags/Stylesheet]]
     text-rendering: auto;
 }
 
+/* Reset Automatic Numbering on a per tiddler body basis */
+
+.tc-tiddler-frame {
+	counter-reset: katexEqnNo;
+}
+
 /* Avoid TW5's max-width: 100% */
 
 .katex svg {
-  max-width: initial;
+	max-width: initial;
 }
 
 /* Override font URLs */


### PR DESCRIPTION
This PR fixes #6041 add automatic numbering reset to KaTex style-sheet, that has been discussed at: https://github.com/Jermolene/TiddlyWiki5/discussions/6039

Using `.tc-tiddler-frame` will also include elements that will be added to the ViewTemplate in the future. 