### PR TITLE
Update the tiddler "Simple ways to write protect tiddlers" to use data-tags

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/Simple ways to write protect tiddlers.tid
+++ b/editions/tw5.com/tiddlers/howtos/Simple ways to write protect tiddlers.tid
@@ -1,6 +1,6 @@
 created: 20180310002601813
-modified: 20180310003428093
-tags: Learning
+modified: 20211106021629911
+tags: Learning [[How to apply custom styles]]
 title: Simple ways to write protect tiddlers
 type: text/vnd.tiddlywiki
 
@@ -10,9 +10,8 @@ Sometimes you want to protect individual tiddlers from accidental changes, eithe
 
 Create a tiddler with the following contents and tag it as `$:/tags/Stylesheet` :
 
-```
-.tc-tagged-Locked button[title="Edit this tiddler"]   {display: none;}
-
+```css
+[data-tags*="Locked"] button[title="Edit this tiddler"]   {display: none;}
 ```
 
 If your TW language isn't English, then you'll need to change the text in 'title="...."' to whatever the text is when you hover over the edit button.


### PR DESCRIPTION
The tiddler [[Simple ways to write protect tiddlers]] mention the deprecated method explained in [[How to apply custom styles by tag]]. This PR update the tiddler to use the new data-tags method and add the tag "How to apply custom styles" to improve discoverability.