### PR TITLE
 New tag  - Message Examples

### DIFF
--- a/editions/tw5.com/tiddlers/messages/SampleModal.tid
+++ b/editions/tw5.com/tiddlers/messages/SampleModal.tid
@@ -1,7 +1,8 @@
 created: 20140912145537860
 footer: <$button message="tm-close-tiddler">Close</$button>
-modified: 20140912145537861
+modified: 20211117224341543
 subtitle: This is a modal created especially for <<yourName>>
+tags: [[Message Examples]]
 title: SampleModal
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/messages/SampleWindowTemplate.tid
+++ b/editions/tw5.com/tiddlers/messages/SampleWindowTemplate.tid
@@ -1,6 +1,6 @@
 created: 20211109165213041
-modified: 20211109175739768
-tags: 
+modified: 20211117224321325
+tags: [[Message Examples]]
 title: SampleWindowTemplate
 
 


### PR DESCRIPTION
 New tag  - Message Examples - for routing to file path 'messages', leaving tag 'Messages' for the actual messages.