### PR TITLE
Add tag 'Macro Examples' to examples of macros 

### DIFF
--- a/editions/tw5.com/tiddlers/demonstrations/Tagged with TagMacro.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/Tagged with TagMacro.tid
@@ -1,5 +1,6 @@
 created: 20150221230034000
+modified: 20211116034929868
+tags: [[tag Macro (Examples)]] [[Macro Examples]]
 title: Example for tag Macro
-tags: [[tag Macro (Examples)]]
 
 This tiddler exists to demonstrate the <<.mlink tag>> macro.

--- a/editions/tw5.com/tiddlers/macros/examples/colour-picker Macro (Example 1).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/colour-picker Macro (Example 1).tid
@@ -1,6 +1,6 @@
 created: 20160418154853776
-modified: 20160418155450547
-tags: 
+modified: 20211116034610950
+tags: [[Macro Examples]]
 title: colour-picker Macro (Example 1)
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/macros/examples/image-picker Macro (Example 1).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/image-picker Macro (Example 1).tid
@@ -1,6 +1,6 @@
 created: 20160418155523369
-modified: 20160418155913663
-tags: 
+modified: 20211116035014728
+tags: [[Macro Examples]]
 title: image-picker Macro (Example 1)
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/macros/examples/image-picker Macro (Example 2).tid
+++ b/editions/tw5.com/tiddlers/macros/examples/image-picker Macro (Example 2).tid
@@ -1,6 +1,6 @@
 created: 20160418155523369
-modified: 20160418155913663
-tags: 
+modified: 20211116035110986
+tags: [[Macro Examples]]
 title: image-picker Macro (Example 2)
 type: text/vnd.tiddlywiki
 


### PR DESCRIPTION
Add tag 'Macro Examples' to examples of macros to facilitate file routing.