### PR TITLE
Add keyword-spacing rule to .eslintrc.yml to reflect the project code style.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,15 +1,8 @@
-# Known minified files
+# Ignore "third party" code whose style we will not change.
 /boot/sjcl.js
+/core/modules/utils/base64-utf8/base64-utf8.module.js
 /core/modules/utils/base64-utf8/base64-utf8.module.min.js
 /core/modules/utils/diff-match-patch/diff_match_patch.js
-/plugins/tiddlywiki/async/files/async.min.v1.5.0.js
-/plugins/tiddlywiki/codemirror-autocomplete/files/addon/hint/anyword-hint.js
-/plugins/tiddlywiki/codemirror-autocomplete/files/addon/hint/css-hint.js
-/plugins/tiddlywiki/codemirror-autocomplete/files/addon/hint/html-hint.js
-/plugins/tiddlywiki/codemirror-autocomplete/files/addon/hint/javascript-hint.js
-/plugins/tiddlywiki/codemirror-autocomplete/files/addon/hint/show-hint.js
-/plugins/tiddlywiki/codemirror-autocomplete/files/addon/hint/xml-hint.js
-/plugins/tiddlywiki/codemirror-closebrackets/files/addon/edit/closebrackets.js
-/plugins/tiddlywiki/codemirror-closebrackets/files/addon/edit/matchbrackets.js
-/plugins/tiddlywiki/codemirror-closetag/files/addon/edit/closetag.js
-/plugins/tiddlywiki/codemirror-closetag/files/addon/fold/xml-fold.js
+/core/modules/utils/diff-match-patch/diff_match_patch_uncompressed.js
+/core/modules/utils/dom/csscolorparser.js
+/plugins/tiddlywiki/*/files/

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -64,7 +64,23 @@ rules:
   init-declarations: 'off'
   jsx-quotes: error
   key-spacing: 'off'
-  keyword-spacing: 'off'
+  keyword-spacing:
+    - error
+    - before: true
+      after: false
+      overrides:
+        'case':
+          after: true
+        'do':
+          'after': true
+        'else':
+          after: true
+        'return':
+          after: true
+        'throw':
+          after: true
+        'try':
+          after: true
   line-comment-position: 'off'
   linebreak-style: 'off'
   lines-around-comment: 'off'

--- a/package.json
+++ b/package.json
@@ -23,13 +23,16 @@
     "tiddlywiki5",
     "wiki"
   ],
-  "dependencies": {},
   "devDependencies": {
-    "eslint": "^7.10.0"
+    "eslint": "^7.32.0"
   },
   "bundleDependencies": [],
   "license": "BSD",
   "engines": {
     "node": ">=0.8.2"
+  },
+  "scripts": {
+    "lint": "eslint ."
   }
+
 }


### PR DESCRIPTION
- Update .eslintignore to ignore "third party" code.
- Add a "lint" script to package.json so `npm run lint` runs eslint on the repo.