### PR TITLE
Improve readability for documentation macros

### DIFF
--- a/editions/tw5.com/tiddlers/system/operator-macros.tid
+++ b/editions/tw5.com/tiddlers/system/operator-macros.tid
@@ -1,7 +1,7 @@
 created: 20150117152607000
-modified: 20150228114306000
-title: $:/editions/tw5.com/operator-macros
+modified: 20220227210111054
 tags: $:/tags/Macro
+title: $:/editions/tw5.com/operator-macros
 
 \define .operator-examples(op,text:"Examples") <$link to="$op$ Operator (Examples)">$text$</$link>
 
@@ -48,3 +48,5 @@ tags: $:/tags/Macro
 <$macrocall $name=".note" _="This operator is <<.em not>> available when ~TiddlyWiki is running in a web browser."/>
 
 \end
+
+<pre><$view field="text"/></pre>

--- a/editions/tw5.com/tiddlers/system/style-guide-macros.tid
+++ b/editions/tw5.com/tiddlers/system/style-guide-macros.tid
@@ -1,5 +1,7 @@
-title: $:/editions/tw5.com/style-guide-macros
+created: 20220227210120989
+modified: 20220227210123695
 tags: $:/tags/Macro
+title: $:/editions/tw5.com/style-guide-macros
 
 \define style-guide(good,bad)
 <table>
@@ -15,3 +17,5 @@ tags: $:/tags/Macro
 </tbody>
 </table>
 \end
+
+<pre><$view field="text"/></pre>

--- a/editions/tw5.com/tiddlers/system/variable-macros.tid
+++ b/editions/tw5.com/tiddlers/system/variable-macros.tid
@@ -1,7 +1,7 @@
 created: 20150228114241000
-modified: 20150228141312000
-title: $:/editions/tw5.com/variable-macros
+modified: 20220227210136243
 tags: $:/tags/Macro
+title: $:/editions/tw5.com/variable-macros
 
 \define .variable-examples(v,text:"Examples") <$link to="$v$ Variable (Examples)">$text$</$link>
 \define .macro-examples(m,text:"Examples") <$link to="$m$ Macro (Examples)">$text$</$link>
@@ -17,3 +17,5 @@ It can be set to <<.value yes>> or <<.value no>> prior to transcluding such a bu
 
 The standard page template sets it to the value found in [[$configTiddler$]], with the result that this becomes the default for the whole page. The user can adjust this default by using a tickbox on the <<.controlpanel-tab Settings>> tab of the [[Control Panel|$:/ControlPanel]].
 \end
+
+<pre><$view field="text"/></pre>

--- a/editions/tw5.com/tiddlers/system/wikitext-macros.tid
+++ b/editions/tw5.com/tiddlers/system/wikitext-macros.tid
@@ -1,5 +1,5 @@
 created: 20150117184156000
-modified: 20220122143551571
+modified: 20220227210152153
 tags: $:/tags/Macro
 title: $:/editions/tw5.com/wikitext-macros
 type: text/vnd.tiddlywiki
@@ -64,3 +64,5 @@ $$$
 
 <<tw-code $tiddler$>>
 \end
+
+<pre><$view field="text"/></pre>


### PR DESCRIPTION
While I was recording a video, I found out, that those macros are not readable by users in view mode.