### PR TITLE
Fix tag 'Hidden Settings' on 'Hidden Setting: New-Image Type

### DIFF
--- a/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting NewImageType.tid
+++ b/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting NewImageType.tid
@@ -1,5 +1,7 @@
+created: 20211116222524148
+modified: 20211116222535549
+tags: [[Hidden Settings]]
 title: Hidden Setting: New-Image Type
-tags: [[Hidden Setting]]
 type: text/vnd.tiddlywiki
 
 By default new images are created with the image-type `jpeg`


### PR DESCRIPTION
Fix tag 'Hidden Settings' on 'Hidden Setting: New-Image Type. Wrongly named 'Hidden Setting'. 