### PR TITLE
Add explanatory material to GettingStarted

### DIFF
--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
@@ -1,12 +1,12 @@
 created: 20131129090249275
-modified: 20200507203622933
+modified: 20211111163520352
 tags: [[Working with TiddlyWiki]]
 title: GettingStarted
 type: text/vnd.tiddlywiki
 
-Click here to download an empty copy of TiddlyWiki: {{$:/editions/tw5.com/snippets/download-empty-button}}
+In its basic form, TiddlyWiki is an HTML file. Click here to download an empty HTML copy of TiddlyWiki: {{$:/editions/tw5.com/snippets/download-empty-button}}
 
-The next step is to choose a method for saving changes. There's a wide variety of methods available, with different features and limitations. Click on the badge for a method to see more information about it. You can also click on one of the platform filters to restrict the listing to methods that work with that platform.
+Because it is an HTML file, there is no built-in mechanism for saving changes except the [[fallback saver|Saving with the HTML5 fallback saver]], which can be somewhat inconvenient. But there are other methods for saving. So the next step is to choose a method for saving changes. There's a wide variety of methods available, with different features and limitations. Click on the badge for a method to see more information about it. You can also click on one of the platform filters to restrict the listing to methods that work with that platform.
 
 <<.warning "Don't attempt to use the browser ''File''/''Save'' menu option to save changes (it doesn't work)">><br/><br/>
 


### PR DESCRIPTION
Apparently not all newcomers understand that what they are about to download is an HTML file. This can be off-putting. This change adds clarification to what the user should see and expect.

See https://talk.tiddlywiki.org/t/onboarding-for-newcomers-who-are-non-developers-is-very-difficult/1506/11