### PR TITLE
Ensure the operator examples have unique id

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/cycle Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/cycle Operator (Examples).tid
@@ -18,4 +18,4 @@ Cycle through a list of values to add as a tag, in reverse order:
 
 <<.using-days-of-week>>
 <<.operator-example 1 """[list[Days of the Week]first[]] +[cycle{Days of the Week!!list}]""">>
-<<.operator-example 1 """[list[Days of the Week]first[]] +[cycle{Days of the Week!!list},[2]]""">>
+<<.operator-example 2 """[list[Days of the Week]first[]] +[cycle{Days of the Week!!list},[2]]""">>

--- a/editions/tw5.com/tiddlers/filters/examples/log Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/log Operator (Examples).tid
@@ -11,4 +11,4 @@ Logarithm of `100` with base `10`:
 <<.operator-example 2 "[[100]log[10]]">>
 
 Natural logarithm of 10 (base `e`), equivalent to `ln(10)` in mathematics:
-<<.operator-example 2 "[[10]log[]]">>
+<<.operator-example 3 "[[10]log[]]">>

--- a/editions/tw5.com/tiddlers/filters/examples/match Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/match Operator (Examples).tid
@@ -5,4 +5,4 @@ title: match Operator (Examples)
 type: text/vnd.tiddlywiki
 
 <<.operator-example 1 "a b c +[match[b]]">>
-<<.operator-example 1 "[match[HelloThere]]">>
+<<.operator-example 2 "[match[HelloThere]]">>


### PR DESCRIPTION
The first parameter of the operator examples macro is used for
constructing unique state tiddler titles. The cycle, log, and
match operators had duplicates, causing examples to share state
with each other.