### PR TITLE
Extends :map filter run prefix to provide missing variables

### DIFF
--- a/core/modules/filterrunprefixes/map.js
+++ b/core/modules/filterrunprefixes/map.js
@@ -15,7 +15,8 @@ Export our filter prefix function
 exports.map = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		if(results.length > 0) {
-			var inputTitles = results.toArray();
+			var inputTitles = results.toArray(),
+				index = 0;
 			results.clear();
 			$tw.utils.each(inputTitles,function(title) {
 				var filtered = operationSubFunction(options.wiki.makeTiddlerIterator([title]),{
@@ -25,12 +26,19 @@ exports.map = function(operationSubFunction,options) {
 								return "" + title;
 							case "..currentTiddler":
 								return widget.getVariable("currentTiddler");
+							case "index":
+								return "" + index;
+							case "revIndex":
+								return "" +  (inputTitles.length - 1 - index);
+							case "length":
+								return "" + inputTitles.length;
 							default:
 								return widget.getVariable(name);
 						}
 					}
 				});
 				results.push(filtered[0] || "");
+				++index;
 			});
 		}
 	}

--- a/editions/test/tiddlers/tests/test-prefixes-filter.js
+++ b/editions/test/tiddlers/tests/test-prefixes-filter.js
@@ -384,6 +384,8 @@ describe("'reduce' and 'intersection' filter prefix tests", function() {
 		expect(wiki.filterTiddlers("[tag[shopping]] :map[get[description]else{!!title}]").join(",")).toBe("A square of rich chocolate cake,a round yellow seed,Milk,Rice Pudding");
 		// Return the first title from :map if the filter returns more than one result
 		expect(wiki.filterTiddlers("[tag[shopping]] :map[tags[]]").join(",")).toBe("shopping,shopping,shopping,shopping");
+		// Prepend the position in the list using the index and length variables
+		expect(wiki.filterTiddlers("[tag[shopping]] :map[get[title]addprefix[-]addprefix<length>addprefix[of]addprefix<index>]").join(",")).toBe("0of4-Brownies,1of4-Chick Peas,2of4-Milk,3of4-Rice Pudding");
 	});
 });
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210618134753828
-modified: 20211029025811183
+modified: 20211029082538212
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Map Filter Run Prefix]]
 title: Map Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -15,5 +15,5 @@ For each title in a shopping list, calculate the total cost of purchasing each i
 
 <<.operator-example 2 "[tag[shopping]] :map[get[quantity]else[0]multiply{!!price}]">>
 
-
-<<.operator-example 2 "[tag[shopping]] :map[<index>addsuffix[-]addsuffix<revIndex>addsuffix<length>]">>
+For each title in a shopping list, prefix it with its position in the list:
+<<.operator-example 2 "[tag[shopping]] :map[<currentTiddler>addprefix[-]addprefix<index>]">>

--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210618134753828
-modified: 20210618140945870
+modified: 20211029025811183
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Map Filter Run Prefix]]
 title: Map Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -14,3 +14,6 @@ Replace the input titles with the caption field if it exists, otherwise preserve
 For each title in a shopping list, calculate the total cost of purchasing each item:
 
 <<.operator-example 2 "[tag[shopping]] :map[get[quantity]else[0]multiply{!!price}]">>
+
+
+<<.operator-example 2 "[tag[shopping]] :map[<index>addsuffix[-]addsuffix<revIndex>addsuffix<length>]">>

--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix.tid
@@ -18,9 +18,9 @@ The following variables are available within the filter run:
 
 * ''currentTiddler'' - the input title
 * ''..currentTiddler'' - the value of the variable `currentTiddler` outside the filter run.
-* ''index'' - the numeric index of the current list item (with zero being the first item in the list) <<.from-version "5.2.1">>
-* ''revIndex'' - the reverse numeric index of the current list item (with zero being the last item in the list) <<.from-version "5.2.1">>
-* ''length'' - the total length of the input list <<.from-version "5.2.1">>
+* ''index'' - <<.from-version "5.2.1">> the numeric index of the current list item (with zero being the first item in the list).
+* ''revIndex'' - <<.from-version "5.2.1">> the reverse numeric index of the current list item (with zero being the last item in the list).
+* ''length'' - <<.from-version "5.2.1">> the total length of the input list.
 
 Filter runs used with the `:map` prefix should return the same number of items that they are passed. Any missing entries will be treated as an empty string. In particular, when retrieving the value of a field with the [[get Operator]] it is helpful to guard against a missing field value using the [[else Operator]]. For example `[get[myfield]else[default-value]...`.
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix.tid
@@ -1,5 +1,5 @@
 created: 20210618133745003
-modified: 20210618134747652
+modified: 20211029025541750
 tags: [[Filter Syntax]] [[Filter Run Prefix]]
 title: Map Filter Run Prefix
 type: text/vnd.tiddlywiki
@@ -13,6 +13,14 @@ type: text/vnd.tiddlywiki
 Each input title from previous runs is passed to this run in turn. The filter run transforms the input titles and the output of this run replaces the input title. For example, the filter run `[get[caption]else{!!title}]` replaces each input title with its caption field, unless the field does not exist in which case the title is preserved.
 
 Note that within the filter run, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits filter runs like `:map[{!!price}multiply{!!cost}]` to be used for computation. The value of currentTiddler outside the run is available in the variable "..currentTiddler".
+
+The following variables are available within the filter run:
+
+* ''currentTiddler'' - the input title
+* ''..currentTiddler'' - the value of the variable `currentTiddler` outside the filter run.
+* ''index'' - the numeric index of the current list item (with zero being the first item in the list) <<.from-version "5.2.1">>
+* ''revIndex'' - the reverse numeric index of the current list item (with zero being the last item in the list) <<.from-version "5.2.1">>
+* ''length'' - the total length of the input list <<.from-version "5.2.1">>
 
 Filter runs used with the `:map` prefix should return the same number of items that they are passed. Any missing entries will be treated as an empty string. In particular, when retrieving the value of a field with the [[get Operator]] it is helpful to guard against a missing field value using the [[else Operator]]. For example `[get[myfield]else[default-value]...`.
 


### PR DESCRIPTION
Extends `:map` filter run prefix to provide  the missing variables index, revIndex and length as provided in `:reduce`

Documentation update and tests are included.

Fixes #6118 