### PR TITLE
Fix sorting of sidebar language, plugin and theme list

### DIFF
--- a/core/ui/MoreSideBar/plugins/Languages.tid
+++ b/core/ui/MoreSideBar/plugins/Languages.tid
@@ -2,4 +2,4 @@ title: $:/core/ui/MoreSideBar/Plugins/Languages
 tags: $:/tags/MoreSideBar/Plugins
 caption: {{$:/language/ControlPanel/Plugins/Languages/Caption}}
 
-<$list filter="[!has[draft.of]plugin-type[language]sort[description]]" template="$:/core/ui/PluginListItemTemplate" emptyMessage={{$:/language/ControlPanel/Plugins/Empty/Hint}}/>
+<$list filter="[!has[draft.of]plugin-type[language]sort[name]]" template="$:/core/ui/PluginListItemTemplate" emptyMessage={{$:/language/ControlPanel/Plugins/Empty/Hint}}/>

--- a/core/ui/MoreSideBar/plugins/Plugins.tid
+++ b/core/ui/MoreSideBar/plugins/Plugins.tid
@@ -2,4 +2,4 @@ title: $:/core/ui/MoreSideBar/Plugins/Plugins
 tags: $:/tags/MoreSideBar/Plugins
 caption: {{$:/language/ControlPanel/Plugins/Plugins/Caption}}
 
-<$list filter="[!has[draft.of]plugin-type[plugin]sort[description]]" template="$:/core/ui/PluginListItemTemplate" emptyMessage={{$:/language/ControlPanel/Plugins/Empty/Hint}}>>/>
+<$list filter="[!has[draft.of]plugin-type[plugin]sort[name]]" template="$:/core/ui/PluginListItemTemplate" emptyMessage={{$:/language/ControlPanel/Plugins/Empty/Hint}}>>/>

--- a/core/ui/MoreSideBar/plugins/Theme.tid
+++ b/core/ui/MoreSideBar/plugins/Theme.tid
@@ -2,4 +2,4 @@ title: $:/core/ui/MoreSideBar/Plugins/Theme
 tags: $:/tags/MoreSideBar/Plugins
 caption: {{$:/language/ControlPanel/Plugins/Themes/Caption}}
 
-<$list filter="[!has[draft.of]plugin-type[theme]sort[description]]" template="$:/core/ui/PluginListItemTemplate" emptyMessage={{$:/language/ControlPanel/Plugins/Empty/Hint}}/>
+<$list filter="[!has[draft.of]plugin-type[theme]sort[name]]" template="$:/core/ui/PluginListItemTemplate" emptyMessage={{$:/language/ControlPanel/Plugins/Empty/Hint}}/>


### PR DESCRIPTION
This PR changes the sidebar lists for language, plugin and theme to sort alphabetically by name rather than by description.

Fixes #6452

Before:
![image](https://user-images.githubusercontent.com/68092/156137772-b0204f09-4038-4a50-a177-f2cd3815a53b.png)

After:
![image](https://user-images.githubusercontent.com/68092/156137921-7052625a-5c87-4369-aa35-f8dcf3a7d2fc.png)
