### PR TITLE
Type coercion for EditTextWidget

### DIFF
--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -32,6 +32,11 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	};
 
 	/*
+	Initialize the global List of type modules
+	*/
+	EditTextWidget.typeModules = $tw.modules.getModulesByTypeAsHashmap("inputtype", "type");
+
+	/*
 	Inherit from the base widget class
 	*/
 	EditTextWidget.prototype = new Widget();
@@ -134,12 +139,18 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 					updateFields = {
 						title: self.editTitle
 					};
+				if (self.typeModule && self.typeModule.fromValue) {
+					value = self.typeModule.fromValue.call(this,value);
+				}
 				updateFields[self.editField] = value;
 				self.wiki.addTiddler(new $tw.Tiddler(self.wiki.getCreationFields(),tiddler,updateFields,self.wiki.getModificationFields()));
 			};
 		}
 		if(this.editType) {
 			type = this.editType;
+		}
+		if(this.typeModule && this.typeModule.toValue) {
+			value = this.typeModule.toValue.call(this,value);
 		}
 		return {value: value || "", type: type, update: update};
 	};
@@ -205,6 +216,9 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		// Get the rest of our parameters
 		this.editTag = this.getAttribute("tag",tag) || "input";
 		this.editType = this.getAttribute("type",type);
+		// Fetch type module if any exists.
+		// This module takes kare of converting between TW5 and HTML5 representation of the value.
+		this.typeModule = EditTextWidget.typeModules[this.editType];
 		// Make the child widgets
 		this.makeChildWidgets();
 		// Determine whether to show the toolbar

--- a/core/modules/editor/types/date.js
+++ b/core/modules/editor/types/date.js
@@ -1,0 +1,27 @@
+/*\
+title: $:/core/modules/editor/types/date.js
+type: application/javascript
+module-type: inputtype
+
+Type module for HTML5 input elements with type="date"
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.type = "date";
+
+exports.toValue = function(twDateTimeString) {
+	var date = $tw.utils.parseDate(twDateTimeString);
+	return $tw.utils.isValidDate(date) ? date.toISOString().substring(0,10) : "";
+};
+
+exports.fromValue = function(isoDateString) {
+	var date = new Date(isoDateString);
+	return $tw.utils.isValidDate(date) ? $tw.utils.stringifyDate(date) : "";
+};
+
+})();

--- a/core/modules/editor/types/datetime.js
+++ b/core/modules/editor/types/datetime.js
@@ -1,0 +1,27 @@
+/*\
+title: $:/core/modules/editor/types/datetime.js
+type: application/javascript
+module-type: inputtype
+
+Type module for HTML5 input elements with type="datetime-local"
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.type = "datetime-local";
+
+exports.toValue = function(twDateTimeString) {
+	var date = $tw.utils.parseDate(twDateTimeString);
+	return $tw.utils.isValidDate(date) ? date.toISOString().substring(0,16) : "";
+};
+
+exports.fromValue = function(isoDateTimeString) {
+	var date = new Date(isoDateTimeString);
+	return $tw.utils.isValidDate(date) ? $tw.utils.stringifyDate(date) : "";
+};
+
+})();

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -336,6 +336,10 @@ exports.formatTitleString = function(template,options) {
 	return result;
 };
 
+exports.isValidDate = function(date) {
+	return (date instanceof Date) && !isNaN(date.valueOf());
+}
+
 exports.formatDateString = function(date,template) {
 	var result = "",
 		t = template,

--- a/editions/dev/tiddlers/new/InputTypeModules.tid
+++ b/editions/dev/tiddlers/new/InputTypeModules.tid
@@ -1,0 +1,47 @@
+created: 202112111013000000
+modified: 202112111013000000
+title: inputtype-modules
+type: text/vnd.tiddlywiki
+
+Modules of the type `inputtype` provide a way to convert the TiddlyWiki internal representation of a value into a value used within the HTML-value-attribute of an input tag and back.
+
+These modules are used to allow the date and time types of HTML5 input tags to function seamlessly with TiddlyWiki's date/time format.
+
+A module of type `inputtype` exports the `type` property that specifies on which type of `input` element they are applied to. In addition to that, they contain two exported functions `toValue` and `fromValue`. These functions are called each time a value needs to be converted from TW5`s representation into the HTML-value-attribute and vice versa.
+
+```js
+/*\
+title: $:/core/modules/editor/types/date.js
+type: application/javascript
+module-type: inputtype
+
+Type module for HTML5 input elements with type="date"
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.type = "date";
+
+exports.toValue = function(twDateTimeString) {
+    var date = $tw.utils.parseDate(twDateTimeString);
+    return $tw.utils.isValidDate(date) ? date.toISOString().substring(0,10) : "";
+};
+
+
+exports.fromValue = function(isoDateString) {
+    var date = new Date(isoDateString);
+    return $tw.utils.isValidDate(date) ? $tw.utils.stringifyDate(date) : "";
+}
+
+})();
+```
+
+The above example shows the inputtype-module for the type `date`. The `toValue` function parses the TiddlyWiki Date-Format into a date value and converts it into ISO-8601 format. The `date` input-element does not support the time portion of the ISO-8601 format. Therefore the value is truncate to only contain the date part.
+
+The `fromValue` function reverses the process by parsing the ISO-8601 value supplied by the input-element and converting it into a TiddlyWiki's DateFormat. This value is returned to be used by TiddlyWiki.
+
+All `inputtype` modules are stored within the `core/modules/editor/types/` directory.

--- a/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
@@ -38,6 +38,7 @@ The content of the `<$edit-text>` widget is ignored.
 |disabled|<<.from-version "5.1.23">> Optional, disables the text input if set to "yes". Defaults to "no"|
 |fileDrop|<<.from-version "5.2.0">> Optional. When set to "yes" allows dropping or pasting images into the editor to import them. Defaults to "no"|
 
+<<.from-version "5.2.2">> When using the types `date` or `datetime-local` as the type of `<$edit-text>` widget, the value is stored using TiddlyWiki's DateFormat not in the format normaly used by the HTML input element.
 
 ! Example
 


### PR DESCRIPTION
As promised in discussion #6301 I created a pull request containing a PoC for the new inputtype modules.

This set of two patches adds infrastructure and documentation to do type coercion on input fields. It introduces a new module-type `inputtype` that can convert values between the internal TW5 representation and the representation used by the value attribute of the HTML-tag.

The comment on commit 1fa29ee8073ac2d6fafb15afd13c81be0cc22beb describes this mechanism in more detail.
The second commit (f8b628d1cbedab426ecff7774902fd723722a324) contains the documentation.
If there is a need for changes or more documenation, tests, etc. feel free to let me know.