### PR TITLE
Prevent browser storage plugin from skipping items when items are removed at startup

### DIFF
--- a/plugins/tiddlywiki/browser-storage/rawmarkup.js
+++ b/plugins/tiddlywiki/browser-storage/rawmarkup.js
@@ -26,6 +26,7 @@ if(Object.prototype.hasOwnProperty.call($tw.hooks.names,hookName)) {
 // Load tiddlers from browser storage
 function hookBootTiddlersLoaded() {
 	var url = window.location.pathname,
+		keysToDelete = [],
 		log = [];
 	// Check that browser storage is available
 	try {
@@ -55,7 +56,9 @@ function hookBootTiddlersLoaded() {
 							existingTiddler = $tw.wiki.getTiddler(title);
 						if(existingTiddler && existingTiddler.isEqual(incomingTiddler)) {
 							// If the incoming tiddler is the same as the existing then we can delete the local storage version
-							window.localStorage.removeItem(key);
+							// Defer deletion until after this loop, since deleting will shift the index and cause the
+							// index+1 item to be skipped.
+							keysToDelete.push(key);
 						} else {
 							$tw.wiki.addTiddler(incomingTiddler);
 							log.push(title);
@@ -65,6 +68,9 @@ function hookBootTiddlersLoaded() {
 			}
 		}
 	}
+	$tw.utils.each(keysToDelete,function(key) {
+		window.localStorage.removeItem(key);
+	});
 	// Make sure that all the tiddlers we've loaded are marked as dirty at startup
 	Array.prototype.push.apply($tw.boot.preloadDirty,log);
 	// Save the log


### PR DESCRIPTION
While looping over all the browser storage items by index, the items
should not be removed because removing alters the index positions. The
item following the removed one will be skipped by the loop. The skipped
localstorage item will therefore not be loaded into the current tiddlywiki session.

Instead, accumulate a list of keys to remove and remove them after the
loop.