### PR TITLE
Extend the EditTextWidget and fields to allow Date-Pickers and other tags

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -95,8 +95,8 @@ function FramedEngine(options) {
 			{name: "dragover",handlerObject: this.widget,handlerMethod: "handleDragOverEvent"},
 			{name: "dragleave",handlerObject: this.widget,handlerMethod: "handleDragLeaveEvent"},
 			{name: "dragend",handlerObject: this.widget,handlerMethod: "handleDragEndEvent"},
-			{name: "drop", handlerObject: this.widget,handlerMethod: "handleDropEvent"},
-			{name: "paste", handlerObject: this.widget,handlerMethod: "handlePasteEvent"},
+			{name: "drop",handlerObject: this.widget,handlerMethod: "handleDropEvent"},
+			{name: "paste",handlerObject: this.widget,handlerMethod: "handlePasteEvent"},
 			{name: "click",handlerObject: this.widget,handlerMethod: "handleClickEvent"}
 		]);
 	}

--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -132,6 +132,19 @@ FramedEngine.prototype.setText = function(text,type) {
 };
 
 /*
+Set the validation status of the input field
+If the parameter is true, the field is valid. If it's false it is not valid
+and should be shown as such to the user.
+*/
+FramedEngine.prototype.updateValidationStatus = function(isValid) {
+	if(isValid) {
+		$tw.utils.removeClass(this.domNode,this.widget.editErrorClass);
+	} else {
+		$tw.utils.addClass(this.domNode,this.widget.editErrorClass);
+	}
+}
+
+/*
 Update the DomNode with the new text
 */
 FramedEngine.prototype.updateDomNodeText = function(text) {

--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -82,6 +82,19 @@ SimpleEngine.prototype.setText = function(text,type) {
 };
 
 /*
+Set the validation status of the input field
+If the parameter is true, the field is valid. If it's false it is not valid
+and should be shown as such to the user.
+*/
+SimpleEngine.prototype.updateValidationStatus = function(isValid) {
+	if(isValid) {
+		$tw.utils.removeClass(this.domNode,this.widget.editErrorClass);
+	} else {
+		$tw.utils.addClass(this.domNode,this.widget.editErrorClass);
+	}
+}
+
+/*
 Update the DomNode with the new text
 */
 SimpleEngine.prototype.updateDomNodeText = function(text) {

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -221,7 +221,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes["default"] || changedAttributes["class"] || changedAttributes.placeholder || changedAttributes.size || changedAttributes.autoHeight || changedAttributes.minHeight || changedAttributes.focusPopup ||  changedAttributes.rows || changedAttributes.tabindex || changedAttributes.cancelPopups || changedAttributes.inputActions || changedAttributes.refreshTitle || changedAttributes.autocomplete || changedTiddlers[HEIGHT_MODE_TITLE] || changedTiddlers[ENABLE_TOOLBAR_TITLE] || changedAttributes.disabled || changedAttributes.fileDrop) {
 			this.refreshSelf();
 			return true;
-		} else if (changedTiddlers[this.editRefreshTitle]) {
+		} else if(changedTiddlers[this.editRefreshTitle]) {
 			this.engine.updateDomNodeText(this.getEditInfo().value);
 		} else if(changedTiddlers[this.editTitle]) {
 			var editInfo = this.getEditInfo();
@@ -306,7 +306,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		var propertiesToCopy = propertiesToCopy || [],
 			newEvent = this.document.createEventObject ? this.document.createEventObject() : this.document.createEvent("Events");
 		if(newEvent.initEvent) {
-			newEvent.initEvent(event.type, true, true);
+			newEvent.initEvent(event.type,true,true);
 		}
 		$tw.utils.each(propertiesToCopy,function(prop){
 			newEvent[prop] = event[prop];

--- a/editions/tw5.com/tiddlers/images/Value transformations.svg
+++ b/editions/tw5.com/tiddlers/images/Value transformations.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64.157005mm"
+   height="29.740005mm"
+   viewBox="0 0 64.157005 29.740005"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="Arrow1Send"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9562" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Send-3"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9562-6" />
+    </marker>
+  </defs>
+  <g
+     id="layer1"
+     transform="translate(-16.643257,-18.311505)">
+    <text
+       xml:space="preserve"
+       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
+       x="37.550411"
+       y="21.527843"
+       id="text5090"><tspan
+         id="tspan5088"
+         style="font-size:4.23333px;stroke-width:0.264583"
+         x="37.550411"
+         y="21.527843">TW5 field</tspan></text>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Send)"
+       d="M 40.760143,24.493964 V 35.384493"
+       id="path9429" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Send-3)"
+       d="M 52.42257,37.169834 V 26.279305"
+       id="path9429-7" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.52777px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
+       x="16.548517"
+       y="31.805136"
+       id="text10857"><tspan
+         id="tspan10855"
+         style="stroke-width:0.264583"
+         x="16.548517"
+         y="31.805136">toInputValue</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.52777px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
+       x="53.956135"
+       y="31.805136"
+       id="text11301"><tspan
+         id="tspan11299"
+         style="stroke-width:0.264583"
+         x="53.956135"
+         y="31.805136">fromInputValue</tspan></text>
+    <g
+       id="g15663">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.612694;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6690"
+         width="35.519291"
+         height="7.5835614"
+         x="29.564837"
+         y="40.161602" />
+      <path
+         d="m 65.084131,40.161603 v 7.583561 H 29.564837"
+         style="fill:none;stroke:#787878;stroke-width:0.612694;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2552" />
+      <path
+         id="rect846"
+         style="fill:none;stroke:#282828;stroke-width:0.612694;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 29.564837,47.745164 V 40.161603 H 65.08413" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:0;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.264583"
+         x="30.247374"
+         y="45.370037"
+         id="text13577"><tspan
+           id="tspan13575"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:2;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.264583"
+           x="30.247374"
+           y="45.370037">HTML element<tspan
+   style="font-size:4.58611px;line-height:2;letter-spacing:0px;baseline-shift:baseline"
+   id="tspan16786">|</tspan></tspan></text>
+    </g>
+  </g>
+</svg>

--- a/editions/tw5.com/tiddlers/images/Value transformations.svg.meta
+++ b/editions/tw5.com/tiddlers/images/Value transformations.svg.meta
@@ -1,0 +1,3 @@
+title: Value transformation.svg
+type: image/svg+xml
+tags: picture

--- a/editions/tw5.com/tiddlers/widgets/EditTextWidget Transformations.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditTextWidget Transformations.tid
@@ -1,0 +1,44 @@
+created: 20220109200433409
+modified: 20220109200433409
+tags: Widgets
+title: EditTextWidget value transformations
+type: text/vnd.tiddlywiki
+
+By default, the [[<$edit-text> widget|EditTextWidget]] show the value of a field exactly like it is stored within the associated field. The `toInputValue` and `fromInputValue` attributes provide a way to change this behaviour.
+
+The filter assigned `toInputValue` attribute is used to modify the value after it was read from the field, before it is displayed to the user. If this filter returns no value, an empty value is assigned to the generated HTML editing element.
+
+The filter assigned to the `fromInputValue` attribute is used to modify the value that was entered by the user, before it is stored into the field. If this filter returns no value, the CSS class specified in the `errorClass` attribute is assigned to the generated HTML editing element.
+
+! Transforming values
+
+As an example for the transformation that can be done by using the `toInputValue` and `fromInputValue` attributes, let's build a date picker that uses the HTML5 "date" input type and stores its value inside a TW5 field.
+
+HTML5 defines an input type "date" that expects its value to be a simplified form of the [[ISO 8601|https://en.wikipedia.org/wiki/ISO_8601]] date format. TiddlyWiki uses its own [[date format||date format]]. We use `fromInputValue` and `toInputValue` to convert between the two formats:
+
+<$macrocall $name=".example" n="1"
+eg="""<$edit-text field="mydate" type="date" placeholder="Set your date" toInputValue="[format:date[YYYY-0MM-0DD]]" fromInputValue="[parsedate[ISO]]"/>
+<$view field="mydatetime"/>
+"""/>
+
+The `toInputValue` filter uses the `format` filter to convert the date from the TW5 date format into the HTML representation. For example, the field value "20220102000000000" will be converted into "2022-01-02".
+
+The `fromInputValue` filter is used after the user changed the value. It converts the HTML5 representation of the value back to the TW5 [[date format|date format]] via the `parsedate` filter. For example, the HTML value `2022-02-05" will be converted back to `20220205000000000".
+
+[img[Value transformation.svg]]
+
+For everything to work correctly, the `toInputValue` and `fromInputValue` filters must be complementary. If the output of the `toInputValue` filter can not be converted back to the original value by the `fromInputValue` filter, strange things may happen.
+
+! Input validation
+
+The `fromInputValue` filter can be used on its own to validate the input value. This works by assigning a filter to `fromInputValue` that returns the original value or nothing. If nothing is returned, the value will __not__ be saved to the field and the `errorClass` CSS class will be assigned to the generated editing element.
+
+As an example, let's generate an input field that only accepts integer numbers:
+
+<$macrocall $name=".example" n="1"
+eg="""<$set name="digits-only" value="^[0-9]*$">
+<$edit-text field="mynumbers" placeholder="Input only numbers" fromInputValue="[regexp<digits-only>]"/><br/>
+</$set>
+"""/>
+
+The `regexp` filter only returns the original value if it matches the supplied regular expression. If the regular expression does not match, no value is returned.

--- a/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
@@ -1,6 +1,6 @@
 caption: edit-text
 created: 20131024141900000
-modified: 20211104200554064
+modified: 20220109200041033
 tags: Widgets
 title: EditTextWidget
 type: text/vnd.tiddlywiki
@@ -37,7 +37,9 @@ The content of the `<$edit-text>` widget is ignored.
 |refreshTitle |<<.from-version 5.1.23>> An optional tiddler title that makes the input field update whenever the specified tiddler changes |
 |disabled|<<.from-version "5.1.23">> Optional, disables the text input if set to "yes". Defaults to "no"|
 |fileDrop|<<.from-version "5.2.0">> Optional. When set to "yes" allows dropping or pasting images into the editor to import them. Defaults to "no"|
-
+|toInputValue|<<.from-version "5.2.2">> Optional. Filter used to convert the value of the field into a value assigned to the generated `<input>`/`<textarea>`. See [[EditTextWidget value transformations|EditTextWidget value transformations]] for more information.|
+|fromInputValue|<<.from-version "5.2.2">> Optional. Filter used to convert the text entered into the generated `<input>`/`<textarea>` into a value to be stored in the field. See [[EditTextWidget value transformations|EditTextWidget value transformations]] for more information.|
+|errorClass|<<.from-version "5.2.2">> A CSS class that is assigned to the generated HTML editing element if `fromInputValue` returns an empty result. (defaults to `tw-input-error`)|
 
 ! Example
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -245,6 +245,10 @@ input[type="search"]::-webkit-search-results-decoration {
 	-webkit-appearance:none;
 }
 
+input.tw-input-error {
+	text-decoration: red solid underline;
+}
+
 .tc-muted {
 	color: <<colour muted-foreground>>;
 }


### PR DESCRIPTION
This Pull request is the result of the discussion #6301.

It extends TiddlyWiki in multiple ways:

1. It allows transformation of the data stored in a field when it is used as the value of a HTML-tag. That way HTML5 date and time pickers can be used.
2. It adds the `parseDate` filter to allow processing of dates in ISO-8601 format.
3. It allows the same transformation mechanism to be used for input validation.
4. It allows the rendering of fields to be extended. Custom input tags can be used for tiddler fields.

Currently the documentation is missing. I'll add the documentation as soon as the technical discussion is resolved.