### PR TITLE
Trim Saga: THE END

### DIFF
--- a/core/ui/AdvancedSearch.tid
+++ b/core/ui/AdvancedSearch.tid
@@ -2,6 +2,7 @@ title: $:/AdvancedSearch
 icon: $:/core/images/advanced-search-button
 color: #bbb
 
+\whitespace trim
 <div class="tc-advanced-search">
 <$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/AdvancedSearch]!has[draft.of]]" default="$:/core/ui/AdvancedSearch/System" actions="""<$action-setfield $tiddler="$:/state/advancedsearch/currentTab" text=<<currentTab>>/>""" explicitState="$:/state/tab--1498284803"/>
 </div>

--- a/core/ui/ControlPanel.tid
+++ b/core/ui/ControlPanel.tid
@@ -2,6 +2,7 @@ title: $:/ControlPanel
 icon: $:/core/images/options-button
 color: #bbb
 
+\whitespace trim
 <div class="tc-control-panel">
 <$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/ControlPanel]!has[draft.of]]" default="$:/core/ui/ControlPanel/Info" explicitState="$:/state/tab-1749438307"/>
 </div>

--- a/core/ui/Manager/ItemMainFields.tid
+++ b/core/ui/Manager/ItemMainFields.tid
@@ -2,6 +2,7 @@ title: $:/Manager/ItemMain/Fields
 tags: $:/tags/Manager/ItemMain
 caption: {{$:/language/Manager/Item/Fields}}
 
+\whitespace trim
 <table>
 <tbody>
 <$list filter="[all[current]fields[]sort[title]] -text" template="$:/core/ui/TiddlerFieldTemplate" variable="listItem"/>

--- a/core/ui/Manager/ItemSidebarColour.tid
+++ b/core/ui/Manager/ItemSidebarColour.tid
@@ -7,9 +7,12 @@ height: 1em;
 background-color: $(colour)$
 \end
 
+\whitespace trim
 <$vars colour={{!!color}}>
 <p style=<<swatch-styles>>/>
 </$vars>
 <p>
-<$edit-text field="color" tag="input" type="color"/> / <$edit-text field="color" tag="input" type="text" size="9"/>
+<$edit-text field="color" tag="input" type="color"/>
+&#32;/&#32;
+<$edit-text field="color" tag="input" type="text" size="9"/>
 </p>

--- a/core/ui/Manager/ItemSidebarTools.tid
+++ b/core/ui/Manager/ItemSidebarTools.tid
@@ -2,9 +2,14 @@ title: $:/Manager/ItemSidebar/Tools
 tags: $:/tags/Manager/ItemSidebar
 caption: {{$:/language/Manager/Item/Tools}}
 
+\whitespace trim
 <p>
-<$button to=<<currentTiddler>>>{{$:/core/images/link}} open</$button>
+<$button to=<<currentTiddler>>>
+{{$:/core/images/link}}&#32;open
+</$button>
 </p>
 <p>
-<$button message="tm-edit-tiddler" param=<<currentTiddler>>>{{$:/core/images/edit-button}} edit</$button>
+<$button message="tm-edit-tiddler" param=<<currentTiddler>>>
+{{$:/core/images/edit-button}}&#32;edit
+</$button>
 </p>

--- a/core/wiki/macros/colour-picker.tid
+++ b/core/wiki/macros/colour-picker.tid
@@ -21,17 +21,22 @@ $actions$
 \end
 
 \define colour-picker-recent-inner(actions)
+\whitespace trim
 <$set name="colour-picker-value" value="$(recentColour)$">
 <$macrocall $name="colour-picker-inner" actions="""$actions$"""/>
 </$set>
 \end
 
 \define colour-picker-recent(actions)
-{{$:/language/ColourPicker/Recent}} <$list filter="[list[$:/config/ColourPicker/Recent]]" variable="recentColour">
-<$macrocall $name="colour-picker-recent-inner" actions="""$actions$"""/></$list>
+\whitespace trim
+{{$:/language/ColourPicker/Recent}}<$list filter="[list[$:/config/ColourPicker/Recent]]" variable="recentColour">
+&#32;
+<$macrocall $name="colour-picker-recent-inner" actions="""$actions$"""/>
+</$list>
 \end
 
 \define colour-picker(actions)
+\whitespace trim
 <div class="tc-colour-chooser">
 
 <$macrocall $name="colour-picker-recent" actions="""$actions$"""/>
@@ -39,12 +44,14 @@ $actions$
 ---
 
 <$list filter="LightPink Pink Crimson LavenderBlush PaleVioletRed HotPink DeepPink MediumVioletRed Orchid Thistle Plum Violet Magenta Fuchsia DarkMagenta Purple MediumOrchid DarkViolet DarkOrchid Indigo BlueViolet MediumPurple MediumSlateBlue SlateBlue DarkSlateBlue Lavender GhostWhite Blue MediumBlue MidnightBlue DarkBlue Navy RoyalBlue CornflowerBlue LightSteelBlue LightSlateGrey SlateGrey DodgerBlue AliceBlue SteelBlue LightSkyBlue SkyBlue DeepSkyBlue LightBlue PowderBlue CadetBlue Azure LightCyan PaleTurquoise Cyan Aqua DarkTurquoise DarkSlateGrey DarkCyan Teal MediumTurquoise LightSeaGreen Turquoise Aquamarine MediumAquamarine MediumSpringGreen MintCream SpringGreen MediumSeaGreen SeaGreen Honeydew LightGreen PaleGreen DarkSeaGreen LimeGreen Lime ForestGreen Green DarkGreen Chartreuse LawnGreen GreenYellow DarkOliveGreen YellowGreen OliveDrab Beige LightGoldenrodYellow Ivory LightYellow Yellow Olive DarkKhaki LemonChiffon PaleGoldenrod Khaki Gold Cornsilk Goldenrod DarkGoldenrod FloralWhite OldLace Wheat Moccasin Orange PapayaWhip BlanchedAlmond NavajoWhite AntiqueWhite Tan BurlyWood Bisque DarkOrange Linen Peru PeachPuff SandyBrown Chocolate SaddleBrown Seashell Sienna LightSalmon Coral OrangeRed DarkSalmon Tomato MistyRose Salmon Snow LightCoral RosyBrown IndianRed Red Brown FireBrick DarkRed Maroon White WhiteSmoke Gainsboro LightGrey Silver DarkGrey Grey DimGrey Black" variable="colour-picker-value">
+&#32;
 <$macrocall $name="colour-picker-inner" actions="""$actions$"""/>
 </$list>
 
 ---
 
 <$edit-text tiddler="$:/config/ColourPicker/New" tag="input" default="" placeholder=""/>
+&#32;
 <$edit-text tiddler="$:/config/ColourPicker/New" type="color" tag="input"/>
 <$set name="colour-picker-value" value={{$:/config/ColourPicker/New}}>
 <$macrocall $name="colour-picker-inner" actions="""$actions$"""/>

--- a/core/wiki/macros/copy-to-clipboard.tid
+++ b/core/wiki/macros/copy-to-clipboard.tid
@@ -2,16 +2,19 @@ title: $:/core/macros/copy-to-clipboard
 tags: $:/tags/Macro
 
 \define copy-to-clipboard(src,class:"tc-btn-invisible",style)
+\whitespace trim
 <$button class=<<__class__>> style=<<__style__>> message="tm-copy-to-clipboard" param=<<__src__>> tooltip={{$:/language/Buttons/CopyToClipboard/Hint}}>
-{{$:/core/images/copy-clipboard}} <$text text={{$:/language/Buttons/CopyToClipboard/Caption}}/>
+{{$:/core/images/copy-clipboard}}
+&#32;
+<$text text={{$:/language/Buttons/CopyToClipboard/Caption}}/>
 </$button>
 \end
 
 \define copy-to-clipboard-above-right(src,class:"tc-btn-invisible",style)
+\whitespace trim
 <div style="position: relative;">
 <div style="position: absolute; bottom: 0; right: 0;">
 <$macrocall $name="copy-to-clipboard" src=<<__src__>> class=<<__class__>> style=<<__style__>>/>
 </div>
 </div>
 \end
-

--- a/core/wiki/macros/dumpvariables.tid
+++ b/core/wiki/macros/dumpvariables.tid
@@ -2,6 +2,7 @@ title: $:/core/macros/dumpvariables
 tags: $:/tags/Macro
 
 \define dumpvariables()
+\whitespace trim
 <ul>
 <$list filter="[variables[]]" variable="varname">
 <li>

--- a/core/wiki/macros/tag.tid
+++ b/core/wiki/macros/tag.tid
@@ -7,12 +7,16 @@ fill:$(foregroundColor)$;
 color:$(foregroundColor)$;
 \end
 
+<!-- This has no whitespace trim to avoid modifying $actions$. Closing tags omitted for brevity. -->
 \define tag-pill-inner(tag,icon,colour,fallbackTarget,colourA,colourB,element-tag,element-attributes,actions)
-<$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
-<$element-tag$ $element-attributes$ class="tc-tag-label tc-btn-invisible" style=<<tag-pill-styles>>>
-$actions$<$transclude tiddler="""$icon$"""/><$view tiddler=<<__tag__>> field="title" format="text" />
-</$element-tag$>
-</$vars>
+<$vars
+	foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">>
+	backgroundColor="""$colour$"""
+><$element-tag$
+	$element-attributes$
+	class="tc-tag-label tc-btn-invisible"
+	style=<<tag-pill-styles>>
+>$actions$<$transclude tiddler="""$icon$"""/><$view tiddler=<<__tag__>> field="title" format="text" />
 \end
 
 \define tag-pill-body(tag,icon,colour,palette,element-tag,element-attributes,actions)
@@ -20,6 +24,7 @@ $actions$<$transclude tiddler="""$icon$"""/><$view tiddler=<<__tag__>> field="ti
 \end
 
 \define tag-pill(tag,element-tag:"span",element-attributes:"",actions:"")
+\whitespace trim
 <span class="tc-tag-list-item" data-tag-title=<<__tag__>>>
 <$let currentTiddler=<<__tag__>>>
 <$macrocall $name="tag-pill-body" tag=<<__tag__>> icon={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] }}} colour={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}} palette={{$:/palette}} element-tag="""$element-tag$""" element-attributes="""$element-attributes$""" actions="""$actions$"""/>

--- a/core/wiki/macros/thumbnails.tid
+++ b/core/wiki/macros/thumbnails.tid
@@ -1,16 +1,28 @@
 title: $:/core/macros/thumbnails
 tags: $:/tags/Macro
 
+<!-- This macro does not use \whitespace trim because it could affect the caption -->
 \define thumbnail(link,icon,color,background-color,image,caption,width:"280",height:"157")
-<$link to="""$link$"""><div class="tc-thumbnail-wrapper">
-<div class="tc-thumbnail-image" style="width:$width$px;height:$height$px;"><$reveal type="nomatch" text="" default="""$image$""" tag="div" style="width:$width$px;height:$height$px;">
-[img[$image$]]
-</$reveal><$reveal type="match" text="" default="""$image$""" tag="div" class="tc-thumbnail-background" style="width:$width$px;height:$height$px;background-color:$background-color$;"></$reveal></div><div class="tc-thumbnail-icon" style="fill:$color$;color:$color$;">
-$icon$
-</div><div class="tc-thumbnail-caption">
-$caption$
-</div>
-</div></$link>
+<$link to="""$link$"""><div class="tc-thumbnail-wrapper"
+><div
+	class="tc-thumbnail-image"
+	style="width:$width$px;height:$height$px;"><$reveal
+	type="nomatch"
+	text=""
+	default="""$image$"""
+	tag="div"
+	style="width:$width$px;height:$height$px;"
+>[img[$image$]]</$reveal><$reveal
+	type="match"
+	text=""
+	default="""$image$"""
+	tag="div"
+	class="tc-thumbnail-background"
+	style="width:$width$px;height:$height$px;background-color:$background-color$;"
+></$reveal></div><div
+	class="tc-thumbnail-icon"
+	style="fill:$color$;color:$color$;"
+>$icon$</div><div class="tc-thumbnail-caption">$caption$</div></div></$link>
 \end
 
 \define thumbnail-right(link,icon,color,background-color,image,caption,width:"280",height:"157")

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -2,6 +2,7 @@ title: $:/core/macros/translink
 tags: $:/tags/Macro
 
 \define translink(title,mode:"block")
+\whitespace trim
 <div style="border:1px solid #ccc; padding: 0.5em; background: black; foreground; white;">
 <$link to="""$title$""">
 <$text text="""$title$"""/>


### PR DESCRIPTION
This is it. Unless a tiddler snuck in during the saga (which probably happened), all unnecessary whitespace is gone.

However, at this point, it's about maintaining proper trimming hygiene. Some tiddlers don't have "\whitespace trim" because they don't need them, but with even a slight modification, this would change. Take this:

```
<div>

<span>

Text

</span>

</div>

```
Seems like there's a lot of whitespace, but there is none. But take this:
```
<div>
<span>

Text

</span>

</div>

```
This has whitespace all over it, and needs a trim pragma. **I** know all the rules about when whitespace is and is not automatically trimmed because I wrote uglify. I probably know it better than anyone, and I know that the rules are fairly complicated.

My point is that I think even trying to maintain trim hygiene, with all these other developers, TiddlyWiki is going to backslide, so... have fun with that.

Anyway, at this point, it may be perfect. And most importantly, Uglify trims TiddlyWiki just great.