### PR TITLE
Consider non-existent tiddlers untagged

### DIFF
--- a/core/modules/filters/untagged.js
+++ b/core/modules/filters/untagged.js
@@ -19,7 +19,7 @@ exports.untagged = function(source,operator,options) {
 	var results = [],
 		expected = (operator.prefix === "!");
 	source(function(tiddler,title) {
-		if((tiddler && $tw.utils.isArray(tiddler.fields.tags) && tiddler.fields.tags.length > 0) === expected) {
+		if(((tiddler && $tw.utils.isArray(tiddler.fields.tags) && tiddler.fields.tags.length > 0) === expected) || (!tiddler && !expected)) {
 			results.push(title);
 		}
 	});

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -428,6 +428,9 @@ Tests the filtering mechanism.
 		it("should handle the untagged operator", function() {
 			expect(wiki.filterTiddlers("[untagged[]sort[title]]").join(",")).toBe("$:/ShadowPlugin,a fourth tiddler,filter regexp test,has filter,hasList,one");
 			expect(wiki.filterTiddlers("[!untagged[]sort[title]]").join(",")).toBe("$:/TiddlerTwo,Tiddler Three,TiddlerOne");
+			// Should consider non-existent tiddlers untagged.
+			expect(wiki.filterTiddlers("[enlist[a b c]untagged[]]").join(",")).toBe("a,b,c");
+			expect(wiki.filterTiddlers("[enlist[a b c]!untagged[]]").join(",")).toBe("");
 		});
 	
 		it("should handle the links operator", function() {


### PR DESCRIPTION
Fixes regression introduced in 575c23359.

Fixes: #6119
See-also: 575c23359 (Update untagged filter to avoid $tw.utils.pushTop (#6034), 2021-09-18)