### PR TITLE
Add doc tiddlers for reduce filter run prefix functionality

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
@@ -1,5 +1,5 @@
 created: 20150124182421000
-modified: 20210618153333369
+modified: 20211124161020340
 tags: [[Filter Syntax]]
 title: Filter Expression
 type: text/vnd.tiddlywiki
@@ -25,7 +25,7 @@ If a run has:
 * named prefix `:filter`, it receives the filter output so far as its input. The next run is evaluated for each title of the input, removing every input title for which the output is an empty list. <<.from-version "5.1.23">>
 * named prefix `:intersection` replaces all filter output so far with titles that are present in the output of this run, as well as the output from previous runs. Forms the input for the next run. <<.from-version "5.1.23">>
 * named prefix `:reduce` replaces all filter output so far with a single item by repeatedly applying a formula to each input title. A typical use is to add up the values in a given field of each input title. <<.from-version "5.1.23">>
-** [[Examples|Filter Run Prefix (Examples)]]
+** See [[Reduce Filter Run Prefix]].
 * named prefix `:sort` sorts all filter output so far by applying this run to each input title and sorting according to that output. <<.from-version "5.2.0">>
 ** See [[Sort Filter Run Prefix]].
 * named prefix `:map` transforms all filter output so far by applying this run to each input title and replacing the input title with the output of this run for that title.
@@ -33,8 +33,6 @@ If a run has:
 
 
 <<.tip "Compare named filter run prefix `:filter` with [[filter Operator]] which applies a subfilter to every input title, removing the titles that return an empty result from the subfilter">>
-
-<<.tip "Compare named filter run prefix `:reduce` with [[reduce Operator]] which is used to used to flatten a list of items down to a single item by repeatedly applying a subfilter.">> 
 
 <<.tip """Within the filter runs prefixed with `:reduce`, `:sort`, `:map` and `:filter`, the "currentTiddler" variable is set to the title of the tiddler being processed. The value of currentTiddler outside the subfilter is available in the variable "..currentTiddler".<<.from-version "5.2.0">>""" >>
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
@@ -1,5 +1,5 @@
 created: 20150124182421000
-modified: 20211124161020340
+modified: 20211124193218807
 tags: [[Filter Syntax]]
 title: Filter Expression
 type: text/vnd.tiddlywiki
@@ -33,6 +33,8 @@ If a run has:
 
 
 <<.tip "Compare named filter run prefix `:filter` with [[filter Operator]] which applies a subfilter to every input title, removing the titles that return an empty result from the subfilter">>
+
+<<.tip "Compare named filter run prefix `:reduce` with [[reduce Operator]] which is used to used to flatten a list of items down to a single item by repeatedly applying a subfilter.">> 
 
 <<.tip """Within the filter runs prefixed with `:reduce`, `:sort`, `:map` and `:filter`, the "currentTiddler" variable is set to the title of the tiddler being processed. The value of currentTiddler outside the subfilter is available in the variable "..currentTiddler".<<.from-version "5.2.0">>""" >>
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20201117073343969
-modified: 20210428084013109
+modified: 20211124153029405
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]]
 title: Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -27,23 +27,7 @@ The following examples use the [[field Operator]] and [[compare Operator]] tiddl
 
 !! `:reduce` examples
 
-```
-[tag[shopping]] :reduce[get[quantity]add<accumulator>]
-```
-
-is equivalent to:
-
-```
-\define num-items() [get[quantity]add<accumulator>]
-
-[tag[shopping]reduce<num-items>]
-```
-
-Specifying a default value when input is empty:
-
-`[tag[non-existent]] :reduce[get[price]multiply{!!quantity}add<accumulator>] :else[[0]]`
-
-<$macrocall $name=".tip" _="""Unlike the [[reduce Operator]], the `:reduce` prefix cannot specify an initial value for the accumulator, so its initial value will always be empty (which is treated as 0 by mathematical operators). So `=1 =2 =3 :reduce[multiply<accumulator>]` will produce 0, not 6. If you need to specify an initial accumulator value, use the [[reduce Operator]]."""/>
+See [[Reduce Filter Run Prefix (Examples)]]
 
 !! `:sort` examples
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Reduce Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Reduce Filter Run Prefix (Examples).tid
@@ -1,0 +1,27 @@
+created: 20211124151912931
+modified: 20211124160747921
+tags: [[Filter Syntax]] [[Reduce Filter Run Prefix]] [[Filter Run Prefix Examples]]
+title: Reduce Filter Run Prefix (Examples)
+type: text/vnd.tiddlywiki
+
+\define multiply-input() [multiply<accumulator>]
+
+The following examples use these data tiddlers:
+
+<ul>
+<$list filter="[tag[shopping]!has[draft.of]]">
+<li>
+''<$link><$text text=<<currentTiddler>>/></$link>'' quantity: <$text text={{!!quantity}}/>,  price: <$text text={{!!price}}/>
+</li>
+</$list>
+</ul>
+
+<<.operator-example 1 "[tag[shopping]] :reduce[get[quantity]add<accumulator>]">>
+<<.operator-example 2 "[tag[shopping]] :reduce[get[price]multiply{!!quantity}add<accumulator>]">>
+<<.operator-example 3 "[tag[shopping]] :reduce[<index>compare:number:gt[0]then<accumulator>addsuffix[, ]addsuffix<currentTiddler>else<currentTiddler>]" "Uses `<index>` to act differently on the first item than the rest. Just for demonstration. Better to use the [[join Operator]] to accomplish this task">>
+<<.operator-example 4 "[tag[non-existent]] :reduce[get[price]multiply{!!quantity}add<accumulator>]" "Empty input produces empty output">>
+<<.operator-example 5 "[tag[non-existent]] :reduce[get[price]multiply{!!quantity}add<accumulator>] :else[[0]]" "Use `:else` to ensure output if input was empty">>
+
+<$macrocall $name=".tip" _="""Unlike the [[reduce Operator]], the `:reduce` prefix cannot specify an initial value for the accumulator, so its initial value will always be empty (which is treated as 0 by mathematical operators). So `=1 =2 =3 :reduce[multiply<accumulator>]` will produce 0, not 6. If you need to specify an initial accumulator value, use the [[reduce Operator]]."""/>
+<<.operator-example 6 "=1 =2 =3 :reduce[multiply<accumulator>]" "Empty initial value is treated as 0 by mathematical operators">>
+<<.operator-example 7 "=1 =2 =3 +[reduce<multiply-input>,[1]]" "Setting initial value is sometimes necessary for correct results">>

