### PR TITLE
[fr_FR] French translation update

### DIFF
--- a/editions/fr-FR/tiddlers/$ _editions_tw5.com_doc-macros.tid
+++ b/editions/fr-FR/tiddlers/$ _editions_tw5.com_doc-macros.tid
@@ -1,0 +1,174 @@
+created: 20150117152607000
+modified: 20220220000852855
+tags: $:/tags/Macro
+title: $:/editions/tw5.com/doc-macros
+type: text/vnd.tiddlywiki
+
+\define .concat(1,2,3,4,5) $1$$2$$3$$4$$5$
+
+\define .def(_) <dfn class="doc-def">$_$</dfn>
+\define .em(_) <em class="doc-em">$_$</em>
+\define .strong(_) <strong class="doc-strong">$_$</strong>
+\define .place(_) <code class="doc-place">$_$</code>
+\define .word(_) "$_$"
+
+\define .preamble(_) :.doc-preamble $_$
+\define .note(_)
+@@.doc-note
+;Note
+: $_$
+@@
+\end
+
+\define .tid(_) <code class="doc-tiddler">$_$</code>
+\define .tag(_) <code class="doc-tag">$_$</code>
+\define .field(_) <code class="doc-field">$_$</code>
+\define .value(_) <code class="doc-value">$_$</code>
+\define .op(_) <code class="doc-operator">$_$</code>
+\define .var(_) <code class="doc-var">$_$</code>
+\define .wid(_) <code class="doc-widget">$$_$</code>
+\define .attr(_) <code class="doc-attr">$_$</code>
+\define .param(_) <code class="doc-param">$_$</code>
+
+\define .mtitle(_) $_$ Macro
+\define .otitle(_) $_$ Operator
+\define .vtitle(_) $_$ Variable
+
+\define .link(_,to) <$link to="$to$">$_$</$link>
+\define .clink(_,to) <span class="doc-clink"><<.link """$_$""" "$to$">></span>
+\define .dlink(_,to) <$macrocall $name=".link" _=<<.def "$_$">> to="$to$">/>
+\define .dlink-ex(_,to) <a href="$to$" class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><<.def "$_$">></a>
+\define .flink(to) <$macrocall $name=".link" _=<<.field {{$to$!!caption}}>> to="$to$"/>
+\define .mlink(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to=<<.mtitle "$_$">>/>
+\define .mlink2(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to="$to$"/>
+\define .olink(_) <$macrocall $name=".link" _=<<.op "$_$">> to=<<.otitle "$_$">>/>
+\define .olink2(_,to) <$macrocall $name=".link" _=<<.op "$_$">> to=<<.otitle "$to$">>/>
+\define .vlink(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to=<<.vtitle "$_$">>/>
+\define .vlink2(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to="$to$"/>
+\define .wlink(to) <$macrocall $name=".link" _=<<.wid {{$to$!!caption}}>> to="$to$"/>
+\define .wlink2(_,to) <$macrocall $name=".link" _="$_$" to="$to$"/>
+
+\define .key(_) <span class="doc-key">$_$</span>
+\define .combokey(_) <$macrocall $name=".if" cond="$_$" then=<<.key '$_$'>>/>
+\define .keycombo(1,2,3,4) <<.combokey "$1$">><<.if "$2$" +>><<.combokey "$2$">><<.if "$3$" +>><<.combokey "$3$">><<.if "$4$" +>><<.combokey "$4$">>
+
+\define .tab(_) <span class="doc-tab">{{$_$!!caption}}</span>
+\define .sidebar-tab(_) <<.tab "$:/core/ui/SideBar/$_$">>
+\define .more-tab(_) <<.tab "$:/core/ui/MoreSideBar/$_$">>
+\define .info-tab(_) <<.tab "$:/core/ui/TiddlerInfo/$_$">>
+\define .controlpanel-tab(_) <<.tab "$:/core/ui/ControlPanel/$_$">>
+\define .advancedsearch-tab(_) <<.tab "$:/core/ui/AdvancedSearch/$_$">>
+\define .toc-tab() <<.tab "TableOfContents">>
+\define .example-tab(_) <span class="doc-tab">$_$</span>
+
+\define .button(_) <span class="doc-button">{{$:/core/ui/Buttons/$_$!!caption}}</span>
+
+\define .icon(_) <span class="doc-icon">{{$_$}}</span>
+
+\define .tip(_) <div class="doc-icon-block"><div class="doc-block-icon">{{$:/core/images/tip}}</div> $_$</div>
+\define .warning(_) <div class="doc-icon-block"><div class="doc-block-icon">{{$:/core/images/warning}}</div> $_$</div>
+
+\define .state-prefix() $:/state/editions/tw5.com/
+
+\define .lorem()
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+\end
+
+\define .toc-lorem()
+C'est un exemple de tiddler. Voir [[Macros Table des matières (Exemples)|Table-of-Contents Macros (Examples)]].
+
+<<.lorem>>
+\end
+
+\define .example(n,eg,egvar:NO-SUCH-VAR)
+<div class="doc-example">
+<$reveal default="$egvar$" type="match" text="NO-SUCH-VAR">
+	<$macrocall $name="copy-to-clipboard-above-right" src="""$eg$"""/>
+	<$codeblock code="""$eg$"""/>
+</$reveal>
+<$reveal default="$egvar$" type="nomatch" text="NO-SUCH-VAR">
+	<!-- allow an example to contain """ -->
+	<$macrocall $name="copy-to-clipboard-above-right" src=<<$egvar$>>/>
+	<$codeblock code=<<$egvar$>>/>
+</$reveal>
+<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix[$n$]]" variable=".state">
+<$reveal state=<<.state>> type="nomatch" text="show">
+	<dl>
+	<dd><$button set=<<.state>> setTo="show">Essayez</$button></dd>
+	</dl>
+</$reveal>
+<$reveal state=<<.state>> type="match" text="show">
+	<dl>
+	<dd><$button set=<<.state>> setTo="">Cachez</$button></dd>
+	</dl>
+	<blockquote class="doc-example-result">
+	<$reveal default="$egvar$" type="match" text="NO-SUCH-VAR">
+		$eg$
+	</$reveal>
+	<$reveal default="$egvar$" type="nomatch" text="NO-SUCH-VAR">
+		<<$egvar$>>
+	</$reveal>
+	</blockquote>
+</$reveal>
+</$list>
+\end
+
+\define .bad-example(eg)
+<table class="doc-bad-example">
+<tbody>
+<tr class="evenRow">
+<td><span class="tc-inline-style" style="font-size:1.5em;">&#9888;</span> Warning:<br> Don't do it this way!</td>
+<td>
+
+$eg$
+</td>
+</tr>
+</tbody>
+</table>
+\end
+
+\define .link-badge(text,link,colour)
+<a href=<<__link__>> class="doc-link-badge" style="background-color:$colour$;" target="_blank" rel="noopener noreferrer"><$text text=<<__text__>>/></a>
+\end
+
+
+\define .link-badge-added(link,colour:#ffe246) <<.link-badge "added" """$link$""" """$colour$""">>
+\define .link-badge-addendum(link,colour:#fcc84a) <<.link-badge "addendum" """$link$""" """$colour$""">>
+\define .link-badge-extended(link,colour:#f9a344) <<.link-badge "extended" """$link$""" """$colour$""">>
+\define .link-badge-fixed(link,colour:#ffa86d) <<.link-badge "fixed" """$link$""" """$colour$""">>
+\define .link-badge-here(link,colour:#d88e63) <<.link-badge "here" """$link$""" """$colour$""">>
+\define .link-badge-hide(link,colour:#9d959f) <<.link-badge "hide" """$link$""" """$colour$""">>
+\define .link-badge-improved(link,colour:#7593c7) <<.link-badge "improved" """$link$""" """$colour$""">>
+\define .link-badge-modified(link,colour:#7f99c9) <<.link-badge "modified" """$link$""" """$colour$""">>
+\define .link-badge-removed(link,colour:#a9aabc) <<.link-badge "removed" """$link$""" """$colour$""">>
+\define .link-badge-renamed(link,colour:#b4b995) <<.link-badge "renamed" """$link$""" """$colour$""">>
+\define .link-badge-updated(link,colour:#91ba66) <<.link-badge "updated" """$link$""" """$colour$""">>
+
+\define .tiddler-fields(tiddler)
+<$tiddler tiddler=<<__tiddler__>>>
+<div class="doc-tiddler-fields">
+<h2>
+<$link>
+<span class="tc-tiddler-title-icon">{{||$:/core/ui/TiddlerIcon}}</span><$text text=<<currentTiddler>>/>
+</$link>
+</h2>
+<table class="tc-view-field-table">
+<tbody>
+<$list filter="[all[current]fields[]sort[title]] -title" template="$:/core/ui/TiddlerFieldTemplate" variable="listItem"/>
+</tbody>
+</table>
+</div>
+</$tiddler>
+\end
+
+\define .banner-credits(credit,url)
+<img src=<<__url__>> width="140" style="float:left;margin-right:0.5em;"/>
+
+$credit$
+
+<div style="clear:both;">
+
+</div>
+\end
+
+<pre><$view field="text"/></pre>

--- a/editions/fr-FR/tiddlers/$__editions_fr-FR_util-macros.tid
+++ b/editions/fr-FR/tiddlers/$__editions_fr-FR_util-macros.tid
@@ -36,3 +36,4 @@ type: text/vnd.tiddlywiki
 <!-- NO-BREAK SPACE Unicode: U+00A0, UTF-8: C2 A0, ISO-8859-1: A0 -->
 «&#160;$text$&#160;»
 \end
+\define fr(cible) <$link to="$cible$"><$view tiddler="$cible$" field="fr-title">{{$cible$!!title}}</$view></$link>

--- a/editions/fr-FR/tiddlers/Community Links Aggregator.tid
+++ b/editions/fr-FR/tiddlers/Community Links Aggregator.tid
@@ -1,0 +1,12 @@
+created: 20210322151848025
+fr-title: Agrégateur de liens communautaire
+modified: 20220217174626896
+tags: Community
+title: Community Links Aggregator
+wl-field-name-note: C.text
+
+L'Agrégateur de liens communautaire est une collection fréquemment mise à jour de liens vers des ressources utiles et intéressantes sur <<tw>>, dénichés par notre équipe d'éditeurs communautaires. Le site agrège les liens soigneusement sélectionnés par les membres de la communauté <<tw>>. Il permet de visualiser les liens les plus récents, et de les explorer par catégorie et chronologiquement.
+
+https://links.tiddlywiki.com/
+
+Plus les contributeurs sont nombreux, et mieux le site fonctionne<<!>> Comme chacun n'est pas tenu de recenser chaque lien qui passe, la pression individuelle sur les contributeurs est réduite. L'agrégation des liens réduit aussi l'impact d'une erreur, par exemple d'une erreur de catégorisation<<:>> si un contributeur catégorise un lien dans la mauvaise rubrique, le site permet de voir qu'une seule personne a utilisé cette rubrique, alors que la majorité utilise la catégorie appropriée. Ainsi, nous espérons qu'une sorte de //intelligence collective// émergera, avec un consensus sur la manière la plus utile de décrire et de catégoriser les liens.

--- a/editions/fr-FR/tiddlers/Community Links Aggregator.tid
+++ b/editions/fr-FR/tiddlers/Community Links Aggregator.tid
@@ -3,7 +3,6 @@ fr-title: Agrégateur de liens communautaire
 modified: 20220217174626896
 tags: Community
 title: Community Links Aggregator
-wl-field-name-note: C.text
 
 L'Agrégateur de liens communautaire est une collection fréquemment mise à jour de liens vers des ressources utiles et intéressantes sur <<tw>>, dénichés par notre équipe d'éditeurs communautaires. Le site agrège les liens soigneusement sélectionnés par les membres de la communauté <<tw>>. Il permet de visualiser les liens les plus récents, et de les explorer par catégorie et chronologiquement.
 

--- a/editions/fr-FR/tiddlers/Community.tid
+++ b/editions/fr-FR/tiddlers/Community.tid
@@ -1,10 +1,13 @@
-fr-title: Communauté
 created: 20130909151600000
-modified: 20141019103047540
+fr-title: Communauté
+modified: 20220217155910582
 tags: TableOfContents
 title: Community
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
-C'est ici que nous rassemblons les dernières productions les plus utiles en provenance de la communauté <<tw>>.
+<<.tip "Les liens les plus utiles et les plus récents sont maintenant regroupés dans [[l’Agrégateur de liens communautaire|Community Links Aggregator]].">>
 
-<<tabs "Forums Latest Tutorials Resources Examples Articles Meetups" "Latest">>
+Lorsque tous les liens pertinents auront été transférés, ces entrées seront retirées du site tiddlywiki.com.
+
+<<tabs "Forums Latest Tutorials [[Community Editions]] [[Community Plugins]] [[Community Themes]] [[Community Palettes]] [[Other Resources]] Examples Articles Meetups" "Latest">>

--- a/editions/fr-FR/tiddlers/Community.tid
+++ b/editions/fr-FR/tiddlers/Community.tid
@@ -4,7 +4,6 @@ modified: 20220217155910582
 tags: TableOfContents
 title: Community
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 <<.tip "Les liens les plus utiles et les plus récents sont maintenant regroupés dans [[l’Agrégateur de liens communautaire|Community Links Aggregator]].">>
 

--- a/editions/fr-FR/tiddlers/Developers.tid
+++ b/editions/fr-FR/tiddlers/Developers.tid
@@ -1,12 +1,18 @@
 created: 20150412191004348
 fr-title: Développeurs
-modified: 20150621192259510
+modified: 20220217174800697
 tags: Community
 title: Developers
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
-Les développeurs disposent de plusieurs ressources pour discuter et contribuer au développement de TiddlyWiki.
+Plusieurs ressources permettent aux développeurs d'en apprendre plus sur <<tw>>, de collaborer et de discuter de son développement.
 
-* [[tiddlywiki.com/dev|https://tiddlywiki.com/dev]] la documentation officielle de développement 
-* [[TiddlyWikiDev group|http://groups.google.com/group/TiddlyWikiDev]] pour les discussions au sujet du développement de TiddlyWiki
-* https://github.com/Jermolene/TiddlyWiki5 pour le code source et l'activité de développement
+* [[tiddlywiki.com/dev|https://tiddlywiki.com/dev]] est la documentation officielle des développeurs
+* Vous pouvez vous impliquer dans le développement de <<tw>> sur [[GitHub|https://github.com/Jermolene/TiddlyWiki5]]
+** Les [[discussions|https://github.com/Jermolene/TiddlyWiki5/discussions]] sont disponibles pour les questions ouvertes et les questions/réponses.
+** Les [[problèmes|https://github.com/Jermolene/TiddlyWiki5/issues]] permettent de signaler les bogues et de proposer de nouvelles idées spécifiques, réalistes et raisonnables
+* L'ancien groupe ~TiddlyWikiDev sur Google Group est maintenant fermé, et remplacé par les [[discussions GitHub|https://github.com/Jermolene/TiddlyWiki5/discussions]], mais une archive reste disponible<<:>> https://groups.google.com/group/TiddlyWikiDev
+** Une fonctionnalité de recherche étendue du groupe est disponible sur [[mail-archive.com|https://www.mail-archive.com/tiddlywikidev@googlegroups.com/]]
+* Pour les dernières nouvelles, suivez [[@TiddlyWiki sur Twitter|http://twitter.com/#!/TiddlyWiki]]
+* Tchatchez sur https://gitter.im/TiddlyWiki/public (une salle dédiée au développement arrive bientôt)

--- a/editions/fr-FR/tiddlers/Developers.tid
+++ b/editions/fr-FR/tiddlers/Developers.tid
@@ -4,7 +4,6 @@ modified: 20220217174800697
 tags: Community
 title: Developers
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 Plusieurs ressources permettent aux développeurs d'en apprendre plus sur <<tw>>, de collaborer et de discuter de son développement.
 

--- a/editions/fr-FR/tiddlers/Federatial.tid
+++ b/editions/fr-FR/tiddlers/Federatial.tid
@@ -1,9 +1,3 @@
-C.modified: 20170718160846820
-C.tags: Definitions
-C.text: Federatial Limited is a software consultancy founded by JeremyRuston, the creator of TiddlyWiki. Federatial helps organisations explore new user interaction concepts through rapid prototyping of sophisticated web-based tools.
-
-See https://federatial.com/ and https://twitter.com/federatial for more information.
-
 created: 20130825154900000
 modified: 20220219164816011
 tags: Definitions

--- a/editions/fr-FR/tiddlers/Federatial.tid
+++ b/editions/fr-FR/tiddlers/Federatial.tid
@@ -1,0 +1,17 @@
+C.modified: 20170718160846820
+C.tags: Definitions
+C.text: Federatial Limited is a software consultancy founded by JeremyRuston, the creator of TiddlyWiki. Federatial helps organisations explore new user interaction concepts through rapid prototyping of sophisticated web-based tools.
+
+See https://federatial.com/ and https://twitter.com/federatial for more information.
+
+created: 20130825154900000
+modified: 20220219164816011
+tags: Definitions
+title: Federatial
+type: text/vnd.tiddlywiki
+
+Federatial Limited est une entreprise de consultants en logiciel fondée par JeremyRuston, le créateur de <<tw>>.
+
+Federatial aide les organisations à explorer de nouveaux concepts d'interaction utilisateur grâce au prototypage rapide d'outils sophistiqués basés sur le web.
+
+Pour plus d'informations, visitez [[https://federatial.com/]] et [[https://twitter.com/federatial]].

--- a/editions/fr-FR/tiddlers/Forums.tid
+++ b/editions/fr-FR/tiddlers/Forums.tid
@@ -5,7 +5,6 @@ modified: 20220217174719926
 tags: Community
 title: Forums
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 ! Forum en français
 

--- a/editions/fr-FR/tiddlers/Forums.tid
+++ b/editions/fr-FR/tiddlers/Forums.tid
@@ -1,25 +1,40 @@
 caption: Forum
 created: 20140721121924384
 fr-title: Forum
-modified: 20150614155153966
+modified: 20220217174719926
 tags: Community
 title: Forums
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
-! Utilisateurs
+! Forum en français
 
-Les groupes de discussion ~TiddlyWiki sont des listes de publipostage pour discuter de ~TiddlyWiki<<:>> demandes d'aide, annonces de nouvelles version et plugins, échanges sur les nouvelles fonctionnalités, ou simples partages d'expériences. Vous pouvez participer via le site web associé, ou souscrire par email.
+La communauté francophone sur <<tw>> a son forum, venez contribuer<<!>>
 
-* Le groupe principal de ~TiddlyWiki<<:>> http://groups.google.com/group/TiddlyWiki
-*> Notez qu'il n'est nul besoin d'avoir un compte Google pour vous joindre aux groupes de discussion. Souscrire par l'envoi d'un email à mailto:tiddlywiki+subscribe@googlegroups.com ou mailto:tiddlywikidev+subscribe@googlegroups.com.
-* Visualiser les enregistrements de nos réguliers [[TiddlyWiki Hangouts]]
-* Suivre [[@TiddlyWiki sur Twitter|http://twitter.com/TiddlyWiki]] pour les dernières nouvelles.
+https://forum.tiddlywiki.fr/
 
-! Développeurs
+! Forums officiels
 
-* Le groupe TiddlyWikiDev pour les dévelopeurs<<:>> http://groups.google.com/group/TiddlyWikiDev
-*> Notez qu'il n'est nul besoin d'avoir un compte Google pour vous joindre aux groupes de discussion. Souscrire par l'envoi d'un email à mailto:tiddlywiki+subscribe@googlegroups.com ou mailto:tiddlywikidev+subscribe@googlegroups.com.
-* Suivre [[@TiddlyWiki sur Twitter|http://twitter.com/TiddlyWiki]] pour les dernières nouvelles.
-* Impliquez-vous dans le [[développement sur GitHub|https://github.com/Jermolene/TiddlyWiki5]]
+Le nouveau forum officiel pour discuter de <<tw>><<:>> demandes d'aide, annonces de nouvelles version et plugins, échanges sur les nouvelles fonctionnalités, ou simples partages d'expériences. Vous pouvez participer via le site web associé, ou souscrire par email.
 
-Les nouvelles versions de TiddlyWiki, TiddlyDesktop et TiddlyFox sont annoncés par les groupes de discussion et [[Twitter|https://twitter.com/TiddlyWiki]] (vous pouvez aussi souscrire au flux Atom/RSS des [[versions de TiddlyWiki sur GitHub|https://github.com/jermolene/tiddlywiki5/releases.atom]])
+https://talk.tiddlywiki.org/
+
+Notez que talk.tiddlywiki.org est un service communautaire que nous hébergeons et maintenons nous-mêmes. Les modestes frais de mise à disposition du site sont couverts par les contributions de la communauté.
+
+Pour le confort de la communauté, l'ancien groupe <<tw>>, hébergé sur Google Groups depuis 2005, reste fonctionnel.
+
+https://groups.google.com/group/TiddlyWiki
+
+! Forums des développeurs
+
+{{Developers}}
+
+! Autres forums
+
+* [[TiddlyWiki Subreddit|https://www.reddit.com/r/TiddlyWiki5/]]
+* Tchatchez avec Gitter sur https://gitter.im/TiddlyWiki/public<<!>>
+* Tchatchez avec Discord sur https://discord.gg/HFFZVQ8
+
+!! Documentation
+
+Il existe un groupe de discussion spécialement dédié aux initiatives d'amélioration de la documentation<<:>> https://groups.google.com/group/tiddlywikidocs

--- a/editions/fr-FR/tiddlers/HelloThere.tid
+++ b/editions/fr-FR/tiddlers/HelloThere.tid
@@ -2,12 +2,12 @@ caption: Bienvenue !
 created: 20130822170200000
 fr-title: Bienvenue !
 list: [[Discover TiddlyWiki]] [[Some of the things you can do with TiddlyWiki]] [[Ten reasons to switch to TiddlyWiki]] Examples [[History of TiddlyWiki]] [[What happened to the original TiddlyWiki?]]
-modified: 20160603043549286
+modified: 20220217174842374
 tags: TableOfContents
 title: HelloThere
 type: text/vnd.tiddlywiki
 
-''N'avez-vous jamais eu la sensation que votre tête était trop petite pour contenir tout ce dont vous avez besoin de mémoriser&nbsp;?''
+''N'avez-vous jamais eu la sensation que votre tête était trop petite pour contenir tout ce que vous avez besoin de mémoriser<<?>>''
 
 Bienvenue sur TiddlyWiki, un carnet de notes web [[non-linéaire|Philosophy of Tiddlers]] pour [[saisir|Creating and editing tiddlers]], [[organiser|Structuring TiddlyWiki]] et [[partager|Sharing your tiddlers with others]] des informations simples ou complexes.
 
@@ -17,19 +17,22 @@ Utilisez-le pour gérer votre [[liste de tâches|TaskManagementExample]], faire 
 <<list-thumbnails filter:"[tag[HelloThumbnail]]" width:"168" height:"95">>
 </div>
 
-Contrairement aux services en ligne classiques, TiddlyWiki vous permet de choisir où conserver vos informations , et garantit que, dans les décennies à venir, vous pourrez toujours utiliser les notes que vous prenez aujourd'hui.
+Contrairement aux services en ligne classiques, TiddlyWiki vous permet de choisir où conserver vos informations, et garantit que, dans les décennies à venir, vous pourrez toujours utiliser les notes que vous prenez aujourd'hui.
 
-<div style="font-size:0.7em;text-align:center;margin-top:3em;margin-bottom:3em;">
-<a href="http://groups.google.com/group/TiddlyWiki" class="tc-btn-big-green" style="background-color:#FF8C19;" target="_blank" rel="noopener noreferrer">
-{{$:/core/images/mail}} ~TiddlyWiki Mailing List
+<div style="font-size:0.7em;text-align:center;margin:3em auto;">
+<a href="https://talk.tiddlywiki.org/" class="tc-btn-big-green" style="border-radius:4px;background-color:#FF8C19;" target="_blank" rel="noopener noreferrer">
+{{$:/core/images/help}} ~TalkTW
 </a>
-<a href="https://www.youtube.com/c/JeremyRuston" class="tc-btn-big-green" style="background-color:#e52d27;" target="_blank" rel="noopener noreferrer">
-{{$:/core/images/video}} ~TiddlyWiki sur ~YouTube
+<a href="https://www.youtube.com/c/JeremyRuston" class="tc-btn-big-green" style="border-radius:4px;background-color:#e52d27;" target="_blank" rel="noopener noreferrer">
+{{$:/core/images/video}} ~YouTube
 </a>
-<a href="https://twitter.com/TiddlyWiki" class="tc-btn-big-green" style="background-color:#5E9FCA;" target="_blank" rel="noopener noreferrer">
-{{$:/core/images/twitter}} @~TiddlyWiki sur Twitter
+<a href="https://twitter.com/TiddlyWiki" class="tc-btn-big-green" style="border-radius:4px;background-color:#5E9FCA;" target="_blank" rel="noopener noreferrer">
+{{$:/core/images/twitter}} Twitter
 </a>
-<a href="https://github.com/Jermolene/TiddlyWiki5" class="tc-btn-big-green" style="background-color:#444;" target="_blank" rel="noopener noreferrer">
-{{$:/core/images/github}} ~TiddlyWiki sur ~GitHub
+<a href="https://github.com/Jermolene/TiddlyWiki5" class="tc-btn-big-green" style="border-radius:4px;background-color:#444;" target="_blank" rel="noopener noreferrer">
+{{$:/core/images/github}} ~GitHub
+</a>
+<a href="https://gitter.im/TiddlyWiki/public" class="tc-btn-big-green" style="border-radius:4px;background-color:#753a88;background-image:linear-gradient(to left,#cc2b5e,#753a88);" target="_blank" rel="noopener noreferrer">
+{{$:/core/images/gitter}} Gitter
 </a>
 </div>

--- a/editions/fr-FR/tiddlers/JeremyRuston.tid
+++ b/editions/fr-FR/tiddlers/JeremyRuston.tid
@@ -1,27 +1,9 @@
-C.modified: 20170920131119498
-C.tags: Definitions
-C.text: I'm the original inventor of TiddlyWiki. You can hire me through [[Federatial]], and find me on these services:
-
-* jeremy (at) jermolene (dot) com
-* [[Jermolene on GitHub|https://github.com/Jermolene]]
-* [[Jermolene on GitTip|https://www.gittip.com/Jermolene/]], a micropayment service
-* [[@Jermolene on Twitter|http://twitter.com/#!/jermolene]]
-* [[Jermy on LinkedIn|http://www.linkedin.com/in/jermy]]
-* [[Jermy on Flickr|http://www.flickr.com/photos/jermy/]]
-
-Further information:
-
-* An [[interview with me in The Inquirer|http://www.theinquirer.net/inquirer/feature/2105529/bt-software-engineer-tells-telco-source]] by Wendy Grossman
-* A [[hilarious interview with me|https://www.youtube.com/watch?v=auyIhw8MTmQ]] from British television in 1983
-* Here's a video of a presentation I did in 2007 called [["How to Start an Open Source Project"|http://vimeo.com/856110]].
-
 caption: Jeremy Ruston
 created: 20130825162500000
 modified: 20220219163924300
 tags: Definitions
 title: JeremyRuston
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 Je suis l'inventeur original de TiddlyWiki. Vous pouvez m'engager sur [[Federatial]], et me retrouver sur ces services<<:>>
 

--- a/editions/fr-FR/tiddlers/JeremyRuston.tid
+++ b/editions/fr-FR/tiddlers/JeremyRuston.tid
@@ -1,21 +1,39 @@
-caption: Jeremy Ruston
-created: 20130825162500000
-modified: 20150623064203685
-tags: Definitions
-title: JeremyRuston
-type: text/vnd.tiddlywiki
-
-Je suis l'inventeur original de TiddlyWiki. Vous pouvez me retrouver sur ces services<<:>>
+C.modified: 20170920131119498
+C.tags: Definitions
+C.text: I'm the original inventor of TiddlyWiki. You can hire me through [[Federatial]], and find me on these services:
 
 * jeremy (at) jermolene (dot) com
 * [[Jermolene on GitHub|https://github.com/Jermolene]]
-* [[Jermolene on GitTip|https://www.gittip.com/Jermolene/]], micropaiements
+* [[Jermolene on GitTip|https://www.gittip.com/Jermolene/]], a micropayment service
 * [[@Jermolene on Twitter|http://twitter.com/#!/jermolene]]
 * [[Jermy on LinkedIn|http://www.linkedin.com/in/jermy]]
 * [[Jermy on Flickr|http://www.flickr.com/photos/jermy/]]
 
-Encore plus d'infos<<:>>
+Further information:
+
+* An [[interview with me in The Inquirer|http://www.theinquirer.net/inquirer/feature/2105529/bt-software-engineer-tells-telco-source]] by Wendy Grossman
+* A [[hilarious interview with me|https://www.youtube.com/watch?v=auyIhw8MTmQ]] from British television in 1983
+* Here's a video of a presentation I did in 2007 called [["How to Start an Open Source Project"|http://vimeo.com/856110]].
+
+caption: Jeremy Ruston
+created: 20130825162500000
+modified: 20220219163924300
+tags: Definitions
+title: JeremyRuston
+type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
+
+Je suis l'inventeur original de TiddlyWiki. Vous pouvez m'engager sur [[Federatial]], et me retrouver sur ces services<<:>>
+
+* jeremy (at) jermolene (dot) com
+* [[Jermolene sur GitHub|https://github.com/Jermolene]]
+* [[Jermolene sur GitTip|https://www.gittip.com/Jermolene/]], un service de micropaiements
+* [[@Jermolene sur Twitter|http://twitter.com/#!/jermolene]]
+* [[Jermy sur LinkedIn|http://www.linkedin.com/in/jermy]]
+* [[Jermy sur Flickr|http://www.flickr.com/photos/jermy/]]
+
+Informations supplémentaires<<:>>
 
 * Une [[interview de moi sur The Inquirer|http://www.theinquirer.net/inquirer/feature/2105529/bt-software-engineer-tells-telco-source]] par Wendy Grossman
 * Une [[interview hilarante avec moi|https://www.youtube.com/watch?v=auyIhw8MTmQ]] de la télévision britanique en 1983
-* Ici, un vidéo de présentation que j'ai réalisée en 2007 appelée [["How to Start an Open Source Project"|http://vimeo.com/856110]].
+* Ici, une vidéo de présentation que j'ai réalisée en 2007 intitulée [["How to Start an Open Source Project"|http://vimeo.com/856110]].

--- a/editions/fr-FR/tiddlers/ListField.tid
+++ b/editions/fr-FR/tiddlers/ListField.tid
@@ -1,14 +1,24 @@
+C.modified: 20150124202924000
+C.tags: Fields
+C.text: The `list` [[field of a tiddler|TiddlerFields]] is an optional feature that can be used to help structure your content. Its value is a [[title list|Title List]], and it can be used in several ways:
+
+* The `list` field of a tiddler that is being used as a tag determines the ordering of the tiddlers that carry that tag - see [[Tagging]] for details
+* The `list` [[filter|Filters]] selects the entries from a list
+* The `listed` [[filter|Filters]] selects the tiddlers that list the selected tiddler(s)
+* The NavigatorWidget manipulates a StoryList tiddler containing a `list` field of the tiddlers that are displayed in the main story column
+
 caption: list
 created: 20130830092500000
 fr-title: Champ liste
-modified: 20150614082620572
+modified: 20220219194303634
 tags: Fields
 title: ListField
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
-[[Champ de tiddler|TiddlerFields]], `list`  peut aider à structurer son contenu. Sa valeur est une [[liste de titres|Title List]], et peut être maniée de différentes façons<<:>>
+Le [[champ de tiddler|TiddlerFields]] `list` est une fonctionnalité optionnelle qui peut vous aider à structurer votre contenu. Sa valeur est une [[liste de titres|Title List]], qui peut être utilisée de différentes façons<<:>>
 
-* Le champ `list` d'un tiddler utilisé comme étiquette détermine l'ordre des tiddlers portant ce tag - voir [[ Étiqueter |Tagging]] pour plus de détails
-* Le [[filtre|Filters]] `list` sélectionne les entrées d'une liste
-* Le [[filtre|Filters]] `listed` sélectionne les tiddlers listant le(s) tiddler(s) sélectionné(s)
-* Le NavigatorWidget manipule un tiddler $:/StoryList contenant un champ `list` des tiddlers affichés dans la colonne principale ''Récents''
+* Le champ `list` d'un tiddler utilisé comme tag détermine l'ordre des tiddlers portant ce tag -- voir [[Étiqueter|Tagging]] pour plus de détails
+* Le [[filtre|Filters]] `list` sélectionne les entrées d'une liste -- voir <<fr "list Operator">>
+* Le [[filtre|Filters]] `listed` sélectionne les tiddlers listant le(s) tiddler(s) sélectionné(s) -- voir <<fr "listed Operator">>
+* Le widget <<.wlink NavigatorWidget>> manipule un tiddler $:/StoryList dont le champ `list` contient les tiddlers affichés dans la vue principale

--- a/editions/fr-FR/tiddlers/ListField.tid
+++ b/editions/fr-FR/tiddlers/ListField.tid
@@ -1,12 +1,3 @@
-C.modified: 20150124202924000
-C.tags: Fields
-C.text: The `list` [[field of a tiddler|TiddlerFields]] is an optional feature that can be used to help structure your content. Its value is a [[title list|Title List]], and it can be used in several ways:
-
-* The `list` field of a tiddler that is being used as a tag determines the ordering of the tiddlers that carry that tag - see [[Tagging]] for details
-* The `list` [[filter|Filters]] selects the entries from a list
-* The `listed` [[filter|Filters]] selects the tiddlers that list the selected tiddler(s)
-* The NavigatorWidget manipulates a StoryList tiddler containing a `list` field of the tiddlers that are displayed in the main story column
-
 caption: list
 created: 20130830092500000
 fr-title: Champ liste
@@ -14,7 +5,6 @@ modified: 20220219194303634
 tags: Fields
 title: ListField
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 Le [[champ de tiddler|TiddlerFields]] `list` est une fonctionnalité optionnelle qui peut vous aider à structurer votre contenu. Sa valeur est une [[liste de titres|Title List]], qui peut être utilisée de différentes façons<<:>>
 

--- a/editions/fr-FR/tiddlers/Macros in WikiText.tid
+++ b/editions/fr-FR/tiddlers/Macros in WikiText.tid
@@ -1,10 +1,3 @@
-C.modified: 20150221094003000
-C.tags: WikiText
-C.text: The use of [[macros|Macros]] in WikiText has two distinct aspects:
-
-* [[Defining macros|Macro Definitions in WikiText]]
-* [[Calling macros|Macro Calls in WikiText]]
-
 caption: Macros
 created: 20131205160746466
 fr-title: Macros en WikiTexte

--- a/editions/fr-FR/tiddlers/Macros in WikiText.tid
+++ b/editions/fr-FR/tiddlers/Macros in WikiText.tid
@@ -1,12 +1,19 @@
+C.modified: 20150221094003000
+C.tags: WikiText
+C.text: The use of [[macros|Macros]] in WikiText has two distinct aspects:
+
+* [[Defining macros|Macro Definitions in WikiText]]
+* [[Calling macros|Macro Calls in WikiText]]
+
 caption: Macros
 created: 20131205160746466
-fr-title: Macros dans WikiText
-modified: 20150621152601026
+fr-title: Macros en WikiTexte
+modified: 20220219191257167
 tags: WikiText
 title: Macros in WikiText
 type: text/vnd.tiddlywiki
 
-L'utilisation des [[macros|Macros]] dans [[WikiTexte|WikiText]] a deux aspects distincts<<:>>
+L'utilisation des [[macros|Macros]] en [[WikiTexte|WikiText]] recouvre deux aspects distincts<<:>>
 
-* [[Définition des macros|Macro Definitions in WikiText]]
-* [[Appel des macros|Macro Calls in WikiText]]
+* [[La définition des macros|Macro Definitions in WikiText]]
+* [[L'appel des macros|Macro Calls in WikiText]]

--- a/editions/fr-FR/tiddlers/Macros.tid
+++ b/editions/fr-FR/tiddlers/Macros.tid
@@ -1,34 +1,9 @@
-C.modified: 20220128112317724
-C.tags: Concepts Reference
-C.text: A <<.def macro>> is a named snippet of text. WikiText can use the name as a shorthand way of [[transcluding|Transclusion]] the snippet. Such transclusions are known as <<.def "macro calls">>, and each call can supply a different set of parameters that get substituted for special placeholders within the snippet.
-
-For the syntax, see [[Macros in WikiText]].
-
-Most macros are in fact just parameterised [[variables|Variables]].
-
-They are created using the `\define` [[pragma|Pragma]]. (Behind the scenes, this is transformed into a <<.wlink SetWidget>>, i.e. macros and variables are two sides of the same coin.)
-
-The snippet and its incoming parameter values are treated as simple strings of characters with no WikiText meaning, at least until the placeholders have been filled in and the macro call has returned. This means that a macro can assemble and return the complete syntax of a ~WikiText component, such as a [[link|Linking in WikiText]]. (See [[Transclusion and Substitution]] for further discussion of this.)
-
-Within a snippet itself, the only markup detected is `$name$` (a placeholder for a macro parameter) and `$(name)$` (a placeholder for a [[variable|Variables]]).
-
-The <<.mlink dumpvariables>> macro lists all variables (including macros) that are available at that position in the widget tree.
-
-An <<.wlink ImportVariablesWidget>> widget can be used to copy macro definitions to another branch of the [[widget tree|Widgets]]. ~TiddlyWiki uses this technique internally to implement global macros -- namely any macros defined in tiddlers with the <<.tag $:/tags/Macro>> tag. (The tag <<.tag $:/tags/Macro/View>> is used to define macros that should only be available within the main view template and the preview panel).
-
-For maximum flexibility, macros can also be <<.js-macro-link "written as JavaScript modules">>.
-
-A similar effect to a parameterised macro call can be produced by setting [[variables|Variables]] around a [[transclusion|Transclusion]].
-
-~TiddlyWiki's core has [[several macros|Core Macros]] built in.
-
 caption: Macros
 created: 20140211171341271
 modified: 20220219192959452
 tags: Concepts Reference
 title: Macros
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 Une <<.def macro>> est un //bout de texte// auquel on donne un nom. Le <<fr WikiText>> utilise ce nom comme raccourci pour [[transclure|Transclusion]] le //bout de texte//. Ces [[transclusions|Transclusion]] particulières s'appellent des <<.def "appels de macro">>, et chaque appel peut transmettre un ensemble différent d'arguments, qui se substituent à leur emplacement dans le //bout de texte//.
 

--- a/editions/fr-FR/tiddlers/Macros.tid
+++ b/editions/fr-FR/tiddlers/Macros.tid
@@ -1,19 +1,53 @@
+C.modified: 20220128112317724
+C.tags: Concepts Reference
+C.text: A <<.def macro>> is a named snippet of text. WikiText can use the name as a shorthand way of [[transcluding|Transclusion]] the snippet. Such transclusions are known as <<.def "macro calls">>, and each call can supply a different set of parameters that get substituted for special placeholders within the snippet.
+
+For the syntax, see [[Macros in WikiText]].
+
+Most macros are in fact just parameterised [[variables|Variables]].
+
+They are created using the `\define` [[pragma|Pragma]]. (Behind the scenes, this is transformed into a <<.wlink SetWidget>>, i.e. macros and variables are two sides of the same coin.)
+
+The snippet and its incoming parameter values are treated as simple strings of characters with no WikiText meaning, at least until the placeholders have been filled in and the macro call has returned. This means that a macro can assemble and return the complete syntax of a ~WikiText component, such as a [[link|Linking in WikiText]]. (See [[Transclusion and Substitution]] for further discussion of this.)
+
+Within a snippet itself, the only markup detected is `$name$` (a placeholder for a macro parameter) and `$(name)$` (a placeholder for a [[variable|Variables]]).
+
+The <<.mlink dumpvariables>> macro lists all variables (including macros) that are available at that position in the widget tree.
+
+An <<.wlink ImportVariablesWidget>> widget can be used to copy macro definitions to another branch of the [[widget tree|Widgets]]. ~TiddlyWiki uses this technique internally to implement global macros -- namely any macros defined in tiddlers with the <<.tag $:/tags/Macro>> tag. (The tag <<.tag $:/tags/Macro/View>> is used to define macros that should only be available within the main view template and the preview panel).
+
+For maximum flexibility, macros can also be <<.js-macro-link "written as JavaScript modules">>.
+
+A similar effect to a parameterised macro call can be produced by setting [[variables|Variables]] around a [[transclusion|Transclusion]].
+
+~TiddlyWiki's core has [[several macros|Core Macros]] built in.
+
 caption: Macros
 created: 20140211171341271
-modified: 20150622110720298
+modified: 20220219192959452
 tags: Concepts Reference
 title: Macros
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
-Les macros sont des bouts de texte qui peuvent être insérés à l'aide d'un raccourci concis<<dp>>
+Une <<.def macro>> est un //bout de texte// auquel on donne un nom. Le <<fr WikiText>> utilise ce nom comme raccourci pour [[transclure|Transclusion]] le //bout de texte//. Ces [[transclusions|Transclusion]] particulières s'appellent des <<.def "appels de macro">>, et chaque appel peut transmettre un ensemble différent d'arguments, qui se substituent à leur emplacement dans le //bout de texte//.
 
-```
-<<maMacro>>
-```
+Pour une description de la syntaxe, voir <<fr "Macros in WikiText">>.
 
-Vous pouvez écrire vos propres [[macros en WikiText|Macros in WikiText]] ou pour plus de souplesse, vous pouvez écrire des [[macros en Javascript|JavaScript Macros]].
+La plupart des macros sont en fait des [[variables|Variables]] paramétrées.
 
-Les macros suivantes sont fournies avec <<tw>><<dp>>
+Elles sont définies en utilisant le [[pragma|Pragma]] `\define`. (En coulisses, cette syntaxe est transformé en <<fr SetWidget>>, donc les macros et les variables sont bien les deux faces de la même pièce.)
 
-<<list-links "[tag[Macros]]">>
+Le //bout de texte// et ses arguments sont traités comme de simple chaînes de caractères, sans interprétation du <<fr WikiText>>, au moins jusqu'à ce que le dernier emplacement ait été rempli et que l'appel de macro soit terminé. Cela signifie qu'une macro peut assembler et renvoyer la syntaxe complète d'un composant <<fr WikiText>>, comme un [[lien|Linking in WikiText]] par exemple. (Voir <<fr "Transclusion and Substitution">> pour une discussion plus approfondie sur ce sujet.)
 
+A l'intérieur d'un //bout de texte// lui-même, le seul balisage détecté est `$nom$` (un emplacement pour le paramètre `nom` qui sera substitué par l'argument correspondant reçu au moment d'un appel de macro) et `$(nom)$` (un emplacement pour une [[variable|Variables]]).
+
+La macro <<.mlink dumpvariables>> liste toutes les variables (y-compris les macros) qui sont disponibles à cet endroit de l'arborescence des widgets.
+
+Un widget <<.wlink ImportVariablesWidget>> peut être utilisé pour copier une définition de macro vers une autre branche de [[l'arbre des widgets|Widgets]]. <<tw>> utilise cette technique en interne pour implémenter des macros globales -- c'est-à-dire des macros définies dans des tiddlers étiquetés <<.tag $:/tags/Macro>>. (Le tag <<.tag $:/tags/Macro/View>> est quant à lui utilisé pour définir des macros qui ne doivent être disponibles que dans le modèle de vue principal et le panneau de prévisualisation.)
+
+Pour un maximum de flexibilité, les macros peuvent aussi être <<.js-macro-link "écrites en tant que modules JavaScript">>.
+
+Un effet similaire à l'utilisation de macros paramétrées peut être obtenu en encadrant une [[transclusion|Transclusion]] par une définition de [[variables|Variables]].
+
+<<tw>> intègre [[plusieurs macros|Core Macros]] dans son cœur.

--- a/editions/fr-FR/tiddlers/Philosophy of Tiddlers.tid
+++ b/editions/fr-FR/tiddlers/Philosophy of Tiddlers.tid
@@ -1,18 +1,9 @@
-C.modified: 20140919160655340
-C.tags: Learning
-C.text: The purpose of recording and organising information is so that it can be used again. The value of recorded information is directly proportional to the ease with which it can be re-used.
-
-The philosophy of [[tiddlers|Tiddlers]] is that we maximise the possibilities for re-use by slicing information up into the smallest semantically meaningful units with [[rich modelling of relationships between them|Structuring TiddlyWiki]]. Then we use aggregation and composition to weave the fragments together to present narrative stories.
-
-TiddlyWiki aspires to provide an algebra for tiddlers, a concise way of expressing and exploring the relationships between items of information.
-
 created: 20131128075743966
 fr-title: Philosophie des tiddlers
 modified: 20220220004339779
 tags: Learning
 title: Philosophy of Tiddlers
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 Lorsqu'on enregistre et organise des informations, on se donne pour objectif de pouvoir les réutiliser plus tard. La valeur d'une information conservée est directement proportionnelle à la facilité avec laquelle on peut la réutiliser.
 

--- a/editions/fr-FR/tiddlers/Philosophy of Tiddlers.tid
+++ b/editions/fr-FR/tiddlers/Philosophy of Tiddlers.tid
@@ -1,12 +1,21 @@
+C.modified: 20140919160655340
+C.tags: Learning
+C.text: The purpose of recording and organising information is so that it can be used again. The value of recorded information is directly proportional to the ease with which it can be re-used.
+
+The philosophy of [[tiddlers|Tiddlers]] is that we maximise the possibilities for re-use by slicing information up into the smallest semantically meaningful units with [[rich modelling of relationships between them|Structuring TiddlyWiki]]. Then we use aggregation and composition to weave the fragments together to present narrative stories.
+
+TiddlyWiki aspires to provide an algebra for tiddlers, a concise way of expressing and exploring the relationships between items of information.
+
 created: 20131128075743966
 fr-title: Philosophie des tiddlers
-modified: 20141203144108401
+modified: 20220220004339779
 tags: Learning
 title: Philosophy of Tiddlers
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
 Lorsqu'on enregistre et organise des informations, on se donne pour objectif de pouvoir les réutiliser plus tard. La valeur d'une information conservée est directement proportionnelle à la facilité avec laquelle on peut la réutiliser.
 
 La philosophie des [[tiddlers|Tiddlers]] consiste à maximiser les possibilités de réutilisation en découpant l'information en unités sémantiques aussi petites que possible, grâce à une [[modélisation riche des relations entre elles|Structuring TiddlyWiki]]. On utilise ensuite l'agrégation et la composition pour tisser les fragments entre eux afin de construire des déroulés cohérents.
 
-TiddlyWiki a pour ambition de proposer une algèbre pour les tiddlers<<dp>> une manière concise d'exprimer et d'explorer les relations entre les diverses pièces d'information.
+<<tw>> a pour ambition de proposer une algèbre pour les tiddlers<<dp>> une manière concise d'exprimer et d'explorer les relations entre les diverses bribes d'information.

--- a/editions/fr-FR/tiddlers/Saving.tid
+++ b/editions/fr-FR/tiddlers/Saving.tid
@@ -1,10 +1,69 @@
-fr-title: Sauvegarder les modifications
 created: 20140912140651119
-modified: 20141116123050408
+fr-title: Sauvegarder les modifications
+list: 
+modified: 20220217174230426
+saving-browser: Firefox Chrome Edge [[Internet Explorer]] Safari Opera
+saving-os: Windows Mac Linux Android iOS
 tags: [[Working with TiddlyWiki]]
 title: Saving
 type: text/vnd.tiddlywiki
 
-Voici les méthodes disponibles pour sauvegarder vos modifications avec TiddlyWiki<<dp>>
+\define alltagsfilter()  
+<$vars tag1="tag[" tag2="]" lb="[" rb="tag[Saving]sort[delivery]]">
+<$set filter="[list[]addprefix<tag1>addsuffix<tag2>]+[join[]addprefix<lb>addsuffix<rb>]" name="alltags" select=0>
+<$text text=<<alltags>>/>
+</$set>
+</$vars>
+\end
 
-<<list-links "[tag[Saving]]">>
+\define saverssidebaritem(item:"Linux")
+<$checkbox tiddler=<<qualify $:/temp/$item$>> field="status" checked="selected" checkactions=<<checkactions "$item$">> uncheckactions=<<uncheckactions "$item$">> default="closed"> $item$</$checkbox><br/>
+\end
+
+\define saverssidebaritemlist(fieldname:"os")
+<$list filter="[enlist{!!$fieldname$}]" variable="currentItem">
+<$macrocall $name="saverssidebaritem" item=<<currentItem>>/>
+</$list>
+\end
+
+\define uncheckactions(item:"Linux")
+<$action-listops  $subfilter="-[[$item$]]"/>
+\end
+
+\define checkactions(item:"Linux")
+<$action-listops $subfilter="[[$item$]]"/>
+\end
+
+\define uncheckactions(item:"Linux")
+<$action-listops $subfilter="-[[$item$]]"/>
+\end
+
+Méthodes disponibles pour enregistrer les modifications avec <<tw>><<:>>
+
+<div class="tc-wrapper-flex">
+<div class="tc-saving-sidebar">
+  <div class="tc-saving-sidebar-category">
+      <div class="tc-saving-sidebar-category-title">Plateforme</div>
+     <div class="tc-saving-sidebar-category-item">
+                <<saverssidebaritemlist "saving-os">>
+      </div>
+   </div>
+   <div class="tc-saving-sidebar-category">
+       <div class="tc-saving-sidebar-category-title">Navigateur internet</div>
+        <div class="tc-saving-sidebar-category-item">
+               <<saverssidebaritemlist "saving-browser">>
+        </div>
+  </div>
+  
+</div>
+
+<!-- Page content -->
+<div class="content">
+<$wikify text=<<alltagsfilter>> name="alltagsfilterwikified">
+<$list filter=<<alltagsfilterwikified>>>
+{{||$:/_tw5.com-card-template}}
+</$list>
+</$wikify>
+
+</div>
+</div>

--- a/editions/fr-FR/tiddlers/Structuring TiddlyWiki.tid
+++ b/editions/fr-FR/tiddlers/Structuring TiddlyWiki.tid
@@ -1,19 +1,9 @@
-C.modified: 20150124211518000
-C.tags: [[Working with TiddlyWiki]]
-C.text: TiddlyWiki5 provides several features to help you structure information as [[tiddlers|Tiddlers]], and model the relationships between them:
-
-* TiddlerLinks
-* [[Tagging]]
-* [[Title Lists|Title List]]
-* DataTiddlers
-
 created: 20131128090536894
 fr-title: Structurer TiddlyWiki
 modified: 20220220003638545
 tags: [[Working with TiddlyWiki]]
 title: Structuring TiddlyWiki
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 TiddlyWiki5 fournit plusieurs fonctionnalités qui vous aideront à structurer les informations sous forme de [[tiddlers|Tiddlers]], et à modéliser les relations entre eux<<:>>
 

--- a/editions/fr-FR/tiddlers/Structuring TiddlyWiki.tid
+++ b/editions/fr-FR/tiddlers/Structuring TiddlyWiki.tid
@@ -1,13 +1,23 @@
+C.modified: 20150124211518000
+C.tags: [[Working with TiddlyWiki]]
+C.text: TiddlyWiki5 provides several features to help you structure information as [[tiddlers|Tiddlers]], and model the relationships between them:
+
+* TiddlerLinks
+* [[Tagging]]
+* [[Title Lists|Title List]]
+* DataTiddlers
+
 created: 20131128090536894
 fr-title: Structurer TiddlyWiki
-modified: 20150620093923918
+modified: 20220220003638545
 tags: [[Working with TiddlyWiki]]
 title: Structuring TiddlyWiki
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
-TiddlyWiki5 fournit plusieurs fonctionnalités qui vous aideront à structurer les informations sous forme de [[tiddlers|Tiddlers]], et à modéliser les relations entre eux<<dp>>
+TiddlyWiki5 fournit plusieurs fonctionnalités qui vous aideront à structurer les informations sous forme de [[tiddlers|Tiddlers]], et à modéliser les relations entre eux<<:>>
 
-* [[Liens dans un tiddler|TiddlerLinks]]
-* [[Étiqueter par tag|Tagging]]
-* [[Tiddler de listes|ListWidget]]
-* [[Tiddlers de données|DataTiddlers]]
+* <<fr TiddlerLinks>>
+* <<fr Tagging>>
+* <<fr "Title List">>
+* <<fr DataTiddlers>>

--- a/editions/fr-FR/tiddlers/Tagging.tid
+++ b/editions/fr-FR/tiddlers/Tagging.tid
@@ -1,35 +1,79 @@
+C.modified: 20160612132049797
+C.tags: [[Working with TiddlyWiki]] Concepts
+C.text: Tagging is a way of organising tiddlers into categories. For example, if you had tiddlers representing various individuals, you could tag them as ''friend'', ''family'', ''colleague'' etc to indicate these people's relationships to you.
+
+A tag is in fact just a tiddler (or a potential tiddler), and it can have tags of its own. You can add any number of tags to the same tiddler.
+
+See [[Creating and editing tiddlers]] for instructions on how to tag.
+
+By tagging your tiddlers, you can view, navigate and organise your information in numerous additional ways:
+
+* The coloured tag pills on a tiddler give you quick access to all the other tiddlers with the same tag, as well as to the tiddler that represents the tag itself.
+
+* If a tiddler is serving as a tag, then the ''Tagging'' tab in its InfoPanel will show you which tiddlers are currently tagged with it.
+
+* The ''More'' tab of the sidebar has a ''Tags'' tab that presents an overview of all your tags and lets you access all your tagged tiddlers.
+
+* You can use [[filters|Filters]] to create lists of tiddlers based on their tags. You can then display any combination of the [[fields|TiddlerFields]] of those tiddlers. For example, you could build a glossary by listing the title and text of all tiddlers tagged ''Glossary''. Such lists can be formatted in any way you wish: e.g. bulleted, numbered or comma-separated.
+
+* There are a number of special ''system tags'' that control the layout of tiddlers and the entire ~TiddlyWiki page. See [[Page and tiddler layout customisation]] for instructions.
+
+There are two more things you can do with tags:
+
+! Set a tag's colour and icon
+
+You can use the <<.icon $:/core/images/tag-button>> [[tag manager|$:/TagManager]], found on the ''Tags'' tab under ''More'' in the sidebar, to change the colour of a tag's pill or add an icon to the pill.
+
+* To change the colour, click the button in the ''Colour'' column to select from a colour picker. Alternatively, click the icon in the ''Info'' column, then type a [[CSS]] colour value in the ''Colour'' field
+* To change the icon, click the <<.icon $:/core/images/down-arrow>> button in the ''Icon'' column and choose from the list of available icons
+
+! Change the order in which tags are listed
+
+By default, tagged tiddlers are listed in alphabetical order.
+
+If you want any other order, add a <<.flink ListField>> field to the tag tiddler, and set its value to be a [[list of the tiddlers|Title List]] in that order.
+
+The ''list'' field doesn't have to mention all of the tiddlers. See the [[precise rules|Order of Tagged Tiddlers]] ~TiddlyWiki uses to order tagged tiddlers.
+
 created: 20140904075400000
 fr-title: Étiqueter par tag
-modified: 20150624092812640
+modified: 20220220002448916
 tags: [[Working with TiddlyWiki]] Concepts
 title: Tagging
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
-Étiqueter un tiddler consiste à assigner par  un tag à un tiddler une catégorie de votre choix (voir [[Créer et éditer des tiddlers|Creating and editing tiddlers]] pour des instructions sur la manière de taguer). Par exemple, les tiddlers représentant des individus pourraient être étiquetés par les tags ''ami'', ''famille'', ''collègue'', etc. pour indiquer leur relation avec l'auteur. Plusieurs tags peuvent être appliqués au même tiddler.
+L'étiquetage des tiddlers permet de les organiser en catégories. Par exemple, les tiddlers représentant des individus pourraient être étiquetés avec les tags ''ami'', ''famille'', ''collègue'', etc. pour indiquer leur relation avec l'auteur.
+
+Un tag est en fait un simple tiddler (ou un tiddler potentiel), qui peut lui-même avoir ses propres tags. Plusieurs tags peuvent être appliqués au même tiddler.
+
+Voir <<fr "Creating and editing tiddlers">> pour des instructions sur la façon d'étiqueter les tiddlers.
 
 Le fait d'étiqueter les tiddlers vous procure de nombreux moyens supplémentaires de visualiser, parcourir, et organiser vos informations<<:>>
 
-* Les pastilles colorées pour chaque tag d'un tiddler vous donnent accès à tous les autres tiddlers de même tag, ainsi qu'au tiddler correspondant au tag lui-même.
-* L'onglet //Étiqueté// dans le panneau d'informations du tiddler (accessible en cliquant sur le bouton {{$:/core/images/info-button}}) vous donne les liens vers tous les tiddlers tagués avec le titre du tiddler courant.
-* Vous pouvez utiliser l'onglet Tags dans l'onglet Plus de la barre latérale pour visualiser tous vos tags et accéder à vos tiddlers étiquetés.
-* Vous pouvez utiliser des [[filtres|Filters]] pour créer des listes de tiddlers selon leurs tags, puis afficher toute combinaison de champs souhaitée. Par exemple, vous pouvez créer une liste qui montre à la fois le titre et le texte de tous les tiddlers étiquetés //Glossaire//. Ces listes peuvent être formatées à votre goût<<:>> avec des puces, des nombres, ou séparées par des virgules, etc.
-* Les tags <<gf système>> peuvent servir à personnaliser la mise en forme des tiddlers et de la page ~TiddlyWiki dans son ensemble. Voir les instructions correspondantes dans [[Personnalisation de la mise en forme de la page et des tiddlers|Page and tiddler layout customisation]].
+* Les pastilles colorées pour chaque tag d'un tiddler vous donnent accès à tous les autres tiddlers portant le même tag, ainsi qu'au tiddler correspondant au tag lui-même.
+
+* Lorsqu'un tiddler est utilisé pour étiqueter d'autres tiddlers, l'onglet ''Étiquetage'' dans son [[panneau d'informations|InfoPanel]] liste tous les tiddlers tagués avec le titre du tiddler courant.
+
+* L'onglet ''Plus'' de la barre latérale contient un onglet ''Tags'' qui permet de visualiser tous vos tags et d'accéder à vos tiddlers étiquetés.
+
+* Vous pouvez utiliser des [[filtres|Filters]] pour créer des listes de tiddlers selon leurs tags, puis afficher toute combinaison de [[champs|TiddlerFields]] souhaitée. Par exemple, vous pouvez créer un glossaire en listant le titre et le texte de tous les tiddlers étiquetés //Glossaire//. De telles listes peuvent être formatées à votre goût<<:>> avec des puces, des nombres, ou séparées par des virgules, etc.
+
+* Les <<gf "tags système">> contrôlent la mise en forme des tiddlers et de la page <<tw>> dans son ensemble. Voir les instructions correspondantes dans <<fr "Page and tiddler layout customisation">>.
 
 Encore deux choses que les tags permettent de faire<<:>>
 
-! Affecter des couleurs et des icones à un tag
+! Affecter des couleurs et des icônes à un tag
 
-Vous pouvez utiliser le [[gestionnaire de tags|$:/TagManager]], présent dans l'onglet Tags de l'onglet Plus de la barre latérale, pour affecter une couleur de fond et/ou une icone à un tag.
+Vous pouvez utiliser le <<.icon $:/core/images/tag-button>> [[gestionnaire de tags|$:/TagManager]], présent dans l'onglet ''Tags'' de l'onglet ''Plus'' de la barre latérale, pour affecter une couleur de fond et/ou une icône à un tag.
 
-* Les couleurs peuvent être affectées à un tag soit en spécifiant la valeur CSS de la couleur dans la fenêtre supérieure dans la colonne des couleurs, soit en choisissant une couleur à partir du menu déroulant proposé.
-* Les icones peuvent être affectées à un tag en cliquant sur le bouton {{$:/core/images/down-arrow}} dans la colonne des icones et en choisissant une des icones proposées.
+* Les couleurs peuvent être affectées à un tag en cliquant sur le bouton de la colonne des couleurs et en sélectionnant une proposition. Sinon, spécifiez la valeur [[CSS]] de la couleur dans la zone de saisie accessible en cliquant sur le bouton <<.icon $:/core/images/info-button>>.
+* Les icônes peuvent être affectées à un tag en cliquant sur le bouton <<.icon $:/core/images/down-arrow>> dans la colonne des icônes et en choisissant une des icônes proposées.
 
-! Utiliser des champs `list` pour ajuster l'ordre des listes par tag
+! Changer l'ordre dans lequel les tiddlers sont listés
 
-Si vous voulez créer une liste de tiddlers à l'aide d'un [[filtre|Filters]] à partir d'un tag qu'ils ont en commun, en les triant selon un ordre particulier plutôt que selon l'ordre alphabétique par défaut, vous pouvez créer un champ appelé 'list' dans le tiddler du tag lui-même, et y ajouter les titres des tiddlers à ordonner dans l'ordre désiré. ~TiddlyWiki triera les listes de tiddlers tagués dans l'ordre de priorité suivant<<:>>
+Par défaut, les tiddlers tagués sont listés dans l'ordre alphabétique.
 
-* Premièrement, les tiddlers placés dans le [[champ list|ListField]] du tiddler de tag seront placés dans une nouvelle liste dans le même ordre
-* Deuxièmement, tout tiddler sans place fixe mais disposant d'un champ ''list-before'' sera placé avant le tiddler indiqué dans le champ
-** (si le champ ''list-before'' est vide, alors le tiddler sans place prédéfinie sera placé au début de la liste)
-* Troisièmement, tout tiddler sans place prédéfinie disposant d'un champ ''list-after'' sera placé juste après le tiddler indiqué dans le champ
-* Enfin, tout tiddler n'ayant toujours pas de place prédéfinie sera placé à la fin de la liste
+Si vous voulez un ordre différent, ajoutez un champ `list` au tiddler du tag, et affectez lui comme valeur la [[liste de ses tiddlers|Title List]] dans l'ordre choisi.
+
+Le champ `list` n'a pas besoin de contenir tous les tiddlers. <<tw>> utilise des [[règles précises|Order of Tagged Tiddlers]] pour trier les tiddlers tagués.

--- a/editions/fr-FR/tiddlers/Tagging.tid
+++ b/editions/fr-FR/tiddlers/Tagging.tid
@@ -1,47 +1,9 @@
-C.modified: 20160612132049797
-C.tags: [[Working with TiddlyWiki]] Concepts
-C.text: Tagging is a way of organising tiddlers into categories. For example, if you had tiddlers representing various individuals, you could tag them as ''friend'', ''family'', ''colleague'' etc to indicate these people's relationships to you.
-
-A tag is in fact just a tiddler (or a potential tiddler), and it can have tags of its own. You can add any number of tags to the same tiddler.
-
-See [[Creating and editing tiddlers]] for instructions on how to tag.
-
-By tagging your tiddlers, you can view, navigate and organise your information in numerous additional ways:
-
-* The coloured tag pills on a tiddler give you quick access to all the other tiddlers with the same tag, as well as to the tiddler that represents the tag itself.
-
-* If a tiddler is serving as a tag, then the ''Tagging'' tab in its InfoPanel will show you which tiddlers are currently tagged with it.
-
-* The ''More'' tab of the sidebar has a ''Tags'' tab that presents an overview of all your tags and lets you access all your tagged tiddlers.
-
-* You can use [[filters|Filters]] to create lists of tiddlers based on their tags. You can then display any combination of the [[fields|TiddlerFields]] of those tiddlers. For example, you could build a glossary by listing the title and text of all tiddlers tagged ''Glossary''. Such lists can be formatted in any way you wish: e.g. bulleted, numbered or comma-separated.
-
-* There are a number of special ''system tags'' that control the layout of tiddlers and the entire ~TiddlyWiki page. See [[Page and tiddler layout customisation]] for instructions.
-
-There are two more things you can do with tags:
-
-! Set a tag's colour and icon
-
-You can use the <<.icon $:/core/images/tag-button>> [[tag manager|$:/TagManager]], found on the ''Tags'' tab under ''More'' in the sidebar, to change the colour of a tag's pill or add an icon to the pill.
-
-* To change the colour, click the button in the ''Colour'' column to select from a colour picker. Alternatively, click the icon in the ''Info'' column, then type a [[CSS]] colour value in the ''Colour'' field
-* To change the icon, click the <<.icon $:/core/images/down-arrow>> button in the ''Icon'' column and choose from the list of available icons
-
-! Change the order in which tags are listed
-
-By default, tagged tiddlers are listed in alphabetical order.
-
-If you want any other order, add a <<.flink ListField>> field to the tag tiddler, and set its value to be a [[list of the tiddlers|Title List]] in that order.
-
-The ''list'' field doesn't have to mention all of the tiddlers. See the [[precise rules|Order of Tagged Tiddlers]] ~TiddlyWiki uses to order tagged tiddlers.
-
 created: 20140904075400000
 fr-title: Étiqueter par tag
 modified: 20220220002448916
 tags: [[Working with TiddlyWiki]] Concepts
 title: Tagging
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 L'étiquetage des tiddlers permet de les organiser en catégories. Par exemple, les tiddlers représentant des individus pourraient être étiquetés avec les tags ''ami'', ''famille'', ''collègue'', etc. pour indiquer leur relation avec l'auteur.
 

--- a/editions/fr-FR/tiddlers/TiddlerLinks.tid
+++ b/editions/fr-FR/tiddlers/TiddlerLinks.tid
@@ -1,11 +1,37 @@
+C.modified: 20141231093344090
+C.tags: Concepts
+C.text: Links are regions of a tiddler that can be clicked to cause navigation to a different tiddler. The navigation behaviour is determined by the current StoryView; the classic TiddlyWiki view displays the story as a linear sequence of tiddlers.
+
+Holding the ''control'' or ''command'' key while clicking on a tiddler link opens the target tiddler but doesn't navigate to it. This can be a useful way of queueing up tiddlers to be read later.
+
+Links are useful for modelling organic relationships between tiddlers, and particularly for expressing the navigational paths between tiddlers.
+
+The InfoPanel lists incoming links to a tiddler in the tab ''References''.
+
+[[Filters]] can include the following filter operators that work with links:
+
+* `[links[]]` - returns the titles of the tiddlers that are linked from the currently selected tiddler(s)
+* `[backlinks[]]` - returns the titles of the tiddlers that link to the currently selected tiddler(s)
+
+TiddlyWiki5 alters the appearance of tiddler links to convey additional information about the target of the link:
+
+|!Link description |!Link appearance |
+|To a tiddler that exists |[[LikeThis|TiddlerLinks]] |
+|To a tiddler that doesn't exist |[[LikeThis|ATiddlerThatDoesntExist]] |
+|To a shadow tiddler that has not been overridden |[[LikeThis|$:/core/copyright.txt]] |
+|To a shadow tiddler that has been overridden by an ordinary tiddler |[[LikeThis|$:/SiteTitle]] |
+
+External links are shown like this: https://tiddlywiki.com/ or [[like this|https://tiddlywiki.com/]].
+
 created: 20130825202900000
 fr-title: Liens dans un Tiddler
-modified: 20150624092911695
+modified: 20220219170847313
 tags: Concepts
 title: TiddlerLinks
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
-Les liens sont des éléments d'un tiddler où cliquer engendre la navigation vers un tiddler différent. Le comportement d'une navigation est déterminé par le StoryView (la vue) en cours&lt;&lt;;&gt;&gt; par défaut, la vue classique de TiddlyWiki montre son déroulé comme une suite linéaire de tiddlers.
+Les liens sont des éléments d'un tiddler où cliquer engendre la navigation vers un tiddler différent. Le comportement d'une navigation est déterminé par le StoryView (la vue) en cours<<:>> par défaut, la vue classique de TiddlyWiki montre son déroulé comme une suite linéaire de tiddlers.
 
 Presser la touche ''control'' ou ''command'' en cliquant sur le lien d'un link ouvre le tiddler cible sans s'y déplacer. Cela peut-être un moyen pratique de dresser une suite de tiddlers à lire plus tard.
 
@@ -13,12 +39,12 @@ Les liens sont utiles pour modéliser des relations organiques entre tiddlers, e
 
 Le [[panneau d'information|InfoPanel]] liste la provenance des liens vers un tiddler dans l'onglet ''References''.
 
-Les [[filtres|Filters]] peuvent inclure les opérateur de filtrage suivant qui fonctionnent avec les liens&lt;&lt;:&gt;&gt;
+Les [[filtres|Filters]] peuvent inclure les opérateur de filtrage suivant qui fonctionnent avec les liens<<:>>
 
 * `[links[]]` - renvoie les titres des tiddlers dont les liens proviennent de la sélection des tiddler(s) en cours
 * `[backlinks[]]` - renvoie les titres des tiddlers destination des liens des tiddler(s) en cours sélectionnés
 
-TiddlyWiki5 modifie l'apparence des liens des tiddlers pour donner plus d'informations sur la cible du lien&lt;&lt;:&gt;&gt;
+TiddlyWiki5 modifie l'apparence des liens des tiddlers pour donner plus d'informations sur la cible du lien<<:>>
 
 |!Description lien |!Affichage lien |
 |Vers tiddler existant |[[Ainsi|TiddlerLinks]] |
@@ -26,4 +52,4 @@ TiddlyWiki5 modifie l'apparence des liens des tiddlers pour donner plus d'inform
 |Vers tiddler shadow non remplacé |[[Ainsi|$:/core/copyright.txt]] |
 |Vers tiddler shadow remplacé par un tiddler ordinaire|[[Ainsi|$:/SiteTitle]] |
 
-Les liens externes sont affichés comme ceci&lt;&lt;:&gt;&gt; https://tiddlywiki.com/ ou [[comme ça|https://tiddlywiki.com/]].
+Les liens externes sont affichés comme ceci<<:>> https://tiddlywiki.com/ ou [[comme ça|https://tiddlywiki.com/]].

--- a/editions/fr-FR/tiddlers/TiddlerLinks.tid
+++ b/editions/fr-FR/tiddlers/TiddlerLinks.tid
@@ -1,35 +1,9 @@
-C.modified: 20141231093344090
-C.tags: Concepts
-C.text: Links are regions of a tiddler that can be clicked to cause navigation to a different tiddler. The navigation behaviour is determined by the current StoryView; the classic TiddlyWiki view displays the story as a linear sequence of tiddlers.
-
-Holding the ''control'' or ''command'' key while clicking on a tiddler link opens the target tiddler but doesn't navigate to it. This can be a useful way of queueing up tiddlers to be read later.
-
-Links are useful for modelling organic relationships between tiddlers, and particularly for expressing the navigational paths between tiddlers.
-
-The InfoPanel lists incoming links to a tiddler in the tab ''References''.
-
-[[Filters]] can include the following filter operators that work with links:
-
-* `[links[]]` - returns the titles of the tiddlers that are linked from the currently selected tiddler(s)
-* `[backlinks[]]` - returns the titles of the tiddlers that link to the currently selected tiddler(s)
-
-TiddlyWiki5 alters the appearance of tiddler links to convey additional information about the target of the link:
-
-|!Link description |!Link appearance |
-|To a tiddler that exists |[[LikeThis|TiddlerLinks]] |
-|To a tiddler that doesn't exist |[[LikeThis|ATiddlerThatDoesntExist]] |
-|To a shadow tiddler that has not been overridden |[[LikeThis|$:/core/copyright.txt]] |
-|To a shadow tiddler that has been overridden by an ordinary tiddler |[[LikeThis|$:/SiteTitle]] |
-
-External links are shown like this: https://tiddlywiki.com/ or [[like this|https://tiddlywiki.com/]].
-
 created: 20130825202900000
 fr-title: Liens dans un Tiddler
 modified: 20220219170847313
 tags: Concepts
 title: TiddlerLinks
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 Les liens sont des éléments d'un tiddler où cliquer engendre la navigation vers un tiddler différent. Le comportement d'une navigation est déterminé par le StoryView (la vue) en cours<<:>> par défaut, la vue classique de TiddlyWiki montre son déroulé comme une suite linéaire de tiddlers.
 

--- a/editions/fr-FR/tiddlers/TiddlyFox Apocalypse.tid
+++ b/editions/fr-FR/tiddlers/TiddlyFox Apocalypse.tid
@@ -1,0 +1,46 @@
+created: 20171109170823847
+fr-title: L'apocalypse de TiddlyFox
+modified: 20220217174448054
+tags: TiddlyFox
+title: TiddlyFox Apocalypse
+type: text/vnd.tiddlywiki
+
+! Résumé
+
+Le 14 novembre 2017 Mozilla [[a publié Firefox 57|https://blog.mozilla.org/blog/2017/09/26/firefox-quantum-beta-developer-edition/]], une nouvelle version majeure comprenant de nombreuses améliorations et correctifs de sécurité. Toutefois, ces améliorations comportaient ''des changements fondamentaux du modèle de sécurité qui ont eu comme effet indésirable d'empêcher ~TiddlyFox de fonctionner''.
+
+TiddlyFox restera disponible pour les [[utilisateurs d'anciennes versions de Firefox|https://groups.google.com/d/topic/tiddlywiki/OJQ0yRq4zog/discussion]], mais ceux qui passeront à une version plus récente devront choisir une autre façon de gérer la sauvegarde des modifications avec TiddlyWiki.
+
+Heureusement, il existe de nouvelles façons de travailler avec TiddlyWiki et les utilisateurs ont de nombreux choix alternatifs (voir les détails dans <<fr GettingStarted>>). La disparition de TiddlyFox a provoqué plusieurs de ces développements récents et pourrait finalement être bénéfique pour la communauté.
+
+Ces développements font l'objet d'une [[discussion|https://groups.google.com/d/topic/tiddlywiki/LcldXzPlTK0/discussion]] sur les forums TiddlyWiki.
+
+! Contexte
+
+Firefox a été initialement publié en novembre 2004, quelques mois après la première version de TiddlyWiki. C'était très comparable au Faucon Millénium pour l'Étoile de la Mort de Microsoft (incarnée par Internet Explorer). IE écrasait depuis 5 ans le marché des navigateurs, provoquant la frustration de nombreux développeurs web face aux extensions au HTML de Microsoft qui étaient devenus des standards //de facto// au détriment d'une innovation qui aurait pu bénéficier à l'ensemble de la communauté web.
+
+Firefox a vite eu du succès car il réussissait à afficher les pages web avec un rendu assez proche d'Internet Explorer tout en offrant une meilleure expérience utilisateur. Ses avantages résidaient en grande partie dans la possibilité offerte à l'utilisateur de modifier chaque aspect du navigateur. Deux innovations étaient à l'origine de cette capacité<<:>>
+
+* L'intégralité de l'interface utilisateur du navigateur était écrite en [[XUL|https://en.wikipedia.org/wiki/XUL]], une extension au HTML qui lui permettait d'afficher des interface utilisateur conventionnelles (à l'époque, le HTML était limité à un simple rendu de documents structurés). Ajuster quelques lignes de code en XUL pouvait radicalement transformer l'interface du navigateur.
+* L'architecture d'extensions de Mozilla donnait les pleins pouvoirs aux extensions, leur permettant d'observer et d'interagir profondément avec le moteur du navigateur lui-même, ainsi qu'avec le système de fichiers de l'ordinateur sur lequel il s'exécutait.
+
+Ces deux conditions permirent l'épanouissement d'un large écosystème d'extensions autour de Firefox, pour certaines extrêmement populaires. Dans de nombreux cas, les innovations apportées par des extensions furent ensuite intégrées dans le navigateur, en particulier le débogueur [[Firebug|https://en.wikipedia.org/wiki/Firebug_(software)]] qui fut par la suite cloné par tous les éditeurs de navigateurs.
+
+Firefox resta très populaire jusqu'à ce que Google rejoigne le développement du moteur rival ~WebKit pour développer Chome. Google choisit une approche très différente des compromis au cœur d'un navigateur, se concentrant sur l'amélioration de la sécurité au détriment de toute autre considération. Ils innovèrent avec l'isolation de chaque onglet dans un processus dédié, qui fut rapidement repris par les principaux navigateurs concurrents.
+
+L'orientation de Google les empêcha d'adopter l'approche libertaire de Mozilla pour les extensions. Au lieu d'avoir accès à tout l'environnement du navigateur et au système, les extensions de Chrome ne voient qu'une petite partie de ce qui se passe dans le navigateur, et n'ont qu'un accès minimal aux ressources de l'hôte.
+
+Le ralliement de Mozilla à l'approche de la [[sécurité des extensions de navigateurs|https://support.mozilla.org/en-US/kb/firefox-add-technology-modernizing]] de Google était inévitable. A ce point, Mozilla aurait été irresponsable de publier un navigateur construit sur un modèle de sécurité notoirement inférieur à celui du leader du marché.
+
+! Leçons
+
+Une partie de la fécondité de l'écosystème autour de TiddlyWiki provient de l'adoption des deux principes de Firefox cités précédemment<<:>>
+
+* Construire l'interface utilisateur de l'application avec les mêmes primitives que son contenu
+* Permettre aux extensions d'accéder et interagir librement avec la logique interne de l'application.
+
+Ces deux caractéristiques confrontent TiddlyWiki aux mêmes défis de sécurité que Firefox en son temps. Un TiddlyWiki orienté principalement vers la sécurité serait contraint de réduire ces possibilités.
+
+! Le futur
+
+Dans le domaine des interfaces basées sur les navigateurs et des interactions utilisateur, l'innovation a maintenant quitté les extensions pour migrer vers une nouvelle génération d'environnements qui simplifient la créations de navigateurs sur-mesure basés sur des moteurs de rendu HTML libres sur étagère. Ainsi, TiddlyDesktop utilise [[nwjs|https://nwjs.io]], et [[Beaker Browser]] utilise une alternative nommée [[Electron|https://electron.atom.io/]].

--- a/editions/fr-FR/tiddlers/TiddlyFox.tid
+++ b/editions/fr-FR/tiddlers/TiddlyFox.tid
@@ -1,17 +1,20 @@
 created: 20130825161100000
-modified: 20160602060511458
+modified: 20220217174534558
 tags: Definitions
 title: TiddlyFox
 type: text/vnd.tiddlywiki
 
 //~TiddlyFox// est une extension pour Firefox qui permet aux fichiers <<tw>> autonomes d'enregistrer leurs modifications directement sur le système de fichiers. //~TiddlyFox// fonctionne aussi bien sur les versions station de travail que mobile de [[Firefox]]. Voir [[Enregistrer avec TiddlyFox|Saving with TiddlyFox]] ou [[Enregistrer avec TiddlyFox pour Android|Saving with TiddlyFox on Android]] pour des instructions détaillées.
 
-//~TiddlyFox// peut être téléchargé depuis le site //Mozilla Addons//<<dp>>
+~TiddlyFox est maintenant obsolète car il n'est plus compatible avec les dernières versions de Firefox (voir <<fr "TiddlyFox Apocalypse">>). Il existe de nombreuses alternatives à ~TiddlyFox, mais aucune ne fonctionne exactement de la même façon. Voir <<fr GettingStarted>> pour plus d'informations.
+
+
+//~TiddlyFox// peut être téléchargé depuis le site //Mozilla Addons//<<:>>
 
 https://addons.mozilla.org/fr/firefox/addon/tiddlyfox/
 
 <<<
-Vous pouvez également installer la dernière version de développement de ~TiddlyFox directement depuis GitHub<<dp>>
+Vous pouvez également installer la dernière version de développement de ~TiddlyFox directement depuis GitHub<<:>>
 
 https://github.com/TiddlyWiki/TiddlyFox/raw/master/tiddlyfox.xpi
 <<<

--- a/editions/fr-FR/tiddlers/TiddlyWiki.tid
+++ b/editions/fr-FR/tiddlers/TiddlyWiki.tid
@@ -1,12 +1,25 @@
+C.modified: 20170127221451610
+C.tags: Concepts
+C.text: ~TiddlyWiki is a rich, interactive tool for manipulating complex data with structure that doesn't easily fit into conventional tools like spreadsheets or wordprocessors.
+
+~TiddlyWiki is designed to fit around your brain, helping you deal with the things that won't fit. The [[fundamental idea|Philosophy of Tiddlers]] is that information is more useful and reusable if we cut it up into the smallest semantically meaningful chunks -- [[tiddlers|Tiddlers]] -- and give them titles so that they can be [[structured|Structuring TiddlyWiki]] with [[links|TiddlerLinks]], [[tags|Tagging]], [[lists|ListField]] and [[macros|Macros]]. Tiddlers use a WikiText notation that concisely represents a wide range of text formatting and hypertext features. ~TiddlyWiki aims to provide a fluid interface for working with tiddlers, allowing them to be aggregated and composed into longer narratives.
+
+People love using ~TiddlyWiki. Because it can be used without any complicated server infrastructure, and because it is [[open source|OpenSource]], it has brought unprecedented freedom to everyone to keep their precious information under their own control.
+
+~TiddlyWiki was originally created by JeremyRuston and is now a thriving [[open source|License]] project with a busy [[Community]] of independent developers.
+
 caption: TiddlyWiki
 created: 20130822170700000
-modified: 20150622113210434
+modified: 20220219162827424
 tags: Concepts
 title: TiddlyWiki
 type: text/vnd.tiddlywiki
+wl-field-name-note: C.text
 
-~TiddlyWiki est un outil riche et interactif, capable de manipuler des données structurées complexes. Il est assez éloigné des outils conventionnels comme les traitements de texte ou les feuilles de calcul.
+<<tw>> est un outil riche et interactif, capable de manipuler des données complexes dont la structure n'est pas adaptée aux outils conventionnels comme les traitements de texte ou les feuilles de calcul.
 
-~TiddlyWiki est conçu pour s'adapter à votre cerveau, en vous aidant à gérer ce qui s'adapte mal. L'[[idée fondamentale|Philosophy of Tiddlers]] est que les informations sont plus utiles et plus facilement réutilisables quand on les découpe en morceaux sémantiques aussi petits que possible -- [[les tiddlers|Tiddlers]] -- en leur donnant des titres à partir desquels le wiki pourra se [[structurer|Structuring TiddlyWiki]] à l'aide de [[liens|TiddlerLinks]], d'[[étiquettes|Tagging]], de [[listes|ListField]] et de [[macros|Macros]]. Les tiddlers utilisent une notation [[WikiTexte|WikiText]] qui permet de représenter de façon concise une grande panoplie de fonctions hypertexte et de formatage. Le but de ~TiddlyWiki est de fournir une interface de travail fluide, à même de faciliter l'agrégation des tiddlers et leur recomposition en textes plus long.
+<<tw>> est conçu pour s'adapter à votre cerveau, en vous aidant à gérer ce qui s'adapte mal. L'[[idée fondamentale|Philosophy of Tiddlers]] est que les informations sont plus utiles et plus facilement réutilisables quand on les découpe en morceaux sémantiques aussi petits que possible -- [[les tiddlers|Tiddlers]] -- en leur donnant des titres à partir desquels le wiki pourra se [[structurer|Structuring TiddlyWiki]] à l'aide de [[liens|TiddlerLinks]], d'[[étiquettes|Tagging]], de [[listes|ListField]] et de [[macros|Macros]]. Les tiddlers utilisent une notation [[WikiTexte|WikiText]] qui permet de représenter de façon concise une grande panoplie de fonctions hypertexte et de formatage. Le but de <<tw>> est de fournir une interface de travail fluide, à même de faciliter l'agrégation des tiddlers et leur recomposition en textes plus long.
 
-Les gens [[adorent utiliser|Raves]] ~TiddlyWiki. Parce qu'on peut l'utiliser en l'absence d'infrastructure de serveurs compliquée, et parce qu'il est [[open source|OpenSource]], il a apporté une liberté inédite à ceux qui veulent garder le contrôle de leurs précieuses informations. ~TiddlyWiki a été créé initialement par JeremyRuston et est maintenant devenu un projet //open source// qui s'épanouit grâce à une [[communauté|Community]] active de développeurs indépendants.
+Les gens adorent utiliser <<tw>>. Comme on peut l'utiliser en l'absence d'infrastructure de serveurs compliquée, et qu'il est [[open source|OpenSource]], il a apporté une liberté inédite à ceux qui veulent garder le contrôle de leurs précieuses informations.
+
+<<tw>> a été créé initialement par JeremyRuston et est maintenant devenu un projet //open source// qui s'épanouit grâce à une [[communauté|Community]] active de développeurs indépendants.

--- a/editions/fr-FR/tiddlers/TiddlyWiki.tid
+++ b/editions/fr-FR/tiddlers/TiddlyWiki.tid
@@ -1,20 +1,9 @@
-C.modified: 20170127221451610
-C.tags: Concepts
-C.text: ~TiddlyWiki is a rich, interactive tool for manipulating complex data with structure that doesn't easily fit into conventional tools like spreadsheets or wordprocessors.
-
-~TiddlyWiki is designed to fit around your brain, helping you deal with the things that won't fit. The [[fundamental idea|Philosophy of Tiddlers]] is that information is more useful and reusable if we cut it up into the smallest semantically meaningful chunks -- [[tiddlers|Tiddlers]] -- and give them titles so that they can be [[structured|Structuring TiddlyWiki]] with [[links|TiddlerLinks]], [[tags|Tagging]], [[lists|ListField]] and [[macros|Macros]]. Tiddlers use a WikiText notation that concisely represents a wide range of text formatting and hypertext features. ~TiddlyWiki aims to provide a fluid interface for working with tiddlers, allowing them to be aggregated and composed into longer narratives.
-
-People love using ~TiddlyWiki. Because it can be used without any complicated server infrastructure, and because it is [[open source|OpenSource]], it has brought unprecedented freedom to everyone to keep their precious information under their own control.
-
-~TiddlyWiki was originally created by JeremyRuston and is now a thriving [[open source|License]] project with a busy [[Community]] of independent developers.
-
 caption: TiddlyWiki
 created: 20130822170700000
 modified: 20220219162827424
 tags: Concepts
 title: TiddlyWiki
 type: text/vnd.tiddlywiki
-wl-field-name-note: C.text
 
 <<tw>> est un outil riche et interactif, capable de manipuler des données complexes dont la structure n'est pas adaptée aux outils conventionnels comme les traitements de texte ou les feuilles de calcul.
 

--- a/languages/fr-FR/GettingStarted.tid
+++ b/languages/fr-FR/GettingStarted.tid
@@ -1,18 +1,35 @@
+created: 20131129090249275
+fr-title: La mise en route
+modified: 20220217175123712
+tags: [[Working with TiddlyWiki]]
 title: GettingStarted
+type: text/vnd.tiddlywiki
 
-\define lingo-base() $:/language/ControlPanel/Basics/
-Bienvenue sur ~TiddlyWiki et parmi la communauté ~TiddlyWiki.
 
-Avant de confier à TiddlyWiki des informations importantes, commencez par vérifier que vos modifications peuvent être sauvegardées
-correctement — reportez-vous aux [[instructions détaillées|https://tiddlywiki.com/languages/fr-FR/index.html#Saving]] sur https://tiddlywiki.com/.
+Téléchargez un <<tw>> vide en cliquant sur ce bouton<<:>> {{$:/editions/fr-FR/snippets/download-empty-button}}
 
-!! Personnalisez ce ~TiddlyWiki
+L'étape suivante consiste à choisir une solution d'enregistrement des modifications. De nombreuses méthodes sont disponibles, chacune avec ses atouts et ses limites. Cliquez sur la fiche d'une méthode pour voir plus d'informations la concernant. Vous pouvez aussi cocher une case de plateformes et de navigateur pour afficher les solutions qui fonctionnent pour cette combinaison.
 
-<div class="tc-control-panel">
+<<.warning "N'utilisez pas le menu ''Fichier''/''Enregistrer'' du navigateur internet pour enregistrer vos modifications (ça ne marche pas)<<!>>">><br/><br/>
 
-|<$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link> |<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
-|<$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link> |<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
-|<$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link> |<<lingo DefaultTiddlers/TopHint>><br> <$edit-text tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
+{{Saving}}
+
+
+
+Autres informations<<:>>
+
+* [[Protéger le contenu avec un mot de passe|Encryption]] grâce au système de chiffrement intégré à <<tw>><<;>>
+* [[Enregistrer avec Tiddlyspot|Saving on TiddlySpot]], un service gratuit qui vous permet d'utiliser <<tw>> en ligne<<;>>
+* Sauvegarde avec TiddlyDesktop, une application de bureautique dédiée au travail avec <<tw>><<;>>
+* Vous pouvez aussi télécharger ce <<tw>> complet, avec toute sa documentation<<:>><div>
+
+<<<
+{{$:/snippets/download-wiki-button}}
+
+Si le bouton ne fonctionne pas, sauvegardez ce lien<<:>>
+
+<a href="https://tiddlywiki.com/languages/fr-FR/index.html" download="index.html">~https://tiddlywiki.com/languages/fr-FR/index.html</a>
+
+Votre navigateur vous demandera sans doute confirmation avant de démarrer le téléchargement.
+<<<
 </div>
-
-Rendez-vous dans le [[panneau de contrôle|$:/ControlPanel]] pour plus d'options.


### PR DESCRIPTION
Update of French translations, starting from the default StoryList of the fr-FR edition.

Although most commits only contain translations, two of them change some code : 

- [8ca5908](https://github.com/Jermolene/TiddlyWiki5/pull/6467/commits/8ca5908bfe08c0f554a67e7651b66e77e6dd7abf) adds a new macro in a tiddler which belongs to fr-FR edition
- [4f39b80](https://github.com/Jermolene/TiddlyWiki5/pull/6467/commits/4f39b80adde764fa965918789d531af703abb8eb) updates macros from a tiddler which initially belongs to tw5.com edition but contains text that must be translated.