### PR TITLE
Changed vanilla/reset.tid to be a css file

### DIFF
--- a/themes/tiddlywiki/vanilla/reset.tid
+++ b/themes/tiddlywiki/vanilla/reset.tid
@@ -1,5 +1,5 @@
 title: $:/themes/tiddlywiki/vanilla/reset
-type: text/plain
+type: text/css
 
 /*! modern-normalize v1.0.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
 


### PR DESCRIPTION
Was there a reason this css file in the vanilla theme was flagged as text/plain? It was preventing plugins like tiddlywiki/highlight and flibbles/uglify from doing anything with it.