### PR TITLE
Docs: mention MessageCatcher widget in LinkCatcher tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/LinkCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/LinkCatcherWidget.tid
@@ -1,6 +1,6 @@
 caption: linkcatcher
 created: 20131024141900000
-modified: 20211009122821108
+modified: 20220226121122574
 tags: Widgets MessageHandlerWidgets TriggeringWidgets
 title: LinkCatcherWidget
 type: text/vnd.tiddlywiki
@@ -25,3 +25,4 @@ The content of the `<$linkcatcher>` widget is displayed normally.
 |setTo |Value to be assigned by the `set` attribute |
 |actions |Actions to be performed when a link is caught. Within the action string, the variable "navigateTo" contains the title of the tiddler being navigated. <<.from-version "5.1.23">> the <<.def "modifier">> variable lists the modifier keys that are pressed when the action is invoked. The possible modifiers are ''ctrl'', ''ctrl-alt'', ''ctrl-shift'', ''alt'', ''alt-shift'', ''shift'' and ''ctrl-alt-shift'' |
 
+<<.tip """<<.from-version "5.2.0">> For more complex use cases involving trapping the <<.param tm-navigate>> message consider the MessageCatcherWidget which provides greater flexibility""">>


### PR DESCRIPTION
This PR adds a tip about using $messagecatcher for more complex use cases in the tiddler concerning $linkcatcher.