### PR TITLE
Add MessageHandlerWidgets and TriggeringWidgets tags

### DIFF
--- a/editions/tw5.com/tiddlers/MessageHandlerWidgets.tid
+++ b/editions/tw5.com/tiddlers/MessageHandlerWidgets.tid
@@ -1,0 +1,12 @@
+created: 20211031174746965
+modified: 20211031181800684
+title: MessageHandlerWidgets
+type: text/vnd.tiddlywiki
+
+Message handler widgets are those widgets which can react to one or more [[widget messages|Messages]].
+
+<<.tip "Widget messages are similar to low-level DOM events, except they are higher-level and specific to TiddlyWiki. To handle DOM events see the EventCatcherWidget">>
+
+The following message handler widgets are provided:
+
+<<list-links "[tag[MessageHandlerWidgets]]">>

--- a/editions/tw5.com/tiddlers/TriggeringWidgets.tid
+++ b/editions/tw5.com/tiddlers/TriggeringWidgets.tid
@@ -1,0 +1,12 @@
+created: 20211031172716741
+modified: 20211031174029381
+title: TriggeringWidgets
+type: text/vnd.tiddlywiki
+
+Triggering widgets are a type of widget which can trigger ActionWidgets. Typically these widgets (such as the ButtonWidget) will trigger actions based on interaction from the user.
+
+The following triggering widgets are provided:
+
+<<list-links "[tag[TriggeringWidgets]]">>
+
+See ActionWidgets for more information and examples of how TriggeringWidgets and ActionWidgets work together.

--- a/editions/tw5.com/tiddlers/widgets/ActionWidgets.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionWidgets.tid
@@ -1,10 +1,10 @@
 created: 20141008134425548
-modified: 20210630163127249
+modified: 20211031172913375
 tags: Widgets
 title: ActionWidgets
 type: text/vnd.tiddlywiki
 
-Action widgets are a special type of widget that have no visual appearance but perform an action when triggered (such as sending a message, navigating to a tiddler, or changing the value of a tiddler). Action widgets are used in association with other widgets that trigger those actions (for example, the ButtonWidget).
+Action widgets are a special type of widget that have no visual appearance but perform an action when triggered (such as sending a message, navigating to a tiddler, or changing the value of a tiddler). Action widgets are used in association with other widgets that [[trigger those actions|TriggeringWidgets]] (for example, the ButtonWidget).
 
 The following action widgets are provided:
 
@@ -17,7 +17,7 @@ There are two ways to use action widgets:
 
 !! Using action string attributes
 
-The action widgets are passed as a string to the `actions` attribute of the triggering widget. Usually, it is more convenient to use a macro to assign the action widgets to a variable. For example, here is a button that triggers two actions of sending different messages:
+The action widgets are passed as a string to the `actions` attribute of the [[triggering widget|TriggeringWidgets]]. Usually, it is more convenient to use a macro to assign the action widgets to a variable. For example, here is a button that triggers two actions of sending different messages:
 
 ```
 \define my-actions()
@@ -32,7 +32,7 @@ Click me!
 
 !! Directly embedding action widgets
 
-The action widgets need not be immediate children of their triggering widget, but they must be descendents of it. The actions are performed in sequence. Here is the above example rewritten to use embedding:
+The action widgets need not be immediate children of their [[triggering widget|TriggeringWidgets]], but they must be descendents of it. The actions are performed in sequence. Here is the above example rewritten to use embedding:
 
 ```
 <$button>

--- a/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ButtonWidget.tid
@@ -1,7 +1,7 @@
 caption: button
 created: 20131024141900000
-modified: 20201108183908170
-tags: Widgets
+modified: 20211009121239795
+tags: Widgets TriggeringWidgets
 title: ButtonWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
@@ -1,7 +1,7 @@
 caption: checkbox
 created: 20131024141900000
-modified: 20201109090732190
-tags: Widgets
+modified: 20211009121239806
+tags: Widgets TriggeringWidgets
 title: CheckboxWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/DraggableWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DraggableWidget.tid
@@ -1,7 +1,7 @@
 caption: draggable
 created: 20170406081938627
-modified: 20210912141544224
-tags: Widgets
+modified: 20211009122105437
+tags: Widgets TriggeringWidgets
 title: DraggableWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/DroppableWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DroppableWidget.tid
