### PR TITLE
charcode-jsstring-macros-charcode-operator

### DIFF
--- a/core/modules/config.js
+++ b/core/modules/config.js
@@ -38,4 +38,19 @@ exports.htmlBlockElements = "address,article,aside,audio,blockquote,canvas,dd,de
 
 exports.htmlUnsafeElements = "script".split(",");
 
+
+// Character code lookups used in charcode filter and macro
+exports.lookup = {
+	"tab": 9,
+	"\\t": 9,
+	"lf": 10,
+	"\\n": 10,
+	"ff": 12,
+	"\\f": 12,
+	"cr": 13,
+	"\\r": 13,
+	"\\_": 32,
+	"space": 32
+}
+
 })();

--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -175,10 +175,12 @@ exports.pad = function(source,operator,options) {
 }
 
 exports.charcode = function(source,operator,options) {
-	var chars = [];
+	var lookup = $tw.config.lookup,
+		chars = [];
 	$tw.utils.each(operator.operands,function(operand) {
-		if(operand !== "") {
-			chars.push(String.fromCharCode($tw.utils.parseInt(operand)));
+		var code = lookup[operand.toLowerCase()] || operand;
+		if(code !== "") {
+			chars.push(String.fromCharCode($tw.utils.parseInt(code)));
 		}
 	});
 	return [chars.join("")];

--- a/core/modules/macros/charcode.js
+++ b/core/modules/macros/charcode.js
@@ -1,0 +1,37 @@
+/*\
+title: $:/core/modules/macros/charcode.js
+type: application/javascript
+module-type: macro
+
+Macro to return a character using the character-code as input.
+If the code isn't found the character is returned.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.name = "charcode";
+
+exports.params = [
+	{name: "codes"},
+];
+
+exports.run = function(codes) {
+	var lookup = $tw.config.lookup,
+		tokens = codes.trim().split(/\s+/),
+		results = [];
+	tokens.map(function(name) {
+		var code = lookup[name.toLowerCase()];
+		if (code) {
+			results.push(String.fromCharCode(code));
+		} else {
+			results.push(String.fromCharCode($tw.utils.parseInt(name)));
+		}
+	})
+	return results.join("");
+}
+
+})();

--- a/core/modules/macros/jsstring.js
+++ b/core/modules/macros/jsstring.js
@@ -1,0 +1,36 @@
+/*\
+title: $:/core/modules/macros/jsstring.js
+type: application/javascript
+module-type: macro
+
+Macro to returns a string and replaces \r, \n, \t strings with their character codes.
+All existing CRLF's are removed, which allows us to make the wikitext more readable.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.name = "jsstring";
+
+exports.params = [
+	{name: "text"}//,
+//	{name: "mode", default: "strict"}
+];
+
+/*
+mode: relaxed .. Native \r\n are removed prior to activating the character codes. Better wikitext readability
+      strict  .. (default) Behaves like a standard js-string
+*/
+
+exports.run = function(text, mode) {
+//	if (mode === "relaxed") {
+//		return text.replace(/\r?\n/g,"").replace(/\\n/g,"\n").replace(/\\r/g,"\r").replace(/\\t/g,"\t");
+//	} else if (mode === "strict") {
+		return text.replace(/\\n/g,"\n").replace(/\\r/g,"\r").replace(/\\t/g,"\t");
+//	}
+}
+
+})();

--- a/core/modules/macros/morph-string.js
+++ b/core/modules/macros/morph-string.js
@@ -1,0 +1,54 @@
+/*\
+title: $:/core/modules/macros/morph-string.js
+type: application/javascript
+module-type: macro
+
+Macro to return a string that is shifted in the unicode character space
+
+\*/
+(function(){
+
+	/*jslint node: true, browser: true */
+	/*global $tw: false */
+	"use strict";
+	
+
+exports.name = "morph-string";
+
+exports.params = [
+	{name: "text"},
+	{name: "by"}
+];
+
+exports.run = function(text, by) {
+	// var result = text.fromCharCode($tw.utils.parseInt(operand)));
+
+	// String.prototype.toUnicode = function () {
+	// 	return this.replace(/./g, function (char) {
+	// 		return "&#" + String.charCodeAt(char) + ";";
+	// 	});
+	// };
+
+    // function fromCharacter(character) {
+    //     return character.codePointAt(undefined).toString(16);
+    // }
+	// /*
+    //  * toUnicode.fromString('🎉 👋');
+    //  * //> [ '1f389', '20', '1f44b' ]
+    //  */
+    // function fromString(characters, prefix = '') {
+    //     return [...characters].reduce((accumulator, character) => {
+    //         const unicode = toUnicode.fromCharacter(character);
+    //         accumulator.push(`${prefix}${unicode}`);
+    //         return accumulator;
+    //     }, []);
+    // }
+
+
+
+
+
+	return result;
+};
+
+})();

