### PR TITLE
backlinks uses LinkedList

### DIFF
--- a/core/modules/filters/backlinks.js
+++ b/core/modules/filters/backlinks.js
@@ -16,11 +16,11 @@ Filter operator for returning all the backlinks from a tiddler
 Export our filter function
 */
 exports.backlinks = function(source,operator,options) {
-	var results = [];
+	var results = new $tw.utils.LinkedList();
 	source(function(tiddler,title) {
-		$tw.utils.pushTop(results,options.wiki.getTiddlerBacklinks(title));
+		results.pushTop(options.wiki.getTiddlerBacklinks(title));
 	});
-	return results;
+	return results.makeTiddlerIterator(options.wiki);
 };
 
 })();


### PR DESCRIPTION
Backlinks. Here's another filter that benefits from using LinkedLists.

With an input of 10,000 tiddlers, This filter takes ~150 ms. With linked lists, it takes ~15 ms.