### PR TITLE
Add warnings about non-recursive nature of dynamic attribute values

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
@@ -1,6 +1,6 @@
 caption: HTML
 created: 20131205160816081
-modified: 20220122192311669
+modified: 20220123174919252
 tags: WikiText
 title: HTML in WikiText
 type: text/vnd.tiddlywiki
@@ -94,6 +94,7 @@ attr={{tiddler}}
 attr={{!!field}}
 attr={{tiddler!!field}}
 ```
+<<.warning "The attribute's value will be the exact text retrieved from the TextReference. Any wiki syntax in that text will be left as-is.">>
 
 !! Variable Attribute Values
 
@@ -104,6 +105,7 @@ Variable attribute values are indicated with double angle brackets around a [[ma
 ...
 </div>
 ```
+<<.warning "The text from the macro's definition will be retrieved and text substitution will be performed (i.e. <<.param $param$>> and <<.param &#36;(...)&#36;>> syntax). The attribute's value will be the resulting text. Any wiki syntax in that text (including further macro calls and variable references) will be left as-is.">>
 
 !! Filtered Attribute Values
 
@@ -114,4 +116,4 @@ This example shows how to add a prefix to a value:
 ```
 <$text text={{{ [<currentTiddler>addprefix[$:/myprefix/]] }}} />
 ```
-
+<<.warning "The attribute's value will be the exact text from the first item in the resulting list. Any wiki syntax in that text will be left as-is.">>


### PR DESCRIPTION
It is easy for a user to mistakenly assume dynamic attribute values will be recursively expanded. Added warnings to the documentation in order to dispel those assumptions.

See also @Jermolene's excellent explanation:
 
https://groups.google.com/g/tiddlywiki/c/l6SHB8fIUCM/m/3goZVXQBBAAJ?utm_medium=email&utm_source=footer