### PR TITLE
fix - headings are block elements, and not allowed inside of paragraphs

### DIFF
--- a/plugins/tiddlywiki/dynannotate/examples/combined.tid
+++ b/plugins/tiddlywiki/dynannotate/examples/combined.tid
@@ -58,11 +58,9 @@ Search: <$edit-text tiddler="$:/temp/search" tag="input"/>
 <div class="tc-drop-down-wrapper">
 <div class="tc-drop-down tc-popup-keep" style="max-width:550px;white-space: normal;overflow-y:hidden;">
 <$tiddler tiddler={{$:/temp/dynannotate/demo/annotation-title}}>
-<p>
 <h2>
 This is an annotation
 </h2>
-</p>
 <p>
 The annotation is stored in the tiddler:
 </p>

--- a/plugins/tiddlywiki/dynannotate/examples/viewtemplate-text.tid
+++ b/plugins/tiddlywiki/dynannotate/examples/viewtemplate-text.tid
@@ -44,11 +44,9 @@ title: $:/plugins/tiddlywiki/dynannotate/examples/viewtemplate/text
 <div class="tc-drop-down-wrapper">
 <div class="tc-drop-down tc-popup-keep" style="max-width:550px;white-space: normal;overflow-y:hidden;">
 <$tiddler tiddler={{$:/temp/dynannotate/demo/annotation-title}}>
-<p>
 <h2>
 This is an annotation
 </h2>
-</p>
 <p>
 The annotation is stored in the tiddler:
 </p>


### PR DESCRIPTION
As @nilslindemann found out in: https://github.com/Jermolene/TiddlyWiki5/pull/6156/commits/6103fce5bd862ebe2ff2eb28428e18c1a4c0670f  headings shouldn't be wrapped in P-tags according to the html specs.