### PR TITLE
Fix: issues with drag and drop in Chrome 96

### DIFF
--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -324,7 +324,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	If there are no Files, let the browser handle it.
 	*/
 	EditTextWidget.prototype.handleDropEvent = function(event) {
-		if(event.dataTransfer.files.length) {
+		if($tw.utils.dragEventContainsFiles(event)) {
 			event.preventDefault();
 			event.stopPropagation();
 			this.dispatchDOMEvent(this.cloneEvent(event,["dataTransfer"]));

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -221,7 +221,7 @@ function dragEventContainsType(event,targetType) {
 };
 
 exports.dragEventContainsFiles = function(event) {
-	return (dragEventContainsType(event,"Files") && dragEventContainsType(event,"text/plain"));
+	return (dragEventContainsType(event,"Files") && !dragEventContainsType(event,"text/plain"));
 };
 
 exports.dragEventContainsType = dragEventContainsType;

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -221,7 +221,7 @@ function dragEventContainsType(event,targetType) {
 };
 
 exports.dragEventContainsFiles = function(event) {
-	return (dragEventContainsType(event,"Files") && !$tw.utils.dragEventContainsType(event,"text/plain"));
+	return (dragEventContainsType(event,"Files") && dragEventContainsType(event,"text/plain"));
 };
 
 exports.dragEventContainsType = dragEventContainsType;

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -208,10 +208,10 @@ function parseJSONTiddlers(json,fallbackTitle) {
 	return data;
 };
 
-exports.dragEventContainsFiles = function(event) {
+function dragEventContainsType(event,targetType) {
 	if(event.dataTransfer.types) {
 		for(var i=0; i<event.dataTransfer.types.length; i++) {
-			if(event.dataTransfer.types[i] === "Files") {
+			if(event.dataTransfer.types[i] === targetType) {
 				return true;
 				break;
 			}
@@ -219,5 +219,11 @@ exports.dragEventContainsFiles = function(event) {
 	}
 	return false;
 };
+
+exports.dragEventContainsFiles = function(event) {
+	return (dragEventContainsType(event,"Files") && !$tw.utils.dragEventContainsType(event,"text/plain"));
+};
+
+exports.dragEventContainsType = dragEventContainsType;
 
 })();

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -198,7 +198,8 @@ DropZoneWidget.prototype.handleDropEvent  = function(event) {
 	this.resetState();
 	// Import any files in the drop
 	var numFiles = 0;
-	if(dataTransfer.files) {
+	// If we have type text/vnd.tiddlywiki then skip trying to import files
+	if(dataTransfer.files && !$tw.utils.dragEventContainsType(event,"text/vnd.tiddler")) {
 		numFiles = this.wiki.readFiles(dataTransfer.files,{
 			callback: readFileCallback,
 			deserializer: this.dropzoneDeserializer


### PR DESCRIPTION
Fixes issues with drag and drop (false positives in detection for files being dropped) introduced by Chrome 96. Fixes #6254

* in $dropzone, do not attempt to import files if the `dataTransfer` property of the event contains the type `text/vnd.tiddler`
* in the editor, do not attempt to import files if the `dataTransfer` property of the drop event contains types other than `Files`. Testing for the type `text/plain` is consistent across browsers, this type is never present if files are being dropped.

Tested with latest Chrome and Firefox on Ubuntu and Windows 10, and latest Chrome and Safari on OSX.

