### PR TITLE
change branch from master to tiddlywiki-com

### DIFF
--- a/editions/tw5.com/tiddlers/community/Contributor License Agreement.tid
+++ b/editions/tw5.com/tiddlers/community/Contributor License Agreement.tid
@@ -1,10 +1,10 @@
 created: 20150630205511173
-modified: 20150630205632460
+modified: 20220226175543038
 tags: 
 title: Contributor License Agreement
 type: text/vnd.tiddlywiki
 
 Like other OpenSource projects, TiddlyWiki5 needs a signed contributor license agreement from individual contributors. This is a legal agreement that allows contributors to assert that they own the copyright of their contribution, and that they agree to license it to the UnaMesa Association (the legal entity that owns TiddlyWiki on behalf of the community).
 
-* For individuals use: [[licenses/CLA-individual|https://github.com/Jermolene/TiddlyWiki5/tree/master/licenses/cla-individual.md]]
-* For entities use: [[licenses/CLA-entity|https://github.com/Jermolene/TiddlyWiki5/tree/master/licenses/cla-entity.md]]
+* For individuals use: [[licenses/CLA-individual|https://github.com/Jermolene/TiddlyWiki5/tree/tiddlywiki-com/licenses/cla-individual.md]]
+* For entities use: [[licenses/CLA-entity|https://github.com/Jermolene/TiddlyWiki5/tree/tiddlywiki-com/licenses/cla-entity.md]]

--- a/editions/tw5.com/tiddlers/community/Signing the Contributor License Agreement.tid
+++ b/editions/tw5.com/tiddlers/community/Signing the Contributor License Agreement.tid
@@ -1,5 +1,5 @@
 created: 20150630205653005
-modified: 20190115165616599
+modified: 20220226175503241
 tags: 
 title: Signing the Contributor License Agreement
 type: text/vnd.tiddlywiki
@@ -8,7 +8,7 @@ Create a GitHub pull request to add your name to `cla-individual.md` or `cla-ent
 
 ''step by step''
 
-# Navigate to [[licenses/CLA-individual|https://github.com/Jermolene/TiddlyWiki5/tree/master/licenses/cla-individual.md]] or [[licenses/CLA-entity|https://github.com/Jermolene/TiddlyWiki5/tree/master/licenses/cla-entity.md]] according to whether you are signing as an individual or representative of an organisation
+# Navigate to [[licenses/CLA-individual|https://github.com/Jermolene/TiddlyWiki5/tree/tiddlywiki-com/licenses/cla-individual.md]] or [[licenses/CLA-entity|https://github.com/Jermolene/TiddlyWiki5/tree/tiddlywiki-com/licenses/cla-entity.md]] according to whether you are signing as an individual or representative of an organisation
 # Ensure that the "branch" dropdown at the top left is set to `tiddlywiki-com`
 # Click the "edit" button at the top-right corner (clicking this button will fork the project so you can edit the file)
 # Add your name at the bottom


### PR DESCRIPTION
change branch from master to tiddlywiki-com ... This PR will improve the experience for new users. I found out about this while recording some github and TW related videos.