### PR TITLE
Allow checkboxes to be indeterminate

### DIFF
--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -27,6 +27,7 @@ CheckboxWidget.prototype = new Widget();
 Render this widget into the DOM
 */
 CheckboxWidget.prototype.render = function(parent,nextSibling) {
+	var isChecked;
 	// Save the parent dom node
 	this.parentDomNode = parent;
 	// Compute our attributes
@@ -38,9 +39,13 @@ CheckboxWidget.prototype.render = function(parent,nextSibling) {
 	this.labelDomNode.setAttribute("class","tc-checkbox " + this.checkboxClass);
 	this.inputDomNode = this.document.createElement("input");
 	this.inputDomNode.setAttribute("type","checkbox");
-	if(this.getValue()) {
+	isChecked = this.getValue();
+	if(isChecked) {
 		this.inputDomNode.setAttribute("checked","true");
 		$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
+	}
+	if(isChecked === undefined && this.checkboxIndeterminate) {
+		this.inputDomNode.indeterminate = true;
 	}
 	if(this.isDisabled === "yes") {
 		this.inputDomNode.setAttribute("disabled",true);
@@ -93,6 +98,14 @@ CheckboxWidget.prototype.getValue = function() {
 			if(this.checkboxUnchecked && !this.checkboxChecked) {
 				return true; // Absence of unchecked value
 			}
+			if(this.checkboxChecked && this.checkboxUnchecked) {
+				// Both specified but neither found: indeterminate or false, depending
+				if(this.checkboxIndeterminate) {
+					return undefined;
+				} else {
+					return false;
+				}
+			}
 		}
 		if(this.checkboxListField || this.checkboxListIndex || this.checkboxFilter) {
 			// Same logic applies to lists and filters
@@ -122,7 +135,12 @@ CheckboxWidget.prototype.getValue = function() {
 				return true; // Absence of unchecked value
 			}
 			if(this.checkboxChecked && this.checkboxUnchecked) {
-				return false; // Both specified but neither found: default to false
+				// Both specified but neither found: indeterminate or false, depending
+				if(this.checkboxIndeterminate) {
+					return undefined;
+				} else {
+					return false;
+				}
 			}
 			// Neither specified, so empty list is false, non-empty is true
 			return !!list.length;
@@ -265,6 +283,7 @@ CheckboxWidget.prototype.execute = function() {
 	this.checkboxChecked = this.getAttribute("checked");
 	this.checkboxUnchecked = this.getAttribute("unchecked");
 	this.checkboxDefault = this.getAttribute("default");
+	this.checkboxIndeterminate = this.getAttribute("indeterminate");
 	this.checkboxClass = this.getAttribute("class","");
 	this.checkboxInvertTag = this.getAttribute("invertTag","");
 	this.isDisabled = this.getAttribute("disabled","no");
@@ -277,14 +296,19 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 CheckboxWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedAttributes.tag || changedAttributes.invertTag || changedAttributes.field || changedAttributes.index || changedAttributes.listField || changedAttributes.filter || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes["class"] || changedAttributes.disabled) {
+	if(changedAttributes.tiddler || changedAttributes.tag || changedAttributes.invertTag || changedAttributes.field || changedAttributes.index || changedAttributes.listField || changedAttributes.listIndex || changedAttributes.filter || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes.indeterminate || changedAttributes["class"] || changedAttributes.disabled) {
 		this.refreshSelf();
 		return true;
 	} else {
 		var refreshed = false;
 		if(changedTiddlers[this.checkboxTitle]) {
 			var isChecked = this.getValue();
-			this.inputDomNode.checked = isChecked;
+			this.inputDomNode.checked = !!isChecked;
+			if(isChecked === undefined) {
+				this.inputDomNode.indeterminate = true;
+			} else {
+				this.inputDomNode.indeterminate = false;
+			}
 			refreshed = true;
 			if(isChecked) {
 				$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");

--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -44,7 +44,7 @@ CheckboxWidget.prototype.render = function(parent,nextSibling) {
 		this.inputDomNode.setAttribute("checked","true");
 		$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
 	}
-	if(isChecked === undefined && this.checkboxIndeterminate) {
+	if(isChecked === undefined && this.checkboxIndeterminate === "yes") {
 		this.inputDomNode.indeterminate = true;
 	}
 	if(this.isDisabled === "yes") {
@@ -100,7 +100,7 @@ CheckboxWidget.prototype.getValue = function() {
 			}
 			if(this.checkboxChecked && this.checkboxUnchecked) {
 				// Both specified but neither found: indeterminate or false, depending
-				if(this.checkboxIndeterminate) {
+				if(this.checkboxIndeterminate === "yes") {
 					return undefined;
 				} else {
 					return false;
@@ -136,7 +136,7 @@ CheckboxWidget.prototype.getValue = function() {
 			}
 			if(this.checkboxChecked && this.checkboxUnchecked) {
 				// Both specified but neither found: indeterminate or false, depending
-				if(this.checkboxIndeterminate) {
+				if(this.checkboxIndeterminate === "yes") {
 					return undefined;
 				} else {
 					return false;
@@ -283,7 +283,7 @@ CheckboxWidget.prototype.execute = function() {
 	this.checkboxChecked = this.getAttribute("checked");
 	this.checkboxUnchecked = this.getAttribute("unchecked");
 	this.checkboxDefault = this.getAttribute("default");
-	this.checkboxIndeterminate = this.getAttribute("indeterminate");
+	this.checkboxIndeterminate = this.getAttribute("indeterminate","no");
 	this.checkboxClass = this.getAttribute("class","");
 	this.checkboxInvertTag = this.getAttribute("invertTag","");
 	this.isDisabled = this.getAttribute("disabled","no");

--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -304,11 +304,7 @@ CheckboxWidget.prototype.refresh = function(changedTiddlers) {
 		if(changedTiddlers[this.checkboxTitle]) {
 			var isChecked = this.getValue();
 			this.inputDomNode.checked = !!isChecked;
-			if(isChecked === undefined) {
-				this.inputDomNode.indeterminate = true;
-			} else {
-				this.inputDomNode.indeterminate = false;
-			}
+			this.inputDomNode.indeterminate = (isChecked === undefined);
 			refreshed = true;
 			if(isChecked) {
 				$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");

--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -67,7 +67,7 @@ CheckboxWidget.prototype.getValue = function() {
 	var tiddler = this.wiki.getTiddler(this.checkboxTitle);
 	if(tiddler || this.checkboxFilter) {
 		if(this.checkboxTag) {
-			if(this.checkboxInvertTag) {
+			if(this.checkboxInvertTag === "yes") {
 				return !tiddler.hasTag(this.checkboxTag);
 			} else {
 				return tiddler.hasTag(this.checkboxTag);

--- a/editions/test/tiddlers/tests/test-checkbox-widget.js
+++ b/editions/test/tiddlers/tests/test-checkbox-widget.js
@@ -78,6 +78,21 @@ Tests the checkbox widget thoroughly.
                 startsOutChecked: false,
                 expectedChange: { "TiddlerOne": { expand: "yes" } }
             },
+            {
+                testName: "field mode indeterminate -> true",
+                tiddlers: [{title: "TiddlerOne", text: "Jolly Old World", expand: "some other value"}],
+                widgetText: "<$checkbox tiddler='TiddlerOne' field='expand' indeterminate checked='yes' unchecked='no' />",
+                startsOutChecked: undefined,
+                expectedChange: { "TiddlerOne": { expand: "yes" } }
+            },
+            // true -> indeterminate cannot happen in field mode
+            {
+                testName: "field mode not indeterminate",
+                tiddlers: [{title: "TiddlerOne", text: "Jolly Old World", expand: "some other value"}],
+                widgetText: "<$checkbox tiddler='TiddlerOne' field='expand' indeterminate='' checked='yes' unchecked='no' />",
+                startsOutChecked: false,
+                expectedChange: { "TiddlerOne": { expand: "yes" } }
+            },
         ];
 
         const indexModeTests = fieldModeTests.map(data => {
@@ -201,6 +216,21 @@ Tests the checkbox widget thoroughly.
                 startsOutChecked: true,
                 finalValue: true, // "no" is considered true when neither `checked` nor `unchecked` is specified
                 expectedChange: { "ExampleTiddler": { someField: "no" } }
+            },
+            {
+                testName: "list mode indeterminate -> true",
+                tiddlers: [{title: "Colors", colors: "orange"}],
+                widgetText: "<$checkbox tiddler='Colors' listField='colors' indeterminate unchecked='red' checked='green' />",
+                startsOutChecked: undefined,
+                expectedChange: { "Colors": { colors: "orange green" } }
+            },
+            // true -> indeterminate cannot happen in list mode
+            {
+                testName: "list mode not indeterminate",
+                tiddlers: [{title: "Colors", colors: "orange"}],
+                widgetText: "<$checkbox tiddler='Colors' listField='colors' unchecked='red' checked='green' />",
+                startsOutChecked: false,
+                expectedChange: { "Colors": { colors: "orange green" } }
             },
         ];
 
@@ -378,6 +408,45 @@ Tests the checkbox widget thoroughly.
                             "<$checkbox filter='[list[Colors!!colors]]' checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> />",
                 startsOutChecked: true,
                 expectedChange: { "Colors": { colors: "" } }
+            },
+
+            {
+                testName: "filter mode indeterminate -> true",
+                tiddlers: [{title: "Colors", colors: "orange yellow"}],
+                widgetText: "\\define checkActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='green'/>\n" +
+                            "\\define uncheckActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='-green'/>\n" +
+                            "<$checkbox filter='[list[Colors!!colors]]' indeterminate checked='green' unchecked='red' default='green' checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> />",
+                startsOutChecked: undefined,
+                expectedChange: { "Colors": { colors: "orange yellow green" } }
+            },
+            {
+                testName: "filter mode true -> indeterminate",
+                tiddlers: [{title: "Colors", colors: "green orange yellow"}],
+                widgetText: "\\define checkActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='green'/>\n" +
+                            "\\define uncheckActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='-green'/>\n" +
+                            "<$checkbox filter='[list[Colors!!colors]]' indeterminate checked='green' unchecked='red' default='green' checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> />",
+                startsOutChecked: true,
+                finalValue: undefined,
+                expectedChange: { "Colors": { colors: "orange yellow" } }
+            },
+            {
+                testName: "filter mode not indeterminate -> true",
+                tiddlers: [{title: "Colors", colors: "orange yellow"}],
+                widgetText: "\\define checkActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='green'/>\n" +
+                            "\\define uncheckActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='-green'/>\n" +
+                            "<$checkbox filter='[list[Colors!!colors]]' checked='green' unchecked='red' default='green' checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> />",
+                startsOutChecked: false,
+                expectedChange: { "Colors": { colors: "orange yellow green" } }
+            },
+            {
+                testName: "filter mode true -> not indeterminate",
+                tiddlers: [{title: "Colors", colors: "green orange yellow"}],
+                widgetText: "\\define checkActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='green'/>\n" +
+                            "\\define uncheckActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='-green'/>\n" +
+                            "<$checkbox filter='[list[Colors!!colors]]' checked='green' unchecked='red' default='green' checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> />",
+                startsOutChecked: true,
+                finalValue: false,
+                expectedChange: { "Colors": { colors: "orange yellow" } }
             },
         ];
 

--- a/editions/test/tiddlers/tests/test-checkbox-widget.js
+++ b/editions/test/tiddlers/tests/test-checkbox-widget.js
@@ -81,7 +81,7 @@ Tests the checkbox widget thoroughly.
             {
                 testName: "field mode indeterminate -> true",
                 tiddlers: [{title: "TiddlerOne", text: "Jolly Old World", expand: "some other value"}],
-                widgetText: "<$checkbox tiddler='TiddlerOne' field='expand' indeterminate checked='yes' unchecked='no' />",
+                widgetText: "<$checkbox tiddler='TiddlerOne' field='expand' indeterminate='yes' checked='yes' unchecked='no' />",
                 startsOutChecked: undefined,
                 expectedChange: { "TiddlerOne": { expand: "yes" } }
             },
@@ -220,7 +220,7 @@ Tests the checkbox widget thoroughly.
             {
                 testName: "list mode indeterminate -> true",
                 tiddlers: [{title: "Colors", colors: "orange"}],
-                widgetText: "<$checkbox tiddler='Colors' listField='colors' indeterminate unchecked='red' checked='green' />",
+                widgetText: "<$checkbox tiddler='Colors' listField='colors' indeterminate='yes' unchecked='red' checked='green' />",
                 startsOutChecked: undefined,
                 expectedChange: { "Colors": { colors: "orange green" } }
             },
@@ -415,7 +415,7 @@ Tests the checkbox widget thoroughly.
                 tiddlers: [{title: "Colors", colors: "orange yellow"}],
                 widgetText: "\\define checkActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='green'/>\n" +
                             "\\define uncheckActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='-green'/>\n" +
-                            "<$checkbox filter='[list[Colors!!colors]]' indeterminate checked='green' unchecked='red' default='green' checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> />",
+                            "<$checkbox filter='[list[Colors!!colors]]' indeterminate='yes' checked='green' unchecked='red' default='green' checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> />",
                 startsOutChecked: undefined,
                 expectedChange: { "Colors": { colors: "orange yellow green" } }
             },
@@ -424,7 +424,7 @@ Tests the checkbox widget thoroughly.
                 tiddlers: [{title: "Colors", colors: "green orange yellow"}],
                 widgetText: "\\define checkActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='green'/>\n" +
                             "\\define uncheckActions() <$action-listops $tiddler='Colors' $field='colors' $subfilter='-green'/>\n" +
-                            "<$checkbox filter='[list[Colors!!colors]]' indeterminate checked='green' unchecked='red' default='green' checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> />",
+                            "<$checkbox filter='[list[Colors!!colors]]' indeterminate='yes' checked='green' unchecked='red' default='green' checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> />",
                 startsOutChecked: true,
                 finalValue: undefined,
                 expectedChange: { "Colors": { colors: "orange yellow" } }

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
@@ -106,20 +106,20 @@ This example creates the same checkbox as in the list mode example, selecting be
 
 !! Indeterminate checkboxes
 
-If both the ''checked'' and ''unchecked'' attributes are specified, but neither one is found in the specified field (or index), the result can be ambiguous. Should the checkbox be checked or unchecked? Normally in such cases the checkbox will be unchecked, but if the ''indeterminate'' attribute is set, the checkbox will instead be in an "indeterminate" state. An indeterminate checkbox counts as false for most purposes &mdash; if you click it, the checkbox will become checked and the ''checkactions'', if any, will be triggered &mdash; but indeterminate checkboxes are displayed differently in the browser.
+If both the ''checked'' and ''unchecked'' attributes are specified, but neither one is found in the specified field (or index), the result can be ambiguous. Should the checkbox be checked or unchecked? Normally in such cases the checkbox will be unchecked, but if the ''indeterminate'' attribute is set to "yes" (default is "no"), the checkbox will instead be in an "indeterminate" state. An indeterminate checkbox counts as false for most purposes &mdash; if you click it, the checkbox will become checked and the ''checkactions'', if any, will be triggered &mdash; but indeterminate checkboxes are displayed differently in the browser.
 
 This example shows indeterminate checkboxes being used for categories in a shopping list (which could also be sub-tasks in a todo list, or many other things). If only some items in a category are selected, the category checkbox is indeterminate. You can click on the category checkboxes to see how indeterminate states are treated the same as the unchecked state, and clicking the box checks it and applies its check actions (in this case, checking all the boxes in that category). Try editing the <<.field fruits>> and <<.field vegetables>> fields on this tiddler and see what happens to the example when you do.
 
 <<wikitext-example-without-html """\define check-all(field-name:"items") <$action-listops $field="selected-$field-name$" $filter="[list[!!$field-name$]]" />
 \define uncheck-all(field-name:"items") <$action-listops $field="selected-$field-name$" $filter="[[]]" />
 
-<$checkbox filter="[list[!!selected-fruits]count[]]" checked={{{ [list[!!fruits]count[]] }}} unchecked="0" checkactions=<<check-all fruits>> uncheckactions=<<uncheck-all fruits>> indeterminate> fruits</$checkbox>
+<$checkbox filter="[list[!!selected-fruits]count[]]" checked={{{ [list[!!fruits]count[]] }}} unchecked="0" checkactions=<<check-all fruits>> uncheckactions=<<uncheck-all fruits>> indeterminate="yes"> fruits</$checkbox>
 <ul style="list-style: none">
 <$list variable="fruit" filter="[list[!!fruits]]">
 <li><$checkbox listField="selected-fruits" checked=<<fruit>>> <<fruit>></$checkbox></li>
 </$list>
 </ul>
-<$checkbox filter="[list[!!selected-vegetables]count[]]" checked={{{ [list[!!vegetables]count[]] }}} unchecked="0" checkactions=<<check-all vegetables>> uncheckactions=<<uncheck-all vegetables>> indeterminate> veggies</$checkbox>
+<$checkbox filter="[list[!!selected-vegetables]count[]]" checked={{{ [list[!!vegetables]count[]] }}} unchecked="0" checkactions=<<check-all vegetables>> uncheckactions=<<uncheck-all vegetables>> indeterminate="yes"> veggies</$checkbox>
 <ul style="list-style: none">
 <$list variable="veggie" filter="[list[!!vegetables]]">
 <li><$checkbox listField="selected-vegetables" checked=<<veggie>>> <<veggie>></$checkbox></li>

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
@@ -112,23 +112,18 @@ This example shows indeterminate checkboxes being used for categories in a shopp
 
 <<wikitext-example-without-html """\define check-all(field-name:"items") <$action-listops $field="selected-$field-name$" $filter="[list[!!$field-name$]]" />
 \define uncheck-all(field-name:"items") <$action-listops $field="selected-$field-name$" $filter="[[]]" />
-<ul style="list-style: none">
-<li>
+
 <$checkbox filter="[list[!!selected-fruits]count[]]" checked={{{ [list[!!fruits]count[]] }}} unchecked="0" checkactions=<<check-all fruits>> uncheckactions=<<uncheck-all fruits>> indeterminate> fruits</$checkbox>
 <ul style="list-style: none">
 <$list variable="fruit" filter="[list[!!fruits]]">
 <li><$checkbox listField="selected-fruits" checked=<<fruit>>> <<fruit>></$checkbox></li>
 </$list>
 </ul>
-</li>
-<li>
 <$checkbox filter="[list[!!selected-vegetables]count[]]" checked={{{ [list[!!vegetables]count[]] }}} unchecked="0" checkactions=<<check-all vegetables>> uncheckactions=<<uncheck-all vegetables>> indeterminate> veggies</$checkbox>
 <ul style="list-style: none">
 <$list variable="veggie" filter="[list[!!vegetables]]">
 <li><$checkbox listField="selected-vegetables" checked=<<veggie>>> <<veggie>></$checkbox></li>
 </$list>
-</ul>
-</li>
 </ul>
 
 <p>Selected veggies: {{!!selected-vegetables}}<br/>

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
@@ -3,6 +3,8 @@ created: 20131024141900000
 modified: 20220402023600000
 tags: Widgets TriggeringWidgets
 colors: red orange yellow blue
+fruits: bananas oranges grapes
+vegetables: carrots potatoes
 title: CheckboxWidget
 type: text/vnd.tiddlywiki
 
@@ -29,6 +31,7 @@ The content of the `<$checkbox>` widget is displayed within an HTML `<label>` el
 |checked |The value of the field corresponding to the checkbox being checked |
 |unchecked |The value of the field corresponding to the checkbox being unchecked |
 |default |The default value to use if the field is not defined |
+|indeterminate |Whether ambiguous values can produce indeterminate checkboxes (see below) |
 |class |The class that will be assigned to the label element <$macrocall $name=".tip" _="""<<.from-version "5.2.3">> `tc-checkbox` is always applied by default, as well as `tc-checkbox-checked` when checked"""/> |
 |actions |<<.from-version "5.1.14">> A string containing ActionWidgets to be triggered when the status of the checkbox changes (whether it is checked or unchecked) |
 |uncheckactions |<<.from-version "5.1.16">> A string containing ActionWidgets to be triggered when the checkbox is unchecked |
@@ -100,3 +103,33 @@ This example creates the same checkbox as in the list mode example, selecting be
 \define uncheckActions() <$action-listops $field="colors" $subfilter="red -green"/>
 <$checkbox filter="[list[!!colors]]" checked="green" unchecked="red" default="red" checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> > Is "green" in colors?</$checkbox><br />''colors:'' {{!!colors}}
 """>>
+
+!! Indeterminate checkboxes
+
+If both the ''checked'' and ''unchecked'' attributes are specified, but neither one is found in the specified field (or index), the result can be ambiguous. Should the checkbox be checked or unchecked? Normally in such cases the checkbox will be unchecked, but if the ''indeterminate'' attribute is set, the checkbox will instead be in an "indeterminate" state. An indeterminate checkbox counts as false for most purposes &mdash; if you click it, the checkbox will become checked and the ''checkactions'', if any, will be triggered &mdash; but indeterminate checkboxes are displayed differently in the browser.
+
+This example shows indeterminate checkboxes being used for categories in a shopping list (which could also be sub-tasks in a todo list, or many other things). If only some items in a category are selected, the category checkbox is indeterminate. You can click on the category checkboxes to see how indeterminate states are treated the same as the unchecked state, and clicking the box checks it and applies its check actions (in this case, checking all the boxes in that category). Try editing the <<.field fruits>> and <<.field vegetables>> fields on this tiddler and see what happens to the example when you do.
+
+<<wikitext-example-without-html """\define check-all(field-name:"items") <$action-listops $field="selected-$field-name$" $filter="[list[!!$field-name$]]" />
+\define uncheck-all(field-name:"items") <$action-listops $field="selected-$field-name$" $filter="[[]]" />
+<ul style="list-style: none">
+<li>
+<$checkbox filter="[list[!!selected-fruits]count[]]" checked={{{ [list[!!fruits]count[]] }}} unchecked="0" checkactions=<<check-all fruits>> uncheckactions=<<uncheck-all fruits>> indeterminate> fruits</$checkbox>
+<ul style="list-style: none">
+<$list variable="fruit" filter="[list[!!fruits]]">
+<li><$checkbox listField="selected-fruits" checked=<<fruit>>> <<fruit>></$checkbox></li>
+</$list>
+</ul>
+</li>
+<li>
+<$checkbox filter="[list[!!selected-vegetables]count[]]" checked={{{ [list[!!vegetables]count[]] }}} unchecked="0" checkactions=<<check-all vegetables>> uncheckactions=<<uncheck-all vegetables>> indeterminate> veggies</$checkbox>
+<ul style="list-style: none">
+<$list variable="veggie" filter="[list[!!vegetables]]">
+<li><$checkbox listField="selected-vegetables" checked=<<veggie>>> <<veggie>></$checkbox></li>
+</$list>
+</ul>
+</li>
+</ul>
+
+<p>Selected veggies: {{!!selected-vegetables}}<br/>
+Selected fruits: {{!!selected-fruits}}</p>""">>


### PR DESCRIPTION
Fixes #6564.

See the example at the bottom of the CheckboxWidget tiddler for why this is useful: it allows lists of categories, where checking items in a category will check the category box if the category is filled, uncheck it if the category is empty, and leave it in an "indeterminate" state if the category is only *partly* filled.