### PR TITLE
Docs: Filter Operators: indicate Selection Constructors

### DIFF
--- a/editions/tw5.com/tiddlers/filters/Filter Operators.tid
+++ b/editions/tw5.com/tiddlers/filters/Filter Operators.tid
@@ -1,5 +1,5 @@
 created: 20140410103123179
-modified: 20210830010231559
+modified: 20211217141224284
 tags: Filters
 title: Filter Operators
 type: text/vnd.tiddlywiki
@@ -10,18 +10,21 @@ type: text/vnd.tiddlywiki
 <td>{{!!op-purpose}}</td>
 <td align="center"><$list filter="[all[current]tag[Common Operators]]">✓</$list></td>
 <td align="center"><$list filter="[all[current]tag[Negatable Operators]]">`!`</$list></td>
+<td align="center"><$list filter="[all[current]tag[Selection Constructors]!tag[Selection Constructors: Conditional]]">`C`</$list><$list filter="[all[current]tag[Selection Constructors]tag[Selection Constructors: Conditional]]">`C?`</$list></td>
 </tr></$list>
 \end
 
 \define .group-heading(_)
-<tr class="doc-table-subheading"><th colspan="4" align="center">$_$</th></tr>
+<tr class="doc-table-subheading"><th colspan="5" align="center">$_$</th></tr>
 \end
 
 A <<.def "filter operator">> is a predefined keyword attached to an individual [[step|Filter Step]] of a [[filter|Filters]]. It defines the particular action of that step.
 
 ''Important:'' Each first [[step|Filter Step]] of a [[filter run|Filter Run]] not given any input titles receives the output of <$link to="all Operator">[all[tiddlers]]</$link> as its input.
 
-The following table lists all core operators, the most common ones marked ✓. The last column indicates whether an operator allows ''negation'' using the <$link to="Filter Step"><code>!</code> prefix</$link>. For specifics as to each operator's negated output please refer to its documentation.
+The following table lists all core operators, the most common ones marked ✓. The `!` column indicates whether an operator allows ''negation'' using the <$link to="Filter Step"><code>!</code> prefix</$link>. For specifics as to each operator's negated output please refer to its documentation. 
+
+Most steps process the [[selection of titles|Title Selection]] that are supplied as their input, but a few [[construct an entirely new selection|Selection Constructors]] instead, as indicated by the last column. A `C?` indicates it might construct a new selection, depending on usage. For specifics as to each operator's selection creation please refer to its documentation. 
 
 <table>
 <tr>
@@ -29,6 +32,7 @@ The following table lists all core operators, the most common ones marked ✓. T
 <th align="left">Purpose</th>
 <th align="center">✓</th>
 <th align="center">`!`</th>
+<th align="center">`C`</th>
 </tr>
 <<.operator-rows "[tag[Filter Operators]!tag[Order Operators]!tag[Mathematics Operators]!tag[String Operators]!tag[Tag Operators]!tag[Special Operators]sort[]]">>
 <<.group-heading "Order Operators">>
@@ -45,6 +49,6 @@ The following table lists all core operators, the most common ones marked ✓. T
 <<.operator-rows "[tag[Filter Operators]!tag[Order Operators]!tag[Mathematics Operators]!tag[String Operators]!tag[Tag Operators]tag[Special Operators]sort[]]">>
 </table>
 
-A typical step is written as `[operator[parameter]]`, although not all of the operators need a [[parameter|Filter Parameter]].
+A typical step is written as `[operator[parameter]]`, although not all of the operators need a [[parameter|Filter Parameter]]. 
 
-Most steps process the [[selection of titles|Title Selection]] that are supplied as their input, but a few [[construct an entirely new selection|Selection Constructors]] instead. For the exact rules, see [[Filter Syntax]].
+For the exact rules, see [[Filter Syntax]].

--- a/editions/tw5.com/tiddlers/filters/all.tid
+++ b/editions/tw5.com/tiddlers/filters/all.tid
@@ -1,11 +1,11 @@
 caption: all
 created: 20140410103123179
-modified: 20161128185445034
+modified: 20211217135719266
 op-input: ignored, unless the parameter is empty
 op-output: the titles that belong to all the specified categories
 op-parameter: zero or more categories
 op-purpose: find all titles of a fundamental category
-tags: [[Filter Operators]] [[Common Operators]] [[Selection Constructors]]
+tags: [[Filter Operators]] [[Common Operators]] [[Selection Constructors]] [[Selection Constructors: Conditional]]
 title: all Operator
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/filters/subfilter Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/subfilter Operator.tid
@@ -1,6 +1,6 @@
 caption: subfilter
 created: 20181031175129475
-modified: 20211030223407188
+modified: 20211217135706478
 op-input: a [[selection of titles|Title Selection]] passed as input to the subfilter
 op-neg-input: a [[selection of titles|Title Selection]] passed as input to the subfilter
 op-neg-output: those input titles that are <<.em not>> returned from the subfilter  <<.place S>>
@@ -8,7 +8,7 @@ op-output: the [[selection of titles|Title Selection]] returned from the subfilt
 op-parameter: a [[filter expression|Filter Expression]]
 op-parameter-name: S
 op-purpose: select titles from the operand interpreted as a [[filter expression|Filter Expression]]
-tags: [[Filter Operators]] [[Field Operators]] [[Selection Constructors]] [[Negatable Operators]]
+tags: [[Filter Operators]] [[Field Operators]] [[Selection Constructors]] [[Negatable Operators]] [[Selection Constructors: Conditional]]
 title: subfilter Operator
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Cascade Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Cascade Filter Run Prefix.tid
@@ -10,7 +10,7 @@ type: text/vnd.tiddlywiki
 |''input'' |all titles from previous filter runs |
 |''output''|the input titles as modified by the filters returned by this filter run |
 
