### PR TITLE
Add documentation tiddlers for intersection filter run prefix

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
@@ -1,5 +1,5 @@
 created: 20150124182421000
-modified: 20210618153333369
+modified: 20211129014550442
 tags: [[Filter Syntax]]
 title: Filter Expression
 type: text/vnd.tiddlywiki
@@ -24,6 +24,7 @@ If a run has:
 * named prefixes for filter runs are available. <<.from-version "5.1.23">>
 * named prefix `:filter`, it receives the filter output so far as its input. The next run is evaluated for each title of the input, removing every input title for which the output is an empty list. <<.from-version "5.1.23">>
 * named prefix `:intersection` replaces all filter output so far with titles that are present in the output of this run, as well as the output from previous runs. Forms the input for the next run. <<.from-version "5.1.23">>
+** See [[Intersection Filter Run Prefix]].
 * named prefix `:reduce` replaces all filter output so far with a single item by repeatedly applying a formula to each input title. A typical use is to add up the values in a given field of each input title. <<.from-version "5.1.23">>
 ** [[Examples|Filter Run Prefix (Examples)]]
 * named prefix `:sort` sorts all filter output so far by applying this run to each input title and sorting according to that output. <<.from-version "5.2.0">>

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Run Prefix (Examples).tid
@@ -1,29 +1,12 @@
 created: 20201117073343969
-modified: 20210428084013109
+modified: 20211128234044179
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]]
 title: Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
 
-!! Difference between `+` and `:intersection`
+!! `:intersection` examples
 
-The `+` prefix should be thought of as an "AND" in formal logic, e.g. "give me all titles that satisfy condition A ''and'' condition B". But it's not suitable for all cases; if condition B uses a filter operator that replaces its input, then it will be difficult to use the `+` prefix. For example, if you wanted to find out what tags two tiddlers have in common, you might try to write a filter expression like:
-
-* <$link to="tags Operator">`[[field Operator]tags[]] +[[compare Operator]tags[]]`</$link>
-
-But that won't work, because the second filter run will end up throwing away its input and replacing it with an input consisting of the single title `[[compare Operator]]`. So the result you'd get from that filter expression would be just the tags of the `compare Operator` tiddler.
-
-For cases like this, the `:intersection` prefix is what you need. It takes the filter output so far, //sets it aside//, and starts the next filter run with all tiddler titles as input. Then once the latest filter run has completed, it takes the latest output, compares it to the set-aside output, and produces a new output that contains only titles that appeared in both the set-aside output and the latest output. So to get only the tags that the `field Operator` and `compare Operator` tiddlers have in common, you would write a filter expression like this:
-
-* <$link to="tags Operator">`[[field Operator]tags[]] :intersection[[compare Operator]tags[]]`</$link>
-
-The following examples use the [[field Operator]] and [[compare Operator]] tiddlers and their respective tags.
-
-<<.operator-example 1 "[[field Operator]tags[]]">>
-<<.operator-example 2 "[[compare Operator]tags[]]">>
-
-<<.operator-example 3 "[[field Operator]tags[]] +[[compare Operator]tags[]]" """The "field Operator" tiddler's tags are lost, so only the "compare Operator" tiddler's tags are returned""">>
-
-<<.operator-example 4 "[[field Operator]tags[]] :intersection[[compare Operator]tags[]]" """Returns the tags that both tiddlers have in common""">>
+See [[Intersection Filter Run Prefix (Examples)]]
 
 !! `:reduce` examples
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Intersection Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Intersection Filter Run Prefix (Examples).tid
@@ -1,0 +1,36 @@
+created: 20211128212902292
+modified: 20211128233320674
+tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Intersection Filter Run Prefix]]
+title: Intersection Filter Run Prefix (Examples)
+type: text/vnd.tiddlywiki
+
+<<.operator-example 1 "A B C D :intersection[enlist[C D E F]]">>
+
+<<.operator-example 2 "A B C D :intersection[enlist[A B C D]]">>
+
+<<.operator-example 3 "A B C D :intersection[enlist[E F G H]]">>
+
+<<.operator-example 4 ":intersection[enlist[A B C D]]" "Using intersection in the first filter run is of little use. The result will always be empty.">>
+
+!! Difference between `+` and `:intersection`
+
+The `+` prefix should be thought of as an "AND" in formal logic, e.g. "give me all titles that satisfy condition A ''and'' condition B". But it's not suitable for all cases; if condition B uses a filter operator that replaces its input, then it will be difficult to use the `+` prefix. For example, if you wanted to find out what tags two tiddlers have in common, you might try to write a filter expression like:
+
+* <$link to="tags Operator">`[[field Operator]tags[]] +[[compare Operator]tags[]]`</$link>
+
+But that won't work, because the second filter run will end up throwing away its input and replacing it with an input consisting of the single title `[[compare Operator]]`. So the result you'd get from that filter expression would be just the tags of the `compare Operator` tiddler.
+
+For cases like this, the `:intersection` prefix is what you need. It takes the filter output so far, //sets it aside//, and starts the next filter run with all tiddler titles as input. Then once the latest filter run has completed, it takes the latest output, compares it to the set-aside output, and produces a new output that contains only titles that appeared in both the set-aside output and the latest output. So to get only the tags that the `field Operator` and `compare Operator` tiddlers have in common, you would write a filter expression like this:
+
+* <$link to="tags Operator">`[[field Operator]tags[]] :intersection[[compare Operator]tags[]]`</$link>
+
+The following examples use the [[field Operator]] and [[compare Operator]] tiddlers and their respective tags.
+
+<<.operator-example 5 "[[field Operator]tags[]]">>
+<<.operator-example 6 "[[compare Operator]tags[]]">>
+
+<<.operator-example 7 "[[field Operator]tags[]] +[[compare Operator]tags[]]" """The "field Operator" tiddler's tags are lost, so only the "compare Operator" tiddler's tags are returned""">>
+
+<<.operator-example 8 "[[field Operator]tags[]] :intersection[[compare Operator]tags[]]" """Returns the tags that both tiddlers have in common""">>
+
+

--- a/editions/tw5.com/tiddlers/filters/syntax/Intersection Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Intersection Filter Run Prefix.tid
@@ -1,0 +1,15 @@
+created: 20211128212902292
+modified: 20211128212904721
+tags: [[Filter Syntax]] [[Filter Run Prefix]]
+title: Intersection Filter Run Prefix
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.23">>
+
+|''purpose'' |find the intersection of titles from previous runs with titles in this filter run |
+|''input'' |all titles from previous filter runs |
+|''output''|the titles that are present in both the result of this filter run and the output from previous runs |
+
+The filter output from previous runs is set aside. The `:intersection` filter run is started with all tiddler titles as input. Once this latest filter run has completed, the latest output is compared to the set-aside output. A new output is produced that contains only titles that appeared in both the set-aside output and the latest output.
+
+[[Examples|Intersection Filter Run Prefix (Examples)]]


### PR DESCRIPTION
Add separate documentation tiddlers for the `:intersection` filter run prefix functionality following the pattern set by the :sort and :map filter run prefixes.

Moved the existing `:intersection` examples from "Filter Run Prefix (Examples).tid" to "Intersection Filter Run Prefix (Examples)" and added new examples.