### PR TITLE
Fixed minor issue with list-links and wikilinks

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -7,9 +7,9 @@ tags: $:/tags/Macro
 <$list filter="$filter$" emptyMessage=<<__emptyMessage__>>>
 <$subtype$>
 <$link to={{!!title}}>
-<$transclude field="caption">
+<$view field="caption">
 <$view field="title"/>
-</$transclude>
+</$view>
 </$link>
 </$subtype$>
 </$list>
@@ -31,9 +31,9 @@ tags: $:/tags/Macro
 <div>
 <$transclude tiddler="""$itemTemplate$""">
 <$link to={{!!title}}>
-<$transclude field="caption">
+<$view field="caption">
 <$view field="title"/>
-</$transclude>
+</$view>
 </$link>
 </$transclude>
 </div>


### PR DESCRIPTION
These should be view widgets, not transclude widgets.

If someone has a value like "MyTiddler" as a caption, and they have wikilinks enabled, they'll get these stupid double-nested `<a>` elements that are stupid and broken.