### PR TITLE
Add doc related to WikiText parser modes

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/Pragma.tid
+++ b/editions/tw5.com/tiddlers/concepts/Pragma.tid
@@ -1,6 +1,6 @@
 created: 20150219175930000
-modified: 20180928145730028
-tags: Concepts
+modified: 20220122182842041
+tags: Concepts [[WikiText Parser Modes]]
 title: Pragma
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/system/wikitext-macros.tid
+++ b/editions/tw5.com/tiddlers/system/wikitext-macros.tid
@@ -1,7 +1,8 @@
 created: 20150117184156000
-modified: 20150117184616000
-title: $:/editions/tw5.com/wikitext-macros
+modified: 20220122143551571
 tags: $:/tags/Macro
+title: $:/editions/tw5.com/wikitext-macros
+type: text/vnd.tiddlywiki
 
 \define wikitext-example(src)
 <div class="doc-example">
@@ -41,6 +42,17 @@ $$$text/vnd.tiddlywiki
 $src$
 $$$
 </div>
+\end
+
+\define wikitext-example-table-header() <thead><tr><th/><th>wiki text</th><th>renders as</th></tr></thead>
+
+\define wikitext-example-table-row(id, code)
+ <tr>
+<th><<__id__>></th><td><$codeblock code=<<__code__>>/></td><td>
+
+<<__code__>>
+</td>
+</tr>
 \end
 
 \define tw-code(tiddler)

--- a/editions/tw5.com/tiddlers/widgets/MacroCallWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/MacroCallWidget.tid
@@ -1,6 +1,6 @@
 caption: macrocall
 created: 20131024141900000
-modified: 20200928102843275
+modified: 20220122193731433
 tags: Widgets
 title: MacroCallWidget
 type: text/vnd.tiddlywiki
@@ -37,6 +37,8 @@ You can see several examples of the macro call widget within the core:
 * Listing module information: [[$:/snippets/modules]]
 * Listing field information: [[$:/snippets/allfields]]
 * Generating `data:` URIs: [[$:/themes/tiddlywiki/starlight/styles.tid]]
+
+See also [[WikiText parser mode: macro examples]]
 
 ! Content and Attributes
 

--- a/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
@@ -1,9 +1,9 @@
+caption: transclude
 created: 20130824142500000
-modified: 20140717175900970
+modified: 20220122190609396
 tags: Widgets
 title: TranscludeWidget
 type: text/vnd.tiddlywiki
-caption: transclude
 
 ! Introduction
 
@@ -22,12 +22,12 @@ The TranscludeWidget treats any contained content as a fallback if the target of
 
 ! Parsing modes
 
-TiddlyWiki parses text in two modes:
+TiddlyWiki [[parses text in two modes|WikiText Parser Modes]]:
 
-* ''inline'' mode recognises character formatting such as emphasis, links
-* ''block'' mode recognises all the ''inline'' formatting, and adds block formatting such as tables, headings and lists
+* [[inline mode|Inline Mode WikiText]] recognises character formatting such as emphasis, links
+* [[block mode|Block Mode WikiText]] recognises all the ''inline'' formatting, and adds block formatting such as tables, headings and lists
 
-Usually, the mode is determined by whether the transclude widget itself has been parsed in block or inline mode. This can be overridden with the `mode` attribute.
+Usually, the mode is determined by whether the transclude widget itself has been parsed in block or inline mode. This can be overridden with the <<.attr mode>> attribute.
 
 For example, consider tiddler "A" with this content:
 
