### PR TITLE
Add "enabled" attribute to draggable widget

### DIFF
--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -82,7 +82,7 @@ DraggableWidget.prototype.execute = function() {
 	this.endActions = this.getAttribute("endactions");
 	this.dragImageType = this.getAttribute("dragimagetype");
 	this.dragHandleSelector = this.getAttribute("selector");
-	this.dragEnable = (this.getAttribute("enable") || "yes") === "yes";
+	this.dragEnable = this.getAttribute("enable","yes") === "yes";
 	// Make the child widgets
 	this.makeChildWidgets();
 };

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -48,7 +48,7 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 	if(this.draggableClasses) {
 		classes.push(this.draggableClasses);
 	}
-	if(!this.dragHandleSelector) {
+	if(!this.dragHandleSelector && this.dragEnabled) {
 		classes.push("tc-draggable");
 	}
 	domNode.setAttribute("class",classes.join(" "));
@@ -56,16 +56,18 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);
 	// Add event handlers
-	$tw.utils.makeDraggable({
-		domNode: domNode,
-		dragTiddlerFn: function() {return self.getAttribute("tiddler");},
-		dragFilterFn: function() {return self.getAttribute("filter");},
-		startActions: self.startActions,
-		endActions: self.endActions,
-		dragImageType: self.dragImageType,
-		widget: this,
-		selector: self.dragHandleSelector
-	});
+	if(this.dragEnabled) {
+		$tw.utils.makeDraggable({
+			domNode: domNode,
+			dragTiddlerFn: function() {return self.getAttribute("tiddler");},
+			dragFilterFn: function() {return self.getAttribute("filter");},
+			startActions: self.startActions,
+			endActions: self.endActions,
+			dragImageType: self.dragImageType,
+			widget: this,
+			selector: self.dragHandleSelector
+		});
+	}
 	this.domNodes.push(domNode);
 };
 
@@ -80,6 +82,7 @@ DraggableWidget.prototype.execute = function() {
 	this.endActions = this.getAttribute("endactions");
 	this.dragImageType = this.getAttribute("dragimagetype");
 	this.dragHandleSelector = this.getAttribute("selector");
+	this.dragEnabled = this.getAttribute("enabled") !== "no";
 	// Make the child widgets
 	this.makeChildWidgets();
 };
@@ -89,7 +92,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 DraggableWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tag || changedAttributes["class"]) {
+	if(changedAttributes.tag || changedAttributes["class"] || changedAttributes.enabled) {
 		this.refreshSelf();
 		return true;
 	}

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -48,7 +48,7 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 	if(this.draggableClasses) {
 		classes.push(this.draggableClasses);
 	}
-	if(!this.dragHandleSelector && this.dragEnabled) {
+	if(!this.dragHandleSelector && this.dragEnable) {
 		classes.push("tc-draggable");
 	}
 	domNode.setAttribute("class",classes.join(" "));
@@ -56,7 +56,7 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);
 	// Add event handlers
-	if(this.dragEnabled) {
+	if(this.dragEnable) {
 		$tw.utils.makeDraggable({
 			domNode: domNode,
 			dragTiddlerFn: function() {return self.getAttribute("tiddler");},
@@ -82,7 +82,7 @@ DraggableWidget.prototype.execute = function() {
 	this.endActions = this.getAttribute("endactions");
 	this.dragImageType = this.getAttribute("dragimagetype");
 	this.dragHandleSelector = this.getAttribute("selector");
-	this.dragEnabled = this.getAttribute("enabled") !== "no";
+	this.dragEnable = (this.getAttribute("enable") || "yes") === "yes";
 	// Make the child widgets
 	this.makeChildWidgets();
 };

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -92,7 +92,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 DraggableWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tag || changedAttributes["class"] || changedAttributes.enabled) {
+	if($tw.utils.count(changedAttributes) > 0) {
 		this.refreshSelf();
 		return true;
 	}


### PR DESCRIPTION
This PR adds the `enabled` attribute to the `draggable` widget
By default, the domNode will be drag-enabled
Only if `enabled="no"` the domNode won't be draggable