### PR TITLE
Fix for broken style block wikitext

### DIFF
--- a/core/modules/utils/parsetree.js
+++ b/core/modules/utils/parsetree.js
@@ -25,17 +25,27 @@ exports.getAttributeValueFromParseTreeNode = function(node,name,defaultValue) {
 };
 
 exports.addClassToParseTreeNode = function(node,classString) {
-	var classes = [];
+	var classes = [],
+		attribute;
 	node.attributes = node.attributes || {};
-	node.attributes["class"] = node.attributes["class"] || {type: "string", value: ""};
-	if(node.attributes["class"].type === "string") {
-		if(node.attributes["class"].value !== "") {
-			classes = node.attributes["class"].value.split(" ");
+	attribute = node.attributes["class"];
+	if (!attribute) {
+		// If the class attribute does not exist, we must create it first.
+		attribute = {name: "class", type: "string", value: ""};
+		node.attributes["class"] = attribute;
+		if (node.orderedAttributes) {
+			// If there are orderedAttributes, we've got to add them there too.
+			node.orderedAttributes.push(attribute);
+		}
+	}
+	if(attribute.type === "string") {
+		if(attribute.value !== "") {
+			classes = attribute.value.split(" ");
 		}
 		if(classString !== "") {
 			$tw.utils.pushTop(classes,classString.split(" "));
 		}
-		node.attributes["class"].value = classes.join(" ");
+		attribute.value = classes.join(" ");
 	}
 };
 

--- a/core/modules/utils/parsetree.js
+++ b/core/modules/utils/parsetree.js
@@ -13,8 +13,12 @@ Parse tree utility functions.
 "use strict";
 
 exports.addAttributeToParseTreeNode = function(node,name,value) {
+	var attribute = {name: name, type: "string", value: value};
 	node.attributes = node.attributes || {};
-	node.attributes[name] = {type: "string", value: value};
+	node.attributes[name] = attribute;
+	if(node.orderedAttributes) {
+		node.orderedAttributes.push(attribute);
+	}
 };
 
 exports.getAttributeValueFromParseTreeNode = function(node,name,defaultValue) {
@@ -29,11 +33,11 @@ exports.addClassToParseTreeNode = function(node,classString) {
 		attribute;
 	node.attributes = node.attributes || {};
 	attribute = node.attributes["class"];
-	if (!attribute) {
+	if(!attribute) {
 		// If the class attribute does not exist, we must create it first.
 		attribute = {name: "class", type: "string", value: ""};
 		node.attributes["class"] = attribute;
-		if (node.orderedAttributes) {
+		if(node.orderedAttributes) {
 			// If there are orderedAttributes, we've got to add them there too.
 			node.orderedAttributes.push(attribute);
 		}
@@ -50,11 +54,20 @@ exports.addClassToParseTreeNode = function(node,classString) {
 };
 
 exports.addStyleToParseTreeNode = function(node,name,value) {
-		node.attributes = node.attributes || {};
-		node.attributes.style = node.attributes.style || {type: "string", value: ""};
-		if(node.attributes.style.type === "string") {
-			node.attributes.style.value += name + ":" + value + ";";
+	var attribute;
+	node.attributes = node.attributes || {};
+	attribute = node.attributes.style;
+	if(!attribute) {
+		attribute = {name: "style", type: "string", value: ""};
+		node.attributes.style = attribute;
+		if(node.orderedAttributes) {
+			// If there are orderedAttributes, we've got to add them there too.
+			node.orderedAttributes.push(attribute);
 		}
+	}
+	if(attribute.type === "string") {
+		attribute.value += name + ":" + value + ";";
+	}
 };
 
 exports.findParseTreeNode = function(nodeArray,search) {

--- a/editions/test/tiddlers/tests/test-wikitext.js
+++ b/editions/test/tiddlers/tests/test-wikitext.js
@@ -55,7 +55,11 @@ describe("WikiText tests", function() {
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","No -WikiLink here").indexOf("<a") !== -1).toBe(false);
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","No _WikiLink here").indexOf("<a") !== -1).toBe(false);
 	});
-
+	it("handles style wikitext notation", function() {
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@.myclass\n!header\n@@")).toBe("<h1 class=\"myclass\">header</h1>");
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@.myclass\n<div>\n\nContent</div>\n@@")).toBe("<div class=\"myclass\"><p>Content</p></div>");
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@.myclass\n---\n@@")).toBe("<hr class=\"myclass\">");
+	});
 });
 
 })();

--- a/editions/test/tiddlers/tests/test-wikitext.js
+++ b/editions/test/tiddlers/tests/test-wikitext.js
@@ -59,6 +59,9 @@ describe("WikiText tests", function() {
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@.myclass\n!header\n@@")).toBe("<h1 class=\"myclass\">header</h1>");
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@.myclass\n<div>\n\nContent</div>\n@@")).toBe("<div class=\"myclass\"><p>Content</p></div>");
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@.myclass\n---\n@@")).toBe("<hr class=\"myclass\">");
+		// Test styles can be added too
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@color:red;\n<div>\n\nContent</div>\n@@")).toBe("<div style=\"color:red;\"><p>Content</p></div>");
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@color:red;\n---\n@@")).toBe("<hr style=\"color:red;\">");
 	});
 });
 


### PR DESCRIPTION
Style blocks broke between this release and the last (or maybe the one before that). Came up in my Uglify unit tests.

```
@@.myClass
<div>

Content
</div>
@@
```
This is broken. It no longer injects the class into the div element like it used to.

Reason: style block notation injects into parseTreeNode.attributes, but it was never made aware of parseTreeNode.orderedAttributes. This PR fixes that. Fixed for styles too.

@Jermolene: By the way, styleblocks are still kinda bad. They're using `addAttributeToParseTreeNode` instead of `addStyleToParseTreeNode` like you'd expect. Because of this, they blast away any style that already existed on the contained nodes. Also, because styleblocks look for "^@@(?:\\r?\\n)?" (where the newline is optional), they're impossible to nest. Is this deliberate or a bug?