### PR TITLE
Add a snippet to visualise faulty stylesheets

### DIFF
--- a/core/wiki/debugstylesheets.tid
+++ b/core/wiki/debugstylesheets.tid
@@ -1,0 +1,12 @@
+title: $:/snippets/DebugStylesheets
+
+Broken stylesheet will have a red cross next to their name :
+
+<style>
+[class*="debug"] {display: block;}
+[class*="debug"]:before{content:"❌";}
+</style>
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]has[modified]]" counter=n>
+<style>{{!!text}}.debug<<n>>:before{content:"✔";}</style>
+<$link class={{{[[debug]][<n>]+[join[]]}}}/>
+</$list>

--- a/core/wiki/debugstylesheets.tid
+++ b/core/wiki/debugstylesheets.tid
@@ -1,12 +1,15 @@
 title: $:/snippets/DebugStylesheets
 
-Broken stylesheet will have a red cross next to their name :
+Broken stylesheets will have a red cross next to their name :
 
-<style>
-[class*="debug"] {display: block;}
-[class*="debug"]:before{content:"❌";}
-</style>
+<style>[test]{list-style:'❌'}</style>
+<ul>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]has[modified]]" counter=n>
-<style>{{!!text}}.debug<<n>>:before{content:"✔";}</style>
-<$link class={{{[[debug]][<n>]+[join[]]}}}/>
+<style>{{!!text}}[test="<<n>>"]{list-style:disc;}</style>
+<li test=<<n>>><$link/></li>
 </$list>
+</ul>
+
+Replace "list-style:disc;" by "display:none;" to only display the stylesheets with css syntax error.
+
+These may contains [[unclosed block(s)|https://www.w3.org/TR/css-syntax-3/#consume-a-simple-block]], please review and fix them to prevent tiddlywiki's interface from malfunctioning.


### PR DESCRIPTION
As discussed in https://github.com/Jermolene/TiddlyWiki5/issues/6176, a faulty stylesheet can propagate and break several other stylesheets. This can be tricky to debug in a wiki with a lot of custom stylesheets.

This wikitext snippet display a list of the stylesheets created/modified by the user and will display a red cross next to the one causing a parsing error (updated with 09851dfa00ed021d89753c6d0b5518b44872baa4): 



> ![image](https://user-images.githubusercontent.com/31185220/143483777-c5cce310-0cd7-4c06-93a5-1a1cb3442cd7.png)



The tiddler "Broken stylesheet" contains an unclosed "{" and thus is listed with a red cross next to it's name.

EDIT: Note that the red cross will show up following any css parsing error, not just unclosed "{" (see my comment bellow)
EDIT2: Updated the code to display some guidance on how to fix the error (09851dfa00ed021d89753c6d0b5518b44872baa4)