### PR TITLE
Zero based zth[] operator and documentation

### DIFF
--- a/core/modules/filters/listops.js
+++ b/core/modules/filters/listops.js
@@ -103,4 +103,16 @@ exports.nth = function(source,operator,options) {
 	return results.slice(count - 1,count);
 };
 
+/*
+The zero based nth member of the list
+*/
+exports.zth = function(source,operator,options) {
+	var count = $tw.utils.getInt(operator.operand,0),
+		results = [];
+	source(function(tiddler,title) {
+		results.push(title);
+	});
+	return results.slice(count,count + 1);
+};
+
 })();

--- a/editions/tw5.com/tiddlers/filters/examples/zth Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/zth Operator (Examples).tid
@@ -1,0 +1,10 @@
+created: 20211029023246203
+modified: 20211029023559616
+tags: [[Operator Examples]] [[zth Operator]]
+title: zth Operator (Examples)
+type: text/vnd.tiddlywiki
+
+<<.using-days-of-week>>
+
+<<.operator-example 1 "[list[Days of the Week]zth[]]">>
+<<.operator-example 2 "[list[Days of the Week]zth[5]]">>

--- a/editions/tw5.com/tiddlers/filters/nth.tid
+++ b/editions/tw5.com/tiddlers/filters/nth.tid
@@ -1,15 +1,17 @@
+caption: nth
 created: 20150122204111000
-modified: 20150203192048000
+modified: 20211029023739450
+op-input: a [[selection of titles|Title Selection]]
+op-output: the <<.place N>>th input title
+op-parameter: an integer, defaulting to 1
+op-parameter-name: N
+op-purpose: select the <<.place N>>th input title
 tags: [[Filter Operators]] [[Order Operators]]
 title: nth Operator
 type: text/vnd.tiddlywiki
-caption: nth
-op-purpose: select the <<.place N>>th input title
-op-input: a [[selection of titles|Title Selection]]
-op-parameter: an integer, defaulting to 1
-op-parameter-name: N
-op-output: the <<.place N>>th input title
 
 <<.place N>> is one-based. In other words, `nth[1]` has the same effect as the <<.olink first>> operator.
+
+<<.tip "See <<.olink zth>> for an equivalent operator with a 0 based parameter">>
 
 <<.operator-examples "nth">>

--- a/editions/tw5.com/tiddlers/filters/zth Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/zth Operator.tid
@@ -1,0 +1,18 @@
+caption: zth
+created: 20211029023242012
+modified: 20211029023711450
+op-input: a [[selection of titles|Title Selection]]
+op-output: the <<.place Z>>th input title
+op-parameter: an integer, defaulting to 0
+op-parameter-name: Z
+op-purpose: select the <<.place Z>>th input title
+tags: [[Filter Operators]] [[Order Operators]]
+title: zth Operator
+type: text/vnd.tiddlywiki
+
+<<.from-version 5.2.1>>
+<<.place Z>> is zero-based. In other words, `zth[0]` has the same effect as `nth[1]` and the <<.olink first>> operator.
+
+<<.tip "See <<.olink nth>> for an equivalent operator with a 1 based parameter">>
+
+<<.operator-examples "zth">>


### PR DESCRIPTION
This PR adds a `zth[]` operator, a zero based index equivalent for the `nth[]` operator.

Fixes #6122 