### PR TITLE
findListingsOfTiddler should cache results

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -638,14 +638,20 @@ exports.getTagMap = function() {
 Lookup a given tiddler and return a list of all the tiddlers that include it in the specified list field
 */
 exports.findListingsOfTiddler = function(targetTitle,fieldName) {
+	var titles,
+		fieldIndexer = this.getIndexer("FieldIndexer");
 	fieldName = fieldName || "list";
-	var titles = [];
-	this.each(function(tiddler,title) {
-		var list = $tw.utils.parseStringArray(tiddler.fields[fieldName]);
-		if(list && list.indexOf(targetTitle) !== -1) {
-			titles.push(title);
-		}
-	});
+	if(fieldIndexer) {
+		titles = fieldIndexer.lookup(fieldName, targetTitle);
+	} else {
+		titles = [];
+		this.each(function(tiddler,title) {
+			var list = $tw.utils.parseStringArray(tiddler.fields[fieldName]);
+			if(list && list.indexOf(targetTitle) !== -1) {
+				titles.push(title);
+			}
+		});
+	}
 	return titles;
 };
 

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -638,21 +638,26 @@ exports.getTagMap = function() {
 Lookup a given tiddler and return a list of all the tiddlers that include it in the specified list field
 */
 exports.findListingsOfTiddler = function(targetTitle,fieldName) {
-	var titles,
-		fieldIndexer = this.getIndexer("FieldIndexer");
 	fieldName = fieldName || "list";
-	if(fieldIndexer) {
-		titles = fieldIndexer.lookup(fieldName, targetTitle);
-	} else {
-		titles = [];
-		this.each(function(tiddler,title) {
+	var wiki = this;
+	var listings = this.getGlobalCache("listings-" + fieldName,function() {
+		var listings = Object.create(null);
+		wiki.each(function(tiddler,title) {
 			var list = $tw.utils.parseStringArray(tiddler.fields[fieldName]);
-			if(list && list.indexOf(targetTitle) !== -1) {
-				titles.push(title);
+			if(list) {
+				for(var i = 0; i < list.length; i++) {
+					var listItem = list[i],
+						listing = listings[listItem] || [];
+					if (listing.indexOf(title) === -1) {
+						listing.push(title);
+					}
+					listings[listItem] = listing;
+				}
 			}
 		});
-	}
-	return titles;
+		return listings;
+	});
+	return listings[targetTitle] || [];
 };
 
 /*

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -383,6 +383,11 @@ Tests the filtering mechanism.
 			expect(wiki.filterTiddlers("[list[TiddlerSeventh]sort[title]]").join(",")).toBe("a fourth tiddler,MissingTiddler,Tiddler Three,TiddlerOne");
 			expect(wiki.filterTiddlers("[tag[one]list[TiddlerSeventh]sort[title]]").join(",")).toBe("a fourth tiddler,MissingTiddler,Tiddler Three,TiddlerOne");
 		});
+
+		it("should handle the listed operator", function() {
+			expect(wiki.filterTiddlers("TiddlerOne MissingTiddler +[listed[]]").join(",")).toBe('one,hasList');
+			expect(wiki.filterTiddlers("one two +[listed[tags]]").join(",")).toBe('TiddlerOne,$:/TiddlerTwo,Tiddler Three');
+		});
 	
 		it("should handle the next operator", function() {
 			expect(wiki.filterTiddlers("[[Tiddler Three]next[TiddlerSeventh]]").join(",")).toBe("a fourth tiddler");


### PR DESCRIPTION
`wiki.findListingsOfTiddler` was not using the FieldIndexer when it was available. This made operators like `[listed[]]` slow as butt with large TiddlyWikis.