### PR TITLE
Increase specificity of doc-examples input

### DIFF
--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -1,5 +1,5 @@
 created: 20150117152612000
-modified: 201804111739
+modified: 20211105172548676
 tags: $:/tags/Stylesheet
 title: $:/editions/tw5.com/doc-styles
 type: text/vnd.tiddlywiki
@@ -110,7 +110,8 @@ td svg {
 	padding-bottom: 0;
 	margin-top: 0.2em;
 }
-.doc-example input {
+
+.doc-example input[type=search] { 
   width: 60%;
 }
 .doc-example pre:first-child {


### PR DESCRIPTION
I assume this goes on the master branch and not on docs? Because it's a change to editions, not docs? If wrong, I can start over.

The changes from PR #6139   two weeks ago broke the checkboxwidget examples. 

This PR tweaks  the stylesheet  to make the offending selector more specific to input search boxes (which seem to be what get used in the filter run examples).
