### PR TITLE
Added sourceURL tags to boot js

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2649,3 +2649,4 @@ if(typeof(exports) !== "undefined") {
 } else {
 	_boot(window.$tw);
 }
+//# sourceURL=$:/boot/boot.js

--- a/boot/bootprefix.js
+++ b/boot/bootprefix.js
@@ -117,3 +117,4 @@ if(typeof(exports) === "undefined") {
 	// Export functionality as a module
 	exports.bootprefix = _bootprefix;
 }
+//# sourceURL=$:/boot/bootprefix.js


### PR DESCRIPTION
These two lines will let browsers categorize the boot javascript into their own files, which is just a lot cleaner for anyone working with the browser debugger. Otherwise, methods in those files are listed under "(filename).html", and the shown source includes EVERYTHING, including CSS, the tiddler store, and those uglified encryption libraries. It makes it really slow. And it also makes line number stupid large.

This makes it cleaner.