@@ -1,7 +1,7 @@
 caption: droppable
 created: 20170406082820317
-modified: 20200317142604572
-tags: Widgets
+modified: 20211009122023265
+tags: Widgets TriggeringWidgets
 title: DroppableWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/DropzoneWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DropzoneWidget.tid
@@ -1,7 +1,7 @@
 caption: dropzone
 created: 20131024141900000
-modified: 20210506115809131
-tags: Widgets
+modified: 20211009122205481
+tags: Widgets TriggeringWidgets
 title: DropzoneWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
@@ -1,7 +1,7 @@
 caption: edit-text
 created: 20131024141900000
 modified: 20211021091910134
-tags: Widgets
+tags: Widgets TriggeringWidgets
 title: EditTextWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/EditWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditWidget.tid
@@ -1,7 +1,7 @@
 caption: edit
 created: 20131024141900000
-modified: 20201130184647904
-tags: Widgets
+modified: 20211009121634055
+tags: Widgets TriggeringWidgets
 title: EditWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
@@ -1,6 +1,6 @@
 created: 20201123113532200
-modified: 20210805083352068
-tags: Widgets
+modified: 20211031180336257
+tags: Widgets TriggeringWidgets
 title: EventCatcherWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/FieldManglerWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/FieldManglerWidget.tid
@@ -1,9 +1,9 @@
+caption: fieldmangler
 created: 20131024141900000
-modified: 20150220161229000
-tags: Widgets
+modified: 20211009122821085
+tags: Widgets MessageHandlerWidgets
 title: FieldManglerWidget
 type: text/vnd.tiddlywiki
-caption: fieldmangler
 
 ! Introduction
 

--- a/editions/tw5.com/tiddlers/widgets/KeyboardWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/KeyboardWidget.tid
@@ -1,7 +1,7 @@
 caption: keyboard
 created: 20140302192136805
-modified: 20210612101618855
-tags: Widgets
+modified: 20211009121239821
+tags: Widgets TriggeringWidgets
 title: KeyboardWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/LinkCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/LinkCatcherWidget.tid
@@ -1,7 +1,7 @@
 caption: linkcatcher
 created: 20131024141900000
-modified: 20170707111536556
-tags: Widgets
+modified: 20211009122821108
+tags: Widgets MessageHandlerWidgets TriggeringWidgets
 title: LinkCatcherWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/MessageCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/MessageCatcherWidget.tid
@@ -1,6 +1,6 @@
 created: 20210309133636211
-modified: 20210711193113104
-tags: Widgets
+modified: 20211009122821123
+tags: Widgets MessageHandlerWidgets TriggeringWidgets
 title: MessageCatcherWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/NavigatorWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/NavigatorWidget.tid
@@ -1,7 +1,7 @@
 caption: navigator
 created: 20131024141900000
-modified: 20170629074415261
-tags: Widgets
+modified: 20211009122821140
+tags: Widgets MessageHandlerWidgets
 title: NavigatorWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RadioWidget.tid
@@ -1,7 +1,7 @@
 caption: radio
 created: 20131212195353929
-modified: 20210307154753471
-tags: Widgets
+modified: 20211009121654734
+tags: Widgets TriggeringWidgets
 title: RadioWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/RangeWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RangeWidget.tid
@@ -1,7 +1,7 @@
 caption: range
 created: 20171102134825376
-modified: 20201130193635857
-tags: Widgets
+modified: 20211009121606405
+tags: Widgets TriggeringWidgets
 title: RangeWidget
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/SelectWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SelectWidget.tid
@@ -1,7 +1,7 @@
 caption: select
 created: 20131024141900000
-modified: 20190304122040876
-tags: Widgets
+modified: 20211009121812691
+tags: Widgets TriggeringWidgets
 title: SelectWidget
 type: text/vnd.tiddlywiki
 


### PR DESCRIPTION
Add two new Widget tags to the documentation. The `MessageHandlerWidgets` are those which receive and process widget messages, such as the NavigatorWidget and LinkCatcherWidget. The `TriggeringWidgets` are those which can trigger actions such as the ButtonWidget and CheckboxWidget.