### PR TITLE
WIP: Proposed changes to Help plugin Support messaging

### DIFF
--- a/plugins/tiddlywiki/help/tabs/Support.tid
+++ b/plugins/tiddlywiki/help/tabs/Support.tid
@@ -4,10 +4,12 @@ caption: Support
 
 ~TiddlyWiki is an open source project with a vibrant community of users and developers. We're always happy to help new users get the most from ~TiddlyWiki.
 
-Join the ~TiddlyWiki mailing list:
+The Talk ~TiddlyWiki community forum is open to all for support, discussion 
+
+For those that prefer a Google Group, join the ~TiddlyWiki mailing list:
 
 http://groups.google.com/group/TiddlyWiki
 
-Post bug reports to the ~TiddlyWiki ~GitHub repository:
+Developers can participate in the ~TiddlyWiki ~GitHub repository, as well as sharing reproducible bug reports:
 
 https://github.com/Jermolene/TiddlyWiki5


### PR DESCRIPTION
I’m suggesting some wording changes and including a link to the Talk TW forum as well as the Google Group. 

I’ve also changed the wording around the link to GitHub to be LESS welcoming of bug reports by end users — as I think that might be better helped in the forum or mailing list. 

Instead, the message there is for developers and sophisticated users who can reproduce bug reports. 

I think we could do a lot more with Help, I did some experiments in including more video content, but will leave that for future PRs. 

I’m going to add a discussion thread on Talk to get wider feedback.