### PR TITLE
Fix for action-confirm: avoid errors if event is not defined

### DIFF
--- a/core/modules/widgets/action-confirm.js
+++ b/core/modules/widgets/action-confirm.js
@@ -59,7 +59,7 @@ Invoke the action associated with this widget
 ConfirmWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var invokeActions = true,
 		handled = true,
-	    	win = event.event && event.event.view ? event.event.view : window;
+	    	win = event && event.event && event.event.view ? event.event.view : window;
 	if(this.prompt) {
 		invokeActions = win.confirm(this.message);
 	}


### PR DESCRIPTION
This PR fixes a bug in the pre-release introduced in #5776  where the `<$action-confirm>` widget results in a red error screen when `event` is not defined. 