### PR TITLE
Replace non-working url with forked site

### DIFF
--- a/editions/tw5.com/tiddlers/community/resources/Projectify by Nicolas Petton.tid
+++ b/editions/tw5.com/tiddlers/community/resources/Projectify by Nicolas Petton.tid
@@ -1,11 +1,11 @@
-created: 202101061831
-modified: 20210110204503082
+created: 20210106183100000
+modified: 20220407181245488
 tags: [[Community Plugins]] [[Community Editions]]
 title: Projectify by Nicolas Petton
 type: text/vnd.tiddlywiki
-url: https://projectify.wiki
+url: https://github.com/ThaddeusJiang/Projectify
 
-Project & todo management for TiddlyWiki.
+Project & todo management for ~TiddlyWiki.
 
 {{!!url}}
 
@@ -18,3 +18,5 @@ Projectify features:
 * Projects to structure tasks together into separate todo-lists
 * Support for scheduling tasks
 * A dashboard to quickly view all projects, the inbox, or scheduled tasks
+
+`Note:` The original site, https://projectify.wiki, no longer exists. The provided site is a maintained fork, though not by the original creator. 


### PR DESCRIPTION
Old site doesn't work. Suggested url appears to be actively maintained.