### PR TITLE
Add new tag 'GettingStarted' to Getting Started Tiddlers

### DIFF
--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Android.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Android.tid
@@ -1,6 +1,7 @@
 caption: Android
 created: 20140811171036268
-modified: 20160430121735629
+modified: 20211114031651878
+tags: GettingStarted
 title: GettingStarted - Android
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Chrome.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Chrome.tid
@@ -1,6 +1,7 @@
 caption: Chrome
 created: 20140811165935523
-modified: 20140811170107969
+modified: 20211114031651878
+tags: GettingStarted
 title: GettingStarted - Chrome
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Firefox.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Firefox.tid
@@ -1,6 +1,7 @@
 caption: Firefox
 created: 20140811170425199
-modified: 20140811170527083
+modified: 20211114031651878
+tags: GettingStarted
 title: GettingStarted - Firefox
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Internet Explorer.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Internet Explorer.tid
@@ -1,6 +1,7 @@
 caption: Internet Explorer
 created: 20140811172058274
-modified: 20140811172247864
+modified: 20211114031651879
+tags: GettingStarted
 title: GettingStarted - Internet Explorer
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Node.js.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Node.js.tid
@@ -1,6 +1,7 @@
 caption: Node.js
 created: 20140811172010003
-modified: 20140811172012677
+modified: 20211114031651879
+tags: GettingStarted
 title: GettingStarted - Node.js
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Online.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Online.tid
@@ -1,7 +1,7 @@
 caption: Online
 created: 20160216191710789
-modified: 20170222152427476
-tags: 
+modified: 20211114031651879
+tags: GettingStarted
 title: GettingStarted - Online
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Safari.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Safari.tid
@@ -1,6 +1,7 @@
 caption: Safari
 created: 20140811171121022
-modified: 20150325173956502
+modified: 20211114031651879
+tags: GettingStarted
 title: GettingStarted - Safari
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - iOS.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - iOS.tid
@@ -1,6 +1,7 @@
 caption: iPad/iPhone
 created: 20140811170918707
-modified: 20140811170921731
+modified: 20211114031651879
+tags: GettingStarted
 title: GettingStarted - iOS
 type: text/vnd.tiddlywiki
 


### PR DESCRIPTION
Add new tag to 'GettingStarted' to Getting Started Tiddlers except GettingStarted which is tagged 'Working with TiddlyWiki'. This tag will allow these items and any future new 'GettingStarted' tiddler to be filed in the 'gettingstarted' dir.