### PR TITLE
New tag 'KeyboardDrivenInput' on two tiddlers

### DIFF
--- a/editions/tw5.com/tiddlers/demonstrations/KeyboardDrivenInput/Demonstration_ keyboard-driven-input Macro.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/KeyboardDrivenInput/Demonstration_ keyboard-driven-input Macro.tid
@@ -1,6 +1,6 @@
 created: 20210222140234737
-modified: 20210520174049056
-tags: Learning
+modified: 20211123034501278
+tags: Learning KeyboardDrivenInput
 title: Demonstration: keyboard-driven-input Macro
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/demonstrations/KeyboardDrivenInput/kdi-demo-configtid.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/KeyboardDrivenInput/kdi-demo-configtid.tid
@@ -1,6 +1,7 @@
 created: 20210131043724146
 first-search-filter: [!is[system]search:title<userInput>sort[]]
-modified: 20210204012422020
-tags: 
+modified: 20211123034440629
+tags: KeyboardDrivenInput
 title: kdi-demo-configtid
 type: text/vnd.tiddlywiki
+


### PR DESCRIPTION
New tag 'KeyboardDrivenInput' on two tiddlers so they can stay in 'demonstrations/KeyboardDrivenInput' together.