### PR TITLE
Adds the missing trigonometric filter operators

### DIFF
--- a/core/modules/filters/math.js
+++ b/core/modules/filters/math.js
@@ -166,32 +166,32 @@ exports["standard-deviation"] = makeNumericReducingOperator(
 );
 
 //trigonometry
-exports.cos= makeNumericBinaryOperator(
-    function(a) {return Math.cos(a)}
+exports.cos = makeNumericBinaryOperator(
+	function(a) {return Math.cos(a)}
 );
 
-exports.sin= makeNumericBinaryOperator(
-    function(a) {return Math.sin(a)}
+exports.sin = makeNumericBinaryOperator(
+	function(a) {return Math.sin(a)}
 );
 
-exports.tan= makeNumericBinaryOperator(
-    function(a) {return Math.tan(a)}
+exports.tan = makeNumericBinaryOperator(
+	function(a) {return Math.tan(a)}
 );
 
-exports.acos= makeNumericBinaryOperator(
-    function(a) {return Math.acos(a)}
+exports.acos = makeNumericBinaryOperator(
+	function(a) {return Math.acos(a)}
 );
 
-exports.asin= makeNumericBinaryOperator(
-    function(a) {return Math.asin(a)}
+exports.asin = makeNumericBinaryOperator(
+	function(a) {return Math.asin(a)}
 );
 
-exports.atan= makeNumericBinaryOperator(
-    function(a) {return Math.atan(a)}
+exports.atan = makeNumericBinaryOperator(
+	function(a) {return Math.atan(a)}
 );
 
-exports.atan2= makeNumericBinaryOperator(
-    function(a) {return Math.atan2(a)}
+exports.atan2 = makeNumericBinaryOperator(
+	function(a) {return Math.atan2(a)}
 );
 
 //Calculate the variance of a population of numbers in an array given its mean


### PR DESCRIPTION
This PR adds support to the missing trigonometric filter operators (cos, sin, tan, acos, asin, atan, atan2), allowing to create spider graphs, [pie charts, donut charts, polar charts](https://ffoodd.github.io/chaarts/pie-charts.html) and other geometric shapes with filters, which was previously not possible without add-ons.

Example :

`[[2]cos[]] = -0.4161468365471424`

See also this radar chart made in wikitext by @saqimtiaz using the new trigonometric operators :
https://saqimtiaz.github.io/sq-tw/temp/radar-chart-demo.html