### PR TITLE
Make choice selections save to state tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/saving/Saving.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving.tid
@@ -32,7 +32,7 @@ type: text/vnd.tiddlywiki
 \define checkactions(item:"Linux")
 <$action-listops $tiddler=<<stateTiddler>>  $subfilter="[[$item$]]"/>
 \end
-<$vars stateTiddler=<<qualify "$:/state/">> >
+<$vars stateTiddler=<<qualify "$:/state/gettingstarted">> >
 
 Available methods for saving changes with TiddlyWiki:
 

--- a/editions/tw5.com/tiddlers/saving/Saving.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving.tid
@@ -1,15 +1,15 @@
 created: 20140912140651119
-list: 
-modified: 20200507203641230
+modified: 20220401151525812
 saving-browser: Firefox Chrome Edge [[Internet Explorer]] Safari Opera
 saving-os: Windows Mac Linux Android iOS
 tags: [[Working with TiddlyWiki]]
 title: Saving
 type: text/vnd.tiddlywiki
 
+
 \define alltagsfilter()  
 <$vars tag1="tag[" tag2="]" lb="[" rb="tag[Saving]sort[delivery]]">
-<$set filter="[list[]addprefix<tag1>addsuffix<tag2>]+[join[]addprefix<lb>addsuffix<rb>]" name="alltags" select=0>
+<$set filter="[list<stateTiddler>addprefix<tag1>addsuffix<tag2>]+[join[]addprefix<lb>addsuffix<rb>]" name="alltags" select=0>
 <$text text=<<alltags>>/>
 </$set>
 </$vars>
@@ -26,16 +26,13 @@ type: text/vnd.tiddlywiki
 \end
 
 \define uncheckactions(item:"Linux")
-<$action-listops  $subfilter="-[[$item$]]"/>
+<$action-listops  $tiddler=<<stateTiddler>> $subfilter="-[[$item$]]"/>
 \end
 
 \define checkactions(item:"Linux")
-<$action-listops $subfilter="[[$item$]]"/>
+<$action-listops $tiddler=<<stateTiddler>>  $subfilter="[[$item$]]"/>
 \end
-
-\define uncheckactions(item:"Linux")
-<$action-listops $subfilter="-[[$item$]]"/>
-\end
+<$vars stateTiddler=<<qualify "$:/state/">> >
 
 Available methods for saving changes with TiddlyWiki:
 
@@ -66,3 +63,4 @@ Available methods for saving changes with TiddlyWiki:
 
 </div>
 </div>
+</$vars>


### PR DESCRIPTION
Currently choice selections for _Saving_ options save to current tiddler (Saving), which marks TW as needing to Save.  Visitors then can't close tab without dismissing a warning message. This fixes that by saving the working list to a state tiddler.

Also, _\define uncheckactions_ was defined twice in code.