### PR TITLE
Update getScrollContainer method to work more reliable

### DIFF
--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -66,16 +66,39 @@ exports.toggleClass = function(el,className,status) {
 
 /*
 Get the first parent element that has scrollbars or use the body as fallback.
+From https://stackoverflow.com/questions/35939886/find-first-scrollable-parent/42543908#42543908
+Also, fix for scrollTop bug: https://dev.opera.com/articles/fixing-the-scrolltop-bug/
 */
-exports.getScrollContainer = function(el) {
+exports.getScrollContainer = function(el,includeHidden) {
 	var doc = el.ownerDocument;
-	while(el.parentNode) {
-		el = el.parentNode;
-		if(el.scrollTop) {
-			return el;
+	var style = getComputedStyle(el);
+	var excludeStaticParent = style.position === "absolute";
+	var overflowRegex = includeHidden ? /(auto|scroll|hidden)/ : /(auto|scroll)/;
+	if(style.position === "fixed") {
+		if("scrollingElement" in doc) {
+			return doc.scrollingElement;
+		}
+		if(navigator.userAgent.indexOf("WebKit") !== -1) {
+			return doc.body;
+		}
+		return doc.documentElement;
+	}
+	for(var parent=el; parent=parent.parentElement; ) {
+		style = getComputedStyle(parent);
+		if(excludeStaticParent && style.position === "static") {
+			continue;
+		}
+		if(overflowRegex.test(style.overflow + style.overflowY + style.overflowX)) {
+			return parent;
 		}
 	}
-	return doc.body;
+	if("scrollingElement" in doc) {
+		return doc.scrollingElement;
+	}
+	if(navigator.userAgent.indexOf("WebKit") !== -1) {
+		return doc.body;
+	}
+	return doc.documentElement;
 };
 
 /*


### PR DESCRIPTION
This PR updates the `getScrollContainer` method in `utils/dom.js` to work more reliable
It now detects reliably the real scroll container of an element. Before it almost always detected the document.body

This PR uses https://stackoverflow.com/questions/35939886/find-first-scrollable-parent, a pure JS port of the jQuery UI `scrollParent` method and a fix for the `scrollTop Bug` - see https://dev.opera.com/articles/fixing-the-scrolltop-bug/

This PR then would allow us to use `getScrollContainer` in various places, like in the `pop` storyview to detect the `scrollContainer` of the inserted element and setting its x-overflow to `hidden` during the insert-animation and in the `pageScroller` `scrollIntoView` method where we could use the elements scrollContainer for scrolling - not `window.scrollTo`

I'd like to leave this here for discussion - there are two or three older PR's that tried to sneak this into the core but I believe they were premature

See: #6019 , #6016 , #6025
