### PR TITLE
Add documentation tiddlers for filter filter run prefix

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
@@ -1,5 +1,5 @@
 created: 20150124182421000
-modified: 20210618153333369
+modified: 20211129032301006
 tags: [[Filter Syntax]]
 title: Filter Expression
 type: text/vnd.tiddlywiki
@@ -23,6 +23,7 @@ If a run has:
 * the prefix `~`, if the filter output so far is an empty list then the output titles of the run are [[dominantly appended|Dominant Append]] to the filter's output. If the filter output so far is not an empty list then the run is ignored. <<.from-version "5.1.18">>
 * named prefixes for filter runs are available. <<.from-version "5.1.23">>
 * named prefix `:filter`, it receives the filter output so far as its input. The next run is evaluated for each title of the input, removing every input title for which the output is an empty list. <<.from-version "5.1.23">>
+** See [[Filter Filter Run Prefix]].
 * named prefix `:intersection` replaces all filter output so far with titles that are present in the output of this run, as well as the output from previous runs. Forms the input for the next run. <<.from-version "5.1.23">>
 * named prefix `:reduce` replaces all filter output so far with a single item by repeatedly applying a formula to each input title. A typical use is to add up the values in a given field of each input title. <<.from-version "5.1.23">>
 ** [[Examples|Filter Run Prefix (Examples)]]

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Filter Run Prefix (Examples).tid
@@ -1,0 +1,15 @@
+created: 20211129022707404
+modified: 20211129031840012
+tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Filter Filter Run Prefix]]
+title: Filter Filter Run Prefix (Examples)
+type: text/vnd.tiddlywiki
+
+<<.operator-example 1 "[tag[HelloThere]] :filter[get[text]length[]compare:integer:gteq[1000]]">>
+<<.operator-example 2 "[tag[HelloThere]] :filter[get[text]length[]compare:integer:lteq[2000]]">>
+<<.operator-example 3 "[tag[HelloThere]] :filter[get[text]length[]compare:integer:gteq[1000]] :filter[get[text]length[]compare:integer:lteq[2000]]">>
+<<.operator-example 4 "[tag[Features]] :filter[links[]!is[shadow]is[missing]]">>
+
+<<.operator-example 5 "A B C D E F :filter[<index>remainder[2]compare:integer:eq[0]]" "Return every other element of the input list">>
+
+<<.operator-example 6 "[tag[shopping]] :filter[{!!quantity}compare:integer:gt[4]] :map[addprefix[ ]addprefix{!!quantity}]">>
+<<.operator-example 7 "[tag[shopping]] :filter[{!!quantity}compare:integer:lteq[4]] :map[addprefix[ ]addprefix{!!quantity}]">>

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20211129022707404
-modified: 20211129031840012
+modified: 20211204154839890
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Filter Filter Run Prefix]]
 title: Filter Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -13,3 +13,18 @@ type: text/vnd.tiddlywiki
 
 <<.operator-example 6 "[tag[shopping]] :filter[{!!quantity}compare:integer:gt[4]] :map[addprefix[ ]addprefix{!!quantity}]">>
 <<.operator-example 7 "[tag[shopping]] :filter[{!!quantity}compare:integer:lteq[4]] :map[addprefix[ ]addprefix{!!quantity}]">>
+
+!! Comparison between `:filter` and `:and`/`+` filter run prefixes
+
+The functionality of the <<.op :filter>> filter run prefix has some overlap with the <<.op :and>> prefix (alias <<.op +>>). Notice the filter expressions above all have the following two properties:
+
+# The start of the filter expression transforms the input titles (i.e. `get[text]length[]`, `links[]`, `<index>remainder[2]`, `{!!quantity}`.
+# The end of the filter expression only sends input items to the output if they meet some condition (i.e. `compare`, `is`).
+
+The purpose of the <<.op :filter>> prefix is to return the original input titles despite property #1 causing those input titles to be transformed. That way, the "meet some condition" check can be performed on something other than the original input. If some filter expression does not require property #1, then the <<.op :and>> prefix can be used instead.
+
+| <<.op :filter>> | <<.op :and>> |
+|^<<.operator-example c1.1 "[tag[HelloThere]] :filter[get[text]length[]compare:integer:gteq[1000]]">>|^<<.operator-example c1.2 "[tag[HelloThere]] :and[get[text]length[]compare:integer:gteq[1000]]">>|
+|^<<.operator-example c2.1 "[tag[Features]] :filter[links[]!is[shadow]is[missing]]">>|^<<.operator-example c2.2 "[tag[Features]] :and[links[]!is[shadow]is[missing]]">>|
+|!results are the same|<|
+|^<<.operator-example c3.1 "cat can bat bug :filter[suffix[at]minlength[3]]">>|^<<.operator-example c3.2 "cat can bat bug :and[suffix[at]minlength[3]]">>|

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Filter Run Prefix.tid
@@ -1,0 +1,27 @@
+created: 20211129022455873
+modified: 20211129022550425
+tags: [[Filter Syntax]] [[Filter Run Prefix]]
+title: Filter Filter Run Prefix
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.1.23">>
+
+|''purpose'' |remove every input title for which the filter run output is an empty list |
+|''input'' |all titles from previous filter runs |
+|''output''|the input titles for which the filter run is not empty |
+
+It receives the filter output so far as its input. The next run is evaluated for each title of the input, removing every input title for which the output is an empty list.
+
+Note that within the filter run, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits filter runs like `:filter[{!!price}multiply{!!cost}compare:integer:gteq[5]]` to be used for computation. The value of currentTiddler outside the run is available in the variable "..currentTiddler".
+
+The following variables are available within the filter run:
+
+* ''currentTiddler'' - the input title
+* ''..currentTiddler'' - the value of the variable `currentTiddler` outside the filter run.
+* ''index'' - <<.from-version "5.2.1">> the numeric index of the current list item (with zero being the first item in the list).
+* ''revIndex'' - <<.from-version "5.2.1">> the reverse numeric index of the current list item (with zero being the last item in the list).
+* ''length'' - <<.from-version "5.2.1">> the total length of the input list.
+
+<<.tip "Compare named filter run prefix `:filter` with [[filter Operator]] which applies a subfilter to every input title, removing the titles that return an empty result from the subfilter">>
+
+[[Examples|Filter Filter Run Prefix (Examples)]]

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Run Prefix (Examples).tid
@@ -1,8 +1,12 @@
 created: 20201117073343969
-modified: 20210428084013109
+modified: 20211129032537195
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]]
 title: Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
+
+!! `:filter` examples
+
+See [[Filter Filter Run Prefix (Examples)]]
 
 !! Difference between `+` and `:intersection`
 


### PR DESCRIPTION
Add separate documentation tiddlers for the `:filter` filter run prefix functionality following the pattern set by the `:sort` and `:map` filter run prefixes.

The examples were mostly taken from the `filter` operator while modifying them to take advantage of the ability to inline the subfilter variables.