### PR TITLE
[FR_fr] Fix Latest Version image not displaying

### DIFF
--- a/editions/fr-FR/tiddlers/HelloThumbnail - Latest Version.tid
+++ b/editions/fr-FR/tiddlers/HelloThumbnail - Latest Version.tid
@@ -2,7 +2,7 @@ caption: Quoi de neuf dans <<version>>
 color: #fff
 created: 20160603124050989
 fr-title: BonjourLaVignette - Dernière Version
-image: New Release Banner.png
+image: New Release Banner
 link: Releases
 modified: 20160603124131122
 tags: HelloThumbnail


### PR DESCRIPTION
Image broken link on the welcome screen of French documentation edition.
See "Quoi de neuf dans la version 5.2.0" here: https://tiddlywiki.com/languages/fr-FR/index.html#HelloThere