### PR TITLE
Eventcatcher: check for event properties before accessing

### DIFF
--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -76,20 +76,22 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 						variables["tv-selectednode-posy"] = selectedNode.offsetTop.toString();
 						variables["tv-selectednode-width"] = selectedNode.offsetWidth.toString();
 						variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
+						
+						if(event.clientX && event.clientY) {
+							//Add variables for event X and Y position relative to selected node
+							selectedNodeRect = selectedNode.getBoundingClientRect();
+							variables["event-fromselected-posx"] = (event.clientX - selectedNodeRect.left).toString();
+							variables["event-fromselected-posy"] = (event.clientY - selectedNodeRect.top).toString();
 
-						//Add variables for event X and Y position relative to selected node
-						selectedNodeRect = selectedNode.getBoundingClientRect();
-						variables["event-fromselected-posx"] = (event.clientX - selectedNodeRect.left).toString();
-						variables["event-fromselected-posy"] = (event.clientY - selectedNodeRect.top).toString();
+							//Add variables for event X and Y position relative to event catcher node
+							catcherNodeRect = self.domNode.getBoundingClientRect();
+							variables["event-fromcatcher-posx"] = (event.clientX - catcherNodeRect.left).toString();
+							variables["event-fromcatcher-posy"] = (event.clientY - catcherNodeRect.top).toString();
 
-						//Add variables for event X and Y position relative to event catcher node
-						catcherNodeRect = self.domNode.getBoundingClientRect();
-						variables["event-fromcatcher-posx"] = (event.clientX - catcherNodeRect.left).toString();
-						variables["event-fromcatcher-posy"] = (event.clientY - catcherNodeRect.top).toString();
-
-						//Add variables for event X and Y position relative to the viewport
-						variables["event-fromviewport-posx"] = event.clientX.toString();
-						variables["event-fromviewport-posy"] = event.clientY.toString();
+							//Add variables for event X and Y position relative to the viewport
+							variables["event-fromviewport-posx"] = event.clientX.toString();
+							variables["event-fromviewport-posy"] = event.clientY.toString();
+						}
 					}
 				} else {
 					return false;


### PR DESCRIPTION
Fixes a new bug in `<$eventcatcher>` for custom events where if the event does not have a `clientX` or `clientY` property, it results in an error. This was introduced after the changes in https://github.com/Jermolene/TiddlyWiki5/commit/e9613d7f1225a3fe726e1790cc46e3f6ca9ca934 

The other variables relying on these event properties were being assigned a value of `NaN` but were not causing an exception. Now, we only assign all of the variables relying on these event properties if the event has the relevant properties.