### PR TITLE
The $let widget

### DIFF
--- a/core/modules/widgets/let.js
+++ b/core/modules/widgets/let.js
@@ -36,8 +36,6 @@ LetWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 LetWidget.prototype.render = function(parent,nextSibling) {
-	// Call the constructor
-	Widget.call(this);
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();

--- a/core/modules/widgets/let.js
+++ b/core/modules/widgets/let.js
@@ -30,7 +30,7 @@ var LetWidget = function(parseTreeNode,options) {
 /*
 Inherit from the base widget class
 */
-LetWidget.prototype = Object.create(Widget.prototype);
+LetWidget.prototype = new Widget();
 
 /*
 Render this widget into the DOM
@@ -71,7 +71,7 @@ LetWidget.prototype.computeAttributes = function() {
 };
 
 LetWidget.prototype.getVariableInfo = function(name,options) {
-	// Special handling: If this variable exists in this very $vars, we can
+	// Special handling: If this variable exists in this very $let, we can
 	// use it, but only if it's been staged.
 	if ($tw.utils.hop(this.currentValueFor,name)) {
 		return {
@@ -86,7 +86,7 @@ Refresh the widget by ensuring our attributes are up to date
 */
 LetWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(Object.keys(changedAttributes).length) {
+	if($tw.utils.count(changedAttributes) > 0) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/modules/widgets/let.js
+++ b/core/modules/widgets/let.js
@@ -1,0 +1,96 @@
+/*\
+title: $:/core/modules/widgets/let.js
+type: application/javascript
+module-type: widget
+
+This widget allows defining multiple variables at once, while allowing
+the later variables to depend upon the earlier ones.
+
+```
+\define helloworld() Hello world!
+<$let currentTiddler="target" value={{!!value}} currentTiddler="different">
+  {{!!value}} will be different from <<value>>
+</$let>
+```
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var LetWidget = function(parseTreeNode,options) {
+	// Initialise
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+LetWidget.prototype = Object.create(Widget.prototype);
+
+/*
+Render this widget into the DOM
+*/
+LetWidget.prototype.render = function(parent,nextSibling) {
+	// Call the constructor
+	Widget.call(this);
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
+	this.renderChildren(parent,nextSibling);
+};
+
+LetWidget.prototype.computeAttributes = function() {
+	// Before computing attributes, we must make clear that none of the
+	// existing attributes are staged for lookup, even on a refresh
+	var changedAttributes = {},
+		self = this,
+		value;
+	this.stagedVariables = Object.create(null);
+	$tw.utils.each(this.parseTreeNode.orderedAttributes,function(attribute) {
+		var value = self.computeAttribute(attribute),
+			name = attribute.name;
+		if (self.attributes[name] !== value) {
+			self.attributes[name] = value;
+			changedAttributes[name] = true;
+		}
+		if(name.charAt(0) !== "$") {
+			self.setVariable(name,value);
+			// Now that it's prepped, we're allowed to look this variable up
+			// when defining later variables
+			self.stagedVariables[name] = true;
+		}
+	});
+	return changedAttributes;
+};
+
+LetWidget.prototype.getVariableInfo = function(name,options) {
+	// Special handling: If this variable exists in this very $vars, we can
+	// use it, but only if it's been staged.
+	if (this.stagedVariables[name]) {
+		return {
+			text: this.variables[name].value
+		};
+	}
+	return Widget.prototype.getVariableInfo.call(this,name,options);
+};
+
+/*
+Refresh the widget by ensuring our attributes are up to date
+*/
+LetWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if(Object.keys(changedAttributes).length) {
+		this.refreshSelf();
+		return true;
+	}
+	return this.refreshChildren(changedTiddlers);
+};
+
+exports["let"] = LetWidget;
+
+})();

