### PR TITLE
Add missing parameter to atan2 operator 

### DIFF
--- a/core/modules/filters/math.js
+++ b/core/modules/filters/math.js
@@ -191,7 +191,7 @@ exports.atan = makeNumericBinaryOperator(
 );
 
 exports.atan2 = makeNumericBinaryOperator(
-	function(a) {return Math.atan2(a)}
+	function(a,b) {return Math.atan2(a,b)}
 );
 
 //Calculate the variance of a population of numbers in an array given its mean


### PR DESCRIPTION
The atan2 operator needs two parameters (Binary Mathematics Operators), this PR adds the second one that was missing.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2 for more technical info on the atan2 function.