### PR TITLE
Compiled filters are cached

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -229,6 +229,7 @@ exports.compileFilter = function(filterString) {
 	try {
 		filterParseTree = this.parseFilter(filterString);
 	} catch(e) {
+		// We do not cache this result, so it adjusts along with localization changes
 		return function(source,widget) {
 			return [$tw.language.getString("Error/Filter") + ": " + e];
 		};
@@ -340,13 +341,10 @@ exports.compileFilter = function(filterString) {
 		});
 		return results.toArray();
 	});
-	if(this.filterCacheCount >= 5000) {
-		// I doubt anyone will come close to 5000 cached filters (~7 Mb)
-		// but if we do, it's because something is dynamically creating
-		// filters, in which case, letting the cache grow indefinitely
-		// is a memory leak. The simplest solution is to just clear it
-		// if it gets too large. This'll result in a recaching every
-		// minute or so, which is fine.
+	if(this.filterCacheCount >= 2000) {
+		// To prevent memory leak, we maintain an upper limit for cache size.
+		// Reset if exceeded. This should give us 95% of the benefit
+		// that no cache limit would give us.
 		this.filterCache = Object.create(null);
 		this.filterCacheCount = 0;
 	}


### PR DESCRIPTION
I'm having some real slowdown problems with my large projects, and [I'm not alone](https://groups.google.com/g/tiddlywiki/c/dEhq2V4ZYzg/m/vfMnTUqiAQAJ?utm_medium=email&utm_source=footer).

~95% of all filter usage is done through filterTiddlers(), which means we're constantly recompiling filters just to run them once. So why don't we cache the compiled filters? They are derived solely from their filterString, so we can cache them based on that.

I did ran some profiling. I went to tw5.com, opened 20 tiddlers, then I edited and saved one of them. This called "filterTiddlers()" 2960 times. I captured the arguments for all of those calls and then ran them independently as the test.

![Screen Shot 2022-01-15 at 11 20 03 PM](https://user-images.githubusercontent.com/205465/149647155-59a94362-d19c-4167-b335-2d6e9eb94230.png)

I ran this four time without my change:

Avg Runtime: 329 ms
Avg time in compileFilter(): 40 ms
Avg time Garbage Collecting: 28 ms

And with my change:

Avg Runtime: 208 ms
Avg time in compileFilter(): 1.0 ms
Avg time Garbage Collecting: 15 ms

I think most of those gains are in memory improvement. On tw5.com, after you've visted a ton of pages and all the tabs, the filterCache levels out at around 200 cached filters. Here's a memory snapshot of it.
![Screen Shot 2022-01-15 at 11 27 15 PM](https://user-images.githubusercontent.com/205465/149647336-74d23acb-ba85-4c0d-9ece-272b6421a154.png)

288K retained for 200 filters. THAT may be where the gains are, because if we were calling compileFilter 2960 times before, that's about 4.2Mb that we were allocating with *each refresh* and then just tossing away. Time lost to memory management is hard to track, but even if we ignore this, Reducing compileFilter down to a negligible runtime cuts about 10% of the time off running filters in tw5.com.

@Jermolene, @pmario? Can anyone think of a reason why this wouldn't work?