### PR TITLE
Fix for CodeMirror issues with drop events in Chrome 96

### DIFF
--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -130,6 +130,58 @@ function CodeMirrorEngine(options) {
 		if(!self.widget.isFileDropEnabled) {
 			event.stopPropagation(); // Otherwise TW's dropzone widget sees the drop event
 		}
+		// Detect if Chrome has added a pseudo File object to the dataTransfer
+		if(!$tw.utils.dragEventContainsFiles(event) && event.dataTransfer.files.length) {
+			//Make codemirror ignore the event as well will handle the drop ourselves
+			event.codemirrorIgnore = true;
+			event.preventDefault();
+
+			// from https://github.com/codemirror/CodeMirror/blob/master/src/measurement/position_measurement.js#L673
+			function posFromMouse(cm, e, liberal, forRect) {
+				let display = cm.display
+				if (!liberal && e_target(e).getAttribute("cm-not-content") == "true") return null
+
+				let x, y, space = display.lineSpace.getBoundingClientRect()
+				// Fails unpredictably on IE[67] when mouse is dragged around quickly.
+				try { x = e.clientX - space.left; y = e.clientY - space.top }
+				catch (e) { return null }
+				let coords = cm.coordsChar(cm, x, y), line
+				if (forRect && coords.xRel > 0 && (line = cm.getLine(cm.doc, coords.line).text).length == coords.ch) {
+					let colDiff = window.CodeMirror.countColumn(line, line.length, cm.options.tabSize) - line.length
+					coords = window.CodeMirror.Pos(coords.line, Math.max(0, Math.round((x - paddingH(cm.display).left) / charWidth(cm.display)) - colDiff))
+				}
+				return coords
+			}
+
+			var pos = posFromMouse(cm,event,true);
+			if(!pos || cm.isReadOnly()) {
+				return;
+			}
+			// Don't do a replace if the drop happened inside of the selected text.
+			if (cm.state.draggingText && cm.doc.sel.contains(pos) > -1) {
+				cm.state.draggingText(event);
+				// Ensure the editor is re-focused
+				setTimeout(() => cm.display.input.focus(), 20);
+				return;
+			}
+			try {
+				var text = event.dataTransfer.getData("Text");
+				if (text) {
+					var selected;
+					if (cm.state.draggingText && !cm.state.draggingText.copy) {
+						selected = cm.listSelections();
+					}
+					cm.setCursor(cm.coordsChar({left:event.pageX,top:event.pageY}));
+					//setSelectionNoUndo(cm.doc, simpleSelection(pos, pos))
+					if (selected) for (let i = 0; i < selected.length; ++i) {
+						replaceRange(cm.doc, "", selected[i].anchor, selected[i].head, "drag");
+					}
+					cm.replaceSelection(text, "around", "paste");
+					cm.display.input.focus();
+			  }
+			}
+			catch(e){}
+		}
 		return false;
 	});
 	this.cm.on("keydown",function(cm,event) {

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -132,7 +132,7 @@ function CodeMirrorEngine(options) {
 		}
 		// Detect if Chrome has added a pseudo File object to the dataTransfer
 		if(!$tw.utils.dragEventContainsFiles(event) && event.dataTransfer.files.length) {
-			//Make codemirror ignore the event as well will handle the drop ourselves
+			//Make codemirror ignore the event as we will handle the drop ourselves
 			event.codemirrorIgnore = true;
 			event.preventDefault();
 

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -173,7 +173,7 @@ function CodeMirrorEngine(options) {
 					}
 					cm.setCursor(cm.coordsChar({left:event.pageX,top:event.pageY}));
 					//setSelectionNoUndo(cm.doc, simpleSelection(pos, pos))
-					if (selected) for (let i = 0; i < selected.length; ++i) {
+					if (selected) for (var i = 0; i < selected.length; ++i) {
 						replaceRange(cm.doc, "", selected[i].anchor, selected[i].head, "drag");
 					}
 					cm.replaceSelection(text, "around", "paste");

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -172,9 +172,10 @@ function CodeMirrorEngine(options) {
 						selected = cm.listSelections();
 					}
 					cm.setCursor(cm.coordsChar({left:event.pageX,top:event.pageY}));
-					//setSelectionNoUndo(cm.doc, simpleSelection(pos, pos))
-					if (selected) for (var i = 0; i < selected.length; ++i) {
-						replaceRange(cm.doc, "", selected[i].anchor, selected[i].head, "drag");
+					if (selected) {
+					 	for (var i = 0; i < selected.length; ++i) {
+							replaceRange(cm.doc, "", selected[i].anchor, selected[i].head, "drag");
+						}
 					}
 					cm.replaceSelection(text, "around", "paste");
 					cm.display.input.focus();


### PR DESCRIPTION
This PR resolves the issues with CodeMirror's handling of drop events in Chrome 96 by handling the drop ourselves in those situations. Fixes #6273 

Note that there is a CodeMirror helper method copied verbatim, not sure if we would want to tweak that to abide by our coding style.

While the new handling should only apply when Chrome is doing its new thing with drop events, it is best to be safe and do some cross browser and OS testing: https://saqimtiaz.github.io/sq-tw/temp/cm-drop-patch.html

Things to test in CodeMirror - best to do this in a tiddler with some existing text:
- dragging and dropping tiddler links
- dragging and dropping external links
- dragging and dropping text
- whether the links or text are inserted at the correct place in the text
- dragging and dropping an image and importing it.