@@ -57,6 +57,7 @@ This can be fixed by amending tiddler "A":
 #<$transclude tiddler="B" mode="block"/>
 # Item two
 ```
+See also these [[other examples|WikiText parser mode: transclusion examples]].
 
 ! ~SubTiddler Access
 

--- a/editions/tw5.com/tiddlers/widgets/WikifyWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/WikifyWidget.tid
@@ -1,6 +1,6 @@
 caption: wikify
 created: 20160321144949700
-modified: 20161017122117062
+modified: 20220122191540121
 tags: Widgets
 title: WikifyWidget
 type: text/vnd.tiddlywiki
@@ -17,7 +17,7 @@ The content of the `<$wikify>` widget is the scope for the value assigned to the
 |name |The name of the variable to assign |
 |text |The text to parse and render |
 |type |The ContentType of the text (defaults to `text/vnd.tiddlywiki`) |
-|mode |The parse mode: `block` (the default) or `inline` |
+|mode |The parse mode: [[block|Block Mode WikiText]] (the default) or [[inline|Inline Mode WikiText]] |
 |output |Keyword indicating the desired output type, defaulting to `text` (see below) |
 
 The available output types are:

--- a/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
@@ -1,6 +1,6 @@
 caption: HTML
 created: 20131205160816081
-modified: 20210614100305329
+modified: 20220122192311669
 tags: WikiText
 title: HTML in WikiText
 type: text/vnd.tiddlywiki
@@ -35,9 +35,11 @@ some text <!-- inline comment -->
 
 ! Block mode versus Inline mode
 
-To get the content of an HTML element to be parsed in block mode, the opening tag must be followed by two linebreaks.
+To get the content of an HTML element to be [[parsed|WikiText Parser Modes]] in [[block mode|Block Mode WikiText]], the opening tag must be followed by two linebreaks.
 
-Without the two linebreaks, the tag content will be parsed in inline mode which means that block mode formatting such as wikitext tables, lists and headings is not recognised.
+Without the two linebreaks, the tag content will be [[parsed|WikiText Parser Modes]] in [[inline mode|Inline Mode WikiText]] which means that block mode formatting such as wikitext tables, lists and headings is not recognised.
+
+See also [[WikiText parser mode: HTML examples]] and [[WikiText parser mode transitions]].
 
 ! Self closing elements
 

--- a/editions/tw5.com/tiddlers/wikitext/Macro Calls in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Macro Calls in WikiText.tid
@@ -1,9 +1,9 @@
+caption: Macro Calls
 created: 20150220182252000
-modified: 20150221221340000
+modified: 20220122193853161
 tags: WikiText
 title: Macro Calls in WikiText
 type: text/vnd.tiddlywiki
-caption: Macro Calls
 
 To call a [[macro|Macros]], place `<<`double angle brackets`>>` around the name and any parameter values.
 
@@ -19,7 +19,7 @@ The syntax is actually a shorthand for a <<.wlink MacroCallWidget>> widget. The 
 
 As macros are simply parameterised [[variables|Variables]], a variable's value can be inserted using the same techniques.
 
-[[Examples|Macro Calls in WikiText (Examples)]]
+[[Examples|Macro Calls in WikiText (Examples)]] and [[more examples|WikiText parser mode: macro examples]]
 
 !! Named vs.unnamed parameters
 

--- a/editions/tw5.com/tiddlers/wikitext/Transclusion in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Transclusion in WikiText.tid
@@ -1,6 +1,6 @@
 caption: Transclusion
 created: 20131205160146648
-modified: 20150220161347000
+modified: 20220122193352028
 tags: WikiText
 title: Transclusion in WikiText
 type: text/vnd.tiddlywiki
@@ -48,3 +48,4 @@ See also:
 * TemplateTiddlers
 * TranscludeWidget
 * [[Transclusion and Substitution]]
+* [[WikiText parser mode: transclusion examples]]

--- a/editions/tw5.com/tiddlers/wikitext/Widgets in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Widgets in WikiText.tid
@@ -1,6 +1,6 @@
 caption: Widgets
 created: 20131205160840915
-modified: 20161020210726813
+modified: 20220122193129241
 tags: WikiText
 title: Widgets in WikiText
 type: text/vnd.tiddlywiki
@@ -20,8 +20,8 @@ Note that widgets inherit all the features of [[HTML in WikiText]]:
 ** Macro invocations (eg `attr=<<myMacro>>`)
 ** Transclusions (eg, `attr={{MyTiddler!!field}}`)
 ** Filtered transclusions (eg, `attr={{{ [filter[op]] }}}`)
-* The content of a widget is parsed in inline mode unless the opening tag is followed by two linebreaks, which forces block mode
-** 'Inline mode' means that 'block mode' parse rules like headings, tables and lists are not recognised
+* The content of a widget is [[parsed|WikiText Parser Modes]] in [[inline mode|Inline Mode WikiText]] unless the opening tag is followed by two linebreaks, which forces [[block mode|Block Mode WikiText]]
+** [[inline mode|Inline Mode WikiText]] means that [[block mode|Block Mode WikiText]] parse rules like headings, tables and lists are not recognised
 
 See [[HTML in WikiText]] for more details.
 

--- a/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText (Examples).tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText (Examples).tid
@@ -8,7 +8,7 @@ type: text/vnd.tiddlywiki
 
 <<<
 <<wikitext-example-without-html src:'This is a paragraph.
-Only __//inline mode//__ punctuation is recognized here.
+Only __//inline mode//__ punctuation is recognised here.
 Block mode punctuation will be <b>ignored</b> until
 the paragraph ends (i.e. a blank line is encountered).
 For example:
@@ -23,11 +23,11 @@ multi-line block quotes are ignored
 '>>
 <<<
 
-To get the parser to recognize the above ''block mode'' WikiText, a blank line needs to be inserted after the "For example:" line. The blank line will be treated as the end of the paragraph and the parser will start recognizing ''block mode'' punctuation again. Like this:
+To get the parser to recognise the above ''block mode'' WikiText, a blank line needs to be inserted after the "For example:" line. The blank line will be treated as the end of the paragraph and the parser will start recognising ''block mode'' punctuation again. Like this:
 
 <<<
 <<wikitext-example-without-html src:'This is a paragraph.
-Only __//inline mode//__ punctuation is recognized here.
+Only __//inline mode//__ punctuation is recognised here.
 Block mode punctuation will be <b>ignored</b> until
 the paragraph ends (i.e. a blank line is encountered).
 For example, here is a blank line:

--- a/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText (Examples).tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText (Examples).tid
@@ -1,0 +1,51 @@
+created: 20220115152811251
+modified: 20220115161035903
+tags: [[Block Mode WikiText]]
+title: Block Mode WikiText (Examples)
+type: text/vnd.tiddlywiki
+
+[[Paragraphs|Paragraphs in WikiText]] are the most common WikiText. It is important to know they do not end until a blank line is encountered. Once a paragraph starts the parser will be in ''inline mode''. Until that blank line is encountered other ''block mode'' syntax will be ignored:
+
+<<<
+<<wikitext-example-without-html src:'This is a paragraph.
+Only __//inline mode//__ punctuation is recognized here.
+Block mode punctuation will be <b>ignored</b> until
+the paragraph ends (i.e. a blank line is encountered).
+For example:
+* List item punctuation is ignored
+* So is this horizontal rule:
+---
+|tables|are|ignored|
+! headings are ignored
+<<<
+multi-line block quotes are ignored
+<<<
+'>>
+<<<
+
+To get the parser to recognize the above ''block mode'' WikiText, a blank line needs to be inserted after the "For example:" line. The blank line will be treated as the end of the paragraph and the parser will start recognizing ''block mode'' punctuation again. Like this:
+
+<<<
+<<wikitext-example-without-html src:'This is a paragraph.
+Only __//inline mode//__ punctuation is recognized here.
+Block mode punctuation will be <b>ignored</b> until
+the paragraph ends (i.e. a blank line is encountered).
+For example, here is a blank line:
+
+* due to above blank line,
+* list items work
+* the following horizontal rule also works:
+---
+|!tables|!work|
+|cell 1| cell 2|
+! Headings work
+<<<
+multi-line block quotes work
+<<<
+; Term
+: Definition of that term
+Another paragraph can start here, but it will not end until blank line
+'>>
+<<<
+
+All the block mode examples above except for the paragraph are written one line after the other without blanks between. Those types of WikiText don't require the extra blank line to terminate.

--- a/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText.tid
@@ -5,7 +5,7 @@ tags: [[WikiText Parser Modes]]
 title: Block Mode WikiText
 type: text/vnd.tiddlywiki
 
-Some WikiText is recognized only while the parser is in block mode.
+Some WikiText is recognised only while the parser is in block mode.
 
 Common characteristics of such block mode WikiText:
 
@@ -25,7 +25,7 @@ Common characteristics of such block mode WikiText:
 |[[Tables in WikiText]]|Each table row is a line starting and ending with `|`.|
 |[[Typed Blocks in WikiText]]|Enclosed by lines starting with `$$`.|
 
-The above WikiText types are only recognized in ''block mode''. However, the text <<.em enclosed>> by most of them will be parsed in ''inline mode'' ([[Block Quotes in WikiText]] and [[Styles and Classes in WikiText]] are the two exceptions in which the parser will continue in ''block mode''). While in ''inline mode'' the parser may encounter something which moves it to ''block mode'' (see [[WikiText parser mode transitions]]).
+The above WikiText types are only recognised in ''block mode''. However, the text <<.em enclosed>> by most of them will be parsed in ''inline mode'' ([[Block Quotes in WikiText]] and [[Styles and Classes in WikiText]] are the two exceptions in which the parser will continue in ''block mode''). While in ''inline mode'' the parser may encounter something which moves it to ''block mode'' (see [[WikiText parser mode transitions]]).
 
 At the end of the terminating line, the parser will return to ''block mode''. 
 <<.tip 'Note: [[Hard Linebreaks in WikiText]] require an extra blank line after the trailing `"""` before the parser will return to <b>block mode</b>'>>.

--- a/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText.tid
@@ -1,0 +1,35 @@
+caption: block parser mode
+created: 20220110234234616
+modified: 20220122182842032
+tags: [[WikiText Parser Modes]]
+title: Block Mode WikiText
+type: text/vnd.tiddlywiki
+
+Some WikiText is recognized only while the parser is in block mode.
+
+Common characteristics of such block mode WikiText:
+
+* At least one entire line is required to delimit the WikiText.
+* The closing punctuation must come at the end of the line (in some cases the end of the line //is// the closing punctuation.
+
+|!~WikiText|!Punctuation|
+|[[Block Quotes in WikiText]] |Multi-line block quotes are enclosed by lines containing only the text `<<<`; single line block quotes are also possible.|
+|[[Code Blocks in WikiText]]|Enclosed by lines containing only the text <code>&#96;&#96;&#96;</code>|
+|[[Definitions in WikiText]]|Each term is on its own line and each definition is on its own line.|
+|[[Hard Linebreaks in WikiText]]|Enclosed by lines containing only the text `"""`.|
+|[[Headings in WikiText]]|Entire line starting with `!`.|
+|[[Horizontal Rules in WikiText]]|A line containing only the text `---`.|
+|[[Lists in WikiText]]|Each list item is on its own line.|
+|[[Paragraphs in WikiText]]|Any text other than the start punctuation of one of the other block mode WikiText will start a paragraph. Even the start punctuation of inline mode WikiText will start a paragraph. The parser includes all following lines into the paragraph until it encounters a blank line.|
+|[[Styles and Classes in WikiText]]|Enclosed by lines starting with `@@`.|
+|[[Tables in WikiText]]|Each table row is a line starting and ending with `|`.|
+|[[Typed Blocks in WikiText]]|Enclosed by lines starting with `$$`.|
+
+The above WikiText types are only recognized in ''block mode''. However, the text <<.em enclosed>> by most of them will be parsed in ''inline mode'' ([[Block Quotes in WikiText]] and [[Styles and Classes in WikiText]] are the two exceptions in which the parser will continue in ''block mode''). While in ''inline mode'' the parser may encounter something which moves it to ''block mode'' (see [[WikiText parser mode transitions]]).
+
+At the end of the terminating line, the parser will return to ''block mode''. 
+<<.tip 'Note: [[Hard Linebreaks in WikiText]] require an extra blank line after the trailing `"""` before the parser will return to <b>block mode</b>'>>.
+
+If the punctuation for the above types of WikiText is encountered while the parser is in ''inline mode'', it will be //ignored// and output as-is.
+
+[[Examples|Block Mode WikiText (Examples)]]

--- a/editions/tw5.com/tiddlers/wikitext/parser/Inline Mode WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/Inline Mode WikiText.tid
@@ -1,0 +1,26 @@
+caption: inline parser mode
+created: 20220111000108618
+modified: 20220122182842036
+tags: [[WikiText Parser Modes]]
+title: Inline Mode WikiText
+type: text/vnd.tiddlywiki
+
+Some WikiText is recognized only while the parser is in inline mode.
+
+These WikiText types can be expressed without an entire line of text. They aren't required to be all on one line, just that they <<.em can>> be expressed within a single line. And as such, more than one can appear within a single line.  In other words, line endings are not involved while the parser tries to find where the particular WikiText begins and ends While the parser is in inline mode, it will recognize the punctuation for these WikiText types:
+
+* [[Dashes in WikiText]]
+* [[Formatting in WikiText]]
+* [[HTML in WikiText]]
+* [[Images in WikiText]]
+* [[Linking in WikiText]]
+* [[Macro Calls in WikiText]]
+* [[Styles and Classes in WikiText]] (single line version only)
+* [[Transclusion in WikiText]]
+* [[Variables in WikiText]]
+* [[Widgets in WikiText]]
+
+<<.tip """[[Macro Calls in WikiText]] and  [[Transclusion in WikiText]] will be recognized in block mode if the macro call or transclusion spans an entire line.""">>
+<<.tip """The other ''inline mode'' WikiText types are technically <<.em only>> detected while the parser is in ''inline mode''. However, the opening punctuation will also trigger the start of [[Paragraphs in WikiText]] which will automatically cause the parser to go into ''inline mode''. Therefore, practically speaking, it is just as useful to consider these WikiText types as recognized while the parser is in either ''inline mode'' or ''block mode''""">>
+
+While processing the //enclosed// text of some of these WikiText types, the parser [[will not look for new WikiText|Places where the parser ignores WikiText]]. But for rest of these WikiText types, the parser will continue in ''inline mode'' for the //enclosed// text.  While parsing that text, it might encounter something which [[moves it to block mode|WikiText parser mode transitions]].

--- a/editions/tw5.com/tiddlers/wikitext/parser/Inline Mode WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/Inline Mode WikiText.tid
@@ -5,9 +5,9 @@ tags: [[WikiText Parser Modes]]
 title: Inline Mode WikiText
 type: text/vnd.tiddlywiki
 
-Some WikiText is recognized only while the parser is in inline mode.
+Some WikiText is recognised only while the parser is in inline mode.
 
-These WikiText types can be expressed without an entire line of text. They aren't required to be all on one line, just that they <<.em can>> be expressed within a single line. And as such, more than one can appear within a single line.  In other words, line endings are not involved while the parser tries to find where the particular WikiText begins and ends While the parser is in inline mode, it will recognize the punctuation for these WikiText types:
+These WikiText types can be expressed without an entire line of text. They aren't required to be all on one line, just that they <<.em can>> be expressed within a single line. And as such, more than one can appear within a single line.  In other words, line endings are not involved while the parser tries to find where the particular WikiText begins and ends While the parser is in inline mode, it will recognise the punctuation for these WikiText types:
 
 * [[Dashes in WikiText]]
 * [[Formatting in WikiText]]
@@ -20,7 +20,7 @@ These WikiText types can be expressed without an entire line of text. They aren'
 * [[Variables in WikiText]]
 * [[Widgets in WikiText]]
 
-<<.tip """[[Macro Calls in WikiText]] and  [[Transclusion in WikiText]] will be recognized in block mode if the macro call or transclusion spans an entire line.""">>
-<<.tip """The other ''inline mode'' WikiText types are technically <<.em only>> detected while the parser is in ''inline mode''. However, the opening punctuation will also trigger the start of [[Paragraphs in WikiText]] which will automatically cause the parser to go into ''inline mode''. Therefore, practically speaking, it is just as useful to consider these WikiText types as recognized while the parser is in either ''inline mode'' or ''block mode''""">>
+<<.tip """[[Macro Calls in WikiText]] and  [[Transclusion in WikiText]] will be recognised in block mode if the macro call or transclusion spans an entire line.""">>
+<<.tip """The other ''inline mode'' WikiText types are technically <<.em only>> detected while the parser is in ''inline mode''. However, the opening punctuation will also trigger the start of [[Paragraphs in WikiText]] which will automatically cause the parser to go into ''inline mode''. Therefore, practically speaking, it is just as useful to consider these WikiText types as recognised while the parser is in either ''inline mode'' or ''block mode''""">>
 
 While processing the //enclosed// text of some of these WikiText types, the parser [[will not look for new WikiText|Places where the parser ignores WikiText]]. But for rest of these WikiText types, the parser will continue in ''inline mode'' for the //enclosed// text.  While parsing that text, it might encounter something which [[moves it to block mode|WikiText parser mode transitions]].

--- a/editions/tw5.com/tiddlers/wikitext/parser/Places where the parser ignores WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/Places where the parser ignores WikiText.tid
@@ -1,0 +1,14 @@
+caption: ignore parser mode
+created: 20220111000929700
+modified: 20220122182842038
+tags: [[WikiText Parser Modes]]
+title: Places where the parser ignores WikiText
+type: text/vnd.tiddlywiki
+
+Text enclosed by these constructs is skipped by the parser and WikiText punctuation will be ignored:
+
+|[[Code Blocks in WikiText]]|One of the main purposes of code blocks is to suppress wikitext expansion. Once the code block starts, the parser will ignore all WikiText punctuation until the code block ends.|
+|[[Images in WikiText]]|`[[img|literal image link text]]` - the text enclosed by square braces will be ignored. This means, for example, [[transclusions|Transclusion in WikiText]] and [[macro calls|Macro Calls in WikiText]] cannot be used to dynamically construct the link text|
+|[[Linking in WikiText]]|`[[literal link target|literal link text]]` - the text enclosed by square braces will be ignored. This means, for example, [[transclusions|Transclusion in WikiText]] and [[macro calls|Macro Calls in WikiText]] cannot be used to dynamically construct the link target or the link text|
+|[[Macro Calls in WikiText]]|`<<mymacro ''notbold'' "literal text" "<<macro_expansion_ignored>>" {{transclusion_ignored}}>>` - while processing the text enclosed by a macro call, the parser will follow special rules for detecting macro parameters. These rules do not include detection of WikiText. However, after the parameters are substituted into the macro definition, the result will be parsed using [[normal rules|Wiki Text Parser Modes]]. This will likely result in the detection of any WikiText.|
+

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText Parser Modes.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText Parser Modes.tid
@@ -1,0 +1,13 @@
+created: 20220110233944530
+modified: 20220122182842030
+tags: WikiText
+title: WikiText Parser Modes
+type: text/vnd.tiddlywiki
+
+The WikiText parser has three modes:
+
+* ''pragma mode'' - the parser will recognize only [[pragma mode WikiText|Pragma]] punctuation 
+* ''block mode'' - the parser will recognize only [[block mode WikiText|Block Mode WikiText]] punctuation
+* ''inline mode'' - the parser will recognize only [[inline mode WikiText|Inline Mode WikiText]]
+
+The parser [[transitions between these modes|WikiText parser mode transitions]] based on the text it encounters. In addition, there are  [[places where the parser ignores WikiText|Places where the parser ignores WikiText]] punctuation.

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText Parser Modes.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText Parser Modes.tid
@@ -6,8 +6,8 @@ type: text/vnd.tiddlywiki
 
 The WikiText parser has three modes:
 
-* ''pragma mode'' - the parser will recognize only [[pragma mode WikiText|Pragma]] punctuation 
-* ''block mode'' - the parser will recognize only [[block mode WikiText|Block Mode WikiText]] punctuation
-* ''inline mode'' - the parser will recognize only [[inline mode WikiText|Inline Mode WikiText]]
+* ''pragma mode'' - the parser will recognise only [[pragma mode WikiText|Pragma]] punctuation 
+* ''block mode'' - the parser will recognise only [[block mode WikiText|Block Mode WikiText]] punctuation
+* ''inline mode'' - the parser will recognise only [[inline mode WikiText|Inline Mode WikiText]]
 
 The parser [[transitions between these modes|WikiText parser mode transitions]] based on the text it encounters. In addition, there are  [[places where the parser ignores WikiText|Places where the parser ignores WikiText]] punctuation.

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode transitions.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode transitions.tid
@@ -1,0 +1,59 @@
+created: 20220110235808139
+modified: 20220122184232928
+tags: [[WikiText Parser Modes]]
+title: WikiText parser mode transitions
+type: text/vnd.tiddlywiki
+
+This is a <<.em rough>> diagram whose lines mostly correspond to the parser mode transitions described below:
+<$railroad text="""
+{<"pragma mode">
+{(
+  {<"inline mode"> +} |
+  ({<"block mode">
+    +("<<<" | "@@" | "$$")
+  }
+  "other block mode start punct")
+  {<"inline mode"> +}
+  )
+  +(
+    "block mode close punctuation" |
+    ("blank line" "html open tag")
+  )}
+  +("transclude widget" | "macrocall")
+}
+"""/>
+
+!! Start mode
+
+By default the parser starts in [[block mode|Block Mode WikiText]]. However, a tiddler can instead be transcluded with [[inline mode|Inline Mode WikiText]] in which case [[block mode WikiText|Block Mode WikiText]] will not be recognized.
+
+At the start of text only, the parser will also recognize any [[pragma mode WikiText|Pragma]].
+
+!! Transitions from pragma mode
+
+At the start of text, the parser will recognize any [[pragma|Pragma]]. If none are found then it will move to [[inline|Inline Mode WikiText]] or [[block|Block Mode WikiText]] mode depending on the transclusion mode. If any [[pragma|Pragma]] are found then it will continue looking for [[pragma|Pragma]] until it finds one or more blank lines not followed by the start of a new pragma.
+
+!! Transitions from block mode
+
+When the parser encounters most [[block mode|Block Mode WikiText]] start punctuation it transitions to [[inline mode|Inline Mode WikiText]]. This means
+he text enclosed by most [[block mode|Block Mode WikiText]] constructs will be parsed using [[inline mode|Inline Mode WikiText]].
+
+<<.tip """The start "punctuation" for a paragraph is "invisible". Even for paragraphs the parser moves to [[inline mode|Inline Mode WikiText]]""">>
+
+However, there are a few constructs whose enclosed text is parsed using [[block mode|Block Mode WikiText]]:
+
+* [[Multi-line block quotes|Block Quotes in WikiText]]
+* [[Multi-line style blocks|Styles and Classes in WikiText]]
+* [[Typed blocks|Typed Blocks in WikiText]]
+
+When the start punctuation for these are encountered, the enclosed text will continue to be parsed in [[block mode|Block Mode WikiText]].
+
+[[Horizontal rules|Horizontal Rules in WikiText]] are another special case. They do not enclose any text, so there is no opportunity for the parser to transition to [[inline mode|Inline Mode WikiText]].
+
+Opening [[widget|Widgets in WikiText]] or [[HTML|HTML in WikiText]] tags provide another way the parser can transition. When such a tag is <<.em not>> followed by a blank line, then the contents enclosed by the tag will be parsed in [[inline mode|Inline Mode WikiText]]. See the [[HTML examples|WikiText parser mode: HTML examples]].
+
+!! Transitions from inline mode
+
+* The parser will move back to [[block mode|Block Mode WikiText]] after the end of a line which terminates [[block mode|Block Mode WikiText]] ~WikiText. In other words, when the block mode close punctuation is encountered.
+* When the opening [[widget|Widgets in WikiText]] or [[HTML|HTML in WikiText]] tag is followed by a blank line, then the contents enclosed by the tag will be parsed in [[block mode|Block Mode WikiText]]. See the [[HTML examples|WikiText parser mode: HTML examples]].
+* Transcluded text and text pulled in via a macro call can transition the parser away from [[inline mode|Inline Mode WikiText]]. See [[transclusion examples|WikiText parser mode: transclusion examples]] and [[macro examples|WikiText parser mode: macro examples]] for more details.

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode transitions.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode transitions.tid
@@ -25,13 +25,13 @@ This is a <<.em rough>> diagram whose lines mostly correspond to the parser mode
 
 !! Start mode
 
-By default the parser starts in [[block mode|Block Mode WikiText]]. However, a tiddler can instead be transcluded with [[inline mode|Inline Mode WikiText]] in which case [[block mode WikiText|Block Mode WikiText]] will not be recognized.
+By default the parser starts in [[block mode|Block Mode WikiText]]. However, a tiddler can instead be transcluded with [[inline mode|Inline Mode WikiText]] in which case [[block mode WikiText|Block Mode WikiText]] will not be recognised.
 
-At the start of text only, the parser will also recognize any [[pragma mode WikiText|Pragma]].
+At the start of text only, the parser will also recognise any [[pragma mode WikiText|Pragma]].
 
 !! Transitions from pragma mode
 
-At the start of text, the parser will recognize any [[pragma|Pragma]]. If none are found then it will move to [[inline|Inline Mode WikiText]] or [[block|Block Mode WikiText]] mode depending on the transclusion mode. If any [[pragma|Pragma]] are found then it will continue looking for [[pragma|Pragma]] until it finds one or more blank lines not followed by the start of a new pragma.
+At the start of text, the parser will recognise any [[pragma|Pragma]]. If none are found then it will move to [[inline|Inline Mode WikiText]] or [[block|Block Mode WikiText]] mode depending on the transclusion mode. If any [[pragma|Pragma]] are found then it will continue looking for [[pragma|Pragma]] until it finds one or more blank lines not followed by the start of a new pragma.
 
 !! Transitions from block mode
 

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ HTML examples.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ HTML examples.tid
@@ -1,0 +1,72 @@
+created: 20220122153235162
+modified: 20220122180508134
+tags: [[WikiText parser mode transitions]]
+title: WikiText parser mode: HTML examples
+type: text/vnd.tiddlywiki
+
+<<wikitext-example-without-html "<div>
+
+* blank line after open tag allows
+* block mode punctuation (i.e. this list) to
+* be recognized
+</div>
+">>
+
+---
+
+The open tag blank line "trick" also works inside of punctuation only recognized in inline mode (such as [[Formatting in WikiText]]):
+
+<<wikitext-example-without-html "''<div>
+
+* list item one
+* list item two
+</div>''">>
+
+---
+
+<<wikitext-example-without-html "<div>
+* Open tag without a blank line means
+* block mode punctuation (i.e. this list) will
+* NOT be recognized.
+
+Paragraphs are only recognized in block mode. Even with blank lines, new paragraphs are not recognized.
+
+This also is not a new paragraph.
+</div>">>
+
+---
+
+[[Tables in WikiText]] is one construct for which the open tag blank line "trick" cannot work. In order for the parser to recognize a table row, the entire row must be on a single line.
+
+Adding a blank link after an open tag within a table cell causes the row to span mulitple lines and the parser ceases to be able to recognize it as a table row.
+
+<<wikitext-example-without-html "|table row|all on|one line|is recognized|">>
+
+<<wikitext-example-without-html "|For a blank line after open tag|<div>
+
+* list is recognized
+* but the surrounding table row is not
+</div>|">>
+
+---
+
+The only way to get [[block mode|Block Mode WikiText]] punctuation recognized in [[wikitext tables|Tables in WikiText]] is to use <<.wlink TranscludeWidget>> with <<.attr mode>> = <<.value block>>.
+
+<<wikitext-example-without-html '|Nested table:|<$transclude tiddler="table-example" mode=block/>|'>>
+
+Note that <<.wlink MacroCallWidget>> does not have a similar <<.attr mode>> attribute and the content of macro definitions can only be parsed in [[inline mode|Inline Mode WikiText]]
+
+---
+
+The less convenient `<table>`, `<tr>`, `<td>` html tags can be used as a foolproof way to get [[block mode|Block Mode WikiText]] punctuation recognized inside of table cells.
+
+<<wikitext-example-without-html "<table>
+<tr><td>
+
+* list item one
+* list item two
+</td><td>
+
+|nested|table|
+</td></tr>
+</table>">>

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ HTML examples.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ HTML examples.tid
@@ -8,13 +8,13 @@ type: text/vnd.tiddlywiki
 
 * blank line after open tag allows
 * block mode punctuation (i.e. this list) to
-* be recognized
+* be recognised
 </div>
 ">>
 
 ---
 
-The open tag blank line "trick" also works inside of punctuation only recognized in inline mode (such as [[Formatting in WikiText]]):
+The open tag blank line "trick" also works inside of punctuation only recognised in inline mode (such as [[Formatting in WikiText]]):
 
 <<wikitext-example-without-html "''<div>
 
@@ -27,30 +27,30 @@ The open tag blank line "trick" also works inside of punctuation only recognized
 <<wikitext-example-without-html "<div>
 * Open tag without a blank line means
 * block mode punctuation (i.e. this list) will
-* NOT be recognized.
+* NOT be recognised.
 
-Paragraphs are only recognized in block mode. Even with blank lines, new paragraphs are not recognized.
+Paragraphs are only recognised in block mode. Even with blank lines, new paragraphs are not recognised.
 
 This also is not a new paragraph.
 </div>">>
 
 ---
 
-[[Tables in WikiText]] is one construct for which the open tag blank line "trick" cannot work. In order for the parser to recognize a table row, the entire row must be on a single line.
+[[Tables in WikiText]] is one construct for which the open tag blank line "trick" cannot work. In order for the parser to recognise a table row, the entire row must be on a single line.
 
-Adding a blank link after an open tag within a table cell causes the row to span mulitple lines and the parser ceases to be able to recognize it as a table row.
+Adding a blank link after an open tag within a table cell causes the row to span mulitple lines and the parser ceases to be able to recognise it as a table row.
 
-<<wikitext-example-without-html "|table row|all on|one line|is recognized|">>
+<<wikitext-example-without-html "|table row|all on|one line|is recognised|">>
 
 <<wikitext-example-without-html "|For a blank line after open tag|<div>
 
-* list is recognized
+* list is recognised
 * but the surrounding table row is not
 </div>|">>
 
 ---
 
-The only way to get [[block mode|Block Mode WikiText]] punctuation recognized in [[wikitext tables|Tables in WikiText]] is to use <<.wlink TranscludeWidget>> with <<.attr mode>> = <<.value block>>.
+The only way to get [[block mode|Block Mode WikiText]] punctuation recognised in [[wikitext tables|Tables in WikiText]] is to use <<.wlink TranscludeWidget>> with <<.attr mode>> = <<.value block>>.
 
 <<wikitext-example-without-html '|Nested table:|<$transclude tiddler="table-example" mode=block/>|'>>
 
@@ -58,7 +58,7 @@ Note that <<.wlink MacroCallWidget>> does not have a similar <<.attr mode>> attr
 
 ---
 
-The less convenient `<table>`, `<tr>`, `<td>` html tags can be used as a foolproof way to get [[block mode|Block Mode WikiText]] punctuation recognized inside of table cells.
+The less convenient `<table>`, `<tr>`, `<td>` html tags can be used as a foolproof way to get [[block mode|Block Mode WikiText]] punctuation recognised inside of table cells.
 
 <<wikitext-example-without-html "<table>
 <tr><td>

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ macro examples.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ macro examples.tid
@@ -25,9 +25,9 @@ then
 </$macrocall>""">>
 </tbody></table>
 
