### PR TITLE
Add support for renderEnd method for storyviews

### DIFF
--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -51,6 +51,9 @@ ListWidget.prototype.render = function(parent,nextSibling) {
 	} else {
 		this.storyview = null;
 	}
+	if(this.storyview && this.storyview.renderEnd) {
+		this.storyview.renderEnd();
+	}
 };
 
 /*


### PR DESCRIPTION
This PR adds support for an optional post render method for storyviews called `renderEnd()` that allows storyviews to control the initial display state of the list.

The name of the method is consistent with `refreshStart()` and `refreshEnd()` storyview methods.

Fixes #6408 

I note that we currently do not have developer docs for storyviews, and should add some when the opportunity presents itself.