### PR TITLE
feat: extend tm-open-window to support optional top and left position for new browser window

### DIFF
--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -40,7 +40,7 @@ exports.startup = function() {
 		    srcDocument;
 		// In case that popup blockers deny opening a new window
 		try {
-			srcWindow = window.open("","external-" + title,"scrollbars,width=" + width +  ",height=" + height + (top ? ",top=" + top : "" ) + (left ? ",left=" + left : "" )),
+			srcWindow = window.open("","external-" + title,"scrollbars,width=" + width + ",height=" + height + (top ? ",top=" + top : "" ) + (left ? ",left=" + left : "" )),
 			srcDocument = srcWindow.document;
 		}
 		catch(e) {

--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -32,13 +32,15 @@ exports.startup = function() {
 			template = paramObject.template || "$:/core/templates/single.tiddler.window",
 			width = paramObject.width || "700",
 			height = paramObject.height || "600",
+			top = paramObject.top,
+			left = paramObject.left,
 			variables = $tw.utils.extend({},paramObject,{currentTiddler: title});
 		// Open the window
 		var srcWindow,
 		    srcDocument;
 		// In case that popup blockers deny opening a new window
 		try {
-			srcWindow = window.open("","external-" + title,"scrollbars,width=" + width + ",height=" + height),
+			srcWindow = window.open("","external-" + title,"scrollbars,width=" + width +  ",height=" + height + (top ? ",top=" + top : "" ) + (left ? ",left=" + left : "" )),
 			srcDocument = srcWindow.document;
 		}
 		catch(e) {

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
@@ -20,7 +20,7 @@ The `tm-open-window` [[message|Messages]] opens a tiddler in a new //browser// w
 The `tm-open-window` message is best generated with the ActionSendMessageWidget, which in turn is triggered by a widget such as the ButtonWidget. It is handled by the core itself.
 
 <<.tip """When used with the ActionSendMessageWidget, <<.param 'param'>> becomes <<.param '$param'>> """>>
-<<.tip """Parameters <<.param template>>, <<.param windowTitle>>, <<.param width>>, and <<.param height>> require the ActionSendMessageWidget.""">>
+<<.tip """Parameters <<.param template>>, <<.param windowTitle>>, <<.param width>>, <<.param height>>, <<.param left>> and <<.param top>> require the ActionSendMessageWidget.""">>
 
 
 <$macrocall $name='wikitext-example-without-html'

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
@@ -1,11 +1,11 @@
 caption: tm-open-window
 created: 20160424181447704
-modified: 20211117042202771
+modified: 20220219125413255
 tags: Messages
 title: WidgetMessage: tm-open-window
 type: text/vnd.tiddlywiki
 
-The `tm-open-window` [[message|Message]] opens a tiddler in a new //browser// window. If no parameters are specified, the current tiddler is opened in a new window. Similiar to `tm-modal` any additional parameters passed via the <<.param "paramObject">> are provided as variables to the new window.
+The `tm-open-window` [[message|Messages]] opens a tiddler in a new //browser// window. If no parameters are specified, the current tiddler is opened in a new window. Similiar to `tm-modal` any additional parameters passed via the <<.param "paramObject">> are provided as variables to the new window.
 
 |!Name |!Description |
 |param |Title of the tiddler to be opened in a new browser window, defaults to <<.var "currentTiddler">> if empty |
@@ -13,11 +13,13 @@ The `tm-open-window` [[message|Message]] opens a tiddler in a new //browser// wi
 |windowTitle |Title string for the opened window |
 |width |Width of the new browser window |
 |height |Height of the new browser window |
+|left|<<.from-version "5.2.2">> Optional, left position of new browser window|
+|top|<<.from-version "5.2.2">> Optional, top position of new browser window|
 |paramObject |Hashmap of variables to be provided to the modal, contains all extra parameters passed to the widget sending the message. |
 
 The `tm-open-window` message is best generated with the ActionSendMessageWidget, which in turn is triggered by a widget such as the ButtonWidget. It is handled by the core itself.
 
-<<.tip """When used with the ActionSendMessage Widget, <<.param 'param'>> becomes <<.param '$param'>> """>>
+<<.tip """When used with the ActionSendMessageWidget, <<.param 'param'>> becomes <<.param '$param'>> """>>
 <<.tip """Parameters <<.param template>>, <<.param windowTitle>>, <<.param width>>, and <<.param height>> require the ActionSendMessageWidget.""">>
 
 


### PR DESCRIPTION
This PR extends the widget message `tm-open-window` to support optional top and left parameters for the new browser window.

Closes #6455 