### PR TITLE
Improve affordances for new browser windows

### DIFF
--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -103,7 +103,7 @@ exports.startup = function() {
 	var closeAllWindows = function() {
 		$tw.utils.each($tw.windows,function(win) {
 			win.close();
-		});		
+		});
 	}
 	$tw.rootWidget.addEventListener("tm-close-all-windows",closeAllWindows);
 	// Close open windows when unloading main window

--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -37,7 +37,7 @@ exports.startup = function() {
 			height = paramObject.height || "600",
 			top = paramObject.top,
 			left = paramObject.left,
-			variables = $tw.utils.extend({},paramObject,{currentTiddler: title, "tv-window-template": template});
+			variables = $tw.utils.extend({},paramObject,{currentTiddler: title, "tv-window-id": windowID});
 		// Open the window
 		var srcWindow,
 		    srcDocument;

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-all-windows.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-all-windows.tid
@@ -1,0 +1,20 @@
+created: 20220301162305764
+modified: 20220301180818011
+tags: Messages
+title: WidgetMessage: tm-close-all-windows
+type: text/vnd.tiddlywiki
+
+<<.from-version 5.2.2>>
+The `tm-close-all-windows` [[message|Messages]] closes all additional //browser// window that were opened with [[tm-open-window|WidgetMessage: tm-open-window]]. 
+
+The `tm-close-window` message is best generated with the ActionSendMessageWidget, which in turn is triggered by a widget such as the ButtonWidget. It is handled by the core itself.
+
+<$macrocall $name='wikitext-example-without-html'
+src="""
+<$button>Close All Windows
+<$action-sendmessage 
+  $message="tm-close-all-windows" 
+/>
+</$button>
+""" />
+

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-window.tid
@@ -1,0 +1,42 @@
+caption: tm-open-window
+created: 20220228140417116
+modified: 20220228142337865
+revision: 0
+tags: Messages
+title: WidgetMessage: tm-close-window
+type: text/vnd.tiddlywiki
+
+<<.from-version 5.2.2>>
+The `tm-close-window` [[message|Messages]] closes additional //browser// windows that were previously opened with [[tm-open-window|WidgetMessage: tm-open-window]]. If no parameters are specified, all additional windows are closed. Alternatively, the tiddler and template used to open a new window can be provided as the parameters <<.param param>> and <<.param template>> respectively to close a specific window.
+
+|!Name |!Description |
+|param |(Optional) Title of the tiddler open in the new browser window |
+|template |(Optional) Template used for opening the new browser window. Defaults to `$:/core/templates/single.tiddler.window` |
+
+The `tm-close-window` message is best generated with the ActionSendMessageWidget, which in turn is triggered by a widget such as the ButtonWidget. It is handled by the core itself.
+
+<<.tip """When used with the ActionSendMessageWidget, <<.param 'param'>> becomes <<.param '$param'>> """>>
+<<.tip """The Parameter <<.param template>> requires the ActionSendMessageWidget.""">>
+
+
+<$macrocall $name='wikitext-example-without-html'
+src="""
+<$button>Open Window
+<$action-sendmessage 
+  $message="tm-open-window" 
+  $param="$:/temp/openme" 
+  template="SampleWindowTemplate" 
+  windowTitle="My Window Title"
+  width="400"
+  height="500"
+  something="I just in over in a variable, and boy is my Hashmap tired." />
+</$button>
+<$button>Close Window
+<$action-sendmessage 
+  $message="tm-close-window" 
+  $param="$:/temp/openme" 
+  template="SampleWindowTemplate" 
+/>
+</$button>
+""" />
+

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-close-window.tid
@@ -1,23 +1,20 @@
 caption: tm-open-window
 created: 20220228140417116
-modified: 20220228142337865
-revision: 0
+modified: 20220301180905777
 tags: Messages
 title: WidgetMessage: tm-close-window
 type: text/vnd.tiddlywiki
 
 <<.from-version 5.2.2>>
-The `tm-close-window` [[message|Messages]] closes additional //browser// windows that were previously opened with [[tm-open-window|WidgetMessage: tm-open-window]]. If no parameters are specified, all additional windows are closed. Alternatively, the tiddler and template used to open a new window can be provided as the parameters <<.param param>> and <<.param template>> respectively to close a specific window.
+The `tm-close-window` [[message|Messages]] closes an additional //browser// window that was opened with [[tm-open-window|WidgetMessage: tm-open-window]]. Specify which window to close by setting the value of <<.param param>> to the string used as <<.param windowID>> when opening the window.
 
 |!Name |!Description |
-|param |(Optional) Title of the tiddler open in the new browser window |
-|template |(Optional) Template used for opening the new browser window. Defaults to `$:/core/templates/single.tiddler.window` |
+|param //{default param}//  |String used as <<.param windowID>> when opening the window |
 
 The `tm-close-window` message is best generated with the ActionSendMessageWidget, which in turn is triggered by a widget such as the ButtonWidget. It is handled by the core itself.
 
 <<.tip """When used with the ActionSendMessageWidget, <<.param 'param'>> becomes <<.param '$param'>> """>>
-<<.tip """The Parameter <<.param template>> requires the ActionSendMessageWidget.""">>
-
+<<.tip """To close all additional browser windows that were opened with [[tm-open-window|WidgetMessage: tm-open-window]] use [[WidgetMessage: tm-close-all-windows]]""">>
 
 <$macrocall $name='wikitext-example-without-html'
 src="""
@@ -29,13 +26,13 @@ src="""
   windowTitle="My Window Title"
   width="400"
   height="500"
+  windowID="window1"
   something="I just in over in a variable, and boy is my Hashmap tired." />
 </$button>
 <$button>Close Window
 <$action-sendmessage 
   $message="tm-close-window" 
-  $param="$:/temp/openme" 
-  template="SampleWindowTemplate" 
+  $param="window1" 
 />
 </$button>
 """ />

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
@@ -1,6 +1,6 @@
 caption: tm-open-window
 created: 20160424181447704
-modified: 20220219125413255
+modified: 20220228142325616
 tags: Messages
 title: WidgetMessage: tm-open-window
 type: text/vnd.tiddlywiki
@@ -21,7 +21,7 @@ The `tm-open-window` message is best generated with the ActionSendMessageWidget,
 
 <<.tip """When used with the ActionSendMessageWidget, <<.param 'param'>> becomes <<.param '$param'>> """>>
 <<.tip """Parameters <<.param template>>, <<.param windowTitle>>, <<.param width>>, <<.param height>>, <<.param left>> and <<.param top>> require the ActionSendMessageWidget.""">>
-
+<<.tip """<<.from-version 5.2.2>> To close a window opened with tm-open-window use [[WidgetMessage: tm-close-window]]""">>
 
 <$macrocall $name='wikitext-example-without-html'
 src="""

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-open-window.tid
@@ -1,6 +1,6 @@
 caption: tm-open-window
 created: 20160424181447704
-modified: 20220228142325616
+modified: 20220301162140993
 tags: Messages
 title: WidgetMessage: tm-open-window
 type: text/vnd.tiddlywiki
@@ -8,20 +8,22 @@ type: text/vnd.tiddlywiki
 The `tm-open-window` [[message|Messages]] opens a tiddler in a new //browser// window. If no parameters are specified, the current tiddler is opened in a new window. Similiar to `tm-modal` any additional parameters passed via the <<.param "paramObject">> are provided as variables to the new window.
 
 |!Name |!Description |
-|param |Title of the tiddler to be opened in a new browser window, defaults to <<.var "currentTiddler">> if empty |
-|template |Template in which the tiddler will be rendered in |
+|param //{default param}//  |Title of the tiddler to be opened in a new browser window, defaults to <<.var "currentTiddler">> if empty |
+|template |Template in which the tiddler will be rendered |
 |windowTitle |Title string for the opened window |
 |width |Width of the new browser window |
 |height |Height of the new browser window |
 |left|<<.from-version "5.2.2">> Optional, left position of new browser window|
 |top|<<.from-version "5.2.2">> Optional, top position of new browser window|
-|paramObject |Hashmap of variables to be provided to the modal, contains all extra parameters passed to the widget sending the message. |
+|windowID|<<.from-version "5.2.2">> Optional, unique string used to identify the widow. Can be used with [[WidgetMessage: tm-close-window]] to close the window. Defaults to the value of <<.param param>> |
+|//{any other params}// |Any other parameters are made available as variables within the new window |
 
 The `tm-open-window` message is best generated with the ActionSendMessageWidget, which in turn is triggered by a widget such as the ButtonWidget. It is handled by the core itself.
 
 <<.tip """When used with the ActionSendMessageWidget, <<.param 'param'>> becomes <<.param '$param'>> """>>
 <<.tip """Parameters <<.param template>>, <<.param windowTitle>>, <<.param width>>, <<.param height>>, <<.param left>> and <<.param top>> require the ActionSendMessageWidget.""">>
 <<.tip """<<.from-version 5.2.2>> To close a window opened with tm-open-window use [[WidgetMessage: tm-close-window]]""">>
+<<.tip """<<.from-version 5.2.2>> To open a tiddler in more than one new window, use a unique value for <<.param windowID>>""">>
 
 <$macrocall $name='wikitext-example-without-html'
 src="""


### PR DESCRIPTION
This PR implements two changes:

1. Extends the support for `tm-open-window` to allow opening a tiddler in more than one browser window by specifying a unique `windowID` parameter.
2. Introduces `tm-close-window` and `tm-close-all-windows` to allow closing browser windows opened with `tm-open-window`.
