### PR TITLE
Apply 'Macro Examples' tag to tree-macro-example-*

### DIFF
--- a/editions/tw5.com/tiddlers/macros/examples/tree-macro-example-data.multids
+++ b/editions/tw5.com/tiddlers/macros/examples/tree-macro-example-data.multids
@@ -1,21 +1,6 @@
-title: tree-macro-example-
+modified: 20211114002725075
 tag: [[tree Macro (Examples)]]
+tags: [[Macro Examples]]
+title: tree-macro-example-house-kitchen-window
 
-house: See [[tree Macro (Examples)]]
-house-kitchen: See [[tree Macro (Examples)]]
-house-kitchen-table: See [[tree Macro (Examples)]]
-house-kitchen-sink: See [[tree Macro (Examples)]]
-house-kitchen-window: See [[tree Macro (Examples)]]
-house-attic: See [[tree Macro (Examples)]]
-house-attic-window: See [[tree Macro (Examples)]]
-house-attic-roof: See [[tree Macro (Examples)]]
-house-garden: See [[tree Macro (Examples)]]
-house-garden-shed: See [[tree Macro (Examples)]]
-house-garden-lawn: See [[tree Macro (Examples)]]
-car: See [[tree Macro (Examples)]]
-car-boot: See [[tree Macro (Examples)]]
-car-boot-lock: See [[tree Macro (Examples)]]
-car-boot-handle: See [[tree Macro (Examples)]]
-car-roof: See [[tree Macro (Examples)]]
-car-roof-rails: See [[tree Macro (Examples)]]
-car-roof-aerial: See [[tree Macro (Examples)]]
+See [[tree Macro (Examples)]]


### PR DESCRIPTION
Applying 'Macro Examples' tag to all tiddlers prefixed tree-macro-example-* in order to apply filter rule that will put the in macros/examples.