### PR TITLE
Added Polish translation

### DIFF
--- a/languages/pl-PL/Buttons.multids
+++ b/languages/pl-PL/Buttons.multids
@@ -1,0 +1,189 @@
+title: $:/language/Buttons/
+
+AdvancedSearch/Caption: zaawansowane wyszukiwanie
+AdvancedSearch/Hint: Zaawansowane wyszukiwanie
+Cancel/Caption: anuluj
+Cancel/Hint: Odrzuć zmiany dokonane w tym tiddlerze
+Clone/Caption: skopiuj
+Clone/Hint: Skopiuj tego tiddlera
+Close/Caption: zamknij
+Close/Hint: Zamknij tego tiddlera
+CloseAll/Caption: zamknij wszystkie
+CloseAll/Hint: Zamknij wszystkie tiddlery
+CloseOthers/Caption: zamknij pozostale
+CloseOthers/Hint: Zamknij pozostałe tiddlery
+ControlPanel/Caption: panel kontrolny
+ControlPanel/Hint: Otwórz panel kontrolny
+CopyToClipboard/Caption: skopiuj do schowka
+CopyToClipboard/Hint: Skopiuj ten tekst do schowka
+Delete/Caption: usuń
+Delete/Hint: Usuń tiddlera
+Edit/Caption: edytuj
+Edit/Hint: Edytuj tego tiddlera
+Encryption/Caption: szyfrowanie
+Encryption/Hint: Ustaw lub usuń hasło wymagane do edycji tej wiki
+Encryption/ClearPassword/Caption: usuń hasło
+Encryption/ClearPassword/Hint: Usuń hasło i zapisz wiki bez szyfrowania
+Encryption/SetPassword/Caption: ustaw hasło
+Encryption/SetPassword/Hint: Ustaw hasło by zapisać tą wiki z szyfrowaniem
+ExportPage/Caption: eksportuj wszystko
+ExportPage/Hint: Eksportuj wszystkie tiddlery
+ExportTiddler/Caption: eksportuj tiddlera
+ExportTiddler/Hint: Eksportuj tego tiddlera
+ExportTiddlers/Caption: eksportuj tiddlery
+ExportTiddlers/Hint: Eksportuj tiddlery
+SidebarSearch/Hint: Wybierz pole wyszukiwania w menu bocznym
+Fold/Caption: zwiń tiddlera
+Fold/Hint: Zwiń treść tego tiddlera
+Fold/FoldBar/Caption: pasek odwijania
+Fold/FoldBar/Hint: Opcjonaly pasek to zwijania i odwijania tiddlerów (zwijanie jest po lewej stronie, rozwijanie na dole tiddlera)
+Unfold/Caption: rozwiń tiddlera
+Unfold/Hint: Rozwiń treść tego tiddlera
+FoldOthers/Caption: zwiń pozostałe tiddlery
+FoldOthers/Hint: Zwiń treść pozostałych tiddlerów
+FoldAll/Caption: zwiń wszystkie tiddlery
+FoldAll/Hint: Zwiń treść wszystkich tiddlerów
+UnfoldAll/Caption: rozwiń wszystkie tiddlery
+UnfoldAll/Hint: Rozwiń treść wszystkich otwartych tiddlerów
+FullScreen/Caption: pełny ekran
+FullScreen/Hint: Wejdź lub opuść tryb pełnego ekranu
+Help/Caption: pomoc
+Help/Hint: Pokaż panel pomocy
+Import/Caption: import
+Import/Hint: Importuj rózne typy plików, takie jak tekst, obrazki, JSON, tiddlery
+Info/Caption: info
+Info/Hint: Wyświetl informacje o tym tiddlerze
+Home/Caption: strona główna
+Home/Hint: Otwórz domyślne tiddlery
+Language/Caption: języki
+Language/Hint: Zmień jezyk interfejsu
+Manager/Caption: menedżer tiddlerów
+Manager/Hint: Otwórz menedżer tiddlerów
+More/Caption: więcej
+More/Hint: Więcej akcji
+NewHere/Caption: nowy tiddler tu
+NewHere/Hint: Stwórz nowego tiddlera otagowanego tym tiddlerem
+NewJournal/Caption: nowy dziennik
+NewJournal/Hint: Tworzy nowego tiddlera o typie dziennika
+NewJournalHere/Caption: nowy dziennik tu
+NewJournalHere/Hint: Tworzy nowego tiddlera o typie dziennika otagowanego tym tiddlerem
+NewImage/Caption: nowy obraz
+NewImage/Hint: Stwórz nowego tiddlera o typie obrazu
+NewMarkdown/Caption: nowy Markdown tiddler
+NewMarkdown/Hint: Stwórz nowego tiddlera o typie Markdown
+NewTiddler/Caption: nowy tiddler
+NewTiddler/Hint: Stwórz nowego tiddlera
+OpenWindow/Caption: otwórz w nowym oknie
+OpenWindow/Hint: Otwórz tego tiddlera w nowym oknie
+Palette/Caption: paleta
+Palette/Hint: Wybierz paletę kolorów
+Permalink/Caption: bezpośredni link
+Permalink/Hint: Ustaw adres w przeglądarce na bezpośredni link do tego tiddlera
+Permaview/Caption: permanenty widok
+Permaview/Hint: Ustaw adres w przeglądarce na bezpośredni link do obecnego widoku tiddlerów
+Print/Caption: wydrukuj stronę
+Print/Hint: Drukuje aktualną stronę
+Refresh/Caption: odśwież
+Refresh/Hint: Wykonuje pełne odświeżenie wiki
+Save/Caption: zapisz
+Save/Hint: Zapisz zmiany w tiddlerze
+SaveWiki/Caption: zapisz zmiany
+SaveWiki/Hint: Zapisz zmiany w całej wiki
+StoryView/Caption: widok tiddlerów
+StoryView/Hint: Ustal sposób w jaki tiddlery są wyświetlane
+HideSideBar/Caption: ukryj menu boczne
+HideSideBar/Hint: Ukryj menu boczne
+ShowSideBar/Caption: pokaż menu boczne
+ShowSideBar/Hint: Pokaż menu boczne
+TagManager/Caption: Menedżer tagów
+TagManager/Hint: Otwórz menedżer tagów
+Timestamp/Caption: aktualizacje czasu
+Timestamp/Hint: Wybierz czy zmiany mają aktualizować czas
+Timestamp/On/Caption: zmiany czasu są włączone
+Timestamp/On/Hint: Aktualizuj czas edycji po zapisaniu zmian w tiddlerze
+Timestamp/Off/Caption: zmiany czasu są wyłączone
+Timestamp/Off/Hint: Nie aktualizuj czasu po zapisaniu zmian w tiddlerze
+Theme/Caption: motyw
+Theme/Hint: Wybierz szatę graficzną wiki
+Bold/Caption: pogrubienie
+Bold/Hint: Pogrub zaznaczony tekst
+Clear/Caption: wyczyść
+Clear/Hint: Zapełnij obrazek pojedynczym kolorem
+EditorHeight/Caption: wysokość edytora
+EditorHeight/Caption/Auto: Automatycznie zmieniaj wysokość edytora by zmieścić treść
+EditorHeight/Caption/Fixed: Stała wysokość:
+EditorHeight/Hint: Wybierz wysokość edytora
+Excise/Caption:wytnij
+Excise/Caption/Excise: Wykonaj wycięcie
+Excise/Caption/MacroName: Nazwa makra
+Excise/Caption/NewTitle: Tytuł nowego tiddlera:
+Excise/Caption/Replace: Zastąp wycięty tekst:
+Excise/Caption/Replace/Macro: makro
+Excise/Caption/Replace/Link: link
+Excise/Caption/Replace/Transclusion: transkluzja
+Excise/Caption/Tag: Otaguj nowego tiddlera nazwą tego
+Excise/Caption/TiddlerExists: Uwaga: Tiddler już istnieje
+Excise/Hint: Wytnij zaznaczony tekst i wstaw go do nowego tidlera
+Heading1/Caption: nagłówek 1
+Heading1/Hint: Zmień zaznaczony tekst na nagłówek 1. stopnia
+Heading2/Caption: nagłówek 2
+Heading2/Hint: Zmień zaznaczony tekst na nagłówek 2. stopnia
+Heading3/Caption: nagłówek 3
+Heading3/Hint: Zmień zaznaczony tekst na nagłówek 3. stopnia
+Heading4/Caption: nagłówek 4
+Heading4/Hint: Zmień zaznaczony tekst na nagłówek 4. stopnia
+Heading5/Caption: nagłówek 5
+Heading5/Hint: Zmień zaznaczony tekst na nagłówek 5. stopnia
+Heading6/Caption: nagłówek 6
+Heading6/Hint: Zmień zaznaczony tekst na nagłówek 1. stopnia
+Italic/Caption: kursywa
+Italic/Hint: Sformatuj zaznaczony tekst kursywą
+LineWidth/Caption: szerokość linii
+LineWidth/Hint: Ustaw szerokość rysowanej linii
+Link/Caption: link
+Link/Hint: Stwórz wikilink
+Linkify/Caption: wikilink
+Linkify/Hint: Zamknij zaznaczony tekst w nawiasach kwadratowych
+ListBullet/Caption: lista punktowana
+ListBullet/Hint: Zamień zaznaczony tekst na listę punktowana
+ListNumber/Caption: lista numerowana
+ListNumber/Hint: Zamień zaznaczony tekst na listę numerowaną
+MonoBlock/Caption: blok o stałej czcionce
+MonoBlock/Hint: Zmień zaznaczony tekst na blok z czcionką o stałej szerokości
+MonoLine/Caption: stała czcionka
+MonoLine/Hint: Zmień czcionkę zaznaczonego tekstu na taką o stałej szerokości
+Opacity/Caption: przeźroczystość
+Opacity/Hint: Ustaw przeźroczystość rysowania
+Paint/Caption: kolor rysowania
+Paint/Hint: Ustaw kolor rysowania
+Picture/Caption: obraz
+Picture/Hint: Dodaj obraz
+Preview/Caption: podgląd
+Preview/Hint: Pokaż panel podglądu
+PreviewType/Caption: rodzaj podglądu
+PreviewType/Hint: Wybierz rodzaj podglądu
+Quote/Caption: cytat
+Quote/Hint: Zamień zaznaczony tekst na cytat
+RotateLeft/Caption: obróć w lewo
+RotateLeft/Hint: Obróc obraz w lewo o 90 stopni
+Size/Caption: rozmiar obrazu
+Size/Caption/Height: Wysokość:
+Size/Caption/Resize: Przeskaluj obraz
+Size/Caption/Width: Szerokość:
+Size/Hint: Ustaw rozmiar obrazu
+Stamp/Caption: pieczątka
+Stamp/Caption/New: Dodaj własną
+Stamp/Hint: Dodaj prekonfigurowany fragment tekstu
+Stamp/New/Title: Nazwa wyświetlana w menu
+Stamp/New/Text:  Tekst fragmetu. Pamiętaj by dodać opis w polu nagłówku.
+Strikethrough/Caption: przekreślenie
+Strikethrough/Hint: Przekreśl zaznaczony tekst
+Subscript/Caption: indeks dolny
+Subscript/Hint: Zamień zaznaczony tekst na indeks dolny
+Superscript/Caption: indeks górny
+Superscript/Hint: Zamień zaznaczony tekst na indeks górny
+ToggleSidebar/Hint: Zmień widzialność menu bocznego
+Transcludify/Caption: transkluzja
+Transcludify/Hint: Zamknij zaznaczony tekst w klamrach
+Underline/Caption: podkreślenie
+Underline/Hint: Podkreśl zaznaczony tekst

--- a/languages/pl-PL/Buttons.multids
+++ b/languages/pl-PL/Buttons.multids
@@ -80,7 +80,7 @@ Palette/Hint: Wybierz paletę kolorów
 Permalink/Caption: bezpośredni link
 Permalink/Hint: Ustaw adres w przeglądarce na bezpośredni link do tego tiddlera
 Permaview/Caption: permanenty widok
-Permaview/Hint: Ustaw adres w przeglądarce na bezpośredni link do obecnego widoku tiddlerów
+Permaview/Hint: Ustaw adres w przeglądarce na bezpośredni link do obecnego Story River
 Print/Caption: wydrukuj stronę
 Print/Hint: Drukuje aktualną stronę
 Refresh/Caption: odśwież
@@ -89,8 +89,8 @@ Save/Caption: zapisz
 Save/Hint: Zapisz zmiany w tiddlerze
 SaveWiki/Caption: zapisz zmiany
 SaveWiki/Hint: Zapisz zmiany w całej wiki
-StoryView/Caption: widok tiddlerów
-StoryView/Hint: Ustal sposób w jaki tiddlery są wyświetlane
+StoryView/Caption: widok Story River
+StoryView/Hint: Ustal sposób w jaki tiddlery są wyświetlane w Story River (widoku otwartych tiddlerów)
 HideSideBar/Caption: ukryj menu boczne
 HideSideBar/Hint: Ukryj menu boczne
 ShowSideBar/Caption: pokaż menu boczne

--- a/languages/pl-PL/ControlPanel.multids
+++ b/languages/pl-PL/ControlPanel.multids
@@ -17,10 +17,10 @@ Basics/NewJournal/Text/Prompt: Treść nowych dzienników
 Basics/NewJournal/Tags/Prompt: Tagi nowych dzienników
 Basics/NewTiddler/Title/Prompt: Tytuł nowych tiddlerów
 Basics/NewTiddler/Tags/Prompt: Tagi nowych tiddlerów
-Basics/OverriddenShadowTiddlers/Prompt: Liczba nadpisanych ukrytych tiddlerów
+Basics/OverriddenShadowTiddlers/Prompt: Liczba nadpisanych tiddlerów-cieni
 Basics/RemoveTags: Zaktualizuj do obecnego formatu
 Basics/RemoveTags/Hint: Zaktualizuj konfigurację tagów do najnowszego formatu
-Basics/ShadowTiddlers/Prompt: Liczba ukrytych tiddlerów
+Basics/ShadowTiddlers/Prompt: Liczba tiddlerów-cieni
 Basics/Subtitle/Prompt: Podtytuł
 Basics/SystemTiddlers/Prompt: Liczba systemowych tiddlerów
 Basics/Tags/Prompt: Liczba tagów
@@ -201,7 +201,7 @@ Stylesheets/Restore/Caption: Przywróć
 Theme/Caption: Motyw
 Theme/Prompt: Obecny motyw:
 TiddlerFields/Caption: Pola Tiddlerów
-TiddlerFields/Hint: To jest pełna lista wszystich pól użytych w tej wiki (wliczając systemowych ale nie ukrytych tiddlerów)
+TiddlerFields/Hint: To jest pełna lista wszystich pól użytych w tej wiki (wliczając systemowe tiddlery ale nie tiddlery-cienie)
 Toolbars/Caption: Paski Narzędzi
 Toolbars/EditToolbar/Caption: Edytuj Pasek Narzędzi
 Toolbars/EditToolbar/Hint: Wybierz, które przyciski mają być widoczne podczas edycji tiddlera. Przeciągaj by zmieniać kolejność.

--- a/languages/pl-PL/ControlPanel.multids
+++ b/languages/pl-PL/ControlPanel.multids
@@ -8,8 +8,8 @@ Appearance/Hint: Dostosowywanie wyglądu tej TiddlyWiki
 Basics/AnimDuration/Prompt: Długość animacji
 Basics/AutoFocus/Prompt: Domyślne pole z fokusem dla nowych tiddlerów
 Basics/Caption: Podstawowe
-Basics/DefaultTiddlers/BottomHint: Używaj &#91;&#91;podwójnych nawiasów kwadratowych&#93;&#93; dla nazw ze spacjami. Możesz też <$button set="$:/DefaultTiddlers" setTo="[list[$:/StoryList]]">zachować kolejność tiddlerów</$button>
-Basics/DefaultTiddlers/Prompt: Domyślne tiddlery
+Basics/DefaultTiddlers/BottomHint: Używaj &#91;&#91;podwójnych nawiasów kwadratowych&#93;&#93; dla nazw ze spacjami. Możesz też <$button set="$:/DefaultTiddlers" setTo="[list[$:/StoryList]]">przywrócić ostatnią sesję</$button>
+Basics/DefaultTiddlers/Prompt: Domyślnie otwarte tiddlery
 Basics/DefaultTiddlers/TopHint: Wybierz które tiddlery mają być widoczne przy uruchomieniu
 Basics/Language/Prompt: Cześć! Wybrany język to:
 Basics/NewJournal/Title/Prompt: Tytuł nowych dzienników
@@ -41,8 +41,8 @@ KeyboardShortcuts/Hint: Zarządzaj skrótami klawiszowymi
 KeyboardShortcuts/NoShortcuts/Caption: Brak skrótów klawiszowych
 KeyboardShortcuts/Remove/Hint: usuń skrót klawiszowy
 KeyboardShortcuts/Platform/All: Wszystkie platformy
-KeyboardShortcuts/Platform/Mac: Tylko na Macintoshu
-KeyboardShortcuts/Platform/NonMac: Tylko na nie-Macintoshach
+KeyboardShortcuts/Platform/Mac: Tylko na Macach
+KeyboardShortcuts/Platform/NonMac: Tylko na nie-Macach
 KeyboardShortcuts/Platform/Linux: Tylko na Linuxie
 KeyboardShortcuts/Platform/NonLinux: Tylko na nie-Linuxach
 KeyboardShortcuts/Platform/Windows: Tylko na Windowsie