-The filter expression for this filter run is evaluated to return a list of filters. Each input title is then evaluated against each of the filters in turn, and the input title is replaced with the first result of the first filter that returns a non-empty list. If none of the filters return a result for an input title, it is replaced with an empty string.
+The [[filter expression|Filter Expression]] for this [[filter run|Filter Run]] is evaluated to return a list of filters. Each input title is then evaluated against each of the filters in turn, and the input title is replaced with the first result of the first filter that returns a non-empty list. If none of the filters return a result for an input title, it is replaced with an empty string.
 
 The following variables are available within the filter run:
 

--- a/editions/tw5.com/tiddlers/macros/list-links-draggable Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/list-links-draggable Macro.tid
@@ -1,11 +1,13 @@
 caption: list-links-draggable
 created: 20170328204925306
-modified: 20170329093008550
+modified: 20211214141650488
 tags: Macros [[Core Macros]]
 title: list-links-draggable Macro
 type: text/vnd.tiddlywiki
 
 The <<.def list-links-draggable>> [[macro|Macros]] renders the ListField of a tiddler as a list of links that can be reordered via [[drag and drop|Drag and Drop]].
+
+Note: The list must be contained in a different tiddler. I.e. If the list is populated in the list field of the current tiddler, the drag and drop action will have no effect. 
 
 !! Parameters
 

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.1.21.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.1.21.tid
@@ -8,6 +8,12 @@ type: text/vnd.tiddlywiki
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.1.20...v5.1.21]]//
 
+<<.banner-credits
+	credit:"""Congratulations to [[Sylvain Comte|https://github.com/sycom]] for his winning design for the banner for this release (here are the [[other entries|https://groups.google.com/g/tiddlywiki/c/l47ZZzWdDb8/m/a1dnyKG0AQAJ]]).
+"""
+	url:"https://raw.githubusercontent.com/Jermolene/TiddlyWiki5/42060acb43b329036b7436ee154bf605e90efa8e/editions/tw5.com/tiddlers/images/New%20Release%20Banner.jpg"
+>>
+
 This is a bug fix release that resolves issues introduced in the recent [[Release 5.1.20]].
 
 !! Bug Fixes

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.1.22.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.1.22.tid
@@ -8,6 +8,12 @@ type: text/vnd.tiddlywiki
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.1.21...v5.1.22]]//
 
+<<.banner-credits
+	credit:"""Congratulations to [[Thomas Elmiger|https://github.com/telmiger]] for his winning design for the banner for this release (here are the [[other entries|https://groups.google.com/g/tiddlywiki/c/rYrja18_SfQ/m/IX-jFS4cBQAJ]]).
+"""
+	url:"https://raw.githubusercontent.com/Jermolene/TiddlyWiki5/1ed36adab62c117849ee29d9535136eac70d3bc7/editions/tw5.com/tiddlers/images/New%20Release%20Banner.png"
+>>
+
 ! Major Improvements
 
 !!  Dynamic Plugin Loading

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.1.23.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.1.23.tid
@@ -12,6 +12,12 @@ type: text/vnd.tiddlywiki
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.1.22...v5.1.23]]//
 
+<<.banner-credits
+	credit:"""Congratulations to [[Atronoush|https://github.com/atronoush]] for his winning design for the banner for this release (here are the [[other entries|https://groups.google.com/g/tiddlywiki/c/cTgPWl8b_9c/m/RghSSNKXAQAJ]]).
+"""
+	url:"https://raw.githubusercontent.com/Jermolene/TiddlyWiki5/3c003364d2408eb27912187f57f023333cc4f4dd/editions/tw5.com/tiddlers/images/New%20Release%20Banner.png"
+>>
+
 ! Performance Improvements
 
 * <<.link-badge-improved "https://github.com/Jermolene/TiddlyWiki5/pull/5206">> filter execution to use a more efficient linked list structure for intermediate results

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.2.0.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.2.0.tid
@@ -12,6 +12,12 @@ type: text/vnd.tiddlywiki
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.1.23...v5.2.0]]//
 
+<<.banner-credits
+	credit:"""Congratulations to Frank. B for his winning design for the banner for this release (here are the [[other entries|https://groups.google.com/g/tiddlywiki/c/eccIEHZoxsI/m/_MWs3EooBAAJ]]).
+"""
+	url:"https://raw.githubusercontent.com/Jermolene/TiddlyWiki5/32b36fb2aff6bbe4f9281ee56d5bf6b8bbe5454b/editions/tw5.com/tiddlers/images/New%20Release%20Banner.png"
+>>
+
 ! Highlights
 
 !! Unrestricted Fieldnames and the New JSON Store Area

--- a/editions/tw5.com/tiddlers/wikitext/Images in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Images in WikiText.tid
@@ -63,6 +63,6 @@ Renders as:
 ! Importing Images
 
 Use the <<.button import>> button (under the <<.sidebar-tab Tools>> tab in the sidebar), or drag and drop.
-See [[ImportingTiddlers]] for details.
+See [[Importing Tiddlers]] for details.
 
 <<.from-version "5.2.0">> You can also import images by dropping or pasting images into the tiddler editor.


### PR DESCRIPTION
In 'Filter Operators' added column to indicate those operators that construct an entirely new selection i.e. Selection Constructors.

The one question for this was how to indicate the operators (**all**, **subfilter**) that may or may not act as a constructor based on their usage. I for **all**, **subfilter** I added a new tag 'Selection Constructors: Conditional'. This, understandingly, might not a desired direction. An alternative is to remove that tag and just make a general note such as "Please note even if operator is identified with `C` depending on usage, it might not actually create a new selection. Be sure to check individual operator documentation."