### PR TITLE
Add static fallback content/links for tw.org

### DIFF
--- a/editions/tw.org/tiddlers/$__core_templates_static.content.tid
+++ b/editions/tw.org/tiddlers/$__core_templates_static.content.tid
@@ -1,0 +1,18 @@
+title: $:/core/templates/static.content
+
+\define tv-wikilink-template() https://tiddlywiki.org/static/$uri_doubleencoded$.html
+
+<!-- For Google, and people without JavaScript-->
+
+<$reveal default="yes" text=<<savingEmpty>> type="nomatch">
+
+It looks like this browser doesn't run JavaScript. You can use one of these static HTML versions to browse the same content:
+
+* https://tiddlywiki.org/static.html - browse individual tiddlers as separate pages
+* https://tiddlywiki.org/alltiddlers.html#HelloThere - single file containing all tiddlers
+
+---
+
+{{HelloThere}}
+
+</$reveal>


### PR DESCRIPTION
Modified from the static.content template used in the tw5.com branch

I hope the filename is okay? (for that matter, perhaps next PR should be to organize the files a lil more into folders)

I wasn't sure whether to transclude the "TiddlyWiki" or "Table of Contents" tiddlers, nor which order to put them in, so I omitted them. (It may be a good idea to include "TiddlyWiki". Actually, it may be even better to transclude it into HelloThere in case someone new stumbles onto tw.org instead of tw.com)