### PR TITLE
Add a cascade filter run example

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Cascade Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Cascade Filter Run Prefix (Examples).tid
@@ -1,5 +1,8 @@
 created: 20211130114857532
-modified: 20211130132353406
+filter1: [prefix[ca]then[ca]]
+filter2: [suffix[at]then[at]]
+filter3: other
+modified: 20211204010918504
 tags: [[Filter Run Prefix Examples]] [[Filter Syntax]] [[Cascade Filter Run Prefix]]
 title: Cascade Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -20,3 +23,24 @@ For each input title, each of these filters is now applied to in turn until the 
 
 <<.operator-example 1 """[all[shadows+tiddlers]] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]get[text]] +[!is[blank]limit[10]]""">>
 
+!! Extended example
+
+This example illustrates step-by-step how the <<.op :cascade>> filter run works.
+
+A filter expression whose output returns a list of filters is required. Typically such a filter expression will construct the list of filters by querying some field in a set of tiddlers (likely via tag). To keep this example self-contained, 3 filters are stored in the //filter1//, //filter2// and //filter3// fields of this tiddler. [[Text references|TextReference]] and instances of the [[append operator|append Operator]] are used to combine the fields into a list of filters.
+
+The filter `[{!!filter1}append{!!filter2}append{!!filter3}]`, generates this list of filters:
+
+<ul>
+<$list filter="[{!!filter1}append{!!filter2}append{!!filter3}]">
+<li><pre><$text text=<<currentTiddler>>/></pre></li>
+</$list>
+</ul>
+
+For this example, `cat can bat bug` will be used as the input titles. Each input title will be evaluated by <<.op :cascade>> against each of the above filters in turn. To help understand what <<.op :cascade>> sees internally, the following table uses the [[Map Filter Run Prefix]] to show the result of each individual filter.
+
+|^<<.operator-example c1.1 "cat can bat bug :map[prefix[ca]then[ca]]">>|^<<.operator-example c1.2 "cat can bat bug :map[suffix[at]then[at]]">>|^<<.operator-example c1.3 "cat can bat bug :map[[other]]">>|
+
+Click "Try it" on the above 3 examples. The first non-blank value from each row as read from left to right will be returned when <<.op :cascade>> is used. Click "Try it" below to see the final result:
+ 
+<<.operator-example c1.4 "cat can bat bug :cascade[{!!filter1}append{!!filter2}append{!!filter3}]">>


### PR DESCRIPTION
Add a concrete, detailed `cascade` filter run example. It shows the intermediate output of each of the cascaded filters in order to illustrate how it works.