### PR TITLE
Show server response as error message in put saver

### DIFF
--- a/core/modules/savers/put.js
+++ b/core/modules/savers/put.js
@@ -80,6 +80,7 @@ PutSaver.prototype.save = function(text,method,callback) {
 	if(this.etag) {
 		headers["If-Match"] = this.etag;
 	}
+	$tw.notifier.display("$:/language/Notifications/Save/Starting");
 	$tw.utils.httpRequest({
 		url: this.uri(),
 		type: "PUT",

--- a/core/modules/savers/put.js
+++ b/core/modules/savers/put.js
@@ -88,16 +88,20 @@ PutSaver.prototype.save = function(text,method,callback) {
 		callback: function(err,data,xhr) {
 			if(err) {
 				// response is textual: "XMLHttpRequest error code: 412"
-				var status = Number(err.substring(err.indexOf(':') + 2, err.length))
+				var status = Number(err.substring(err.indexOf(':') + 2, err.length)),
+					errorMsg = err;
 				if(status === 412) { // file changed on server
-					callback($tw.language.getString("Error/PutEditConflict"));
+					errorMsg = $tw.language.getString("Error/PutEditConflict");
 				} else if(status === 401) { // authentication required
-					callback($tw.language.getString("Error/PutUnauthorized"));
+					errorMsg = $tw.language.getString("Error/PutUnauthorized");
 				} else if(status === 403) { // permission denied
-					callback($tw.language.getString("Error/PutForbidden"));
-				} else {
-					callback(err); // fail
+					errorMsg = $tw.language.getString("Error/PutForbidden");
 				}
+				if (xhr.responseText) {
+					// treat any server response like a plain text error explanation
+					errorMsg = errorMsg + "\n\n" + xhr.responseText;
+				}
+				callback(errorMsg); // fail
 			} else {
 				self.etag = xhr.getResponseHeader("ETag");
 				if(self.etag == null) {

--- a/core/modules/savers/put.js
+++ b/core/modules/savers/put.js
@@ -87,8 +87,7 @@ PutSaver.prototype.save = function(text,method,callback) {
 		data: text,
 		callback: function(err,data,xhr) {
 			if(err) {
-				// response is textual: "XMLHttpRequest error code: 412"
-				var status = Number(err.substring(err.indexOf(':') + 2, err.length)),
+				var status = xhr.status,
 					errorMsg = err;
 				if(status === 412) { // file changed on server
 					errorMsg = $tw.language.getString("Error/PutEditConflict");

--- a/core/modules/savers/upload.js
+++ b/core/modules/savers/upload.js
@@ -64,6 +64,7 @@ UploadSaver.prototype.save = function(text,method,callback) {
 	var tail = "\r\n--" + boundary + "--\r\n",
 		data = head.join("\r\n") + text + tail;
 	// Do the HTTP post
+	$tw.notifier.display("$:/language/Notifications/Save/Starting");
 	var http = new XMLHttpRequest();
 	http.open("POST",url,true,username,password);
 	http.setRequestHeader("Content-Type","multipart/form-data; charset=UTF-8; boundary=" + boundary);
@@ -81,7 +82,6 @@ UploadSaver.prototype.save = function(text,method,callback) {
 	} catch(ex) {
 		return callback($tw.language.getString("Error/Caption") + ":" + ex);
 	}
-	$tw.notifier.display("$:/language/Notifications/Save/Starting");
 	return true;
 };
 


### PR DESCRIPTION
I'd like to use this on Tiddlyhost so users can get more informative error messages if the put save fails for whatever reason.

This would make the put saver a viable replacement for the legacy upload saver, which is what Tiddlyhost uses currently.

I'm not sure what standard WebDAV servers do, but I would guess they don't provide any response body for put requests, and hence this patch would have no impact for a standard WebDAV server.

(That said, it would be a good idea to test it to make sure there aren't any unexpected regressions for WebDAV or other put saver compatible services.)

Also includes two related small tweaks. See commit messages for details.