--- a/core/modules/widgets/vars.js
+++ b/core/modules/widgets/vars.js
@@ -29,7 +29,7 @@ var VarsWidget = function(parseTreeNode,options) {
 /*
 Inherit from the base widget class
 */
-VarsWidget.prototype = Object.create(Widget.prototype);
+VarsWidget.prototype = new Widget();
 
 /*
 Render this widget into the DOM
@@ -63,7 +63,7 @@ Refresh the widget by ensuring our attributes are up to date
 */
 VarsWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(Object.keys(changedAttributes).length) {
+	if($tw.utils.count(changedAttributes) > 0) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/modules/widgets/vars.js
+++ b/core/modules/widgets/vars.js
@@ -35,8 +35,6 @@ VarsWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 VarsWidget.prototype.render = function(parent,nextSibling) {
-	// Call the constructor
-	Widget.call(this);
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -263,8 +263,7 @@ Compute the current values of the attributes of the widget. Returns a hashmap of
 */
 Widget.prototype.computeAttributes = function() {
 	var changedAttributes = {},
-		self = this,
-		value;
+		self = this;
 	$tw.utils.each(this.parseTreeNode.attributes,function(attribute,name) {
 		var value = self.computeAttribute(attribute);
 		if(self.attributes[name] !== value) {

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -266,22 +266,27 @@ Widget.prototype.computeAttributes = function() {
 		self = this,
 		value;
 	$tw.utils.each(this.parseTreeNode.attributes,function(attribute,name) {
-		if(attribute.type === "filtered") {
-			value = self.wiki.filterTiddlers(attribute.filter,self)[0] || "";
-		} else if(attribute.type === "indirect") {
-			value = self.wiki.getTextReference(attribute.textReference,"",self.getVariable("currentTiddler"));
-		} else if(attribute.type === "macro") {
-			value = self.getVariable(attribute.value.name,{params: attribute.value.params});
-		} else { // String attribute
-			value = attribute.value;
-		}
-		// Check whether the attribute has changed
+		var value = self.computeAttribute(attribute);
 		if(self.attributes[name] !== value) {
 			self.attributes[name] = value;
 			changedAttributes[name] = true;
 		}
 	});
 	return changedAttributes;
+};
+
+Widget.prototype.computeAttribute = function(attribute) {
+	var value;
+	if(attribute.type === "filtered") {
+		value = this.wiki.filterTiddlers(attribute.filter,this)[0] || "";
+	} else if(attribute.type === "indirect") {
+		value = this.wiki.getTextReference(attribute.textReference,"",this.getVariable("currentTiddler"));
+	} else if(attribute.type === "macro") {
+		value = this.getVariable(attribute.value.name,{params: attribute.value.params});
+	} else { // String attribute
+		value = attribute.value;
+	}
+	return value;
 };
 
 /*

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -274,6 +274,11 @@ describe("Widget module", function() {
 		// refresh.
 		wiki.addTiddler({title: "TiddlerOne", text: "newlookup"});
 		expect(widgetNode.refresh({})).toBe(false);
+
+		// But if we make a change that might result in different outfacing
+		// variables, then it should refresh
+		wiki.addTiddler({title: "TiddlerOne", text: "badlookup"});
+		expect(widgetNode.refresh({})).toBe(true);
 	});
 
 	it("should deal with attributes specified as macro invocations", function() {

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -247,6 +247,25 @@ describe("Widget module", function() {
 		expect(wrapper.children[0].children[2].sequenceNumber).toBe(4);
 	});
 
+	it("should deal with the let widget", function() {
+		var wiki = new $tw.Wiki();
+		wiki.addTiddlers([
+			{title: "TiddlerOne", text: "lookup"},
+			{title: "TiddlerTwo", lookup: "value"},
+			{title: "TiddlerThree", value: "Happy Result"}
+		]);
+		var text="\\define macro() TiddlerTwo\n<$let "+
+			"currentTiddler='TiddlerOne' "+
+			"field={{!!text}} "+
+			"currentTiddler=<<macro>> "+
+			"field={{{ [all[current]get<field>] }}} "+
+			"currentTiddler='TiddlerThree'>"+
+				"<$transclude field=<<field>>/></$let>";
+		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
+		var wrapper = renderWidgetNode(widgetNode);
+		expect(wrapper.innerHTML).toBe("<p>Happy Result</p>");
+	});
+
 	it("should deal with attributes specified as macro invocations", function() {
 		var wiki = new $tw.Wiki();
 		// Construct the widget node

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -251,19 +251,29 @@ describe("Widget module", function() {
 		var wiki = new $tw.Wiki();
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "lookup"},
-			{title: "TiddlerTwo", lookup: "value"},
-			{title: "TiddlerThree", value: "Happy Result"}
+			{title: "TiddlerTwo", lookup: "value", newlookup: "value", wrong: "wrong"},
+			{title: "TiddlerThree", text: "wrong", value: "Happy Result", wrong: "ALL WRONG!!"}
 		]);
-		var text="\\define macro() TiddlerTwo\n<$let "+
-			"currentTiddler='TiddlerOne' "+
-			"field={{!!text}} "+
-			"currentTiddler=<<macro>> "+
-			"field={{{ [all[current]get<field>] }}} "+
-			"currentTiddler='TiddlerThree'>"+
-				"<$transclude field=<<field>>/></$let>";
+		var text="\\define macro() TiddlerThree\n"+
+			"\\define currentTiddler() TiddlerOne\n"+
+			"<$let "+
+				"field={{!!text}} "+
+				"currentTiddler='TiddlerTwo' "+
+				"field={{{ [all[current]get<field>] }}} "+
+				"currentTiddler=<<macro>>>"+
+					"<$transclude field=<<field>>/></$let>";
 		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
 		var wrapper = renderWidgetNode(widgetNode);
 		expect(wrapper.innerHTML).toBe("<p>Happy Result</p>");
+
+		// This is important. $Let needs to be aware enough not to let its
+		// own variables interfere with its ability to recognize no change.
+		// Doesn't matter that nothing has changed, we just need to make sure
+		// it recognizes that that its outward facing variables are unchanged
+		// EVEN IF some intermediate variables did change, there's no need to
+		// refresh.
+		wiki.addTiddler({title: "TiddlerOne", text: "newlookup"});
+		expect(widgetNode.refresh({})).toBe(false);
 	});
 
 	it("should deal with attributes specified as macro invocations", function() {

--- a/editions/tw5.com/tiddlers/widgets/LetWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/LetWidget.tid
@@ -5,7 +5,7 @@ caption: let
 
 ! Introduction
 
-The <<.wid let>> widget allows multiple variables to be set in one operation. In some situations it can result in simpler code than using the more flexible <<.wlink SetWidget>> widget. It differs from the <<.wlink VarsWidget>> widget in that variables you're defining may depend on earlier variables defined within the same <<.wid let>>.
+<<.from-version "5.2.1">> The <<.wid let>> widget allows multiple variables to be set in one operation. In some situations it can result in simpler code than using the more flexible <<.wlink SetWidget>> widget. It differs from the <<.wlink VarsWidget>> widget in that variables you're defining may depend on earlier variables defined within the same <<.wid let>>.
 
 ! Content and Attributes
 

--- a/editions/tw5.com/tiddlers/widgets/LetWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/LetWidget.tid
@@ -1,0 +1,57 @@
+title: LetWidget
+created: 20211028115900000
+tags: Widgets
+caption: let
+
+! Introduction
+
+The <<.wid let>> widget allows multiple variables to be set in one operation. In some situations it can result in simpler code than using the more flexible <<.wlink SetWidget>> widget. It differs from the <<.wlink VarsWidget>> widget in that variables you're defining may depend on earlier variables defined within the same <<.wid let>>.
+
+! Content and Attributes
+
+The content of the <<.wid let>> widget is the scope for the value assigned to the variable.
+
+|!Attribute |!Description |
+|//{attributes not starting with $}// |Each attribute name specifies a variable name. The attribute value is assigned to the variable |
+
+Attributes are evaluated in the order they are written. Attributes with the same name are allowed. Each time a duplicate attribute is encountered, it will replace the existing value set by the earlier duplicate.
+
+! Examples
+
+Consider a case where you need to set multiple variables, where some depend on the evaluation of others.
+
+Using the <<.wid let>> widget, this situation may be handled in the following way:
+
+```
+\define helloworld() Hello world!
+
+<$let target="MyTiddler" currentTiddler={{{ [<target>prefix[$:/settings/for/]] }}} settings={{!!text}} currentTiddler=<<target>> >
+  The settings for <<currentTiddler>> are: <<settings>>
+</$let>
+```
+
+In contrast, here is the same example using the <<.wid set>> widget:
+
+```
+<$set name="target" value="MyTiddler" >
+<$set name="currentTiddler" value={{{ [<target>prefix[$:/settings/for/]] }}} >
+<$set name="settings" value={{!!text}} >
+<$set name="currentTiddler" value=<<target>> >
+  The settings for <<currentTiddler>> are: <<settings>>
+</$set>
+</$set>
+</$set>
+</$set>
+```
+
+! Remarks
+
+This widget differs from <<.wid vars>> in the following way:
+
+* Each variable's definition will be immediately available to all proceeding variables in the same let widget. This differs from vars, in which definitions which depend on some variable will always look to the widget's outer scope for a value.
+
+This widget differs from <<.wid set>> in the following ways:
+
+* A fallback (also known as "emptyValue") cannot be specified
+* Filters cannot be used to produce a conditional variable assignment
+* Variable names must be literal strings

--- a/editions/tw5.com/tiddlers/widgets/VarsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/VarsWidget.tid
@@ -6,20 +6,22 @@ caption: vars
 
 ! Introduction
 
-The ''vars'' widget allows multiple variables to be set in one operation. In some situations it can result in simpler code than using the more flexible SetWidget.
+The <<.wid vars>> widget allows multiple variables to be set in one operation. In some situations it can result in simpler code than using the more flexible <<.wlink SetWidget>> widget. It differs from the <<.wlink LetWidget>> in that variables cannot interfere with the evaluation of other variables within the same <<.wid vars>>.
 
 ! Content and Attributes
 
-The content of the `<$vars>` widget is the scope for the value assigned to the variable.
+The content of the <<.wid vars>> widget is the scope for the value assigned to the variable.
 
 |!Attribute |!Description |
 |//{attributes not starting with $}// |Each attribute name specifies a variable name. The attribute value is assigned to the variable |
+
+Attributes will not interfere with the evaluation of other attributes. So if one attribute sets <<.attr currentTiddler>>, and another attribute uses <<.attr currentTiddler>> in its evaluation, it will use the value of <<.attr currentTiddler>> that exists outside the widget's scope.
 
 ! Examples
 
 Consider a case where you need to set multiple variables.
 
-Using the `<$vars>` widget, this situation may be handled in the following way:
+Using the <<.wid vars>> widget, this situation may be handled in the following way:
 
 ```
 \define helloworld() Hello world!
@@ -29,7 +31,7 @@ Using the `<$vars>` widget, this situation may be handled in the following way:
 </$vars>
 ```
 
-In contrast, here is the same example using the `<$set>` widget:
+In contrast, here is the same example using the <<.wid set>> widget:
 
 ```
 <$set name="greeting" value="Hi" >
@@ -43,7 +45,7 @@ In contrast, here is the same example using the `<$set>` widget:
 
 ! Remarks
 
-It should be noted that this widget differs from the set widget in the following ways:
+It should be noted that this widget differs from the <<.wid set>> widget in the following ways:
 
 * A fallback (also known as "emptyValue") cannot be specified
 * Filters cannot be used to produce a conditional variable assignement


### PR DESCRIPTION
Here is the $let widget, which takes advantage of orderedAttributes in order to allow for interdependent variables, as well as multiple definitions of the same variable.

I made a few design decisions while making this:

* I broke some code out of computeAttributes in widget.js" into a computeAttribute method, which is a zero-side-effect method which just returns the value of a passed attribute. I did this to cut down on repetition when $let makes its own computeAttributes method
* I opted not to have the core widget's computeAttributes evaluate attributes in order the way $let does. Since not all widgets have orderedAttributes, and not all attributes in widgets have their "name" member filled out, it made for some ugly logic. But since the order was (and remains) undefined, this can be changed later if desired.

Otherwise, this does everything it's promised to do. It took some special care to make sure it doesn't refresh unnecessarily, but it should all be good now. Also included some documentation (and I touched up varsWidget documentation to use the .wid and .wlink macros when appropriate).

Let me know what ya'll think.