### PR TITLE
Add support to tm-scroll message for scrolling without animating

### DIFF
--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -49,10 +49,14 @@ Handle an event
 */
 PageScroller.prototype.handleEvent = function(event) {
 	if(event.type === "tm-scroll") {
+		var options = {};
+		if(event.paramObject && event.paramObject.hasOwnProperty("animationDuration")) {
+			options.animationDuration = event.paramObject.animationDuration;
+		}
 		if(event.paramObject && event.paramObject.selector) {
-			this.scrollSelectorIntoView(null,event.paramObject.selector);
+			this.scrollSelectorIntoView(null,event.paramObject.selector,null,options);
 		} else {
-			this.scrollIntoView(event.target);
+			this.scrollIntoView(event.target,null,options);
 		}
 		return false; // Event was handled
 	}
@@ -62,9 +66,9 @@ PageScroller.prototype.handleEvent = function(event) {
 /*
 Handle a scroll event hitting the page document
 */
-PageScroller.prototype.scrollIntoView = function(element,callback) {
+PageScroller.prototype.scrollIntoView = function(element,callback,options) {
 	var self = this,
-		duration = $tw.utils.getAnimationDuration(),
+		duration = (options && options.hasOwnProperty("animationDuration")) ? parseInt(options.animationDuration) : $tw.utils.getAnimationDuration(),
 	    srcWindow = element ? element.ownerDocument.defaultView : window;
 	// Now get ready to scroll the body
 	this.cancelScroll(srcWindow);
@@ -122,11 +126,11 @@ PageScroller.prototype.scrollIntoView = function(element,callback) {
 	drawFrame();
 };
 
-PageScroller.prototype.scrollSelectorIntoView = function(baseElement,selector,callback) {
+PageScroller.prototype.scrollSelectorIntoView = function(baseElement,selector,callback,options) {
 	baseElement = baseElement || document.body;
 	var element = baseElement.querySelector(selector);
 	if(element) {
-		this.scrollIntoView(element,callback);
+		this.scrollIntoView(element,callback,options);
 	}
 };
 

--- a/core/modules/widgets/scrollable.js
+++ b/core/modules/widgets/scrollable.js
@@ -38,10 +38,14 @@ ScrollableWidget.prototype.handleScrollEvent = function(event) {
 	if(this.outerDomNode.scrollWidth <= this.outerDomNode.offsetWidth && this.outerDomNode.scrollHeight <= this.outerDomNode.offsetHeight && this.fallthrough === "yes") {
 		return true;
 	}
+	var options = {};
+	if(event.paramObject && event.paramObject.hasOwnProperty("animationDuration")) {
+		options.animationDuration = event.paramObject.animationDuration;
+	}
 	if(event.paramObject && event.paramObject.selector) {
-		this.scrollSelectorIntoView(null,event.paramObject.selector);
+		this.scrollSelectorIntoView(null,event.paramObject.selector,null,options);
 	} else {
-		this.scrollIntoView(event.target);
+		this.scrollIntoView(event.target,null,options);
 	}
 	return false; // Handled event
 };
@@ -49,8 +53,8 @@ ScrollableWidget.prototype.handleScrollEvent = function(event) {
 /*
 Scroll an element into view
 */
-ScrollableWidget.prototype.scrollIntoView = function(element) {
-	var duration = $tw.utils.getAnimationDuration(),
+ScrollableWidget.prototype.scrollIntoView = function(element,callback,options) {
+	var duration = (options && options.hasOwnProperty("animationDuration")) ? parseInt(options.animationDuration) : $tw.utils.getAnimationDuration(),
 	srcWindow = element ? element.ownerDocument.defaultView : window;
 	this.cancelScroll();
 	this.startTime = Date.now();
@@ -114,11 +118,11 @@ ScrollableWidget.prototype.scrollIntoView = function(element) {
 	}
 };
 
-ScrollableWidget.prototype.scrollSelectorIntoView = function(baseElement,selector,callback) {
+ScrollableWidget.prototype.scrollSelectorIntoView = function(baseElement,selector,callback,options) {
 	baseElement = baseElement || document.body;
 	var element = baseElement.querySelector(selector);
 	if(element) {
-		this.scrollIntoView(element,callback);
+		this.scrollIntoView(element,callback,options);
 	}
 };
 

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-scroll.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-scroll.tid
@@ -10,3 +10,6 @@ The `tm-scroll` message causes the surrounding scrollable container to scroll to
 |!Name |!Description |
 |target |Target DOM node the scrollable container should scroll to (note that this parameter can only be set via JavaScript code) |
 |selector |<<.from-version "5.1.23">> Optional string [[CSS selector|https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors]] as an alternate means of identifying the target DOM node |
+|animationDuration |<<.from-version "5.2.2">> Optional number specifying the animation duration in milliseconds for the scrolling. Defaults to the [[global animation duration|$:/config/AnimationDuration]]. |
+
+<<.tip "Set `animationDuration` to `0` to scroll without animation">>


### PR DESCRIPTION
This PR extends the `tm-scroll` widget message to allow scrolling without animating by passing the optional attribute `animationDuration` as `0` or any other interval.

@Jermolene Note that I have left the dud `callback` argument in place in both `PageScroller` and `Scrollable`. My personal preference would be to clean it up and remove it since it is never used, can never be used as the code stands, and only serves to confuse the function signatures. I would appreciate feedback on your preference in this matter. Should I go ahead and clean that up?

Fixes #6406 