### PR TITLE
Fixed issue: deprecated regexp could cause crash

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -95,7 +95,11 @@ function parseFilterOperation(operators,filterString,p) {
 			if(nextBracketPos === -1) {
 				throw "Missing closing bracket in filter expression";
 			}
-			operand.text = filterString.substring(p,nextBracketPos);
+			if(operator.regexp) {
+				operand.text = "";
+			} else {
+				operand.text = filterString.substring(p,nextBracketPos);
+			}
 			operator.operands.push(operand);
 			p = nextBracketPos + 1;
 		}

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -95,10 +95,8 @@ function parseFilterOperation(operators,filterString,p) {
 			if(nextBracketPos === -1) {
 				throw "Missing closing bracket in filter expression";
 			}
-			if(!operator.regexp) {
-				operand.text = filterString.substring(p,nextBracketPos);
-				operator.operands.push(operand);
-			}
+			operand.text = filterString.substring(p,nextBracketPos);
+			operator.operands.push(operand);
 			p = nextBracketPos + 1;
 		}
 

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -256,6 +256,16 @@ Tests the filtering mechanism.
 			expect(wiki.filterTiddlers("[modifier/Jo/]").join(",")).toBe("TiddlerOne,$:/TiddlerTwo,Tiddler Three,a fourth tiddler,one");
 			expect(console.log).toHaveBeenCalledWith("WARNING: Filter", "modifier", "has a deprecated regexp operand", /Jo/);
 		});
+
+		it("should handle regular expression operands without crashing", function() {
+			spyOn(console, 'log');
+			// We don't really care about the results. Just don't get RSoD.
+			expect(() => wiki.filterTiddlers("[all/current/]")).not.toThrow();
+			expect(() => wiki.filterTiddlers("[prefix/anything/]")).not.toThrow();
+			expect(() => wiki.filterTiddlers("[title/anything/]")).not.toThrow();
+			expect(() => wiki.filterTiddlers("[/anything/]")).not.toThrow();
+			expect(() => wiki.filterTiddlers("[//]")).not.toThrow();
+		});
 	
 		it("should handle the prefix operator", function() {
 			expect(wiki.filterTiddlers("[prefix[Tiddler]]").join(",")).toBe("TiddlerOne,Tiddler Three");


### PR DESCRIPTION
Found this issue while writing unit tests for TW5-Uglify.

If you use the deprecated [regexp/operators/] in many contexts, it causes the RSoD. Even "[//]" crashes Tiddlywiki.

The problem occurs because so many filter operators assume there will always be at least one operand. Regexp operators were the exception. My change makes it so the regexp operand is included. Most operators will not test for "regexp" and will treat it like a string operand, but whatever. Better than crashing.

I've never understood how these operators were supposed to work, so let me know if this fix is wrong.