--- a/editions/tw5.com/tiddlers/filters/syntax/Reduce Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Reduce Filter Run Prefix.tid
@@ -1,0 +1,38 @@
+created: 20211124151912931
+modified: 20211124160210519
+tags: [[Filter Syntax]] [[Filter Run Prefix]]
+title: Reduce Filter Run Prefix
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.23">>
+
+|''purpose'' |replaces all filter output so far with a single item by repeatedly applying a filter run to each input title |
+|''input'' |all titles from previous filter runs |
+|''output''|the accumulated single item |
+
+Each input title from previous runs is passed to this run in turn. The result of each previous call to this run is made available in the next call via the variable named "accumulator". The result of the last call to this run is returned as the output.  A typical use is to add up the values in a given field of each input title.
+
+The following variables are available within the filter run:
+
+* ''accumulator'' - the result of the previous filter run
+* ''currentTiddler'' - the input title
+* ''..currentTiddler'' - the value of the variable `currentTiddler` outside the filter run. <<.from-version "5.2.0">>
+* ''index'' - the numeric index of the current list item (with zero being the first item in the list)
+* ''revIndex'' - the reverse numeric index of the current list item (with zero being the last item in the list)
+* ''length'' - the total length of the input list
+
+<<.tip "Compare named filter run prefix `:reduce` with [[reduce Operator]] which is used to used to flatten a list of items down to a single item by repeatedly applying a subfilter.">> 
+
+```
+[tag[shopping]] :reduce[get[quantity]add<accumulator>]
+```
+
+is equivalent to:
+
+```
+\define num-items() [get[quantity]add<accumulator>]
+
+[tag[shopping]reduce<num-items>]
+```
+
+[[Examples|Reduce Filter Run Prefix (Examples)]]

--- a/editions/tw5.com/tiddlers/filters/syntax/Reduce Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Reduce Filter Run Prefix.tid
@@ -1,5 +1,5 @@
 created: 20211124151912931
-modified: 20211124160210519
+modified: 20211124170117511
 tags: [[Filter Syntax]] [[Filter Run Prefix]]
 title: Reduce Filter Run Prefix
 type: text/vnd.tiddlywiki
@@ -21,7 +21,7 @@ The following variables are available within the filter run:
 * ''revIndex'' - the reverse numeric index of the current list item (with zero being the last item in the list)
 * ''length'' - the total length of the input list
 
-<<.tip "Compare named filter run prefix `:reduce` with [[reduce Operator]] which is used to used to flatten a list of items down to a single item by repeatedly applying a subfilter.">> 
+<<.tip "Compare named filter run prefix `:reduce` with [[reduce Operator]] which is used to flatten a list of items down to a single item by repeatedly applying a subfilter.">> 
 
 ```
 [tag[shopping]] :reduce[get[quantity]add<accumulator>]

--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -1,5 +1,5 @@
 created: 20150117152612000
-modified: 20211105172548676
+modified: 20211124164948726
 tags: $:/tags/Stylesheet
 title: $:/editions/tw5.com/doc-styles
 type: text/vnd.tiddlywiki
@@ -112,7 +112,7 @@ td svg {
 }
 
 .doc-example input[type=search] { 
-  width: 60%;
+  width: 95%;
 }
 .doc-example pre:first-child {
 	margin-top: 0;


### PR DESCRIPTION
Add separate documentation tiddlers for the filter run prefix functionality following the pattern set by the `:sort` and `:map` filter run prefixes.

The examples were taken from the `reduce` operator while modifying them to take advantage of the ability to inline the subfilter variables.

Expanded the width of the filter text box so longer filters will fit better.