@@ -113,9 +113,9 @@ Saving/GitService/Path: Ścieżka docelowa do pliku (np. `/wiki/`)
 Saving/GitService/Repo: Docelowe repozytorium (np. `Jermolene/TiddlyWiki5`)
 Saving/GitService/ServerURL: URL do serwera API
 Saving/GitService/UserName: Nazwa użytkownika
-Saving/GitService/GitHub/Caption: ~Zapisywacz GitHub
+Saving/GitService/GitHub/Caption: Zapisywacz GitHub
 Saving/GitService/GitHub/Password: Hasło, token OAUTH lub osobisty token dospu ((sprawdź [[pomoc Githuba|https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line]] by uzyskać więcej szczegółów)
-Saving/GitService/GitLab/Caption: ~Zapisywacz GitLab
+Saving/GitService/GitLab/Caption: Zapisywacz GitLab
 Saving/GitService/GitLab/Password: Osobisty token do API ((sprawdź [[pomoc GitLaba|https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html]] by uzyskać więcej szczegółów)
 Saving/GitService/Gitea/Caption: Zapisywacz Gitea
 Saving/GitService/Gitea/Password: Osobisty token do API (przez interfejs webowy Gitea: `Settings | Applications | Generate New Token`)
@@ -153,7 +153,7 @@ Settings/NavigationAddressBar/Caption: Pasek adresu
 Settings/NavigationAddressBar/Hint: Zachowanie paska adresu w przeglądarce przy otworzeniu tiddlera:
 Settings/NavigationAddressBar/No/Description: Nie aktualizuj paska adresu
 Settings/NavigationAddressBar/Permalink/Description: Pokaż docelowego tiddlera
-Settings/NavigationAddressBar/Permaview/Description: Pokaż docelowego tiddlera i obecny widok
+Settings/NavigationAddressBar/Permaview/Description: Pokaż docelowego tiddlera i obecny Story River
 Settings/NavigationHistory/Caption: Historia Nawigacji
 Settings/NavigationHistory/Hint: Aktualizuj historię nawigacji przeglądarki przy zmianie tiddlera:
 Settings/NavigationHistory/No/Description: Nie aktualizuj historii
@@ -162,9 +162,9 @@ Settings/NavigationPermalinkviewMode/Caption: Tryb linków bezpośrednich/widoku
 Settings/NavigationPermalinkviewMode/Hint: Ustal jak linki bezośrednie/widok się zachowują:
 Settings/NavigationPermalinkviewMode/CopyToClipboard/Description: Skopiuj URL do linku bezpośredniego/widoku do schowka
 Settings/NavigationPermalinkviewMode/UpdateAddressBar/Description: Zaktualizuj pasek adresu o URL do linku bezpośredniego/widoku
-Settings/PerformanceInstrumentation/Caption: Statystyki Działania
-Settings/PerformanceInstrumentation/Hint: Wyświetla statystyki działania w konsoli deweloperskiej przeglądarki. Wymagane ponowne uruchmoenie
-Settings/PerformanceInstrumentation/Description: Włącz statystyki działania
+Settings/PerformanceInstrumentation/Caption: Logowanie w Konsoli
+Settings/PerformanceInstrumentation/Hint: Uruchamia lokowanie w konsoli deweloperskiej przeglądarki. Wymagane ponowne uruchmoenie
+Settings/PerformanceInstrumentation/Description: Włącz logowanie
 Settings/ToolbarButtonStyle/Caption: Styl Przycisków Paska Narzędzi
 Settings/ToolbarButtonStyle/Hint: Wybierz styl przycisków w pasku narzędzi
 Settings/ToolbarButtonStyle/Styles/Borderless: Bez ramki
@@ -179,12 +179,12 @@ Settings/DefaultSidebarTab/Hint: Wybierz która zakładka jest domyślnie otwart
 Settings/DefaultMoreSidebarTab/Caption: Domyślna zakładka w podmenu "Więcej"
 Settings/DefaultMoreSidebarTab/Hint: Wybierz która zakładka ma być domyślnie wybrana w podmenu "Więcej"
 Settings/LinkToBehaviour/Caption: Zachowania Otwierania Tiddlerów
-Settings/LinkToBehaviour/InsideRiver/Hint: Nawigacja //z wewnątrz// widoku tiddlerów
-Settings/LinkToBehaviour/OutsideRiver/Hint: Nawgiacja //z poza// widoku tiddlerów
+Settings/LinkToBehaviour/InsideRiver/Hint: Nawigacja //z wewnątrz// Story River
+Settings/LinkToBehaviour/OutsideRiver/Hint: Nawgiacja //spoza// Story River
 Settings/LinkToBehaviour/OpenAbove: Otwórz ponad obecnym tiddlerem
 Settings/LinkToBehaviour/OpenBelow: Otwórz pod obecnym tiddlerem
-Settings/LinkToBehaviour/OpenAtTop: Otwórz na szczycie widoku tiddlerów
-Settings/LinkToBehaviour/OpenAtBottom: Otwórz na dole widoku tiddlerów
+Settings/LinkToBehaviour/OpenAtTop: Otwórz na szczycie Story River
+Settings/LinkToBehaviour/OpenAtBottom: Otwórz na dole Story River
 Settings/TitleLinks/Caption: Tytuły Tiddlerów
 Settings/TitleLinks/Hint: Opcjonanie wyświetlaj nazwy tiddlerów jako linki
 Settings/TitleLinks/No/Description: Nie wyświetlaj nazw jako linki
@@ -192,7 +192,7 @@ Settings/TitleLinks/Yes/Description: Wyświetlaj nazwy jako linki
 Settings/MissingLinks/Caption: Wiki Linki
 Settings/MissingLinks/Hint: Wybierz czy linkować do nieistniejących jeszcze tiddlerów
 Settings/MissingLinks/Description: Włacz linowanie do nieistniejących tiddlerów
-StoryView/Caption: Widok Tiddlerów
+StoryView/Caption: Widok Story River
 StoryView/Prompt: Obecny widok:
 Stylesheets/Caption: Style:
 Stylesheets/Expand/Caption: Rozwiń Wszystko

--- a/languages/pl-PL/ControlPanel.multids
+++ b/languages/pl-PL/ControlPanel.multids
@@ -1,0 +1,216 @@
+title: $:/language/ControlPanel/
+
+
+Advanced/Caption: Zaawansowane
+Advanced/Hint: Wewnętrzne informacje na temat TiddlyWiki
+Appearance/Caption: Wyświetlanie
+Appearance/Hint: Dostosowywanie wyglądu tej TiddlyWiki
+Basics/AnimDuration/Prompt: Długość animacji
+Basics/AutoFocus/Prompt: Domyślne pole z fokusem dla nowych tiddlerów
+Basics/Caption: Podstawowe
+Basics/DefaultTiddlers/BottomHint: Używaj &#91;&#91;podwójnych nawiasów kwadratowych&#93;&#93; dla nazw ze spacjami. Możesz też <$button set="$:/DefaultTiddlers" setTo="[list[$:/StoryList]]">zachować kolejność tiddlerów</$button>
+Basics/DefaultTiddlers/Prompt: Domyślne tiddlery
+Basics/DefaultTiddlers/TopHint: Wybierz które tiddlery mają być widoczne przy uruchomieniu
+Basics/Language/Prompt: Cześć! Wybrany język to:
+Basics/NewJournal/Title/Prompt: Tytuł nowych dzienników
+Basics/NewJournal/Text/Prompt: Treść nowych dzienników
+Basics/NewJournal/Tags/Prompt: Tagi nowych dzienników
+Basics/NewTiddler/Title/Prompt: Tytuł nowych tiddlerów
+Basics/NewTiddler/Tags/Prompt: Tagi nowych tiddlerów
+Basics/OverriddenShadowTiddlers/Prompt: Liczba nadpisanych ukrytych tiddlerów
+Basics/RemoveTags: Zaktualizuj do obecnego formatu
+Basics/RemoveTags/Hint: Zaktualizuj konfigurację tagów do najnowszego formatu
+Basics/ShadowTiddlers/Prompt: Liczba ukrytych tiddlerów
+Basics/Subtitle/Prompt: Podtytuł
+Basics/SystemTiddlers/Prompt: Liczba systemowych tiddlerów
+Basics/Tags/Prompt: Liczba tagów
+Basics/Tiddlers/Prompt: Liczba tiddlerów
+Basics/Title/Prompt: Tytuł tej ~TiddlyWiki
+Basics/Username/Prompt: Nazwa użytkownika do podpisywania zmian
+Basics/Version/Prompt: Wersja ~TiddlyWiki
+EditorTypes/Caption: Typy edytorów
+EditorTypes/Editor/Caption: Edytor
+EditorTypes/Hint: Te tiddlery określają który edytor jest używany do edycji tiddlerów danych typów.
+EditorTypes/Type/Caption: Typ
+Info/Caption: Info
+Info/Hint: Informacje o tej TiddlyWiki
+KeyboardShortcuts/Add/Prompt: Wpisz tu skrót
+KeyboardShortcuts/Add/Caption: dodaj skrót
+KeyboardShortcuts/Caption: Skróty Klawiszowe
+KeyboardShortcuts/Hint: Zarządzaj skrótami klawiszowymi
+KeyboardShortcuts/NoShortcuts/Caption: Brak skrótów klawiszowych
+KeyboardShortcuts/Remove/Hint: usuń skrót klawiszowy
+KeyboardShortcuts/Platform/All: Wszystkie platformy
+KeyboardShortcuts/Platform/Mac: Tylko na Macintoshu
+KeyboardShortcuts/Platform/NonMac: Tylko na nie-Macintoshach
+KeyboardShortcuts/Platform/Linux: Tylko na Linuxie
+KeyboardShortcuts/Platform/NonLinux: Tylko na nie-Linuxach
+KeyboardShortcuts/Platform/Windows: Tylko na Windowsie
+KeyboardShortcuts/Platform/NonWindows: Tylko na nie-Windowsach
+LayoutSwitcher/Caption: Układ
+LoadedModules/Caption: Wczytane Moduły
+LoadedModules/Hint: To są wszystie wczytane moduły podlinkowane do swoich tiddlerów źródłowych. Te zapisane kursywą nie posiadają źródłowych tiddlerów, zwykle dlatego, że były skonfigorwane podczas procesu uruchomienia.
+Palette/Caption: Paleta
+Palette/Editor/Clone/Caption: kopiuj
+Palette/Editor/Clone/Prompt: Zalecane jest skopiowanie taj ukrytej palety przed edycją
+Palette/Editor/Delete/Hint: usuń tą konfigurację z obecnej palety
+Palette/Editor/Names/External/Show: Pokaż nazwy kolorów, które nie są częścią wybranej palety
+Palette/Editor/Prompt/Modified: Ukryta paleta została zmieniona
+Palette/Editor/Prompt: Edytowanie
+Palette/Editor/Reset/Caption: resetuj
+Palette/HideEditor/Caption: ukryj edytor
+Palette/Prompt: Aktualna paleta:
+Palette/ShowEditor/Caption: pokaż edytor
+Parsing/Caption: Parsowanie
+Parsing/Hint: Tu możesz globalnie włączyć/wyłączyć zasady parsowania. Żeby zmiany zaczęły działać, zapisz i przeładuj wiki. Wyłączenie niektórych zasad może spowodować nieprawidłowe działanie <$text text="TiddlyWiki"/>. Użyj [[trybu bezpiecznego|https://tiddlywiki.com/#SafeMode]] by przywrócić normalne funkcjonowanie.
+Parsing/Block/Caption: Zasady Parsowania Blokowego
+Parsing/Inline/Caption: Zasady Parsowania Liniowego
+Parsing/Pragma/Caption: Zasady Parsowania Pragmy
+Plugins/Add/Caption: Pobierz więcej wtyczek
+Plugins/Add/Hint: Zainstaluj wtyczki z oficjalnej biblioteki
+Plugins/AlreadyInstalled/Hint: Ta wtyczka jest już zainstalowana w wersji <$text text=<<installedVersion>>/>
+Plugins/AlsoRequires: Również wymaga:
+Plugins/Caption: Wtyczki
+Plugins/Disable/Caption: wyłącz
+Plugins/Disable/Hint: Wyłacz tą wtyczkę przy kolejnym uruchomieniu
+Plugins/Disabled/Status: (wyłączony)
+Plugins/Downgrade/Caption: cofnij wersję
+Plugins/Empty/Hint: Brak
+Plugins/Enable/Caption: włącz
+Plugins/Enable/Hint: Włącz tą wtyczkę przy kolejnym uruchomieniu
+Plugins/Install/Caption: instaluj
+Plugins/Installed/Hint: Obecnie zainstalowane wtyczki
+Plugins/Languages/Caption: Języki
+Plugins/Languages/Hint: Wtyczki z paczkami językowymi
+Plugins/NoInfoFound/Hint: Nie znaleziono ''"<$text text=<<currentTab>>/>"''
+Plugins/NotInstalled/Hint: Ta wtyczka nie jest obecnie zainstalowana
+Plugins/OpenPluginLibrary: otwórz bibliotekę wtyczek
+Plugins/ClosePluginLibrary: zamknij bibliotekę wtyczek
+Plugins/PluginWillRequireReload: (wymaga przeładowania)
+Plugins/Plugins/Caption: Wtyczki
+Plugins/Plugins/Hint: Wtyczki
+Plugins/Reinstall/Caption: zainstaluj ponownie
+Plugins/Themes/Caption: Motywy
+Plugins/Themes/Hint: Wtyczki z motywami
+Plugins/Update/Caption: aktualizuj
+Plugins/Updates/Caption: Aktualizacje
+Plugins/Updates/Hint: Dostępne aktualizacje zainstalowanych wtyczek
+Plugins/Updates/UpdateAll/Caption: Zaktualizuj wtyczki: <<update-count>>
+Plugins/SubPluginPrompt: Dostępna liczba podwtyczek: <<count>>
+Saving/Caption: Zapisywanie
+Saving/DownloadSaver/AutoSave/Description: Zezwól serwerowi pobierania na automatyczne zapisywanie
+Saving/DownloadSaver/AutoSave/Hint: Zezwól automatyczne zapisywanie przy zapisywaniu na dysk
+Saving/DownloadSaver/Caption: Zapisywanie na Dysk
+Saving/DownloadSaver/Hint: Te ustawienia są dla zapisywania kompatybilnego z HTML5
+Saving/General/Caption: Ogólne
+Saving/General/Hint: Te ustawienia zmienają działanie wszystkich systemów zapisywania
+Saving/Hint: Ustawienia zapisywania całej TiddlyWiki jako jeden plik poprzez moduł zapisywania
+Saving/GitService/Branch: Docelowa gałąź do zapisu
+Saving/GitService/CommitMessage: Zapisane przez TiddlyWiki
+Saving/GitService/Description: Te ustawiena działają tylko gdy zapisujesz przy pomocy <<service-name>>
+Saving/GitService/Filename: Nazwa docelowego pliku (np. `index.html`)
+Saving/GitService/Path: Ścieżka docelowa do pliku (np. `/wiki/`)
+Saving/GitService/Repo: Docelowe repozytorium (np. `Jermolene/TiddlyWiki5`)
+Saving/GitService/ServerURL: URL do serwera API
+Saving/GitService/UserName: Nazwa użytkownika
+Saving/GitService/GitHub/Caption: ~Zapisywacz GitHub
+Saving/GitService/GitHub/Password: Hasło, token OAUTH lub osobisty token dospu ((sprawdź [[pomoc Githuba|https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line]] by uzyskać więcej szczegółów)
+Saving/GitService/GitLab/Caption: ~Zapisywacz GitLab
+Saving/GitService/GitLab/Password: Osobisty token do API ((sprawdź [[pomoc GitLaba|https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html]] by uzyskać więcej szczegółów)
+Saving/GitService/Gitea/Caption: Zapisywacz Gitea
+Saving/GitService/Gitea/Password: Osobisty token do API (przez interfejs webowy Gitea: `Settings | Applications | Generate New Token`)
+Saving/TiddlySpot/Advanced/Heading: Zaawansowane Ustawienia
+Saving/TiddlySpot/BackupDir: Folder z kopią zapasową
+Saving/TiddlySpot/ControlPanel: Panel Sterowania ~TiddlySpot
+Saving/TiddlySpot/Backups: Kopie zapasowe
+Saving/TiddlySpot/Caption: Zapisywacz ~TiddlySpot
+Saving/TiddlySpot/Description: Te ustawienia działają tylko gdy zapisujesz do [[TiddlySpot|http://tiddlyspot.com]], [[TiddlyHost|https://tiddlyhost.com]], lub do kompatyblinego serwra. Sprawdź [[tutaj|https://github.com/simonbaird/tiddlyhost/wiki/TiddlySpot-Saver-configuration-for-Tiddlyhost-and-Tiddlyspot]] by uzyskać więcej informacji na temat konfiguracji zapisywania do ~TiddlySpot lub ~TiddlyHost.
+Saving/TiddlySpot/Filename: Nazwa Pliku
+Saving/TiddlySpot/Heading: ~TiddlySpot
+Saving/TiddlySpot/Hint: //URL serwera to domyślnie `http://<wikiname>.tiddlyspot.com/store.cgi` ale może być zmienione by użyć własnego, np. `http://example.com/store.php`.//
+Saving/TiddlySpot/Password: Hasło
+Saving/TiddlySpot/ReadOnly: Uwaga: [[TiddlySpot|http://tiddlyspot.com]] obecnie nie pozwala tworzyć nowych stron. Sprawdź [[TiddlyHost|https://tiddlyhost.com]], nową usługę hostingową kompatybilną z ~TiddlySpot.
+Saving/TiddlySpot/ServerURL: URL serwera
+Saving/TiddlySpot/UploadDir: Folder Docelowy
+Saving/TiddlySpot/UserName: Nazwa Wiki
+Settings/AutoSave/Caption: Autozapis
+Settings/AutoSave/Disabled/Description: Nie zapisuj zmian automatycznie
+Settings/AutoSave/Enabled/Description: Zapisuj zmiany automatycznie
+Settings/AutoSave/Hint: Próbuj automatycznie zapisać zmiany podczas edycji, gdy używasz wspierającego to modułu zapisującego
+Settings/CamelCase/Caption: Camel Case WikiLinki
+Settings/CamelCase/Hint: Możesz wyłączyć automatyczne linkowanie fraz w ~CamelCase. Wymaga ponownego uruchomienia.
+Settings/CamelCase/Description: Włącz automatyczne linkowanie ~CamelCase
+Settings/Caption: Ustawienia
+Settings/EditorToolbar/Caption: Pasek Narzędzi Edytora
+Settings/EditorToolbar/Hint: Włącz lub wyłącz pasek narzędzi edytora:
+Settings/EditorToolbar/Description: Pokaż pasek narzędzi edytora
+Settings/InfoPanelMode/Caption: Tryb Panelu Info Tiddlerów
+Settings/InfoPanelMode/Hint: Ustaw kiedy panel info tiddlera zostanie zamknięty:
+Settings/InfoPanelMode/Popup/Description: Panel info wyłacza się automatycznie
+Settings/InfoPanelMode/Sticky/Description: Panel info pozostaje otwarty aż zostanie ręcznie zamknięty
+Settings/Hint: Te ustawienia pozwalają dostosować zachowanie TiddlyWiki
+Settings/NavigationAddressBar/Caption: Pasek adresu
+Settings/NavigationAddressBar/Hint: Zachowanie paska adresu w przeglądarce przy otworzeniu tiddlera:
+Settings/NavigationAddressBar/No/Description: Nie aktualizuj paska adresu
+Settings/NavigationAddressBar/Permalink/Description: Pokaż docelowego tiddlera
+Settings/NavigationAddressBar/Permaview/Description: Pokaż docelowego tiddlera i obecny widok
+Settings/NavigationHistory/Caption: Historia Nawigacji
+Settings/NavigationHistory/Hint: Aktualizuj historię nawigacji przeglądarki przy zmianie tiddlera:
+Settings/NavigationHistory/No/Description: Nie aktualizuj historii
+Settings/NavigationHistory/Yes/Description: Aktualizuj historię
+Settings/NavigationPermalinkviewMode/Caption: Tryb linków bezpośrednich/widoku
+Settings/NavigationPermalinkviewMode/Hint: Ustal jak linki bezośrednie/widok się zachowują:
+Settings/NavigationPermalinkviewMode/CopyToClipboard/Description: Skopiuj URL do linku bezpośredniego/widoku do schowka
+Settings/NavigationPermalinkviewMode/UpdateAddressBar/Description: Zaktualizuj pasek adresu o URL do linku bezpośredniego/widoku
+Settings/PerformanceInstrumentation/Caption: Statystyki Działania
+Settings/PerformanceInstrumentation/Hint: Wyświetla statystyki działania w konsoli deweloperskiej przeglądarki. Wymagane ponowne uruchmoenie
+Settings/PerformanceInstrumentation/Description: Włącz statystyki działania
+Settings/ToolbarButtonStyle/Caption: Styl Przycisków Paska Narzędzi
+Settings/ToolbarButtonStyle/Hint: Wybierz styl przycisków w pasku narzędzi
+Settings/ToolbarButtonStyle/Styles/Borderless: Bez ramki
+Settings/ToolbarButtonStyle/Styles/Boxed: Pudelko
+Settings/ToolbarButtonStyle/Styles/Rounded: Zaokrąglone
+Settings/ToolbarButtons/Caption: Przyciski Menu Narzędzi
+Settings/ToolbarButtons/Hint: Domyślnie wyświetlane przyciski paska narzędzi:
+Settings/ToolbarButtons/Icons/Description: Pokaż ikonę
+Settings/ToolbarButtons/Text/Description: Pokażtekst
+Settings/DefaultSidebarTab/Caption: Domyślna zakładka w menu bocznym
+Settings/DefaultSidebarTab/Hint: Wybierz która zakładka jest domyślnie otwarta w menu bocznym
+Settings/DefaultMoreSidebarTab/Caption: Domyślna zakładka w podmenu "Więcej"
+Settings/DefaultMoreSidebarTab/Hint: Wybierz która zakładka ma być domyślnie wybrana w podmenu "Więcej"
+Settings/LinkToBehaviour/Caption: Zachowania Otwierania Tiddlerów
+Settings/LinkToBehaviour/InsideRiver/Hint: Nawigacja //z wewnątrz// widoku tiddlerów
+Settings/LinkToBehaviour/OutsideRiver/Hint: Nawgiacja //z poza// widoku tiddlerów
+Settings/LinkToBehaviour/OpenAbove: Otwórz ponad obecnym tiddlerem
+Settings/LinkToBehaviour/OpenBelow: Otwórz pod obecnym tiddlerem
+Settings/LinkToBehaviour/OpenAtTop: Otwórz na szczycie widoku tiddlerów
+Settings/LinkToBehaviour/OpenAtBottom: Otwórz na dole widoku tiddlerów
+Settings/TitleLinks/Caption: Tytuły Tiddlerów
+Settings/TitleLinks/Hint: Opcjonanie wyświetlaj nazwy tiddlerów jako linki
+Settings/TitleLinks/No/Description: Nie wyświetlaj nazw jako linki
+Settings/TitleLinks/Yes/Description: Wyświetlaj nazwy jako linki
+Settings/MissingLinks/Caption: Wiki Linki
+Settings/MissingLinks/Hint: Wybierz czy linkować do nieistniejących jeszcze tiddlerów
+Settings/MissingLinks/Description: Włacz linowanie do nieistniejących tiddlerów
+StoryView/Caption: Widok Tiddlerów
+StoryView/Prompt: Obecny widok:
+Stylesheets/Caption: Style:
+Stylesheets/Expand/Caption: Rozwiń Wszystko
+Stylesheets/Hint: To jest wyrenderowany CSS obecnych tiddlerów otagowanych jako <<tag "$:/tags/Stylesheet">>
+Stylesheets/Restore/Caption: Przywróć
+Theme/Caption: Motyw
+Theme/Prompt: Obecny motyw:
+TiddlerFields/Caption: Pola Tiddlerów
+TiddlerFields/Hint: To jest pełna lista wszystich pól użytych w tej wiki (wliczając systemowych ale nie ukrytych tiddlerów)
+Toolbars/Caption: Paski Narzędzi
+Toolbars/EditToolbar/Caption: Edytuj Pasek Narzędzi
+Toolbars/EditToolbar/Hint: Wybierz, które przyciski mają być widoczne podczas edycji tiddlera. Przeciągaj by zmieniać kolejność.
+Toolbars/Hint: Wybierz, które przyciski mają być widoczne.
+Toolbars/PageControls/Caption: Pasek Narzędzi Strony
+Toolbars/PageControls/Hint: Wybierz, które przyciski mają być widoczne w głónym pasku narzędzi. Przeciągaj by zmieniać kolejność.
+Toolbars/EditorToolbar/Caption: Pasek Narzędzi edytora
+Toolbars/EditorToolbar/Hint: Wybierz które przyciski mają być widoczne w pasku narzędzi edytora. Pamiętaj, że tylko niektóre z nich są wyświetlane przy róznych typach tiddlerów. Przeciągaj by zmieniać kolejność
+Toolbars/ViewToolbar/Caption: Pasek Narzędzi Oglądania
+Toolbars/ViewToolbar/Hint: Wybierz które przyciski są widoczne podczas oglądania tiddlera. Przeciągaj by zmieniać kolejność.
+Tools/Download/Full/Caption: Pobierz całą wiki.
+

--- a/languages/pl-PL/Dates.multids
+++ b/languages/pl-PL/Dates.multids
@@ -1,0 +1,88 @@
+title: $:/language/
+
+Date/DaySuffix/1: .
+Date/DaySuffix/2: .
+Date/DaySuffix/3: .
+Date/DaySuffix/4: .
+Date/DaySuffix/5: .
+Date/DaySuffix/6: .
+Date/DaySuffix/7: .
+Date/DaySuffix/8: .
+Date/DaySuffix/9: .
+Date/DaySuffix/10: .
+Date/DaySuffix/11: .
+Date/DaySuffix/12: .
+Date/DaySuffix/13: .
+Date/DaySuffix/14: .
+Date/DaySuffix/15: .
+Date/DaySuffix/16: .
+Date/DaySuffix/17: .
+Date/DaySuffix/18: .
+Date/DaySuffix/19: .
+Date/DaySuffix/20: .
+Date/DaySuffix/21: .
+Date/DaySuffix/22: .
+Date/DaySuffix/23: .
+Date/DaySuffix/24: .
+Date/DaySuffix/25: .
+Date/DaySuffix/26: .
+Date/DaySuffix/27: .
+Date/DaySuffix/28: .
+Date/DaySuffix/29: .
+Date/DaySuffix/30: .
+Date/DaySuffix/31: .
+Date/Long/Day/0: Niedziela
+Date/Long/Day/1: Poniedziałek
+Date/Long/Day/2: Wtorek
+Date/Long/Day/3: Środa
+Date/Long/Day/4: Czwartek
+Date/Long/Day/5: Piątek
+Date/Long/Day/6: Sobota
+Date/Long/Month/1: Styczeń
+Date/Long/Month/2: Luty
+Date/Long/Month/3: Marzec
+Date/Long/Month/4: Kwiecień
+Date/Long/Month/5: Maj
+Date/Long/Month/6: Czerwiec
+Date/Long/Month/7: Lipiec
+Date/Long/Month/8: Sierpień
+Date/Long/Month/9: Wrzesień
+Date/Long/Month/10: Październik
+Date/Long/Month/11: Listopad
+Date/Long/Month/12: Grudzień
+Date/Period/am: AM
+Date/Period/pm: PM
+Date/Short/Day/0: nd
+Date/Short/Day/1: pn
+Date/Short/Day/2: wt
+Date/Short/Day/3: śr
+Date/Short/Day/4: cz
+Date/Short/Day/5: pt
+Date/Short/Day/6: sb
+Date/Short/Month/1: st
+Date/Short/Month/2: lut
+Date/Short/Month/3: mrz
+Date/Short/Month/4: kw
+Date/Short/Month/5: maj
+Date/Short/Month/6: cz
+Date/Short/Month/7: lip
+Date/Short/Month/8: sier
+Date/Short/Month/9: wrz
+Date/Short/Month/10: paź
+Date/Short/Month/11: lis
+Date/Short/Month/12: gr
+RelativeDate/Future/Days: <<period>> dni od teraz
+RelativeDate/Future/Hours: <<period>> godzin od teraz
+RelativeDate/Future/Minutes: <<period>> minut od teraz
+RelativeDate/Future/Months: <<period>> miesięcy od teraz
+RelativeDate/Future/Second: 1 sekunda od teraz
+RelativeDate/Future/Seconds: <<period>> sekund od teraz
+RelativeDate/Future/Years: <<period>> lat od teraz
+RelativeDate/Past/Days: <<period>> dni temu
+RelativeDate/Past/Hours: <<period>> godizn temu
+RelativeDate/Past/Minutes: <<period>> minut temu
+RelativeDate/Past/Months: <<period>> miesięcy temu
+RelativeDate/Past/Second: 1 sekundę temu
+RelativeDate/Past/Seconds: <<period>> sekund temu
+RelativeDate/Past/Years: <<period>> lat temu
+

--- a/languages/pl-PL/Docs/ModuleTypes.multids
+++ b/languages/pl-PL/Docs/ModuleTypes.multids
@@ -16,7 +16,7 @@ parser: Parsery (analizatory składniowe) dla róznych typów treści.
 route: Definiują jak indywidualne wzorce adresów URL są obsługiwane przez wbudowany serwer HTTP.
 saver: Obsługa różnych metod zapisu plików z poziomu przeglądarki.
 startup: Funkcje wywoływane przy uruchomieniu.
-storyview: Widoki tiddlerów zmieniają sposób w jaki tiddlery pojawiają się i jak się zachowują na głównej liście.
+storyview: Zmienają sposób w jaki tiddlery pojawiają się, znikają i zachowują w Story River (widok otwartych tiddlerów)
 texteditoroperation: Operacja na pasku narzędzi edytora tekstu.
 tiddlerdeserializer: Przetwarzanie róznych typów danych na tiddlery.
 tiddlerfield: Definiuje zachowanie pojedyńczego pola w tiddlerze.

--- a/languages/pl-PL/Docs/ModuleTypes.multids
+++ b/languages/pl-PL/Docs/ModuleTypes.multids
@@ -1,0 +1,30 @@
+title: $:/language/Docs/ModuleTypes/
+
+allfilteroperator: Podoperatory dla filtra ''all''.
+animation: Animacje, których można użyć z RevealWidget.
+authenticator: Dostępne uwierzytelniania zapytań przez wbudowany serwer HTTP.
+bitmapeditoroperation: Operacje w pasku narzędzi edytora obrazów.
+command: Komendy, które można wykonać w Node.js.
+config: Dane do dodania do konfiguracji `$tw.config`.
+filteroperator: Operatory filtrów.
+global: Globalne dane do dodania do `$tw`.
+info: Publikują informacje systemowe poprzes pseudo-wtyczkę [[$:/temp/info-plugin]].
+isfilteroperator: Argumenty dla operatora filtra ''is''.
+library: Generyczny typ modułu dla modułów robiących inne rzeczy w JavaScripcie.
+macro: JavaScriptowe definicje makr.
+parser: Parsery (analizatory składniowe) dla róznych typów treści.
+route: Definiują jak indywidualne wzorce adresów URL są obsługiwane przez wbudowany serwer HTTP.
+saver: Obsługa różnych metod zapisu plików z poziomu przeglądarki.
+startup: Funkcje wywoływane przy uruchomieniu.
+storyview: Widoki tiddlerów zmieniają sposób w jaki tiddlery pojawiają się i jak się zachowują na głównej liście.
+texteditoroperation: Operacja na pasku narzędzi edytora tekstu.
+tiddlerdeserializer: Przetwarzanie róznych typów danych na tiddlery.
+tiddlerfield: Definiuje zachowanie pojedyńczego pola w tiddlerze.
+tiddlermethod: Dodaje funkcję do prototype `$tw.Tiddler`.
+upgrader: Aktualizuje tiddlery podczas aktualizacji wiki/importu.
+utils: Dodaje funkcję do `$tw.utils`.
+utils-browser: Dodaje funkcje dla przeglądarki do `$tw.utils`.
+utils-node: Dodaje funkcje dla Node.js do `$tw.utils`.
+widget: Widzety obsługują wyświetlanie i aktualizowanie DOM.
+wikimethod: Dodaje funkcje do `$tw.Wiki`.
+wikirule: Indywidualne zasady parsera (analizatora składniowego) do głównego silnika WikiText.

--- a/languages/pl-PL/Docs/PaletteColours.multids
+++ b/languages/pl-PL/Docs/PaletteColours.multids
@@ -1,0 +1,109 @@
+title: $:/language/Docs/PaletteColours/
+
+alert-background: Tło alertu
+alert-border: Ramka alertu
+alert-highlight: Podświetlenie alertu
+alert-muted-foreground: Stonowany tekst alertu
+background: Ogólne tło
+blockquote-bar: Lewa ramka cytatu
+button-background: Ogólne tło przycisku
+button-border: Ogólna ramka przycisku
+button-foreground: Ogólne tekst przycisku
+dirty-indicator: Wskażnik niezapisanych zmian
+code-background: Tło kodu
+code-border: Ramka kodu
+code-foreground: Tekst kodu
+download-background: Tło przycisku pobierania
+download-foreground: Tekst przycisku pobierania
+dragger-background: Tło przeciąganego tiddlera
+dragger-foreground: Tekst przeciąganego tiddlera
+dropdown-background: Tło rozwijanego elementu
+dropdown-border: Ramka rozwijanego elementu
+dropdown-tab-background-selected: Tło wybranej rowijanej zakładki
+dropdown-tab-background: Tło rozwijanej zakładki
+dropzone-background: Tło komunikatu o wrzucaniu pliku
+external-link-background-hover: Tło po najechaniu na zewnętrzny link
+external-link-background-visited: Tło odwiedzonego zewnętrznego linku
+external-link-background: Tło zewnętrznego linku
+external-link-foreground-hover: Tekst po najechaniu na zewnętrzny link
+external-link-foreground-visited: Tekst odwiedzonego zewnętrznego linku
+external-link-foreground: Tekst zewnętrznego linku
+foreground: Tekst
+menubar-background: Tło paska menu
+menubar-foreground: Tekst paska menu
+message-background: Tło bloku z wiadomością
+message-border: Ramka bloku z wiadomością
+message-foreground: Tekst bloku z wiadomością
+modal-backdrop: Przyciemnieni okna modalnego
+modal-background: Tło okna modalnego
+modal-border: Ramka okna modalnego
+modal-footer-background: Tło stópki okna modalnego
+modal-footer-border: Ramka stópki okna modalnego
+modal-header-border: Ramka nagłówka okna modalnego
+muted-foreground: Ogólny  stonowany tekst
+notification-background: Tło notyfikacji
+notification-border: Ramka notyfikacji
+page-background: Tło strony
+pre-background: Tło sformatowanego kodu
+pre-border: Ramka sformatowanego kodu
+primary: Ogólny, główny kolor
+select-tag-background: Tło elementu `<select>`
+select-tag-foreground: Tekst elementu `<select>`
+sidebar-button-foreground: Kolor przycisku w menu bocznym
+sidebar-controls-foreground-hover: Kolor kontrolki w menu bocznym po najechaniu
+sidebar-controls-foreground: Kolor kontrolki w menu bocznym
+sidebar-foreground-shadow: Cień tekstu w menu bocznym
+sidebar-foreground: Tekst w menu bocznym
+sidebar-muted-foreground-hover: Stonowany tekst w menu bocznym po najechaniu
+sidebar-muted-foreground: Stonowany tekst w menu bocznym
+sidebar-tab-background-selected: Tło wybranej zakładki w menu bocznym
+sidebar-tab-background: Tło zakładki w menu bocznym
+sidebar-tab-border-selected: Ramka wybranej zakładki w menu bocznym
+sidebar-tab-border: Ramka zakładki w menu bocznym
+sidebar-tab-divider: Separator zakładek w menu bocznym
+sidebar-tab-foreground-selected: Tekst wybranej zakładki w menu bocznym
+sidebar-tab-foreground: Tekst zakładki w menu bocznym
+sidebar-tiddler-link-foreground-hover: Tekst po najechaniu linku do tiddlera w menu bocznym
+sidebar-tiddler-link-foreground: Tekst linka do tiddlera w menu bocznym
+site-title-foreground: Tekst nazwy strony
+static-alert-foreground: Tekst statycznego alertu
+tab-background-selected: Tło wybranej zakładki
+tab-background: Tło zakładki
+tab-border-selected: Ramka wybranej zakładki
+tab-border: Ramka zakłądki
+tab-divider: Separator zakładek
+tab-foreground-selected: Tekst wybranej zakładki
+tab-foreground: Tekst zakładki
+table-border: Ramka tabeli
+table-footer-background: Tło stópki tabeli
+table-header-background: Tło nagłówka tabeli
+tag-background: Tło tabeli
+tag-foreground: Tekst tabeli
+tiddler-background: Tło tiddlera
+tiddler-border: Ramka tiddlera
+tiddler-controls-foreground-hover: Tekst kontrolek tiddlera po najechaniu
+tiddler-controls-foreground-selected: Tekst wybranej kontrolki tiddlera
+tiddler-controls-foreground: Tekst kontrolki tiddlera
+tiddler-editor-background: Tło edytora tiddlera
+tiddler-editor-border-image: Ramka obrazka w edytorze tiddlera
+tiddler-editor-border: Ramka editora tiddlera
+tiddler-editor-fields-even: Tło parzystego pola w edytorze tiddlera
+tiddler-editor-fields-odd: Tło nieparzystego pola w edytorze tiddlera
+tiddler-info-background: Tło panelu info tiddlera
+tiddler-info-border: Ramka panelu info tiddlera
+tiddler-info-tab-background: Tło zakładki panelu info tiddlera
+tiddler-link-background: Tło linka tiddlera
+tiddler-link-foreground: Tekst linka tiddlera
+tiddler-subtitle-foreground: Tekst podtytułu tiddlera
+tiddler-title-foreground: Tekst nazwy tiddlera
+toolbar-new-button: Tekst przycisku 'nowy tiddler' w pasku narzędzi
+toolbar-options-button: Tekst przycisku 'opcje' w pasku narzędzi
+toolbar-save-button: Tekst przycisku 'zapisz' w pasku narzędzi
+toolbar-info-button: Tekst przycisku 'info' w pasku narzędzi
+toolbar-edit-button: Tekst przycisku 'edytuj' w pasku narzędzi
+toolbar-close-button: Tekst przycisku 'zamknij' w pasku narzędzi
+toolbar-delete-button: Tekst przycisku 'usuń' w pasku narzędzi
+toolbar-cancel-button: Tekst przycisku 'anuluj' w pasku narzędzi
+toolbar-done-button: Tekst przycisku 'zakończ' w pasku narzędzi
+untagged-background: Tło taga "nieotagowane"
+very-muted-foreground: Bardzo stonowany tekst

--- a/languages/pl-PL/EditTemplate.multids
+++ b/languages/pl-PL/EditTemplate.multids
@@ -3,7 +3,7 @@ title: $:/language/EditTemplate/
 Body/External/Hint: Ten tiddler zawiera treść trzymaną poza głównym plikiem TiddlyWIki. Możesz edytować tagi i pola, ale nie możesz bezpośrednio edytować jego treści.
 Body/Placeholder: Wpisz treść tiddlera
 Body/Preview/Type/Output: rezultat
-Body/Preview/Type/DiffShadow: różnice z ukrytym (jeżeli są)
+Body/Preview/Type/DiffShadow: różnice z cieniem (jeżeli są)
 Body/Preview/Type/DiffCurrent: róznice z obecnym
 Field/Remove/Caption: usuń pole
 Field/Remove/Hint: Usuń pole
@@ -16,8 +16,8 @@ Fields/Add/Prompt: Dodaj nowe pole:
 Fields/Add/Value/Placeholder: wartość pola
 Fields/Add/Dropdown/System: Pola systemowe
 Fields/Add/Dropdown/User: Pola własne
-Shadow/Warning: To jest ukryty tiddler. Wszelkie zmiany jakich tu dokonasz nadpiszą domyślną wersję z wtyczki <<pluginLink>>
-Shadow/OverriddenWarning: To jest zmodyfikowany ukryty tiddler. Usuń go, by przywrócić oryginalną wersję z pluginu <<pluginLink>>
+Shadow/Warning: To jest tiddler-cień. Wszelkie zmiany jakich tu dokonasz nadpiszą domyślną wersję z wtyczki <<pluginLink>>
+Shadow/OverriddenWarning: To jest zmodyfikowany tiddler-cień. Usuń go, by przywrócić oryginalną wersję z pluginu <<pluginLink>>
 Tags/Add/Button: dodaj
 Tags/Add/Button/Hint: dodaj tag
 Tags/Add/Placeholder: nazwa taga

--- a/languages/pl-PL/EditTemplate.multids
+++ b/languages/pl-PL/EditTemplate.multids
@@ -1,0 +1,38 @@
+title: $:/language/EditTemplate/
+
+Body/External/Hint: Ten tiddler zawiera treść trzymaną poza głównym plikiem TiddlyWIki. Możesz edytować tagi i pola, ale nie możesz bezpośrednio edytować jego treści.
+Body/Placeholder: Wpisz treść tiddlera
+Body/Preview/Type/Output: rezultat
+Body/Preview/Type/DiffShadow: różnice z ukrytym (jeżeli są)
+Body/Preview/Type/DiffCurrent: róznice z obecnym
+Field/Remove/Caption: usuń pole
+Field/Remove/Hint: Usuń pole
+Field/Dropdown/Caption: lista pól
+Field/Dropdown/Hint: Pokaż listę pól
+Fields/Add/Button: dodaj
+Fields/Add/Button/Hint: Dodaj nowe pole do tiddlera
+Fields/Add/Name/Placeholder: nazwa pola
+Fields/Add/Prompt: Dodaj nowe pole:
+Fields/Add/Value/Placeholder: wartość pola
+Fields/Add/Dropdown/System: Pola systemowe
+Fields/Add/Dropdown/User: Pola własne
+Shadow/Warning: To jest ukryty tiddler. Wszelkie zmiany jakich tu dokonasz nadpiszą domyślną wersję z wtyczki <<pluginLink>>
+Shadow/OverriddenWarning: To jest zmodyfikowany ukryty tiddler. Usuń go, by przywrócić oryginalną wersję z pluginu <<pluginLink>>
+Tags/Add/Button: dodaj
+Tags/Add/Button/Hint: dodaj tag
+Tags/Add/Placeholder: nazwa taga
+Tags/ClearInput/Caption: wyczyść
+Tags/ClearInput/Hint: Wyczyść tagi
+Tags/Dropdown/Caption: lista tagów
+Tags/Dropdown/Hint: Pokaż listę tagów
+Title/BadCharacterWarning: Uwaga: unikaj używania któregokolwiek z tych znaków w nazwach tiddlerów: <<bad-chars>>
+Title/Exists/Prompt: Docelowy tiddler już istnieje
+Title/Relink/Prompt: Zaktualizuj ''<$text text=<<fromTitle>>/>'' na ''<$text text=<<toTitle>>/>'' w //tagach// i //listach// pól innych tiddlerów
+Title/References/Prompt: Poniższe odniesienia do tego tiddlera nie zostały automatycznie zaktualizowane
+Type/Dropdown/Caption: lista typów treści
+Type/Dropdown/Hint: Wyswietla liste typów treści
+Type/Delete/Caption: usuń typ treści
+Type/Delete/Hint: Usuwa typ treści
+Type/Placeholder: typ treści
+Type/Prompt: Typ:
+

--- a/languages/pl-PL/Exporters.multids
+++ b/languages/pl-PL/Exporters.multids
@@ -1,0 +1,7 @@
+title: $:/language/Exporters/
+
+StaticRiver: Statyczny HTML
+JsonFile: Plik JSON
+CsvFile: Plik CSV
+TidFile: Plik ".tid"
+

--- a/languages/pl-PL/Fields.multids
+++ b/languages/pl-PL/Fields.multids
@@ -1,0 +1,39 @@
+title: $:/language/Docs/Fields/
+
+_canonical_uri: Pełny adres URL do zewnętrznego obrazu
+bag: Nazwa worka, z ktorego pochodzi tiddler
+caption: Tekst wyświetlany na zakładce lub przycisku
+color: Wartość koloru CSS powiążanego z tym tiddlerem
+component: Nazwa komponentu odpowiedzialnego za [[alert|AlertMechanism]]
+current-tiddler: Używane by zapamiętać ostatniego tiddlera w [[liście historii|HistoryMechanism]]
+created: Data kiedy utworzono tiddlera
+creator: Imię twórcy tiddlera
+dependents: Dla wtyczki, lista nazw zależnych wtyczek
+description: Opis wtyczki lub okna modalnego
+draft.of: Dla szkicy, zawiera nazwę tiddlera którego jest szkicem
+draft.title: Dla szkicy, zawiera proponowaną nową nazwę
+footer: Teskt stópki okna modalnego
+hide-body: Ustawienie wartości na ''yes'' ukryje treść tiddlera
+icon: Nazwa tiddlera zawierającego ikonę, która ma być powiązana z tym tiddlerem
+library: Ustawienie wartości na ''yes'' oznacza, że tiddler ma być zapisany jako biblioteka JavaScriptu
+list: Posortowana lista nazw tiddlerów powiązanych z tym tiddlerem
+list-before: Jeżeli ustawione, nazwa tiddlera przed którym ten tiddler będzie dodany w sortowanej liście nazw tiddlerów; lub na początku listy jeżeli pole jest obecne ale puste
+list-after: Jeżeli ustawione, nazwa tiddlera po którym ten tiddler będzie dodany w sortowanej liście nazw tiddlerów; lub na końcu listy jeżeli pole jest obecne ale puste
+modified: Czas i data ostatniej modyfikacji
+modifier: Tytuł tiddlera powiązanego z osobą, która ostatnio modyfikowała tego tiddlera
+name: Czytelna nazwa powiązana z tiddlerem wtyczki
+plugin-priority: Numeryczna wartość określająca tiddlera wtyczki
+plugin-type: Typ tiddlera wtyczki
+revision: Numer rewizji tiddlera przechowywany na serwerze
+released: Data wydania TiddlyWiki
+source: URL źródłowy powiązany z tiddlerem
+subtitle: Podtytuł okna modalnego
+tags: Lista tagów powiązana z tym tiddlerem
+text: Treść tiddlera
+throttle.refresh: Jezeli ustawione, ustala opóźnienie odświeżania tiddlera
+title: Unikatowa nazwa tiddlera
+toc-link: Powoduje, że spisie treści ten tiddler nie będzie podlinkowany (ale dalej bedzie obecny)
+type: Typ treści tiddlera
+version: Informacja o wersji wtyczki
+_is_skinny: Jeżeli obecne, oznacza, że treść tego tiddlera musi być wczytana z serwera
+

--- a/languages/pl-PL/Filters.multids
+++ b/languages/pl-PL/Filters.multids
@@ -8,8 +8,8 @@ Missing: Brakujące tiddlery
 Drafts: Szkice tiddlerów
 Orphans: Tiddlery bez rodzica
 SystemTiddlers: Systemowe tiddlery
-ShadowTiddlers: Ukryte tiddlery
-OverriddenShadowTiddlers: Nadpisane ukryte tiddlery
+ShadowTiddlers: Tiddlery-cienie
+OverriddenShadowTiddlers: Nadpisane tiddlery-cienie
 SessionTiddlers: Tiddlery zmodyfikowane od wczytania wiki
 SystemTags: Tagi systemowe
 StoryList: Tiddlery w Story River, wyłączając <$text text="$:/AdvancedSearch"/>

--- a/languages/pl-PL/Filters.multids
+++ b/languages/pl-PL/Filters.multids
@@ -1,0 +1,16 @@
+title: $:/language/Filters/
+
+AllTiddlers: Wszystkie tiddlery poza systemowymi
+RecentSystemTiddlers: Ostatnio modyfikowane tiddlery, wliczając systemowe
+RecentTiddlers: Ostatnio modyfikowane tiddlery
+AllTags: Wszystkie tagi poza systemowymi
+Missing: Brakujące tiddlery
+Drafts: Szkice tiddlerów
+Orphans: Tiddlery bez rodzica
+SystemTiddlers: Systemowe tiddlery
+ShadowTiddlers: Ukryte tiddlery
+OverriddenShadowTiddlers: Nadpisane ukryte tiddlery
+SessionTiddlers: Tiddlery zmodyfikowane od wczytania wiki
+SystemTags: Tagi systemowe
+StoryList: Tiddlery w głównym widoku, wyłączając <$text text="$:/AdvancedSearch"/>
+TypedTiddlers: Tiddlery o typie innym niż wikitext

--- a/languages/pl-PL/Filters.multids
+++ b/languages/pl-PL/Filters.multids
@@ -12,5 +12,5 @@ ShadowTiddlers: Ukryte tiddlery
 OverriddenShadowTiddlers: Nadpisane ukryte tiddlery
 SessionTiddlers: Tiddlery zmodyfikowane od wczytania wiki
 SystemTags: Tagi systemowe
-StoryList: Tiddlery w głównym widoku, wyłączając <$text text="$:/AdvancedSearch"/>
+StoryList: Tiddlery w Story River, wyłączając <$text text="$:/AdvancedSearch"/>
 TypedTiddlers: Tiddlery o typie innym niż wikitext

--- a/languages/pl-PL/GettingStarted.tid
+++ b/languages/pl-PL/GettingStarted.tid
@@ -1,0 +1,17 @@
+title: Na Dobry Początek
+
+\define lingo-base() $:/language/ControlPanel/Basics/
+Witaj w ~TiddlyWiki oraz jej społeczności
+
+Zanim zaczniesz zapisywać ważne informacje w swojej ~TiddlyWiki ważne jest, żeby mieć niezawodny sposób by zapisywać zmiany. Przejdź do https://tiddlywiki.com/#GettingStarted by otrzymać więcej informacji
+
+!! Skonfiguruj tą ~TiddlyWiki
+
+<div class="tc-control-panel">
+
+|<$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link> |<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
+|<$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link> |<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
+|<$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link> |<<lingo DefaultTiddlers/TopHint>><br> <$edit tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
+</div>
+
+Przejdź do [[panelu sterowania|$:/ControlPanel]] by zmienić pozostałe opcje.

--- a/languages/pl-PL/Help/build.tid
+++ b/languages/pl-PL/Help/build.tid
@@ -1,0 +1,12 @@
+title: $:/language/Help/build
+description: Automatycznie uruchom skonfigurowane komendy
+
+Zbuduj wybrane 'build targets' dla aktualnej wiki. Jeżeli nie podasz żadnych 'build targets' komenda zbuduje je wszystkie
+Build the specified build targets for the current wiki. If no build targets are specified then all available targets will be built.
+
+```
+--build <target> [<target> ...]
+```
+
+'Build targets' są zdefiniowane w pliku `tiddlywiki.info` w folderze gdzie znajduje się wiki.
+

--- a/languages/pl-PL/Help/clearpassword.tid
+++ b/languages/pl-PL/Help/clearpassword.tid
@@ -1,0 +1,8 @@
+title: $:/language/Help/clearpassword
+description: Usuwa hasło dla kolejnych operacji crypto
+
+Usuwa hasło dla kolejnych operacji crypto
+
+```
+--clearpassword
+```

--- a/languages/pl-PL/Help/default.tid
+++ b/languages/pl-PL/Help/default.tid
@@ -1,0 +1,22 @@
+title: $:/language/Help/default
+
+\define commandTitle()
+$:/language/Help/$(command)$
+\end
+```
+użycie: tiddlywiki [<wikifolder>] [--<command> [<args>...]...]
+```
+
+Dostępne komendy:
+
+<ul>
+<$list filter="[commands[]sort[title]]" variable="command">
+<li><$link to=<<commandTitle>>><$macrocall $name="command" $type="text/plain" $output="text/plain"/></$link>: <$transclude tiddler=<<commandTitle>> field="description"/></li>
+</$list>
+</ul>
+
+By otrzymać szczegółowy opis komendy:
+
+```
+tiddlywiki --help <command>
+```

--- a/languages/pl-PL/Help/deletetiddlers.tid
+++ b/languages/pl-PL/Help/deletetiddlers.tid
@@ -1,0 +1,8 @@
+title: $:/language/Help/deletetiddlers
+description: Usuwa grupę tiddlerów
+
+<<.from-version "5.1.20">> Usuwa grupę tiddlerów wedle podanego filtra.
+
+```
+--deletetiddlers <filter>
+```

--- a/languages/pl-PL/Help/editions.tid
+++ b/languages/pl-PL/Help/editions.tid
@@ -1,0 +1,8 @@
+title: $:/language/Help/editions
+description: Wyświetla listę wszystkich dostępnych wydań TiddlyWiki
+
+Wyświetla nazwy i opisy wszystkich dostępnych wydań. Możesz utworzyć nową wiki w wybranej wersji przy pomocy komend `--init`.
+
+```
+--editions
+```

--- a/languages/pl-PL/Help/fetch.tid
+++ b/languages/pl-PL/Help/fetch.tid
@@ -1,0 +1,40 @@
+title: $:/language/Help/fetch
+description: Pobierz tiddlery z wiki po URLu
+
+Pobierze jeden lub wiecej plików przez internet i zaimportuj tiddlery pasujące do filtra, opcjonalnie zmieniając ich nazwy.
+
+```
+--fetch file <url> <import-filter> <transform-filter>
+--fetch files <url-filter> <import-filter> <transform-filter>
+--fetch raw-file <url> <transform-filter>
+--fetch raw-files <url-filter> <transform-filter>
+```
+
+"file" i "files" pobierają wybrane pliki i próbuję zaimportować zawarte w nich tiddlery (w ten sam sposób jakby pliki zostały przeciągnięte do okna przeglądarki).  "raw-file" i "raw-files" pobierają pliki i zapisują je jako surowe dane w tiddlerach, bez dokonywania zmian.
+
+
+"file" i "raw-file" pobierają tylko jeden plik i pierwszy argument to URL do tego pliku.
+
+
+"files" i "raw-files" pobierają wiele plików i pierwszy argument to filtr, który będzie uruchomiony by wygenerowac listę adresów i pobrać z nich pliki. Dla przykładu, jeżeli masz kilka tiddlerów otagowanych jako "remote-server" i każdy ma pole "url", filtre `[tag[remote-server]get[url]]` pobierze wszystkie URLe w nich zawarte.
+
+Dla "file" i "files", argument `<import-filter>` określa filtr, który ograniczy które tiddlery zaimportować. Domyślnie jest to `[all[tiddlers]]`.
+
+Aegument `<transform-filter>` określa opcjonalny filtr, który zmieni nazw zaimportowanych tiddlerów. Dla przykładu, `[addprefix[$:/myimports/]]` doda przedrostek `$:/myimports/` do każdej nazwy.
+
+Jeżeli przed komendą `--fetch` dodasz komendę `--verbose`, to komenda wypisze dodatkowe informacje w czasie importu.
+
+Uwaga: TiddlyWiki nie pobierze starszej wersji już wczytanej wtyczki.
+
+Poniższy przykład pobierze wszystkie niesystemowe wtyczki z https://tiddlywiki.com i zapisze je w pliku JSON:
+
+```
+tiddlywiki --verbose --fetch file "https://tiddlywiki.com/" "[!is[system]]" "" --rendertiddler "$:/core/templates/exporters/JsonFile" output.json text/plain "" exportFilter "[!is[system]]"
+```
+
+Poniższy przykład pobierze plik "favicon" z tiddlywiki.com i zapisze go w pliku "output.com". Zwróc uwagę, że pośredni tiddler "Icon Tiddler" jest w nawiasach w komendzie "--fetch", ponieważ jest użyty jako filtr by nadpisać domyślny tytuł, podczas gdy przy komendzie "--savetiddler" nie ma nawiasów gdyż tam jest użyty bezposrednio jako tytuł
+
+```
+tiddlywiki --verbose --fetch raw-file "https://tiddlywiki.com/favicon.ico" "[[Icon Tiddler]]" --savetiddler "Icon Tiddler" output.ico
+```
+

--- a/languages/pl-PL/Help/help.tid
+++ b/languages/pl-PL/Help/help.tid
@@ -1,0 +1,10 @@
+title: $:/language/Help/help
+description: Wyświetl dodatkowe informacje o komendzie
+
+Wyświetla dodatkowe informacje o komendzie:
+
+```
+--help [<command>]
+```
+
+Jeżeli nie podasz nazwa komendy, wyświetli listę wszystkich dostępnych komend.

--- a/languages/pl-PL/Help/import.tid
+++ b/languages/pl-PL/Help/import.tid
@@ -1,0 +1,24 @@
+title: $:/language/Help/import
+description: Zaimportuj tiddlery z pliku
+
+Importuje tidlerry z TiddlyWiki (`.html`), `.tiddler`, `.tid`, `.json` lub innych lokalnych plików. Deserializator musi być podany, w przeciwieństwie do komendy `--load`, która sama próbuje określic typ danych na podstawie rozszerzenia pliku.
+
+```
+--import <filepath> <deserializer> [<title>] [<encoding>]
+```
+
+Wbudowane deserializatory to:
+
+* application/javascript
+* application/json
+* application/x-tiddler
+* application/x-tiddler-html-div
+* application/x-tiddlers
+* text/html
+* text/plain
+
+Tytuł importowanego tiddlera to domyślnie nazwa pliku.
+
+Kodowanie pliku to domyśłnie "utf8", ale może być też "base64" dla plików binarnych.
+
+Zwróc uwagę, że TiddlyWiki nie zaimportuje starszych wersji już wczytanych wtyczek.

--- a/languages/pl-PL/Help/init.tid
+++ b/languages/pl-PL/Help/init.tid
@@ -1,0 +1,23 @@
+title: $:/language/Help/init
+description: Zainicjalizuj nowy WikiFolder
+
+Inicjalizuje nowy, pusty [[WikiFolder|WikiFolders]] z kopią wybranego wydania.
+
+```
+--init <edition> [<edition> ...]
+```
+
+Dla przykładu:
+
+```
+tiddlywiki ./MyWikiFolder --init empty
+```
+
+Uwagi:
+
+* Folder zostanie utworzony jeżeli jeszcze nie istnieje
+* "edition" ma domyślną wartość ''empty''
+* Komenda się nie powiedzie, jeżeli folder nie jest pusty
+* Komenda usuwa wszelkie definicje `includeWiki` z okujy `tiddlywiki.info`
+* Gdy podasz kilka edycji, edycje wpisane później nadpiszą pliku ze starszych edycji. Na przykład `tiddlywiki.info` zostanie wzięty z ostatniej wybranej edycji
+* `--editions` bez argumentów zwraca listę dostępnych edycji

--- a/languages/pl-PL/Help/listen.tid
+++ b/languages/pl-PL/Help/listen.tid
@@ -1,0 +1,35 @@
+title: $:/language/Help/listen
+description: Tworzy serwer HTTP udostępniający TiddlyWiki
+
+Serwuje wiki po HTTP.
+
+Komenda ta przyjmuje argumenty jako pary `nazwa=wartość`:
+
+```
+--listen [<name>=<value>]...
+```
+
+Wszystkie argumenty są opcjonalne z bezpiecznymi wartościami domyślnimi i mogą być podane w jakiejkolwiek kolejności. Dostępne argumenty to:
+
+* ''host'' - opcjonalna nazwa hosta (domyślnie to "127.0.0.1", czyli "localhost")
+* ''path-prefix'' - opcjonalny przedrostek dodawany do ścieżek
+* ''port'' - port na którym nasłuchuje serwer; nie-numeryczne wartości sa interpretowane jakby to były zmienne środowiskowe z których należy pobrać numer portu (domyślnie to "8080")
+* ''credentials'' - ścieżka do pliku CSV z hasłami (relatywnie do folderu wiki)
+* ''anon-username'' - nazwa użytkownika do podispywania zmian dla anonimowych użytkowników
+* ''username'' - opcjonalna nazwa użytkownika do autoryzacji basic
+* ''password'' - opcjonalne hasło do autoryzacji basic
+* ''authenticated-user-header'' - opcjonalna nazwa nagłówka używanego do autentykacji
+* ''readers'' - lista po przecinku osób, które mogą odczytywać wiki
+* ''writers'' - lista po przecinku osób, które mogą edytować wiki
+* ''csrf-disable'' - ustaw na "yes" by wyłaczyć CSRF (domyślnie to "no")
+* ''root-tiddler'' - tiddler, który będzie stroną główną (domyślnie to "$:/core/save/all")
+* ''root-render-type'' - typ treści w którym główny tiddler bedzie wyświetlony (domyślnie to "text/plain")
+* ''root-serve-type'' - typ treści w którym główny tiddler ma być wysłany (domyślnie to "text/html")
+* ''tls-cert'' - ścieżka do certyfikatu TLS (relatywnie do folderu wiki)
+* ''tls-key'' - ścieżka do klucza TLS (relatywnie do folderu wiki)
+* ''debug-level'' - opcjonalny poziom logowania; ustaw na "debug" by wyświetlać zapytania (domyślnie to "none")
+* ''gzip'' - ustaw na "yes" by właczyć kompresję gzip dla niektórych zapytań http (domyślnie to "no")
+* ''use-browser-cache'' - ustaw na "yes" by pozwolić przeglądarce trzymać odpowiedzi serwera w historii, by zmniejszyć obciązenie (domyślnie to "no")
+
+By zdobyć informacje o tym jak udostępnić swoją lokalną wiki dla całej lokalnej sieci oraz wynikające z tego problemy bezpieczeństwa, przeczytaj sekcję WebServer tiddler na TiddlyWiki.com.
+

--- a/languages/pl-PL/Help/load.tid
+++ b/languages/pl-PL/Help/load.tid
@@ -1,0 +1,19 @@
+title: $:/language/Help/load
+description: Wczytaj tiddlery z pliku
+
+Wczytuje tiddlery z TiddlyWiki (`.html`), `.tiddler`, `.tid`, `.json` lub innych plików lokalnych. Deserializator jest automatycznie ustalany na podstawie rozszerzenia. Użyj komendy `import` jeżeli chcesz ręcznie wybrać deserializator.
+
+```
+--load <filepath> [noerror]
+--load <dirpath> [noerror]
+```
+
+Domyślne komenda ta zwraca błąd, jeżeli nie znajdzie tiddlera. Bład może zostać ukryty przy użyciu argumentu "noerror".
+
+By wczytać tiddlery z zaszyfrowanego pliku TiddlyWiki musisz najpierw podać hasło przy pomocy PasswordCommand. Dla przykładu:
+
+```
+tiddlywiki ./MyWiki --password pa55w0rd --load my_encrypted_wiki.html
+```
+
+Zwróc uwagę, że TiddlyWiki nie wczyta starszych wersji już wczytanych wtyczek.

--- a/languages/pl-PL/Help/makelibrary.tid
+++ b/languages/pl-PL/Help/makelibrary.tid
@@ -1,0 +1,14 @@
+title: $:/language/Help/makelibrary
+description: Tworzy wtyczkę podtrzebną do aktualizacji
+
+Tworzy tiddler `$:/UpgradeLibrary` do aktualizacji.
+
+Wtyczka aktualizacji ma identyczny format jak wtyczka tiddlera o typie `library`. Zawiera kopię każdej wtyczki, motywi i paczki jezykowej dostępnej wewnątrz repozytorium TiddlyWiki5.
+
+Ta komenda jest na użytek wewnętrzny; może też być przydatna dla osób robiących własne paczki aktualizacyjne.
+
+```
+--makelibrary <title>
+```
+
+Domyślna wartość "title" to `$:/UpgradeLibrary`.

--- a/languages/pl-PL/Help/notfound.tid
+++ b/languages/pl-PL/Help/notfound.tid
@@ -1,0 +1,3 @@
+title: $:/language/Help/notfound
+
+Nie znaleziono informacji

--- a/languages/pl-PL/Help/output.tid
+++ b/languages/pl-PL/Help/output.tid
@@ -1,0 +1,11 @@
+title: $:/language/Help/output
+description: Ustaw folder wyjściowy dla kolejnych komend
+
+Ustawia folder wyjściowy (gdzie będą zapisywane pliki) dla kolejnych komend. Domyślny folder to podfolder `output` w obecnej lokalizacji
+
+```
+--output <pathname>
+```
+
+Jeżeli podana ścieżka jest względna, to użyje obecnie wybranego folderu jako bazy. Na przykład `--output .` ustawi folder wyhściowy na obecny folder.
+

--- a/languages/pl-PL/Help/password.tid
+++ b/languages/pl-PL/Help/password.tid
@@ -1,0 +1,10 @@
+title: $:/language/Help/password
+description: Ustawia hasło dla kolejnych komend szyfrujących
+
+Ustawia hasło dla kolejnych komend szyfrujących
+
+```
+--password <password>
+```
+
+''Uwaga'': Nie używaj tego by ukryć dostęp wiki za hasłem. Zamiast tego ustaw hasło w [[ServerCommand]].

--- a/languages/pl-PL/Help/render.tid
+++ b/languages/pl-PL/Help/render.tid
@@ -1,0 +1,35 @@
+title: $:/language/Help/render
+description: Renderuje pojedyncze tiddlery do plików
+
+Renderuje pojedyncze tiddlery po filtrze i zapisuje wyniki do plików.
+
+Opcjonalnie można też podać nazwę szablonowego tiddlera. W tym przypadku zamiast bezpośrednio renderować każdego tiddlera, nazwa każdego pliku zostanie po kolei przekazana do szablonu w zmiennej "currentTiddler" i wyrenderowana.
+
+Nazwy i wartości dodatkowych zmiennych mogą być też podane.
+
+```
+--render <tiddler-filter> [<filename-filter>] [<render-type>] [<template>] [ [<name>] [<value>] ]*
+```
+
+* ''tiddler-filter'': Filtr określający tiddlery, które mają być wyrenderowane
+* ''filename-filter'': Opcjonalny filtr zmieniający nazwy plików. Domyślnie to `[is[tiddler]addsuffix[.html]]`, który używa nazwy tiddleru jako pliku.
+* ''render-type'': Opcjonalny typ renderowania: `text/html` (domyślny) zwraca kod HTML a `text/plain` samą treść z pominięciem tagów HTML i innych nietekstowych treści
+* ''template'': Opcjonalny szablon
+* ''name'': Nazwy zmiennych
+* ''value'': Wartości zmiennych
+
+Domyślnie pliki są zapisywane w folderze `./output`, relatywnych do folderu z wiki. Komenda `--output` może być użyta by zmienić ścieżkę.
+
+Notatki:
+
+* Żadne pliki nie są usuwane z folderu wyjściowego.
+* Wszelkie brakujące foldery zostaną automatycznie utworzone.
+* Jeżeli chcesz użyć tiddlera, który w nazwie ma spacje pamiętaj, by otoczyć go nawiasami kwadratowymi i cudzysłowiem: `--render "[[Motovun Jack.jpg]]"`
+* Do ''filename-filter'' przekazywana jest nazwa obecnie renderowanego tiddlera, tak by można było jej użyć do określenia ścieżki. Na przykład `[encodeuricomponent[]addprefix[static/]]` koduje znaki URI w każdej nazwie, po czym dodaje przedrostek `static/`.
+* Możesz podać kilka zmiennych powtarzając pary ''name''/''value''
+* Komenda `--render` jest bardziej elastyczna niż `--rendertiddler` i `--rendertiddlers`, które są obecnie eliminowane
+
+Przykłady:
+
+* `--render "[!is[system]]" "[encodeuricomponent[]addprefix[tiddlers/]addsuffix[.html]]"` -- renderuje wszystkie niesystemowe tiddlery jako pliki w podfolderze "tiddlers", kodując znaki URI w nazwie i dodając rozszerzenie .html
+

--- a/languages/pl-PL/Help/rendertiddler.tid
+++ b/languages/pl-PL/Help/rendertiddler.tid
@@ -1,0 +1,24 @@
+title: $:/language/Help/rendertiddler
+description: Renderuje pojedynczego tiddlera do wybranego typu
+
+(Uwaga: zalecamy użycie komendy `--render`, która jest dużo bardziej elastyczna i dalej wspierana)
+
+Renderuje pojedynczego tiddlera do wybranego typu treści (domyślnie to `text/html`) i zapisuje go do pliku.
+
+Opcjonalnie można też podać nazwę szablonowego tiddlera. W tym przypadku zamiast bezpośrednio renderować każdego tiddlera, nazwa każdego pliku zostanie po kolei przekazana do szablonu w zmiennej "currentTiddler" i wyrenderowana.
+
+Nazwy i wartości dodatkowych zmiennych mogą być też podane.
+
+```
+--rendertiddler <title> <filename> [<type>] [<template>] [<name>] [<value>]
+```
+
+Domyślnie pliki są zapisywane w folderze `./output`, relatywnym do folderu z wiki. Komenda `--output` może być użyta by zmienić ścieżkę.
+
+Wszelkie brakujące foldery zostaną automatycznie utworzone.
+
+Na przykład, poniższa komenda zapisze wszystkie tiddlery pasujące do filtra `[tag[done]]` do pliku JSON o nazwie `output.json`, używając templatki  `$:/core/templates/exporters/JsonFile`.
+
+```
+--rendertiddler "$:/core/templates/exporters/JsonFile" output.json text/plain "" exportFilter "[tag[done]]"
+```

--- a/languages/pl-PL/Help/rendertiddlers.tid
+++ b/languages/pl-PL/Help/rendertiddlers.tid
@@ -1,0 +1,20 @@
+title: $:/language/Help/rendertiddlers
+description: Renderuje serię tiddlerów do wybranego typu
+
+(Uwaga: zalecamy użycie komendy `--render`, która jest dużo bardziej elastyczna i dalej wspierana)
+
+Renderuje serię tiddlerów do wybranego typu treści (domyślnie to `text/html`) i zapisuje je do pliku.
+
+```
+--rendertiddlers '<filter>' <template> <pathname> [<type>] [<extension>] ["noclean"]
+```
+
+Na przykład:
+
+```
+--rendertiddlers '[!is[system]]' $:/core/templates/static.tiddler.html ./static text/plain
+```
+
+Domyślnie pliki są zapisywane w folderze `./output`, relatywnym do folderu z wiki. Komenda `--output` może być użyta by zmienić ścieżkę.
+
+Wszystkie pliki w docelowym folderze zostaną usunięte, chyba że zostanie użyty argument ''noclean''. Wszelkie brakujące foldery zostaną automatycznie utworzone.

--- a/languages/pl-PL/Help/save.tid
+++ b/languages/pl-PL/Help/save.tid
@@ -1,0 +1,25 @@
+title: $:/language/Help/save
+description: Zapisuje surowe tiddlery do plików
+
+Zapisuje indywidualne tiddlery bazująć na podanym filtrze w ich surowej lub binarnej formie do podanych plików.
+
+```
+--save <tiddler-filter> <filename-filter>
+```
+
+* ''tiddler-filter'': Filtr określający które tiddlery mają być zapisane
+* ''filename-filter'': Opcjonalny filtr konwertujący nazwy tiddlerów do ścieżek. Domyślnie jest to `[is[tiddler]]`, który używa niezmienionej nazwy tiddlera jako nazwy pliku.
+
+Domyślnie pliki są zapisywane w folderze `./output`, relatywnym do folderu z wiki. Komenda `--output` może być użyta by zmienić ścieżkę.
+
+Notatki:
+
+* Pliki NIE SĄ usuwane z folderu docelowego
+* Wszelkie brakujące foldery zostaną automatycznie utworzone.
+* Jeżeli chcesz użyć tiddlera, który w nazwie ma spacje pamiętaj, by otoczyć go nawiasami kwadratowymi i cudzysłowiem: `--save "[[Motovun Jack.jpg]]"`
+* Do ''filename-filter'' przekazywana jest nazwa obecnie renderowanego tiddlera, tak by można było jej użyć do określenia ścieżki. Na przykład `[encodeuricomponent[]addprefix[static/]]` koduje znaki URI w każdej nazwie, po czym dodaje przedrostek `static/`.
+* Komenda `--save` jest bardziej elastyczna niż `--savetiddler` i `--savetiddlers`, które są obecnie eliminowane
+
+Przykłady:
+
+* `--save "[!is[system]is[image]]" "[encodeuricomponent[]addprefix[tiddlers/]]"` -- zapisuje wszystkie niesystemowe tiddlery obrazów jako pliki w podfolderze "tiddlers" z URI enkodowanymi nazwami.

--- a/languages/pl-PL/Help/savetiddler.tid
+++ b/languages/pl-PL/Help/savetiddler.tid
@@ -1,0 +1,14 @@
+title: $:/language/Help/savetiddler
+description: Saves a raw tiddler to a file
+
+(Uwaga: zalecamy użycie komendy `--save`, która jest dużo bardziej elastyczna i dalej wspierana)
+
+Zapisuje pojedynczego tiddlera jako surowy tekst lub dane binarne w wybranej ścieżce.
+
+```
+--savetiddler <title> <filename>
+```
+
+Domyślnie ścieżka do zapisu jest relatywna do folderu `output` w folderze wiki. Komenda `--output` może być użyta by wybrać inny folder wyjściowy.
+
+Brakujące foldery w ścieżce zostają automatycznie utworzone.

--- a/languages/pl-PL/Help/savetiddlers.tid
+++ b/languages/pl-PL/Help/savetiddlers.tid
@@ -1,0 +1,16 @@
+title: $:/language/Help/savetiddlers
+description: Zapisuje tiddlery do folderu
+
+(Uwaga: zalecamy użycie komendy `--save`, która jest dużo bardziej elastyczna i dalej wspierana)
+
+Zapisuje grupę tiddlerów jako surowy tekst lub dane binarne w wybranym folderze.
+
+```
+--savetiddlers <filter> <pathname> ["noclean"]
+```
+
+Domyślnie ścieżka do zapisu jest relatywna do folderu `output` w folderze wiki. Komenda `--output` może być użyta by wybrać inny folder wyjściowy.
+
+Wszystkie pliki z folderu wyjściowego są usuwane przed rozpocząciem zapisu. Można użyć argumentu ''noclean'' by tego nie robić.
+
+Brakujące foldery w ścieżce zostają automatycznie utworzone.

--- a/languages/pl-PL/Help/savewikifolder.tid
+++ b/languages/pl-PL/Help/savewikifolder.tid
@@ -1,0 +1,19 @@
+title: $:/language/Help/savewikifolder
+description: Zapisuje wiki do nowego folderu
+
+<<.from-version "5.1.20">> Zapisuje obecną wiki do nowego folderu wliczając tiddlery, wtyczki i konfigurację:
+
+```
+--savewikifolder <wikifolderpath> [<filter>]
+```
+
+* Docelowy folder musi być pusty lub nieistnieć
+* `filter` określa które tiddlery będą skopiowane, domyślnie to `[all[tiddlers]]`
+* Wtyczki z oficjalnej biblioteki wtyczek są zamieniane na odnośniki do tych wtyczek w pliku `tiddlywiki.info`
+* Własne wtyczki zostają wypakowane do osobnych folderów
+
+Typowe zastosowanie to konwersja pliku TiddlyWiki w formie pliku HTML do formatu folderu:
+
+```
+tiddlywiki --load ./mywiki.html --savewikifolder ./mywikifolder
+```

--- a/languages/pl-PL/Help/server.tid
+++ b/languages/pl-PL/Help/server.tid
@@ -1,0 +1,42 @@
+title: $:/language/Help/server
+description: Tworzy serwer HTTP wystawiający TiddlyWiki (zalecamy użycie komendy "--listen" zamiast tej)
+
+Dawna komenda do stawiania serwera wystawiającego wiki.
+
+```
+--server <port> <root-tiddler> <root-render-type> <root-serve-type> <username> <password> <host> <path-prefix> <debug-level>
+```
+
+The parameters are:
+
+* ''port'' - port na którym nasłuchuje serwer; nie-numeryczne wartości sa interpretowane jakby to były zmienne środowiskowe z których należy pobrać numer portu (domyślnie to "8080")
+* ''root-tiddler'' - tiddler, który będzie stroną główną (domyślnie to "$:/core/save/all")
+* ''root-render-type'' - typ treści w którym główny tiddler bedzie wyświetlony (domyślnie to "text/plain")
+* ''root-serve-type'' - typ treści w którym główny tiddler ma być wysłany (domyślnie to "text/html")
+* ''username'' - opcjonalna nazwa użytkownika do autoryzacji basic
+* ''password'' - opcjonalne hasło do autoryzacji basic
+* ''host'' - opcjonalna nazwa hosta (domyślnie to "127.0.0.1", czyli "localhost")
+* ''path-prefix'' - opcjonalny przedrostek dodawany do ścieżek
+* ''debug-level'' - opcjonalny poziom logowania; ustaw na "debug" by wyświetlać zapytania (domyślnie to "none")
+
+Jeżeli argument ''password'' jest podany to przeglądarka poprosi o login i hasło. Zwróć uwagę, że hasło przesyłane jest jako niezaszyfrowany tekst, więc tej implementacji należy używać tylko w zaufanej sieci lub poprzez HTTPS.
+
+Na przykład:
+
+```
+--server 8080 $:/core/save/all text/plain text/html MyUserName passw0rd
+```
+
+Użytkownik i hasło mogą być pustymi wartościami tekstowymi, jeżeli potrzebujesz ustawić argumenty po nich.
+
+```
+--server 8080 $:/core/save/all text/plain text/html "" "" 192.168.0.245
+```
+
+By zdobyć informacje o tym jak udostępnić swoją lokalną wiki dla całej lokalnej sieci oraz wynikające z tego problemy bezpieczeństwa, przeczytaj sekcję WebServer tiddler na TiddlyWiki.com.
+
+By uruchomić kilka serwerów TiddlyWiki jednocześnie, musisz wystawić każde z nich za innym portem. Może tu być pomocne użycie zmiennych środowiskowych jako wartości portu. Poniższy przykład używa zmiennej środowiskoej `MY_PORT_NUMBER`:
+
+```
+--server MY_PORT_NUMBER $:/core/save/all text/plain text/html MyUserName passw0rd
+```

--- a/languages/pl-PL/Help/setfield.tid
+++ b/languages/pl-PL/Help/setfield.tid
@@ -1,0 +1,17 @@
+title: $:/language/Help/setfield
+description: Przygotowuje zewnętrze tiddlery do użycia
+
+//Uwaga: ta komenda jest eksperymentalna i może zostać w przyszłosci zmieniona lub zastąpiona//
+
+Ustawia wybrane pole grupie tiddlerów na wynik wikifikacji szablonu. Zmienna `currentTiddler` w szablonie jest ustawiana na nazwę aktualnego tiddlera.
+
+```
+--setfield <filter> <fieldname> <templatetitle> <rendertype>
+```
+
+Argumenty to:
+
+* ''filter'' - filtr określający tiddlery, które mają być przygotowane
+* ''fieldname'' - pole do zmiany (domyślnie to "text")
+* ''templatetitle'' - nazwa szablonu, który ma być zwikifikowany do wybranego pola. Jeżeli puste lub niepodane to pole jest usuwane
+* ''rendertype'' - typ tekstu do renderownania (domyślnie to "text/plain"; "text/html" może być użyty by uwzględnić kod HTML)

--- a/languages/pl-PL/Help/unpackplugin.tid
+++ b/languages/pl-PL/Help/unpackplugin.tid
@@ -1,0 +1,8 @@
+title: $:/language/Help/unpackplugin
+description: Wypakuj tiddlery z wtyczki
+
+Wyciąga tiddlery z wtyczki, tworząc z nich zwykłe tiddlery:
+
+```
+--unpackplugin <title>
+```

--- a/languages/pl-PL/Help/verbose.tid
+++ b/languages/pl-PL/Help/verbose.tid
@@ -1,0 +1,8 @@
+title: $:/language/Help/verbose
+description: Przełącz wyświetlanie szczegółowych informacji
+
+Przełącza wyswietlanie szczegółowych informacji podczas wykonywania operacji, przydatne podczas analizy problemów.
+
+```
+--verbose
+```

--- a/languages/pl-PL/Help/version.tid
+++ b/languages/pl-PL/Help/version.tid
@@ -1,0 +1,8 @@
+title: $:/language/Help/version
+description: Wyświetla numer wersji TiddlyWiki
+
+Wyświetla numer wersji TiddlyWiki.
+
+```
+--version
+```

--- a/languages/pl-PL/Import.multids
+++ b/languages/pl-PL/Import.multids
@@ -1,0 +1,35 @@
+title: $:/language/Import/
+
+Editor/Import/Heading: Importuj obrazy i dodaj je do edytora
+Imported/Hint: Poniższe tiddlery zostały zaimportowane:
+Listing/Cancel/Caption: Anuluj
+Listing/Cancel/Warning: Czy chcesz anulować importowanie?
+Listing/Hint: Poniższe tiddlery są gotowe do zaimportowania
+Listing/Import/Caption: Importuj
+Listing/Select/Caption: Wybierz
+Listing/Status/Caption: Status
+Listing/Title/Caption: Tytuł
+Listing/Preview: Podgląd
+Listing/Preview/Text: Tekst
+Listing/Preview/TextRaw: Tekst (oryginalny)
+Listing/Preview/Fields: Pola
+Listing/Preview/Diff: Różnica
+Listing/Preview/DiffFields: Róznica (Pola)
+Listing/Rename/Tooltip: Zmień nazwę tiddlera przed importem
+Listing/Rename/Prompt: Zmień nazwę na:
+Listing/Rename/ConfirmRename: Zmień nazwę tiddlera
+Listing/Rename/CancelRename: Anuluj
+Listing/Rename/OverwriteWarning: Tiddler o tej nazwie już istnieje.
+Upgrader/Plugins/Suppressed/Incompatible: Zablokowano niekompatybilne lub przestarzałe wtyczki.
+Upgrader/Plugins/Suppressed/Version: Zablokowano wtyczkę (ze względu na to, że <<incoming>< nie jest nowsza niż istniejąca już <<existing>>)
+Upgrader/Plugins/Upgraded: Zaktualizowano wtyczkę z <<incoming>> na <<upgrade>>.
+Upgrader/State/Suppressed: Zablokowano tiddler tymczasowego stanu.
+Upgrader/System/Disabled: Wyłączony systemowego tiddlera.
+Upgrader/System/Suppressed: Zablokowano systemowego tiddlera.
+Upgrader/System/Warning: Tiddler z głównym modułem.
+Upgrader/System/Alert: Ta operacja zaimportuje tiddlera, który nadpisze jeden z gównych modułuch. Nie jest to zalecane, gdyż może spowodować niestabilne działanie systemu.
+Upgrader/ThemeTweaks/Created: Zmigrowano dostosowanie motywu z <$text text=<<from>>/>.
+Upgrader/Tiddler/Disabled: Wyłaczono tiddlera.
+Upgrader/Tiddler/Selected: Zaznaczono tiddlera.
+Upgrader/Tiddler/Unselected: Odznaczono tiddlera.
+

--- a/languages/pl-PL/Misc.multids
+++ b/languages/pl-PL/Misc.multids
@@ -67,7 +67,7 @@ OfficialPluginLibrary: Oficjalna Biblioteka Wtyczek ~TiddlyWiki
 OfficialPluginLibrary/Hint: Oficjalna biblioteka wtyczek ~TiddlyWiki z tiddlywiki.com. Wtyczki, motywi i paczki językowe są utrzymywane przez główny zespół TiddlyWiki.
 PageTemplate/Description: domyślny motyw ~TiddlyWiki
 PageTemplate/Name: Domyślny szablon strony
-RecentChanges/DateFormat: YYYY-0MM-0DD
+RecentChanges/DateFormat: 0DD-0MM-YYYY
 Shortcuts/Input/AdvancedSearch/Hint: Otwórzy panel zaawansowanego wyszukiwania z poziomu menu bocznego
 Shortcuts/Input/Accept/Hint: Zaakceptuj zaznaczenia
 Shortcuts/Input/AcceptVariant/Hint: Zaakceptuj zaznaczenia (warianty)
@@ -89,7 +89,7 @@ TagManager/Icon/Heading: Ikona
 TagManager/Icons/None: Brak
 TagManager/Info/Heading: Info
 TagManager/Tag/Heading: Tag
-Tiddler/DateFormat: YYYY-0MM-0DD o 0hh:0mm:0ss
+Tiddler/DateFormat: 0DD-0MM-YYYY o 0hh:0mm:0ss
 UnsavedChangesWarning: Masz niezapisane zmiany
 Yes: Tak
 

--- a/languages/pl-PL/Misc.multids
+++ b/languages/pl-PL/Misc.multids
@@ -1,0 +1,95 @@
+title: $:/language/
+
+AboveStory/ClassicPlugin/Warning: Wygląda na to, że próbujesz wczytać wtyczkę zaprojektowaną dla ~TiddlyWiki Classic. Zwróc uwagę, że [[te wtyczki nie działają z TiddlyWiki 5|https://tiddlywiki.com/#TiddlyWikiClassic]]. Wykryte wtyczki ~TiddlyWiki Classic:
+BinaryWarning/Prompt: Ten tiddler zawiera binarne dane
+ClassicWarning/Hint: Ten tiddler został napisany w formacie dla TiddlyWiki Classic, który nie jest w pełni kompatybilny z TiddlyWiki 5. Więcej informacji dostępnych pod adresem https://tiddlywiki.com/static/Upgrading.html.
+ClassicWarning/Upgrade/Caption: aktualizacja
+CloseAll/Button: zamknij wszystkie
+ColourPicker/Recent: Ostatnie:
+ConfirmCancelTiddler: Czy na pewno chcesz odrzucić zmiany w tiddlerze "<$text text=<<title>>/>"?
+ConfirmDeleteTiddler: Czy na pewno chcesz usunąc tiddlera "<$text text=<<title>>/>"?
+ConfirmOverwriteTiddler: Czy na pewno chcesz nadpisać tiddlera "<$text text=<<title>>/>"?
+ConfirmEditShadowTiddler: Próbujesz utworzyć ukrytego tiddlera. Zmiany te nadpiszą oryginalne, systemowe tiddlery co może utrudniać aktualizację wiki. Czy na pewno chcesz zmodyfikować"<$text text=<<title>>/>"?
+ConfirmAction: Na pewno chcesz kontynuować?
+Count: Ilość
+DefaultNewTiddlerTitle: Nowy Tiddler
+Diffs/CountMessage: Zmiany: <<diff-count>>
+DropMessage: Upuść tutaj (lub wciśnij 'Escape' by anulować)
+Encryption/Cancel: Anuluj
+Encryption/ConfirmClearPassword: Czy na pewno chcesz usunąć hasło? W ten sposób wyłaczysz szyfrowanie przy zapisywaniu wiki
+Encryption/PromptSetPassword: Ustaw nowe hasło dla TiddlyWiki
+Encryption/Username: Użytkownik
+Encryption/Password: Hasło
+Encryption/RepeatPassword: Powtórz hasło
+Encryption/PasswordNoMatch: Hasła się nie zgadzają
+Encryption/SetPassword: Ustaw hasło
+Error/Caption: Bład
+Error/Filter: Bład filtra
+Error/FilterSyntax: Bład składniowy filtra
+Error/FilterRunPrefix: Bład filtra: Nieznany prefiks dla filtra 'run'
+Error/IsFilterOperator: Bład filtra: Nieznany argument dla operatora 'is'
+Error/FormatFilterOperator: Bład filtra: nieznany suffix dla operatora 'format'
+Error/LoadingPluginLibrary: Błąd przy wczytywaniu biblioteki wtyczek
+Error/NetworkErrorAlert: `<h2>''Bład sieciowy''</h2>Połaczenie z serwerem zostało utracone. Możę to być wywołane problemem z internetem. Upewnij się, że masz podłaczenie do internetu przed kolejną próbą.<br><br>''Wszelkie niezapisane zmiany zostaną zsynchronizowane przy odzyskaniu łączności''.`
+Error/PutEditConflict: Pliki zostały zmienione na serwerze
+Error/PutForbidden: Brak uprawnień
+Error/PutUnauthorized: Wymagane uwierzytelnienie
+Error/RecursiveTransclusion: Rekursywna transkluzja wykryta we widżecie transkluzji
+Error/RetrievingSkinny: Bład przy pobieraniu listy tiddlerów
+Error/SavingToTWEdit: Bład przy zapisywaniu do TWEdit
+Error/WhileSaving: Bład przy zapisywaniu
+Error/XMLHttpRequest: Kod błedu XMLHttpRequest
+InternalJavaScriptError/Title: Wewnętrzny bład JavaScript
+InternalJavaScriptError/Hint: Ups, to się nie powinno zdarzyć. Zalecamy ponowne uruchomienie TiddlyWiki poprzez odświeżenie strony w przeglądarce.
+LayoutSwitcher/Description: Otwórzy wybór motywu
+LazyLoadingWarning: <p>Trwa pobieranie zewnętrznych treści z ''<$text text={{!!_canonical_uri}}/>''</p><p>Jeżeli ta wiadomość nie zniknie po chwili, to albo typ tiddlera nie pasuje do typu pobranej treści, lub używasz przeglądarki, która nie wspiera pobierania zewnętrznych treści dla wiki wczytanych jako pliki. Więcej informacji pod adresem https://tiddlywiki.com/#ExternalText</p>
+LoginToTiddlySpace: Zaloguj się do TiddlySpace
+Manager/Controls/FilterByTag/None: (brak)
+Manager/Controls/FilterByTag/Prompt: Filtruj po tagu:
+Manager/Controls/Order/Prompt: Odwrotna kolejność
+Manager/Controls/Search/Placeholder: Szukaj
+Manager/Controls/Search/Prompt: Szukaj:
+Manager/Controls/Show/Option/Tags: tagi
+Manager/Controls/Show/Option/Tiddlers: tiddlery
+Manager/Controls/Show/Prompt: Pokaż:
+Manager/Controls/Sort/Prompt: Sortuj po:
+Manager/Item/Colour: Color
+Manager/Item/Fields: Pola
+Manager/Item/Icon/None: (brak)
+Manager/Item/Icon: Ikona
+Manager/Item/RawText: Czysty tekst
+Manager/Item/Tags: Tagi
+Manager/Item/Tools: Narzędzia
+Manager/Item/WikifiedText: Przetworzony tekst
+MissingTiddler/Hint: Nie znaleziono tiddlera "<$text text=<<currentTiddler>>/>" -- kliknij {{||$:/core/ui/Buttons/edit}} by go utworzyć
+No: Nie
+OfficialPluginLibrary: Oficjalna Biblioteka Wtyczek ~TiddlyWiki
+OfficialPluginLibrary/Hint: Oficjalna biblioteka wtyczek ~TiddlyWiki z tiddlywiki.com. Wtyczki, motywi i paczki językowe są utrzymywane przez główny zespół TiddlyWiki.
+PageTemplate/Description: domyślny motyw ~TiddlyWiki
+PageTemplate/Name: Domyślny szablon strony
+RecentChanges/DateFormat: YYYY-0MM-0DD
+Shortcuts/Input/AdvancedSearch/Hint: Otwórzy panel zaawansowanego wyszukiwania z poziomu menu bocznego
+Shortcuts/Input/Accept/Hint: Zaakceptuj zaznaczenia
+Shortcuts/Input/AcceptVariant/Hint: Zaakceptuj zaznaczenia (warianty)
+Shortcuts/Input/Cancel/Hint: Wyczyść pole
+Shortcuts/Input/Down/Hint: Wybierz kolejną wartość
+Shortcuts/Input/Tab-Left/Hint: Przejdź do poprzedniej zakłądki
+Shortcuts/Input/Tab-Right/Hint: Przejdź do kolejnej zakłądki
+Shortcuts/Input/Up/Hint: Wybierz poprzednią wartość
+Shortcuts/SidebarLayout/Hint: Zmien układ menu bocznego
+Switcher/Subtitle/theme: Zmień Motyw
+Switcher/Subtitle/layout: Zmień Układ
+Switcher/Subtitle/language: Zmień Język
+Switcher/Subtitle/palette: Zmień Paletę
+SystemTiddler/Tooltip: To jest systemowy tiddler
+SystemTiddlers/Include/Prompt: Uwzględnij systemowe tiddlery
+TagManager/Colour/Heading: Kolor
+TagManager/Count/Heading: Ilośc
+TagManager/Icon/Heading: Ikona
+TagManager/Icons/None: Brak
+TagManager/Info/Heading: Info
+TagManager/Tag/Heading: Tag
+Tiddler/DateFormat: YYYY-0MM-0DD o 0hh:0mm:0ss
+UnsavedChangesWarning: Masz niezapisane zmiany
+Yes: Tak
+

--- a/languages/pl-PL/Misc.multids
+++ b/languages/pl-PL/Misc.multids
@@ -9,7 +9,7 @@ ColourPicker/Recent: Ostatnie:
 ConfirmCancelTiddler: Czy na pewno chcesz odrzucić zmiany w tiddlerze "<$text text=<<title>>/>"?
 ConfirmDeleteTiddler: Czy na pewno chcesz usunąc tiddlera "<$text text=<<title>>/>"?
 ConfirmOverwriteTiddler: Czy na pewno chcesz nadpisać tiddlera "<$text text=<<title>>/>"?
-ConfirmEditShadowTiddler: Próbujesz utworzyć ukrytego tiddlera. Zmiany te nadpiszą oryginalne, systemowe tiddlery co może utrudniać aktualizację wiki. Czy na pewno chcesz zmodyfikować"<$text text=<<title>>/>"?
+ConfirmEditShadowTiddler: Próbujesz utworzyć tiddlera-cienia. Zmiany te nadpiszą oryginalne, systemowe tiddlery co może utrudniać aktualizację wiki. Czy na pewno chcesz zmodyfikować"<$text text=<<title>>/>"?
 ConfirmAction: Na pewno chcesz kontynuować?
 Count: Ilość
 DefaultNewTiddlerTitle: Nowy Tiddler

--- a/languages/pl-PL/Modals/Download.tid
+++ b/languages/pl-PL/Modals/Download.tid
@@ -1,0 +1,12 @@
+title: $:/language/Modals/Download
+subtitle: Pobierz zmiany
+footer: <$button message="tm-close-tiddler">Zamknij</$button>
+help: https://tiddlywiki.com/static/DownloadingChanges.html
+
+Ta przeglądarka wspiera tylko ręczne zapisywanie.
+
+By zapisać zmiany, wciśnij prawym przyciskiem na link poniżej i wybierz "Pobierz plik" lub "Zapisz plik", a potem wybierz folder docelowy i nazwę pliku.
+
+//Możesz odrobinę przyśpieszyć ten proces klikając w link trzymając przycisk control (na Windowsie) lub opcje/alt (na Mac OS X). Nie będzie trzeba wtedy wpisywać nazwy ani folderu, ale prawdopodobnie przeglądarka nada plikowi jakąś dziwną nazwę -- musisz zmienić nazwę pliku by miał rozszerzenie `.html` zanim będzie można z nim cokolwiek zrobić.//
+
+Na smartfonach, które nie pozwalają pobierać plików, możesz zamiast tego dodać ten link do ulubionych a następnie zsynchronizować zakładki z komputerm, na którym można zapisywać pliki.

--- a/languages/pl-PL/Modals/SaveInstructions.tid
+++ b/languages/pl-PL/Modals/SaveInstructions.tid
@@ -1,0 +1,21 @@
+title: $:/language/Modals/SaveInstructions
+subtitle: Zapisz swoje zmiany
+footer: <$button message="tm-close-tiddler">Close</$button>
+help: https://tiddlywiki.com/static/SavingChanges.html
+
+Twoje zmieny muszą być zapisane jako plike HTML ~TiddlyWiki.
+
+!!! Przeglądarki na komputerach stacjonarnych
+
+# Wybierz ``Zapisz Jako`` z menu ``Plik``
+# Wybierz nazwię i miejsce
+#* Niektóre przeglądarki wymagają ręcznego ustawienia formatu pliku na ''Strona internetowa, HTML'' lub podobne
+# Zamknij zakładkę
+
+!!! Przeglądarki na smarfonach
+
+# Dodaj stronę do zakładek
+# Jeżeli używasz iCloud lub synchronizacji Google, zakładka zostanie automatycznie zsynchronizowania z komputerem stacjonarnym, gdzie możesz zapisać wiki używając kroków powyżej.
+# Zamknij zakładkę
+
+//Jeżeli otworzysz zakładkę ponownie na Mobilnej Safari zobaczysz ponownie tą wiadomość. Jeżeli chcesz używać tego pliku, po prostu kliknij przycisk ''zamknij'' poniżej//

--- a/languages/pl-PL/NewJournal.multids
+++ b/languages/pl-PL/NewJournal.multids
@@ -1,0 +1,4 @@
+title: $:/config/NewJournal/
+
+title: DDth MMM YYYY
+Text:

--- a/languages/pl-PL/NewJournal.multids
+++ b/languages/pl-PL/NewJournal.multids
@@ -1,4 +1,4 @@
 title: $:/config/NewJournal/
 
-title: DDth MMM YYYY
+title: 0DD-0MM-YYYY
 Text:

--- a/languages/pl-PL/NewJournalTags.tid
+++ b/languages/pl-PL/NewJournalTags.tid
@@ -1,0 +1,3 @@
+title: $:/config/NewJournal/Tags
+
+Dziennik

--- a/languages/pl-PL/Notifications.multids
+++ b/languages/pl-PL/Notifications.multids
@@ -1,0 +1,6 @@
+title: $:/language/Notifications/
+
+Save/Done: Zapisano wiki
+Save/Starting: Rozpoczęto zapisywanie wiki
+CopiedToClipboard/Succeeded: Skopiowano do schowka
+CopiedToClipboard/Failed: Nie udało się skopiować do schowka

--- a/languages/pl-PL/Search.multids
+++ b/languages/pl-PL/Search.multids
@@ -1,0 +1,21 @@
+title: $:/language/Search/
+
+DefaultResults/Caption: Lista
+Filter/Caption: Filtr
+Filter/Hint: Szukaj przy pomocy [[wyrażenia filtrującego|https://tiddlywiki.com/static/Filters.html]]
+Filter/Matches: //<small>trafienia: <<resultCount>></small>//
+Matches: //<small>trafienia: <<resultCount>></small>//
+Matches/All: Wszystkie trafienia
+Matches/Title: Trafienia w nazwach:
+Search: Szukaj
+Search/TooShort: Zbyt krótki tekst wyszukiwania
+Shadows/Caption: Ukryte
+Shadows/Hint: Szukaj wśród ukrytych tiddlerów
+Shadows/Matches: //<small>trafienia: <<resultCount>></small>//
+Standard/Caption: Standardowe
+Standard/Hint: Szukaj wśród własnych tiddlerów
+Standard/Matches: //<small>trafienia: <<resultCount>></small>//
+System/Caption: Systemowe
+System/Hint: Szukaj wśród systemowych tiddlerów
+System/Matches: //<small>trafienia: <<resultCount>></small>//
+

--- a/languages/pl-PL/Search.multids
+++ b/languages/pl-PL/Search.multids
@@ -9,8 +9,8 @@ Matches/All: Wszystkie trafienia
 Matches/Title: Trafienia w nazwach:
 Search: Szukaj
 Search/TooShort: Zbyt krótki tekst wyszukiwania
-Shadows/Caption: Ukryte
-Shadows/Hint: Szukaj wśród ukrytych tiddlerów
+Shadows/Caption: Cienie
+Shadows/Hint: Szukaj wśród tiddlerów-cieni
 Shadows/Matches: //<small>trafienia: <<resultCount>></small>//
 Standard/Caption: Standardowe
 Standard/Hint: Szukaj wśród własnych tiddlerów

--- a/languages/pl-PL/SideBar.multids
+++ b/languages/pl-PL/SideBar.multids
@@ -1,0 +1,18 @@
+title: $:/language/SideBar/
+
+All/Caption: Wszystkie
+Contents/Caption: Treści
+Drafts/Caption: Szkice
+Explorer/Caption: Eksploruj
+Missing/Caption: Brakujące
+More/Caption: Więcej
+Open/Caption: Otwórz
+Orphans/Caption: Bez Rodzica
+Recent/Caption: Ostatnie
+Shadows/Caption: Ukryte
+System/Caption: Systemowe
+Tags/Caption: Tagi
+Tags/Untagged/Caption: nieotagowane
+Tools/Caption: Narzędzia
+Types/Caption: Typy
+

--- a/languages/pl-PL/SideBar.multids
+++ b/languages/pl-PL/SideBar.multids
@@ -9,7 +9,7 @@ More/Caption: Więcej
 Open/Caption: Otwórz
 Orphans/Caption: Bez Rodzica
 Recent/Caption: Ostatnie
-Shadows/Caption: Ukryte
+Shadows/Caption: Cienie
 System/Caption: Systemowe
 Tags/Caption: Tagi
 Tags/Untagged/Caption: nieotagowane

--- a/languages/pl-PL/SiteSubtitle.tid
+++ b/languages/pl-PL/SiteSubtitle.tid
@@ -1,0 +1,3 @@
+title: $:/SiteSubtitle
+
+nieliniowy, internetowy notatnik osobisty

--- a/languages/pl-PL/SiteTitle.tid
+++ b/languages/pl-PL/SiteTitle.tid
@@ -1,0 +1,3 @@
+title: $:/SiteTitle
+
+Moja ~TiddlyWiki

--- a/languages/pl-PL/Snippets/ListByTag.tid
+++ b/languages/pl-PL/Snippets/ListByTag.tid
@@ -1,0 +1,5 @@
+title: $:/language/Snippets/ListByTag
+tags: $:/tags/TextEditor/Snippet
+caption: Lista tiddlerów po tagu
+
+<<list-links "[tag[task]sort[title]]">>

--- a/languages/pl-PL/Snippets/MacroDefinition.tid
+++ b/languages/pl-PL/Snippets/MacroDefinition.tid
@@ -1,0 +1,7 @@
+title: $:/language/Snippets/MacroDefinition
+tags: $:/tags/TextEditor/Snippet
+caption: Definicje makr
+
+\define macroName(param1:"default value",param2)
+Tekst makra
+\end

--- a/languages/pl-PL/Snippets/Table 4x3.tid
+++ b/languages/pl-PL/Snippets/Table 4x3.tid
@@ -1,0 +1,8 @@
+title: $:/language/Snippets/Table4x3
+tags: $:/tags/TextEditor/Snippet
+caption: Tabela z 4 kolumnami i 3 wierszami
+
+|! |!Alpha |!Beta |!Gamma |!Delta |
+|!Jeden | | | | |
+|!Dwa | | | | |
+|!Trzy | | | | |

--- a/languages/pl-PL/Snippets/TableOfContents.tid
+++ b/languages/pl-PL/Snippets/TableOfContents.tid
@@ -1,0 +1,9 @@
+title: $:/language/Snippets/TableOfContents
+tags: $:/tags/TextEditor/Snippet
+caption: Spis Treśći
+
+<div class="tc-table-of-contents">
+
+<<toc-selective-expandable 'Spis Treści'>>
+
+</div>

--- a/languages/pl-PL/ThemeTweaks.multids
+++ b/languages/pl-PL/ThemeTweaks.multids
@@ -4,8 +4,8 @@ ThemeTweaks: Dostosowania Motywu
 ThemeTweaks/Hint: Możesz dostosować pewne aspekty motywu ''Vanilla''
 Options: Opcje
 Options/SidebarLayout: Układ menu bocznego
-Options/SidebarLayout/Fixed-Fluid: Stałe tiddlery, płynne menu boczne
-Options/SidebarLayout/Fluid-Fixed: Płynne tiddlery, stałe menu boczne
+Options/SidebarLayout/Fixed-Fluid: Stałe Story River, zmienne menu boczne
+Options/SidebarLayout/Fluid-Fixed: Zmienne Story River, stałe menu boczne
 Options/StickyTitles: Przyczep nazwy
 Options/StickyTitles/Hint: Spowoduje, że nazwa tiddlera będzie "przyklejona" do górnej części okna przeglądarki
 Options/CodeWrapping: Łam długie linie kodu do nowej linii
@@ -14,7 +14,7 @@ Settings/FontFamily: Czcionka
 Settings/CodeFontFamily: Czcionka kodu
 Settings/EditorFontFamily: Czcionka edytora
 Settings/BackgroundImage: Obraz tła
-Settings/BackgroundImageAttachment: Załacznik do obrazu tła
+Settings/BackgroundImageAttachment: Pozycja obrazu tła
 Settings/BackgroundImageAttachment/Scroll: Przewijaj ze stroną
 Settings/BackgroundImageAttachment/Fixed: Stała pozycja
 Settings/BackgroundImageSize: Rozmiar obrazu tła
@@ -26,17 +26,17 @@ Metrics/FontSize: Rozmiar czcionki
 Metrics/LineHeight: Wysokość linii
 Metrics/BodyFontSize: Rozmiar czcionki w treści tiddlera
 Metrics/BodyLineHeight: Wysokość linii w treści tiddlera
-Metrics/StoryLeft: Lewy margines widoku tiddlerów
-Metrics/StoryLeft/Hint: Szerokość lewego marginesu,<br>tj odstępu między lewą krawędzią strony a krawędzią tiddlera
-Metrics/StoryTop: Górny margines widoku tiddlerów
-Metrics/StoryTop/Hint: Wysokość górnego marginesu,<br>tj odstępu między górną krawędzią strony a krawędzią tiddlera
-Metrics/StoryRight: Prawy margines widoku tiddlerów
-Metrics/StoryRight/Hint: Szerokość prawego marginesu,<br>tj odstępu między menu bocznym a krawędzią tiddlera
-Metrics/StoryWidth: Szerokość widoku tiddlerów
-Metrics/StoryWidth/Hint: Ogólna szerokość widoku tiddlerów
+Metrics/StoryLeft: Lewy margines Story River
+Metrics/StoryLeft/Hint: Odległość lewej krawędzi Story River od<br>lewej krawędzi strony
+Metrics/StoryTop: Górny margines Story River
+Metrics/StoryTop/Hint: Odległość górnej krawędzi Story River od<br>górnej krawędzi strony
+Metrics/StoryRight: Prawy margines Story River
+Metrics/StoryRight/Hint: Odległość prawej krawędzi Story River od<br>lewej krawędzi menu boczne
+Metrics/StoryWidth: Szerokość Story River
+Metrics/StoryWidth/Hint: Ogólna szerokość Story River
 Metrics/TiddlerWidth: Szerokość tiddlera
-Metrics/TiddlerWidth/Hint: Wewnątrz widoku tiddlerów
+Metrics/TiddlerWidth/Hint: Wewnątrz Story River
 Metrics/SidebarBreakpoint: Breakpoint menu bocznego
-Metrics/SidebarBreakpoint/Hint: Minimalna szerokość strony, przy której<br>menu boczne i widok tiddlerów zostaną wyświetlone obok siebie
+Metrics/SidebarBreakpoint/Hint: Minimalna szerokość strony, przy której<br>menu boczne i Story River zostaną wyświetlone obok siebie
 Metrics/SidebarWidth: Szerokość menu bocznego
-Metrics/SidebarWidth/Hint: Szerokość menu bocznego w widoku płynny <-> stały
+Metrics/SidebarWidth/Hint: Szerokość menu bocznego w widoku zmienny-stały

--- a/languages/pl-PL/ThemeTweaks.multids
+++ b/languages/pl-PL/ThemeTweaks.multids
@@ -1,0 +1,42 @@
+title: $:/language/ThemeTweaks/
+
+ThemeTweaks: Dostosowania Motywu
+ThemeTweaks/Hint: Możesz dostosować pewne aspekty motywu ''Vanilla''
+Options: Opcje
+Options/SidebarLayout: Układ menu bocznego
+Options/SidebarLayout/Fixed-Fluid: Stałe tiddlery, płynne menu boczne
+Options/SidebarLayout/Fluid-Fixed: Płynne tiddlery, stałe menu boczne
+Options/StickyTitles: Przyczep nazwy
+Options/StickyTitles/Hint: Spowoduje, że nazwa tiddlera będzie "przyklejona" do górnej części okna przeglądarki
+Options/CodeWrapping: Łam długie linie kodu do nowej linii
+Settings: Ustawienia
+Settings/FontFamily: Czcionka
+Settings/CodeFontFamily: Czcionka kodu
+Settings/EditorFontFamily: Czcionka edytora
+Settings/BackgroundImage: Obraz tła
+Settings/BackgroundImageAttachment: Załacznik do obrazu tła
+Settings/BackgroundImageAttachment/Scroll: Przewijaj ze stroną
+Settings/BackgroundImageAttachment/Fixed: Stała pozycja
+Settings/BackgroundImageSize: Rozmiar obrazu tła
+Settings/BackgroundImageSize/Auto: Automatyczny
+Settings/BackgroundImageSize/Cover: Zapełnij
+Settings/BackgroundImageSize/Contain: Zawrzyj
+Metrics: Rozmiary
+Metrics/FontSize: Rozmiar czcionki
+Metrics/LineHeight: Wysokość linii
+Metrics/BodyFontSize: Rozmiar czcionki w treści tiddlera
+Metrics/BodyLineHeight: Wysokość linii w treści tiddlera
+Metrics/StoryLeft: Lewy margines widoku tiddlerów
+Metrics/StoryLeft/Hint: Szerokość lewego marginesu,<br>tj odstępu między lewą krawędzią strony a krawędzią tiddlera
+Metrics/StoryTop: Górny margines widoku tiddlerów
+Metrics/StoryTop/Hint: Wysokość górnego marginesu,<br>tj odstępu między górną krawędzią strony a krawędzią tiddlera
+Metrics/StoryRight: Prawy margines widoku tiddlerów
+Metrics/StoryRight/Hint: Szerokość prawego marginesu,<br>tj odstępu między menu bocznym a krawędzią tiddlera
+Metrics/StoryWidth: Szerokość widoku tiddlerów
+Metrics/StoryWidth/Hint: Ogólna szerokość widoku tiddlerów
+Metrics/TiddlerWidth: Szerokość tiddlera
+Metrics/TiddlerWidth/Hint: Wewnątrz widoku tiddlerów
+Metrics/SidebarBreakpoint: Breakpoint menu bocznego
+Metrics/SidebarBreakpoint/Hint: Minimalna szerokość strony, przy której<br>menu boczne i widok tiddlerów zostaną wyświetlone obok siebie
+Metrics/SidebarWidth: Szerokość menu bocznego
+Metrics/SidebarWidth/Hint: Szerokość menu bocznego w widoku płynny <-> stały

--- a/languages/pl-PL/TiddlerInfo.multids
+++ b/languages/pl-PL/TiddlerInfo.multids
@@ -3,10 +3,10 @@ title: $:/language/TiddlerInfo/
 Advanced/Caption: Zaawansowane
 Advanced/PluginInfo/Empty/Hint: pusto
 Advanced/PluginInfo/Heading: Szczegóły Wtyczki
-Advanced/PluginInfo/Hint: Ta wtyczka zawiera takie ukryte tiddlery:
+Advanced/PluginInfo/Hint: Ta wtyczka zawiera takie tiddlery-cienie:
 Advanced/ShadowInfo/Heading: Status ukrycia
-Advanced/ShadowInfo/NotShadow/Hint: Tiddler <$link to=<<infoTiddler>>><$text text=<<infoTiddler>>/></$link> nie jest ukrytym tiddlerem
-Advanced/ShadowInfo/Shadow/Hint: Tiddler <$link to=<<infoTiddler>>><$text text=<<infoTiddler>>/></$link> jest ukrytym tiddlerem
+Advanced/ShadowInfo/NotShadow/Hint: Tiddler <$link to=<<infoTiddler>>><$text text=<<infoTiddler>>/></$link> nie jest tiddlerem-cieniem
+Advanced/ShadowInfo/Shadow/Hint: Tiddler <$link to=<<infoTiddler>>><$text text=<<infoTiddler>>/></$link> jest tiddlerem-cieniem
 Advanced/ShadowInfo/Shadow/Source: Zdefiniiowany we wtyczce <$link to=<<pluginTiddler>>><$text text=<<pluginTiddler>>/></$link>
 Advanced/ShadowInfo/OverriddenShadow/Hint: Nadpisany przez zwykłego tiddlera
 Fields/Caption: Pola

--- a/languages/pl-PL/TiddlerInfo.multids
+++ b/languages/pl-PL/TiddlerInfo.multids
@@ -1,0 +1,22 @@
+title: $:/language/TiddlerInfo/
+
+Advanced/Caption: Zaawansowane
+Advanced/PluginInfo/Empty/Hint: pusto
+Advanced/PluginInfo/Heading: Szczegóły Wtyczki
+Advanced/PluginInfo/Hint: Ta wtyczka zawiera takie ukryte tiddlery:
+Advanced/ShadowInfo/Heading: Status ukrycia
+Advanced/ShadowInfo/NotShadow/Hint: Tiddler <$link to=<<infoTiddler>>><$text text=<<infoTiddler>>/></$link> nie jest ukrytym tiddlerem
+Advanced/ShadowInfo/Shadow/Hint: Tiddler <$link to=<<infoTiddler>>><$text text=<<infoTiddler>>/></$link> jest ukrytym tiddlerem
+Advanced/ShadowInfo/Shadow/Source: Zdefiniiowany we wtyczce <$link to=<<pluginTiddler>>><$text text=<<pluginTiddler>>/></$link>
+Advanced/ShadowInfo/OverriddenShadow/Hint: Nadpisany przez zwykłego tiddlera
+Fields/Caption: Pola
+List/Caption: Lista
+List/Empty: Ten tiddler nie posiada żadnych list
+Listed/Caption: W Listach
+Listed/Empty: Ten tiddler nie jest wylistowany w żadnym innym tiddlerze
+References/Caption: Link Zwrotne
+References/Empty: Żaden inny tiddler nie linkuje do tego
+Tagging/Caption: Tagi
+Tagging/Empty: Żaden inny tiddler nie ma w swoich tagach tego
+Tools/Caption: Narzędzia
+

--- a/languages/pl-PL/Types/application_javascript.tid
+++ b/languages/pl-PL/Types/application_javascript.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/application/javascript
+description: Kod JavaScript
+name: application/javascript
+group: Developer
+group-sort: 2

--- a/languages/pl-PL/Types/application_json.tid
+++ b/languages/pl-PL/Types/application_json.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/application/json
+description: Dane JSON
+name: application/json
+group: Developer
+group-sort: 2

--- a/languages/pl-PL/Types/application_x_tiddler_dictionary.tid
+++ b/languages/pl-PL/Types/application_x_tiddler_dictionary.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/application/x-tiddler-dictionary
+description: Słownik danych
+name: application/x-tiddler-dictionary
+group: Developer
+group-sort: 2

--- a/languages/pl-PL/Types/image_gif.tid
+++ b/languages/pl-PL/Types/image_gif.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/image/gif
+description: Obraz GIF
+name: image/gif
+group: Image
+group-sort: 1

--- a/languages/pl-PL/Types/image_jpeg.tid
+++ b/languages/pl-PL/Types/image_jpeg.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/image/jpeg
+description: Obraz JPEG
+name: image/jpeg
+group: Image
+group-sort: 1

--- a/languages/pl-PL/Types/image_png.tid
+++ b/languages/pl-PL/Types/image_png.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/image/png
+description: Obraz PNG
+name: image/png
+group: Image
+group-sort: 1

--- a/languages/pl-PL/Types/image_svg_xml.tid
+++ b/languages/pl-PL/Types/image_svg_xml.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/image/svg+xml
+description: Obraz wektorowy SVG
+name: image/svg+xml
+group: Image
+group-sort: 1

--- a/languages/pl-PL/Types/image_x-icon.tid
+++ b/languages/pl-PL/Types/image_x-icon.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/image/x-icon
+description: Ikona w formacie ICO
+name: image/x-icon
+group: Image
+group-sort: 1

--- a/languages/pl-PL/Types/text_css.tid
+++ b/languages/pl-PL/Types/text_css.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/text/css
+description: Statyczny styl CSS
+name: text/css
+group: Developer
+group-sort: 2

--- a/languages/pl-PL/Types/text_html.tid
+++ b/languages/pl-PL/Types/text_html.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/text/html
+description: Ttekst HTML
+name: text/html
+group: Text
+group-sort: 0

--- a/languages/pl-PL/Types/text_plain.tid
+++ b/languages/pl-PL/Types/text_plain.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/text/plain
+description: Czysty tekst
+name: text/plain
+group: Text
+group-sort: 0

--- a/languages/pl-PL/Types/text_vnd.tiddlywiki.tid
+++ b/languages/pl-PL/Types/text_vnd.tiddlywiki.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/text/vnd.tiddlywiki
+description: TiddlyWiki 5
+name: text/vnd.tiddlywiki
+group: Text
+group-sort: 0

--- a/languages/pl-PL/Types/text_x-tiddlywiki.tid
+++ b/languages/pl-PL/Types/text_x-tiddlywiki.tid
@@ -1,0 +1,5 @@
+title: $:/language/Docs/Types/text/x-tiddlywiki
+description: TiddlyWiki Klasyczny
+name: text/x-tiddlywiki
+group: Text
+group-sort: 0

--- a/languages/pl-PL/icon.tid
+++ b/languages/pl-PL/icon.tid
@@ -1,0 +1,13 @@
+title: $:/languages/pl-PL/icon
+type: image/svg+xml
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 30" width="1200" height="600">
+<clipPath id="t">
+	<path d="M30,15 h30 v15 z v15 h-30 z h-30 v-15 z v-15 h30 z"/>
+</clipPath>
+<path d="M0,0 v30 h60 v-30 z" fill="#00247d"/>
+<path d="M0,0 L60,30 M60,0 L0,30" stroke="#fff" stroke-width="6"/>
+<path d="M0,0 L60,30 M60,0 L0,30" clip-path="url(#t)" stroke="#cf142b" stroke-width="4"/>
+<path d="M30,0 v30 M0,15 h60" stroke="#fff" stroke-width="10"/>
+<path d="M30,0 v30 M0,15 h60" stroke="#cf142b" stroke-width="6"/>
+</svg>

--- a/languages/pl-PL/icon.tid
+++ b/languages/pl-PL/icon.tid
@@ -1,13 +1,7 @@
 title: $:/languages/pl-PL/icon
 type: image/svg+xml
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 30" width="1200" height="600">
-<clipPath id="t">
-	<path d="M30,15 h30 v15 z v15 h-30 z h-30 v-15 z v-15 h30 z"/>
-</clipPath>
-<path d="M0,0 v30 h60 v-30 z" fill="#00247d"/>
-<path d="M0,0 L60,30 M60,0 L0,30" stroke="#fff" stroke-width="6"/>
-<path d="M0,0 L60,30 M60,0 L0,30" clip-path="url(#t)" stroke="#cf142b" stroke-width="4"/>
-<path d="M30,0 v30 M0,15 h60" stroke="#fff" stroke-width="10"/>
-<path d="M30,0 v30 M0,15 h60" stroke="#cf142b" stroke-width="6"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 60 30">
+<rect width="60" height="30" fill="#fff"/>
+<rect width="60" height="15" fill="#dc143c" y="15"/>
 </svg>

--- a/languages/pl-PL/plugin.info
+++ b/languages/pl-PL/plugin.info
@@ -1,0 +1,8 @@
+{
+	"title": "$:/languages/pl-PL",
+	"name": "pl-PL",
+	"plugin-type": "language",
+	"description": "Polish (Poland)",
+	"author": "Maurycy Zarzycki (Evidently Cube)",
+	"core-version": ">=5.2.0"
+}

--- a/languages/pl-PL/readme.md
+++ b/languages/pl-PL/readme.md
@@ -1,0 +1,1 @@
+Translation notes are available here: https://github.com/Jermolene/TiddlyWiki5/discussions/6080


### PR DESCRIPTION
This PR adds Polish translation to Tiddly Wiki. I made it for personal use but figured there might be worth in making this official - I'd be happy to keep it up to date if it gets merged to the core.

Of the most interesting decisions I made there are two:
 - I decided to keep using the english word `tiddler` to refer to tiddlers because I couldn't think of anything in Polish that would adequately represent how tiny a tiddler can be, and still sounded good and like a proper noun in various contexts.
 - I couldn't quite find good wording for "story river" and "story view" - I am still not sure if they are the same thing. I've opted to go with either `tiddler view` or `main view` equivalents wherever it made sense.

I am publishing it as a draft because I want to take another look and use it for a little bit to see if it sounds good.