### PR TITLE
Add deprecation warning to TiddlyFox tiddlers

### DIFF
--- a/editions/tw5.com/tiddlers/definitions/TiddlyFox.tid
+++ b/editions/tw5.com/tiddlers/definitions/TiddlyFox.tid
@@ -1,19 +1,11 @@
 created: 20130825161100000
-modified: 20200104111952539
+modified: 20220330200000000
 tags: Definitions
 title: TiddlyFox
 type: text/vnd.tiddlywiki
 
-TiddlyFox is an extension for older versions of Firefox that allows standalone TiddlyWiki files to save their changes directly to the file system. TiddlyFox works on both desktop and smartphone versions of [[Firefox]]. See [[Saving with TiddlyFox]] or [[Saving with TiddlyFox on Android]] for detailed instructions.
+~TiddlyFox was an extension for older versions of Firefox that allowed standalone TiddlyWiki files to save their changes directly to the file system. ~TiddlyFox worked on both desktop and smartphone versions of [[Firefox]]. See [[Saving with TiddlyFox]] or [[Saving with TiddlyFox on Android]] for instructions in case you are stuck with such an old version of Firefox.
 
-TiddlyFox is now obsolete due to its incompatibility with the latest versions of Firefox - see [[TiddlyFox Apocalypse]]. There are many alternatives to TiddlyFox, but none that work in precisely the same way -- see GettingStarted for details.
+~TiddlyFox is now obsolete due to its incompatibility with the latest versions of Firefox - see [[TiddlyFox Apocalypse]]. There are many alternatives to ~TiddlyFox, but none that work in precisely the same way -- see GettingStarted for details.
 
-TiddlyFox can be downloaded from the Mozilla Addons site:
-
-https://addons.mozilla.org/en-GB/firefox/addon/tiddlyfox/
-
-<<<
-You can also install the latest development version of TiddlyFox direct from GitHub:
-
-https://github.com/TiddlyWiki/TiddlyFox/raw/master/tiddlyfox.xpi
-<<<
+~TiddlyFox can no longer be downloaded from the Mozilla Addons site but is still available from GitHub: https://github.com/TiddlyWiki/TiddlyFox/raw/master/tiddlyfox.xpi

--- a/editions/tw5.com/tiddlers/saving/Saving with TiddlyFox.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving with TiddlyFox.tid
@@ -5,25 +5,26 @@ created: 20131221085742684
 delivery: Browser Extension
 description: Browser extension for older versions of Firefox
 method: save
-modified: 20200507105421421
-tags: Saving Firefox
+modified: 20220330200000000
+tags: Firefox
 title: Saving with TiddlyFox
 type: text/vnd.tiddlywiki
 
-If you're using [[Firefox for Android]], see the instructions for [[Saving with TiddlyFox on Android]].
+----
+<<.warning "''Please note: TiddlyFox no longer works on Firefox since version 57 (released 2017). On later versions choose one of the [[other available methods|Saving]].''">>
+----
 
-# Ensure you have a version of Firefox before version 57. ~TiddlyFox will not work with Firefox 57 and on.  For Firefox 57 and on, consider using the following instead: <<list-links filter:"[tag[Firefox]delivery[Browser Extension]] -[[Saving with TiddlyFox]]">>
-# Install the latest release of the TiddlyFox extension from:
-#* https://addons.mozilla.org/en-GB/firefox/addon/tiddlyfox/
+# Ensure you have a version of Firefox before version 57. ~TiddlyFox will not work with Firefox 57 and on. Read [[TiddlyFox Apocalypse]] for details.
+# ~TiddlyFox is no longer available from addons.mozilla.org, so you will have to install it from GitHub: https://github.com/TiddlyWiki/TiddlyFox/raw/master/tiddlyfox.xpi
 # Restart [[Firefox]]
 # [[Download]] an empty TiddlyWiki by clicking this button:
 #> {{$:/editions/tw5.com/snippets/download-empty-button}}
 # Locate the file you just downloaded
 #* You may rename it, but be sure to keep the `.html` or `.htm` extension
 # Open the file in [[Firefox]]
-#* If you are using TiddlyFox v1.x.x, you will need to click ''OK'' in response to the prompt from TiddlyFox that asks whether to enable saving for this file
-#* If you are using TiddlyFox v2.x.x you will need to click on the icon of a kitten standing on a blue globe to activate saving. There is no prompt in v2.0.1.
-#** For TiddlyFox v2.0.1, you can not be using Private Browsing mode nor can you be using "Never Remember History".
+#* If you are using ~TiddlyFox v1.x.x, you will need to click ''OK'' in response to the prompt from ~TiddlyFox that asks whether to enable saving for this file
+#* If you are using ~TiddlyFox v2.x.x you will need to click on the icon of a kitten standing on a blue globe to activate saving. There is no prompt in v2.0.1.
+#** For ~TiddlyFox v2.0.1, you can not be using Private Browsing mode nor can you be using "Never Remember History".
 # Try creating a new tiddler using the ''new tiddler'' <<.icon $:/core/images/new-button>> button in the sidebar. Type some content for the tiddler, and click the <<.icon $:/core/images/done-button>> ''ok'' button
 # Save your changes by clicking the <<.icon $:/core/images/save-button>> ''save changes'' button in the sidebar
 #* Look for the yellow notification ''Saved wiki'' at the top right of the window


### PR DESCRIPTION
This adds a warning to [Saving with TiddlyFox](https://tiddlywiki.com/#Saving%20with%20TiddlyFox) to clarify that it is obsolete. It also clarifies the main [TiddlyFox](https://tiddlywiki.com/#TiddlyFox) tiddler to clarify this a bit more and removes the [dead link to the addon](https://addons.mozilla.org/en-GB/firefox/addon/tiddlyfox/).

See related discussion in #3323