-The list syntax is recognized in [[block mode|Block Mode WikiText]] and the enclosed contents are parsed using [[inline mode|Inline Mode WikiText]]. When the parser encounters a [[wikitext macro call|Macro Calls in WikiText]] it will use the current parse mode to parse the contents of the macro. The contents of the macro contains table syntax which is only recognized in [[block mode|Block Mode WikiText]]. 
+The list syntax is recognised in [[block mode|Block Mode WikiText]] and the enclosed contents are parsed using [[inline mode|Inline Mode WikiText]]. When the parser encounters a [[wikitext macro call|Macro Calls in WikiText]] it will use the current parse mode to parse the contents of the macro. The contents of the macro contains table syntax which is only recognised in [[block mode|Block Mode WikiText]]. 
 
-Therefore, in #1 above the table syntax is not recognized. In #2 above, the blank line after the open `div` tag moves the parser back into [[block mode|Block Mode WikiText]], the macro call inherits it and the table is recognized.
+Therefore, in #1 above the table syntax is not recognised. In #2 above, the blank line after the open `div` tag moves the parser back into [[block mode|Block Mode WikiText]], the macro call inherits it and the table is recognised.
 
 When calling macros using the [[widget|MacroCallWidget]], the parse mode will be inline (#3 and #4 above) unless it is written as an open tag with a following blank line (#5 above).
 

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ macro examples.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ macro examples.tid
@@ -1,0 +1,55 @@
+created: 20220122144742419
+modified: 20220122180929683
+tags: [[WikiText parser mode transitions]]
+title: WikiText parser mode: macro examples
+type: text/vnd.tiddlywiki
+
+\define boringtable()
+|cell one|cell two|
+|cell three|cell four|
+\end
+With the macro `boringtable` defined as:
+<$codeblock code=<<boringtable>>/>
+then
+<table><<wikitext-example-table-header>><tbody>
+<<wikitext-example-table-row 1 "* <<boringtable>>">>
+<<wikitext-example-table-row 2 """* <div>
+
+<<boringtable>>
+</div>
+""">>
+<<wikitext-example-table-row 3 "* <$macrocall $name=boringtable/>">>
+<<wikitext-example-table-row 4 "* <$macrocall $name=boringtable></$macrocall>">>
+<<wikitext-example-table-row 5 """* <$macrocall $name=boringtable>
+
+</$macrocall>""">>
+</tbody></table>
+
+The list syntax is recognized in [[block mode|Block Mode WikiText]] and the enclosed contents are parsed using [[inline mode|Inline Mode WikiText]]. When the parser encounters a [[wikitext macro call|Macro Calls in WikiText]] it will use the current parse mode to parse the contents of the macro. The contents of the macro contains table syntax which is only recognized in [[block mode|Block Mode WikiText]]. 
+
+Therefore, in #1 above the table syntax is not recognized. In #2 above, the blank line after the open `div` tag moves the parser back into [[block mode|Block Mode WikiText]], the macro call inherits it and the table is recognized.
+
+When calling macros using the [[widget|MacroCallWidget]], the parse mode will be inline (#3 and #4 above) unless it is written as an open tag with a following blank line (#5 above).
+
+<<.tip "See also [[WikiText parser mode: transclusion examples]] for similar examples">>
+
+---
+
+These examples have slightly different behavior. In the previous section, the macro calls were enclosed within list items.  In these examples, the macro calls are at the top level:
+<table><<wikitext-example-table-header>><tbody>
+<<wikitext-example-table-row 1 "<<boringtable>>">>
+<<wikitext-example-table-row 2 """<div>
+
+<<boringtable>>
+</div>
+""">>
+<<wikitext-example-table-row 3 "<$macrocall $name=boringtable/>">>
+<<wikitext-example-table-row 4 "<$macrocall $name=boringtable></$macrocall>">>
+<<wikitext-example-table-row 5 """<$macrocall $name=boringtable>
+
+</$macrocall>""">>
+</tbody></table>
+
+Of these examples, only the two <<.wlink MacroCallWidget>> tags which are not followed by a blank line are parsed using [[inline mode|Inline Mode WikiText]].
+
+<<.tip "See also [[WikiText parser mode: transclusion examples]] for similar examples">>

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ transclusion examples.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ transclusion examples.tid
@@ -1,0 +1,56 @@
+created: 20220122145022547
+modified: 20220122180845946
+tags: [[WikiText parser mode transitions]]
+title: WikiText parser mode: transclusion examples
+type: text/vnd.tiddlywiki
+
+
+Given the tiddler  [[table-example]] defined with these contents:
+<$codeblock code={{table-example}}/>
+then
+<table><<wikitext-example-table-header>><tbody>
+<<wikitext-example-table-row 1 "* {{table-example}}">>
+<<wikitext-example-table-row 2 """* <div>
+
+{{table-example}}
+</div>
+""">>
+<<wikitext-example-table-row 3 "* <$transclude tiddler=table-example/>">>
+<<wikitext-example-table-row 4 "* <$transclude tiddler=table-example></$transclude>">>
+<<wikitext-example-table-row 5 """* <$transclude tiddler=table-example>
+
+</$transclude>""">>
+<<wikitext-example-table-row  6 "* <$transclude tiddler=table-example mode=block/>">>
+</tbody></table>
+
+The list syntax is recognized in [[block mode|Block Mode WikiText]] and the enclosed contents are parsed using [[inline mode|Inline Mode WikiText]]. When the parser encounters a [[wikitext transclusion|Transclusion in WikiText]] it will use the current parse mode to parse the contents of the transcluded tiddler. The contents of the example tiddler contains table syntax which is only recognized in [[block mode|Block Mode WikiText]]. 
+
+Therefore, in #1 above the table syntax is not recognized. In #2 above, the blank line after the open `div` tag moves the parser back into [[block mode|Block Mode WikiText]], the transcluded text inherits it and the table is recognized.
+
+When transcluding tiddlers using the [[widget|TranscludeWidget]], the parse mode will be inline (#3 and #4 above) unless it is written as an open tag with a following blank line (#5 above).
+
+<<.tip "See also [[WikiText parser mode: macro examples]] for similar examples. The only difference here is <<.wlink TranscludeWidget>> has a <<.attr mode>> attribute (extra example #6) which allows the parse mode to be explicitly overridden rather than come implicitly based on the they way the tag is written">>
+
+---
+
+In these examples, the transclusions are at the top level instead of enclosed in list items:
+
+<table><<wikitext-example-table-header>><tbody>
+<<wikitext-example-table-row 1 "{{table-example}}">>
+<<wikitext-example-table-row 2 """<div>
+
+{{table-example}}
+</div>
+""">>
+<<wikitext-example-table-row 3 "<$transclude tiddler=table-example/>">>
+<<wikitext-example-table-row 4 "<$transclude tiddler=table-example></$transclude>">>
+<<wikitext-example-table-row 5 """<$transclude tiddler=table-example>
+
+</$transclude>""">>
+<<wikitext-example-table-row  6 "<$transclude tiddler=table-example mode=inline/>">>
+</tbody></table>
+
+
+Of these examples, only the two <<.wlink TranscludeWidget>> tags which are not followed by a blank line and the widget call using <<.attr mode>>=<<.value inline>> are parsed using [[inline mode|Inline Mode WikiText]].
+
+<<.tip "See also [[WikiText parser mode: macro examples]] for similar examples">>

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ transclusion examples.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText parser mode_ transclusion examples.tid
@@ -23,9 +23,9 @@ then
 <<wikitext-example-table-row  6 "* <$transclude tiddler=table-example mode=block/>">>
 </tbody></table>
 
-The list syntax is recognized in [[block mode|Block Mode WikiText]] and the enclosed contents are parsed using [[inline mode|Inline Mode WikiText]]. When the parser encounters a [[wikitext transclusion|Transclusion in WikiText]] it will use the current parse mode to parse the contents of the transcluded tiddler. The contents of the example tiddler contains table syntax which is only recognized in [[block mode|Block Mode WikiText]]. 
+The list syntax is recognised in [[block mode|Block Mode WikiText]] and the enclosed contents are parsed using [[inline mode|Inline Mode WikiText]]. When the parser encounters a [[wikitext transclusion|Transclusion in WikiText]] it will use the current parse mode to parse the contents of the transcluded tiddler. The contents of the example tiddler contains table syntax which is only recognised in [[block mode|Block Mode WikiText]]. 
 
-Therefore, in #1 above the table syntax is not recognized. In #2 above, the blank line after the open `div` tag moves the parser back into [[block mode|Block Mode WikiText]], the transcluded text inherits it and the table is recognized.
+Therefore, in #1 above the table syntax is not recognised. In #2 above, the blank line after the open `div` tag moves the parser back into [[block mode|Block Mode WikiText]], the transcluded text inherits it and the table is recognised.
 
 When transcluding tiddlers using the [[widget|TranscludeWidget]], the parse mode will be inline (#3 and #4 above) unless it is written as an open tag with a following blank line (#5 above).
 

--- a/editions/tw5.com/tiddlers/wikitext/parser/table-example.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/table-example.tid
@@ -1,0 +1,8 @@
+created: 20220118023452157
+modified: 20220118023529825
+tags: [[WikiText parser mode transitions (Examples)]]
+title: table-example
+type: text/vnd.tiddlywiki
+
+|cell one|cell two|
+|cell three|cell four|


### PR DESCRIPTION
Added documentation and examples about WikiText parser modes and how the parser transitions between them.

Rendered version with all the new tiddlers opened by default can be seen at http://btheado.github.io/TiddlyWiki5/wikitext-parser-mode-docs.html