### PR TITLE
button-widget: This PR fixes a problem, that the selected class attribute in the DOM isn't refreshed

### DIFF
--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -247,7 +247,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 ButtonWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.actions || changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || (this.popupTitle && changedTiddlers[this.popupTitle]) || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle || changedAttributes.disabled) {
+	if(changedAttributes.actions || changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || (this.popupTitle && changedTiddlers[this.popupTitle]) || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle || changedAttributes.disabled || changedAttributes.defaultSetValue) {
 		this.refreshSelf();
 		return true;
 	} else if(changedAttributes["class"]) {


### PR DESCRIPTION
This PR fixes a problem, that the selected class attribute in the DOM isn't refreshed, when the "default" parameter changes when used in the tabs-macro.

While working to improve the tabs-macro, where the button-widget and the refresh-widget have to work together, with the same "default" parameter settings. 

I found out, that the selected class of the button widget isn't updated, while the refresh-widget woks as expected, when the default-parameter kicks in. The result is an inconsistency between the tabs selection and the body content. 
