### PR TITLE
Fix: only refresh styles if the CSS has changed

### DIFF
--- a/core/modules/startup/render.js
+++ b/core/modules/startup/render.js
@@ -42,12 +42,17 @@ exports.startup = function() {
 	$tw.styleWidgetNode = $tw.wiki.makeTranscludeWidget(PAGE_STYLESHEET_TITLE,{document: $tw.fakeDocument});
 	$tw.styleContainer = $tw.fakeDocument.createElement("style");
 	$tw.styleWidgetNode.render($tw.styleContainer,null);
+	$tw.styleWidgetNode.assignedStyles = $tw.styleContainer.textContent;
 	$tw.styleElement = document.createElement("style");
-	$tw.styleElement.innerHTML = $tw.styleContainer.textContent;
+	$tw.styleElement.innerHTML = $tw.styleWidgetNode.assignedStyles;
 	document.head.insertBefore($tw.styleElement,document.head.firstChild);
 	$tw.wiki.addEventListener("change",$tw.perf.report("styleRefresh",function(changes) {
 		if($tw.styleWidgetNode.refresh(changes,$tw.styleContainer,null)) {
-			$tw.styleElement.innerHTML = $tw.styleContainer.textContent;
+			var newStyles = $tw.styleContainer.textContent;
+			if(newStyles !== $tw.styleWidgetNode.assignedStyles) {
+				$tw.styleWidgetNode.assignedStyles = newStyles;
+				$tw.styleElement.innerHTML = $tw.styleWidgetNode.assignedStyles;
+			}
 		}
 	}));
 	// Display the $:/core/ui/PageTemplate tiddler to kick off the display


### PR DESCRIPTION
This PR improves the style refresh so that we only update the contents of the style tag when the CSS generated by the stylesheet tiddlers has actually changed. We now compare the new CSS to the already assigned CSS and do not update the style tag if they are identical.

Previously, in some situations CSS was being reassigned even when it had not changed - leading to a performance hit which in some scenarios was on every keystroke - as `$tw.styleWidgetNode.refresh()` was returning true due to the refresh handling of the widgets being used in the stylesheets. Some widgets refresh themselves and therefore return true, even though the `textContent` of the resultant DOM is identical.

Testing in FF and Chrome on Windows 10 shows that saving the previous value of the CSS is faster by the finest of margins than directly accessing it via the `innerHTML` of the style tag for comparison purposes.