### PR TITLE
Whitespace trim for incredible wikitext uglifying

### DIFF
--- a/core/wiki/peek-stylesheets.tid
+++ b/core/wiki/peek-stylesheets.tid
@@ -1,6 +1,7 @@
 title: $:/snippets/peek-stylesheets
 
 \define expandable-stylesheets-list()
+\whitespace trim
 <ol>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!has[draft.of]]">
 <$vars state=<<qualify "$:/state/peek-stylesheets/open/">>>
@@ -38,6 +39,7 @@ title: $:/snippets/peek-stylesheets
 \end
 
 \define stylesheets-list()
+\whitespace trim
 <ol>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!has[draft.of]]">
 <li>
@@ -57,6 +59,7 @@ title: $:/snippets/peek-stylesheets
 </$list>
 </ol>
 \end
+\whitespace trim
 
 <$vars modeState=<<qualify "$:/state/peek-stylesheets/mode/">>>
 


### PR DESCRIPTION
This is just three `\whitespace trim`. They're just an example for something greater.

Throughout the core, \whitespace trim is *kinda* used when it can be, but it really should be used more. Whenever it is, it allows the wikiparser to toss out a whole bunch of unnecessary textWidgets which contain empty air. So it's a memory and speed improvement.

However, I have an ulterior motive. I authored [TW5-Uglify](https://flibbles.github.io/tw5-uglify/), which uglifies javascript and css in tiddlywikis, but I'm taking it to the next level: **wikitext**. You might think there isn't much to shave off in wikitext, and you'd mostly be right, but it actually adds up. More importantly, my Uglifier *really* benefits from whitespace trim pragma. Look at this macro from "$:/snippets/peek-stylesheets" (the file this pull request is touching):

```html
\define stylesheets-list()
<ol>
<$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!has[draft.of]]">
<li>
<$link>
<$view field="title"/>
</$link>
<$set name="source" tiddler=<<currentTiddler>>>
<$wikify name="styles" text=<<source>>>
<pre>
<code>
<$text text=<<styles>>/>
</code>
</pre>
</$wikify>
</$set>
</li>
</$list>
</ol>
\end
```
If you uglify this as is, you get this:
```html
\define stylesheets-list()
<ol>
<$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!has[draft.of]]">
<li>
<$link>
<$view field=title/>
</$link>
<$set name=source tiddler=<<currentTiddler>>>
<$wikify name=styles text=<<source>>>
<pre>
<code>
<$text text=<<styles>>/>
</code>
</pre>
</$wikify>
</$set>
</li>
</$list>

\end
```
Hardly anything, right? **But** if it has a whitespace trim right under the \define, then you get *this*:
```html
\define stylesheets-list()<ol><$list filter="
[all[shadows+tiddlers]tag[$:/tags
/Stylesheet]!has[draft.of]]"><li><$link><$view 
field=title/></$link><$set name=source tiddler=
<<currentTiddler>>><$wikify name=styles 
text=<<source>>><pre><code><$text text=<<styles>>/>
```
(I added some linebreaks to make it more readable)

Take "$:/snippets/peek-stylesheets"
* without pragma, it goes from 2969 to 2630, or 12% removed
* with the pragma, it goes from 3038 to 2225, or 25% removed

@Jermolene, If it's all right with you, I'd like to go through some of $:/core and add \whitespace trim where it's appropriate. (I've just written about 300+ unit tests about where it's allowed, so I've got a good idea now.)

That said, this pull request does have a visual effect. Because there is hidden whitespace in `<pre>\n<code>\n<$text .../>\n</code>\n</pre>`, the gap under the stylesheet preview was this
![gap](https://user-images.githubusercontent.com/205465/142347005-c65296fb-c899-4ab4-9380-875571a07db0.png)
but now it's this, without the gap:
![nogap](https://user-images.githubusercontent.com/205465/142347025-ad11f9d8-0187-4dd8-9898-712c5c654d75.png)

Which I think was actually intended. If I go through the core like this, I will be careful, and I'd discuss any visual changes in separate PRs. I know when "\whitespace trim" can't be safely used (mostly around macro placeholders). This really is a win,win,win, I'd say. Each whitespace trim only adds a measly 23 bytes to the file, and those can easily be canceled out with a few quotation mark removals.

Whaddaya say?