### PR TITLE
Improve Filters doc and add "Learn more about how to use Filters" link to every operator reference tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/Filters.tid
+++ b/editions/tw5.com/tiddlers/concepts/Filters.tid
@@ -1,23 +1,27 @@
 created: 20130827080000000
-modified: 20150221225414000
+list: [[Introduction to filter notation]] [[Filter Syntax]]
+modified: 20220316120141494
 tags: Reference Concepts
 title: Filters
 type: text/vnd.tiddlywiki
-list: [[Introduction to filter notation]] [[Filter Syntax]]
+
+\define openAdvancedSearch()
+<$action-setfield $tiddler="$:/state/tab--1498284803" text="$:/core/ui/AdvancedSearch/Filter"/>
+<$action-setfield $tiddler="$:/temp/advancedsearch/input" text="[tag[Filters]]"/>
+\end
 
 You can think of TiddlyWiki as a database in which the records are tiddlers. A database typically provides a way of discovering which records match a given pattern, and in ~TiddlyWiki this is done with filters.
 
 A <<.def filter>> is a concise notation for selecting a particular [[set of tiddlers|Title Selection]], known as its <<.def "output">>. Whenever ~TiddlyWiki encounters a filter, it calculates the output. Further work can then be done with just those tiddlers, such as [[counting|CountWidget]] or [[listing|ListWidget]] them.
 
-The following example passes a filter to the <<.mlink list-links>> macro to display a list of all tiddlers whose titles start with the letter H:
+The following example passes a filter to the <<.mlink list-links>> macro to display a list of all tiddlers whose titles are <<.olink2 tagged tag>> with the word <<.word Filters>>:
 
-> `<<list-links "[prefix[H]]">>`
+<<wikitext-example-without-html """<<list-links "[tag[Filters]]">>""" >>
 
-A filter's output can change as tiddlers are added and deleted in the wiki. ~TiddlyWiki recalculates on the fly, automatically updating any filter-based counts or lists as well.
+A filter output can change as tiddlers are added and deleted in the wiki. ~TiddlyWiki recalculates on the fly, automatically updating any filter-based counts or lists as well.
 
-[[Advanced Search|$:/AdvancedSearch]] has a <<.advancedsearch-tab Filter>> tab that makes it easy to experiment with filters.
+''Find out more:''
 
-;Find out more:
-* [[Introduction to filter notation]] -- a step-by-step walkthrough
-* [[Filter Syntax]] -- the detailed technical rules
-* [[Filter Operators]] -- the available methods of filtering
+* <$linkcatcher message="tm-navigate" actions=<<openAdvancedSearch>> >[[Advanced Search|$:/AdvancedSearch]]</$linkcatcher> -- has a <<.advancedsearch-tab Filter>> tab that makes it easy to experiment with filters.
+
+* [[Filtered Transclusions|Transclusion in WikiText]] -- If you want to use filter results in your text

--- a/editions/tw5.com/tiddlers/system/operator-template.tid
+++ b/editions/tw5.com/tiddlers/system/operator-template.tid
@@ -1,8 +1,8 @@
 created: 20150203173506000
-modified: 20150203181725000
-title: $:/editions/tw5.com/operator-template
-tags: $:/tags/ViewTemplate
 list-before: $:/core/ui/ViewTemplate/body
+modified: 20220316121232243
+tags: $:/tags/ViewTemplate
+title: $:/editions/tw5.com/operator-template
 
 \define .op-place()
 <$macrocall $name=".if"
@@ -71,6 +71,9 @@ list-before: $:/core/ui/ViewTemplate/body
 </$set>
 <!-- -->
 </table>
+
+[[Learn more about how to use Filters|Filters]]
+
 <$list filter="[all[current]has[from-version]]" variable="listItem">
 <$macrocall $name=".from-version" version={{!!from-version}}/>
 </$list>


### PR DESCRIPTION
This PR adds a link `[[Learn more about how to use Filters|Filters]]` to every operator reference tiddler. Some users think, filter expressions can be used similar to links. 

In reality they would need [Filtered Transclusions](https://saqimtiaz.github.io/tw5-docs-pr-maker/#Transclusion%20in%20WikiText), which is now linked in the Filters tiddler under "Find out more". 

The Filters tiddler also contains a "copy to clipboard" element with the `<<list-links "[tag[Filters]]">>` example, that reveals additional info about Filters. 

So in sum, the whole thing is better "interconnected" and should provide more relevant info. 

https://talk.tiddlywiki.org/t/getting-tiddler-field-isnt-working/2746 triggered this PR.

The AdvancedSearch link now opens the AdvancedSearch tiddler, selects the "Filter" tab and adds the right text to the search field. 

The "tagged" link opens the "tag Operator" tiddler. .. 