### PR TITLE
ControlPanel Button: use tv-story-list variable

### DIFF
--- a/core/ui/PageControls/controlpanel.tid
+++ b/core/ui/PageControls/controlpanel.tid
@@ -16,6 +16,6 @@ description: {{$:/language/Buttons/ControlPanel/Hint}}
 </$button>
 \end
 
-<$list filter="[list[$:/StoryList]] +[field:title[$:/ControlPanel]]" emptyMessage=<<control-panel-button>>>
+<$list filter="[list<tv-story-list>] +[field:title[$:/ControlPanel]]" emptyMessage=<<control-panel-button>>>
 <<control-panel-button "tc-selected">>
 </$list>


### PR DESCRIPTION
This PR makes the ControlPanel Button show as selected when the `tv-story-list` contains `$:/ControlPanel` in its list field