### PR TITLE
Added modulesproperty filter operator and extended modules operator

### DIFF
--- a/core/modules/filters/moduleproperty.js
+++ b/core/modules/filters/moduleproperty.js
@@ -1,0 +1,30 @@
+/*\
+title: $:/core/modules/filters/moduleproperty.js
+type: application/javascript
+module-type: filteroperator
+
+Filter [[module-name]moduleproperty[name]] retrieve a module property
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+/*
+Export our filter function
+*/
+exports.moduleproperty = function(source,operator,options) {
+	var results = [];
+	source(function(tiddler,title) {
+		var value = require(title)[operator.operand || ""];
+		if(value !== undefined) {
+			results.push(value);
+		}
+	});
+	results.sort();
+	return results;
+};
+
+})();

--- a/core/modules/filters/modules.js
+++ b/core/modules/filters/modules.js
@@ -17,11 +17,24 @@ Export our filter function
 */
 exports.modules = function(source,operator,options) {
 	var results = [];
-	source(function(tiddler,title) {
-		$tw.utils.each($tw.modules.types[title],function(moduleInfo,moduleName) {
-			results.push(moduleName);
+
+	if(operator.operands.length >= 2) {
+		// Return the modules that have the module property specified in the first operand with the value in the second operand
+		source(function(tiddler,title) {
+			$tw.utils.each($tw.modules.types[title],function(moduleInfo,moduleName) {
+				if(require(moduleName)[operator.operands[0]] === operator.operands[1]) {
+					results.push(moduleName);					
+				}
+			});
 		});
-	});
+	} else {
+		// Return all the module names without filtering
+		source(function(tiddler,title) {
+			$tw.utils.each($tw.modules.types[title],function(moduleInfo,moduleName) {
+				results.push(moduleName);
+			});
+		});
+	}
 	results.sort();
 	return results;
 };

--- a/core/modules/filters/modules.js
+++ b/core/modules/filters/modules.js
@@ -17,7 +17,6 @@ Export our filter function
 */
 exports.modules = function(source,operator,options) {
 	var results = [];
-
 	if(operator.operands.length >= 2) {
 		// Return the modules that have the module property specified in the first operand with the value in the second operand
 		source(function(tiddler,title) {

--- a/editions/tw5.com/tiddlers/filters/examples/moduleproperty Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/moduleproperty Operator (Examples).tid
@@ -1,0 +1,11 @@
+created: 20210919201407838
+modified: 20210919201738739
+tags: [[moduleproperty Operator]] [[Operator Examples]]
+title: moduleproperty Operator (Examples)
+type: text/vnd.tiddlywiki
+
+Get the name of the macro in the module `$:/core/modules/macros/qualify.js`:
+<<.operator-example 1 "[[$:/core/modules/macros/qualify.js]moduleproperty[name]]">>
+
+For all macro modules retrieve their name module properties:
+<<.operator-example 2 "[[macro]modules[]moduleproperty[name]]">>

--- a/editions/tw5.com/tiddlers/filters/examples/modules.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/modules.tid
@@ -1,7 +1,10 @@
 created: 20150123221510000
-modified: 20150123221534000
+modified: 20210919201037087
 tags: [[modules Operator]] [[Operator Examples]]
 title: modules Operator (Examples)
 type: text/vnd.tiddlywiki
 
 <<.operator-example 1 "[[filteroperator]modules[]]">>
+
+Get the title of the macro module which a `property` name with value `version`:
+<<.operator-example 2 "[[macro]modules[name],[version]]">>

--- a/editions/tw5.com/tiddlers/filters/moduleproperty Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/moduleproperty Operator.tid
@@ -1,0 +1,12 @@
+caption: modulesproperty
+created: 20210919201126246
+modified: 20210919201347702
+op-input: a [[selection|Title Selection]] of modules
+op-output: the value of the module property as specified in the operand
+op-parameter: module property to retrieve
+op-purpose: retrieve a module property
+tags: [[Filter Operators]] [[Special Operators]]
+title: moduleproperty Operator
+type: text/vnd.tiddlywiki
+
+<<.operator-examples "moduleproperty">>

--- a/editions/tw5.com/tiddlers/filters/modules.tid
+++ b/editions/tw5.com/tiddlers/filters/modules.tid
@@ -1,12 +1,14 @@
+caption: modules
 created: 20140410103123179
-modified: 20150203185838000
+modified: 20210919201148915
+op-input: a [[selection|Title Selection]] of module types
+op-output: the title of each module with any of the input types
+op-parameter: none
+op-purpose: select the names of all modules of the input module types
 tags: [[Filter Operators]] [[Special Operators]]
 title: modules Operator
 type: text/vnd.tiddlywiki
-caption: modules
-op-purpose: select the names of all modules of the input module types
-op-input: a [[selection|Title Selection]] of module types
-op-parameter: none
-op-output: the title of each module with any of the input types
+
+<<.from-version "5.2.0">>The <<.op modules>> filter allows two optional operands. When both are specified, it returns the modules with the module property specified in the first operand which has the value in the second operand.
 
 <<.operator-examples "modules">>


### PR DESCRIPTION
Added `modulesproperty` filter operator and extended `modules` operator from the publishing framework.
Please see the examples in the included documentation for use cases.

Fixes #6009