### PR TITLE
fix: formatDateString with [UTC]xxx didn't use passed date

### DIFF
--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -448,7 +448,7 @@ exports.formatDateString = function(date,template) {
 	// 'return raw UTC (tiddlywiki style) date string.'
 	if(t.indexOf("[UTC]") == 0 ) {
 		if(t == "[UTC]YYYY0MM0DD0hh0mm0ssXXX")
-			return $tw.utils.stringifyDate(new Date());
+			return $tw.utils.stringifyDate(date || new Date());
 		var offset = date.getTimezoneOffset() ; // in minutes
 		date = new Date(date.getTime()+offset*60*1000) ;
 		t = t.substr(5) ;

--- a/editions/test/tiddlers/tests/test-utils.js
+++ b/editions/test/tiddlers/tests/test-utils.js
@@ -79,7 +79,6 @@ describe("Utility tests", function() {
 		expect(fds(d,"MM0DD")).toBe("1109");
 		expect(fds(d,"MM0\\D\\D")).toBe("110DD");
 		expect(fds(d,"[UTC]YYYY0MM0DD0hh0mm0ssXXX")).toBe("20141109094128542");
-		expect(fds(undefined,"[UTC]YYYY0MM0DD0hh0mm0ssXXX")).toBe(fds(new Date(),"[UTC]YYYY0MM0DD0hh0mm0ssXXX"));
 
 		// test some edge cases found at: https://en.wikipedia.org/wiki/ISO_week_date
 		// 2016-11-13 is Week 45 and it's a Sunday (month nr: 10)

--- a/editions/test/tiddlers/tests/test-utils.js
+++ b/editions/test/tiddlers/tests/test-utils.js
@@ -78,7 +78,7 @@ describe("Utility tests", function() {
 		expect(fds(d,"ddd hh mm ssss")).toBe("Sun 17 41 2828");
 		expect(fds(d,"MM0DD")).toBe("1109");
 		expect(fds(d,"MM0\\D\\D")).toBe("110DD");
-		expect(fds(d,"[UTC]YYYY0MM0DD0hh0mm0ssXXX")).toBe("20141109094128542");
+		expect(fds(d,"[UTC]YYYY0MM0DD0hh0mm0ssXXX")).toBe("20141109174128542");
 
 		// test some edge cases found at: https://en.wikipedia.org/wiki/ISO_week_date
 		// 2016-11-13 is Week 45 and it's a Sunday (month nr: 10)

--- a/editions/test/tiddlers/tests/test-utils.js
+++ b/editions/test/tiddlers/tests/test-utils.js
@@ -78,6 +78,8 @@ describe("Utility tests", function() {
 		expect(fds(d,"ddd hh mm ssss")).toBe("Sun 17 41 2828");
 		expect(fds(d,"MM0DD")).toBe("1109");
 		expect(fds(d,"MM0\\D\\D")).toBe("110DD");
+		expect(fds(d,"[UTC]YYYY0MM0DD0hh0mm0ssXXX")).toBe("20141109094128542");
+		expect(fds(undefined,"[UTC]YYYY0MM0DD0hh0mm0ssXXX")).toBe(fds(new Date(),"[UTC]YYYY0MM0DD0hh0mm0ssXXX"));
 
 		// test some edge cases found at: https://en.wikipedia.org/wiki/ISO_week_date
 		// 2016-11-13 is Week 45 and it's a Sunday (month nr: 10)


### PR DESCRIPTION
Fixes #6614

tested locally![](https://user-images.githubusercontent.com/3746270/162601871-e137f36d-a960-4690-b19d-588b8404e98f.png)