--- a/editions/tw5.com/tiddlers/$__StoryList.tid
+++ b/editions/tw5.com/tiddlers/$__StoryList.tid
@@ -1,5 +1,5 @@
-created: 20211126104006194
-list: [[Page and tiddler layout customisation]] [[Creating new buttons for the ViewToolbar and page controls]] [[Structuring TiddlyWiki]] Tagging [[Introduction to Lists]] [[Icon Gallery]] [[How to widen tiddlers (aka storyriver)]] [[How to turn off camel case linking]] [[How to put the last modification date in a banner]] [[How to hide the author's and other fields with CSS]] [[How to export tiddlers]] [[How to Customize TiddlyDesktop]] [[Editing Tiddlers with Vim]] [[Concatenating text and variables using macro substitution]] [[Demonstration: keyboard-driven-input Macro]] HelloThere GettingStarted Community
-modified: 20211126111221917
+created: 20211201213141404
+list: test-join-with-charcode-macro test-jsstring test-jsstring-charcode-side-by-side
+modified: 20211201213141404
 title: $:/StoryList
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/system/DefaultTiddlers.tid
+++ b/editions/tw5.com/tiddlers/system/DefaultTiddlers.tid
@@ -1,8 +1,6 @@
 created: 20131127215321439
-modified: 20140912135951542
+modified: 20211201213107169
 title: $:/DefaultTiddlers
 type: text/vnd.tiddlywiki
 
-HelloThere
-GettingStarted
-Community
+[list[$:/StoryList]]

--- a/editions/tw5.com/tiddlers/test-join-with-charcode-macro.tid
+++ b/editions/tw5.com/tiddlers/test-join-with-charcode-macro.tid
@@ -1,0 +1,13 @@
+created: 20211201181012026
+modified: 20211201213002360
+tags: 
+title: test-join-with-charcode-macro
+type: text/vnd.tiddlywiki
+
+Something like this was discussed at GH: [[ [IDEA] String manipulation operators should be able to deal with \n\t .. and others #4697 |https://github.com/Jermolene/TiddlyWiki5/issues/4697]]
+
+
+<<wikitext-example-without-html """<$button>
+<$action-setfield $tiddler=a text={{{[[go to edit mode to see the linebreaks]split[ ]join<charcode "lf">]}}} />click to write new text to tiddler "a"
+</$button>
+""">>

--- a/editions/tw5.com/tiddlers/test-jsstring-charcode-side-by-side.tid
+++ b/editions/tw5.com/tiddlers/test-jsstring-charcode-side-by-side.tid
@@ -1,0 +1,47 @@
+created: 20211201182207801
+modified: 20211201212946496
+tags: 
+title: test-jsstring-charcode-side-by-side
+type: text/vnd.tiddlywiki
+
+The lookup for the "placeholders" looks like this atm
+
+```
+// Character code lookups used in charcode filter and macro
+exports.lookup = {
+	"tab": 9,
+	"\\t": 9,
+	"lf": 10,
+	"\\n": 10,
+	"ff": 12,
+	"\\f": 12,
+	"cr": 13,
+	"\\r": 13,
+	"\\_": 32,
+	"space": 32
+}
+```
+
+---
+
+''macros''
+
+<<wikitext-example-without-html """{{{ [<jsstring "\n">match[
+]then[matches]else[doesn't match]] }}}  """>>
+
+
+There are 2 possibilities atm `\n  and lf`
+
+<<wikitext-example-without-html """{{{ [<charcode "\n">match[
+]then[matches]else[doesn't match]] }}}  """>>
+
+<<wikitext-example-without-html """{{{ [<charcode "lf">match[
+]then[matches]else[doesn't match]] }}}  """>>
+
+
+''filter operator''
+
+<<wikitext-example-without-html """{{{ [charcode[lf]match[
+]then[matches]else[doesn't match]] }}}  """>>
+
+<<wikitext-example-without-html """{{{ [charcode[lf]match<charcode "10">then[matches]else[doesn't match]] }}}  """>>

--- a/editions/tw5.com/tiddlers/test-jsstring.tid
+++ b/editions/tw5.com/tiddlers/test-jsstring.tid
@@ -1,0 +1,9 @@
+created: 20211201153854223
+modified: 20211201212031699
+tags: 
+title: test-jsstring
+type: text/vnd.tiddlywiki
+
+<<wikitext-example-without-html """<<jsstring "<pre>a\nb</pre>">> """ >>
+ 
+ 


### PR DESCRIPTION
Link to the demo wiki with some info and examples will follow soon. 

There is no docs and no tests atm. 

FORGET about `morph-string` it only contains some code snippets.

This is a draft PR to experiment with the possibilities. The following lookup table is for experimenting atm, which is exposed as `$tw.config.lookup` it should probably be splitted into 2 parts. 1 for `charcode macro` and one for `jsstring` macro

```
// Character code lookups used in charcode filter and macro
exports.lookup = {
	"tab": 9,
	"\\t": 9,
	"lf": 10,
	"\\n": 10,
	"ff": 12,
	"\\f": 12,
	"cr": 13,
	"\\r": 13,
	"\\_": 32,
	"space": 32
}
```
