### PR TITLE
Is draft

### DIFF
--- a/core/modules/filters/is/draft.js
+++ b/core/modules/filters/is/draft.js
@@ -19,7 +19,7 @@ exports.draft = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {
 		source(function(tiddler,title) {
-			if(!tiddler || !$tw.utils.hop(tiddler.fields,"draft.of")) {
+			if(!tiddler || !$tw.utils.hop(tiddler.fields,"draft.of") || (tiddler.fields["draft.of"].length === 0)) {
 				results.push(title);
 			}
 		});

--- a/core/modules/filters/is/draft.js
+++ b/core/modules/filters/is/draft.js
@@ -19,13 +19,13 @@ exports.draft = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {
 		source(function(tiddler,title) {
-			if(!tiddler || !$tw.utils.hop(tiddler.fields,"draft.of") || (tiddler.fields["draft.of"].length === 0)) {
+			if(!tiddler || !tiddler.isDraft()) {
 				results.push(title);
 			}
 		});
 	} else {
 		source(function(tiddler,title) {
-			if(tiddler && $tw.utils.hop(tiddler.fields,"draft.of") && (tiddler.fields["draft.of"].length !== 0)) {
+			if(tiddler && tiddler.isDraft()) {
 				results.push(title);
 			}
 		});

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -463,6 +463,24 @@ Tests the filtering mechanism.
 				expect(wiki.filterTiddlers("[!title[Tiddler Three]is[orphan]sort[title]]").join(",")).toBe("a fourth tiddler,filter regexp test,TiddlerOne");
 				expect(wiki.filterTiddlers("[!title[Tiddler Three]!is[orphan]]").join(",")).toBe("$:/ShadowPlugin,$:/TiddlerTwo,one,hasList,has filter");
 			});
+
+			it("should handle the '[is[draft]]' operator", function() {
+				var wiki = new $tw.Wiki();
+				wiki.addTiddlers([
+					{title: "A"},
+					{title: "Draft of 'A'", "draft.of": "A", "draft.title": "A"},
+					{title: "B"},
+					{title: "Draft of 'B'", "draft.of": "B"},
+					{title: "C"},
+					{title: "Draft of 'C'", "draft.title": "C"},
+					{title: "E"},
+					{title: "Draft of 'E'", "draft.of": "", "draft.title": ""}
+					//{title: "F"} // This one is deliberately missing
+				]);
+				expect(wiki.filterTiddlers("[all[]] F +[is[draft]]")).toEqual(wiki.filterTiddlers("[all[]] F +[has[draft.of]]"));
+				expect(wiki.filterTiddlers("[all[]] F +[!is[draft]]")).toEqual(wiki.filterTiddlers("[all[]] F +[!has[draft.of]]"));
+
+			});
 	
 		});
 	

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -472,14 +472,18 @@ Tests the filtering mechanism.
 					{title: "B"},
 					{title: "Draft of 'B'", "draft.of": "B"},
 					{title: "C"},
+					// Not a true draft. Doesn't have draft.of
 					{title: "Draft of 'C'", "draft.title": "C"},
 					{title: "E"},
+					// Broken. Has draft.of, but it's empty. Still a draft
 					{title: "Draft of 'E'", "draft.of": "", "draft.title": ""}
+					// Not a draft. It doesn't exist.
 					//{title: "F"} // This one is deliberately missing
 				]);
-				// is analagous to [has[draft.of]]
-				expect(wiki.filterTiddlers("[all[]] F +[is[draft]]")).toEqual(wiki.filterTiddlers("[all[]] F +[has[draft.of]]"));
-				expect(wiki.filterTiddlers("[all[]] F +[!is[draft]]")).toEqual(wiki.filterTiddlers("[all[]] F +[!has[draft.of]]"));
+				// is analagous to [has[draft.of]],
+				// except they handle empty draft.of differently
+				expect(wiki.filterTiddlers("[all[]] F +[is[draft]]").join(",")).toEqual("Draft of 'A',Draft of 'B',Draft of 'E'");
+				expect(wiki.filterTiddlers("[all[]] F +[!is[draft]]").join(",")).toEqual("A,B,C,Draft of 'C',E,F");
 				// [is[draft]] and [!is[draft]] are proper complements
 				var included = wiki.filterTiddlers("[all[]] F +[is[draft]]")
 				var excluded = wiki.filterTiddlers("[all[]] F +[!is[draft]]")

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -477,9 +477,15 @@ Tests the filtering mechanism.
 					{title: "Draft of 'E'", "draft.of": "", "draft.title": ""}
 					//{title: "F"} // This one is deliberately missing
 				]);
+				// is analagous to [has[draft.of]]
 				expect(wiki.filterTiddlers("[all[]] F +[is[draft]]")).toEqual(wiki.filterTiddlers("[all[]] F +[has[draft.of]]"));
 				expect(wiki.filterTiddlers("[all[]] F +[!is[draft]]")).toEqual(wiki.filterTiddlers("[all[]] F +[!has[draft.of]]"));
-
+				// [is[draft]] and [!is[draft]] are proper complements
+				var included = wiki.filterTiddlers("[all[]] F +[is[draft]]")
+				var excluded = wiki.filterTiddlers("[all[]] F +[!is[draft]]")
+				var all = [].concat(included, excluded).sort();
+				// combined, they should have exactly one of everything.
+				expect(wiki.filterTiddlers("[all[]] F +[sort[]]")).toEqual(all);
 			});
 	
 		});


### PR DESCRIPTION
Found another problem while writing Uglifier tests.

[is[draft]] is analogous to [has[draft.of]], but [!is[draft]] is _not_ analogous to [!has[draft.of]], nor is it the true complement of [is[draft]], nor was it ever tested.

I've added an adjustment to make [is[draft]] and [!is[draft]] proper complements of each other. This should not cause any trouble with end-users and backward compatibility, because it's actually really tough to make a tiddler with a blank "draft.of" field, which is the one place where they were incorrect.