### PR TITLE
Fix duplicate example id for map filter run prefix

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210618134753828
-modified: 20211029082538212
+modified: 20211125145519506
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Map Filter Run Prefix]]
 title: Map Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -16,4 +16,4 @@ For each title in a shopping list, calculate the total cost of purchasing each i
 <<.operator-example 2 "[tag[shopping]] :map[get[quantity]else[0]multiply{!!price}]">>
 
 For each title in a shopping list, prefix it with its position in the list:
-<<.operator-example 2 "[tag[shopping]] :map[<currentTiddler>addprefix[-]addprefix<index>]">>
+<<.operator-example 3 "[tag[shopping]] :map[<currentTiddler>addprefix[-]addprefix<index>]">>


### PR DESCRIPTION
The first parameter of the operator examples macro is used for constructing unique state tiddler titles. Two of the `:map` filter prefix examples had the same id, causing them to share state with each other. Chose a different id for one of them.