### PR TITLE
Docs: add "Widgets" tag to new docs tiddlers

### DIFF
--- a/editions/tw5.com/tiddlers/MessageHandlerWidgets.tid
+++ b/editions/tw5.com/tiddlers/MessageHandlerWidgets.tid
@@ -1,5 +1,6 @@
 created: 20211031174746965
-modified: 20211031181800684
+modified: 20211113163856255
+tags: Widgets
 title: MessageHandlerWidgets
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/TriggeringWidgets.tid
+++ b/editions/tw5.com/tiddlers/TriggeringWidgets.tid
@@ -1,5 +1,6 @@
 created: 20211031172716741
-modified: 20211031174029381
+modified: 20211113163836901
+tags: Widgets
 title: TriggeringWidgets
 type: text/vnd.tiddlywiki
 


### PR DESCRIPTION
This PR adds the `Widgets` tag to the new documentation tiddlers MessageHandlerWidgets and TriggeringWidgets