### PR TITLE
Update doc list-links-draggabe Macro.tid

### DIFF
--- a/editions/tw5.com/tiddlers/macros/list-links-draggable Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/list-links-draggable Macro.tid
@@ -7,8 +7,6 @@ type: text/vnd.tiddlywiki
 
 The <<.def list-links-draggable>> [[macro|Macros]] renders the ListField of a tiddler as a list of links that can be reordered via [[drag and drop|Drag and Drop]].
 
-Note: The list must be contained in a different tiddler. I.e. If the list is populated in the list field of the current tiddler, the drag and drop action will have no effect. 
-
 !! Parameters
 
 ;tiddler


### PR DESCRIPTION
Unless I misunderstand something:
A quick test indicates that the referred to problem is resolved... I assume it is so because we can now directly edit fields in the current tiddler. This is a pretty significant improvement to list-links-draggable.

Maybe there are other macros similarly affected and where the docs should be updated?