### PR TITLE
fix dropzone closure variable problem - ready to merge

### DIFF
--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -235,7 +235,29 @@ DropZoneWidget.prototype.handlePasteEvent  = function(event) {
 	var self = this,
 		readFileCallback = function(tiddlerFieldsArray) {
 			self.readFileCallback(tiddlerFieldsArray);
-		};
+		},
+		getItem = function(type) {
+			type = type || "text/plain";
+			return function(str) {
+				// Use the deserializer specified if any
+				if(self.dropzoneDeserializer) {
+					tiddlerFields = self.wiki.deserializeTiddlers(null,str,{title: self.wiki.generateNewTitle("Untitled " + type)},{deserializer:self.dropzoneDeserializer});
+					if(tiddlerFields && tiddlerFields.length) {
+						readFileCallback(tiddlerFields);
+					}
+				} else {
+					tiddlerFields = {
+						title: self.wiki.generateNewTitle("Untitled " + type),
+						text: str,
+						type: type
+					};
+					if($tw.log.IMPORT) {
+						console.log("Importing string '" + str + "', type: '" + type + "'");
+					}
+					readFileCallback([tiddlerFields]);
+				}
+			}
+		}
 	// Let the browser handle it if we're in a textarea or input box
 	if(["TEXTAREA","INPUT"].indexOf(event.target.tagName) == -1 && !event.target.isContentEditable) {
 		var self = this,
@@ -251,27 +273,10 @@ DropZoneWidget.prototype.handlePasteEvent  = function(event) {
 				});
 			} else if(item.kind === "string") {
 				// Create tiddlers from string items
-				var tiddlerFields,
-					type = item.type;
-				item.getAsString(function(str) {
-					// Use the deserializer specified if any
-					if(self.dropzoneDeserializer) {
-						tiddlerFields = self.wiki.deserializeTiddlers(null,str,{title: self.wiki.generateNewTitle("Untitled")},{deserializer:self.dropzoneDeserializer});
-						if(tiddlerFields && tiddlerFields.length) {
-							readFileCallback(tiddlerFields);
-						}
-					} else {
-						tiddlerFields = {
-							title: self.wiki.generateNewTitle("Untitled"),
-							text: str,
-							type: type
-						};
-						if($tw.log.IMPORT) {
-							console.log("Importing string '" + str + "', type: '" + type + "'");
-						}
-						readFileCallback([tiddlerFields]);
-					}
-				});
+				var tiddlerFields;
+				// It's important to give getAsString a closure with the right type
+				// So it can be added to the import queue
+				item.getAsString(getItem(item.type));
 			}
 		}
 		// Tell the browser that we've handled the paste

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -232,11 +232,11 @@ DropZoneWidget.prototype.handleDropEvent  = function(event) {
 };
 
 DropZoneWidget.prototype.handlePasteEvent  = function(event) {
-	var self = this,
-		readFileCallback = function(tiddlerFieldsArray) {
+	var self = this;
+	var	readFileCallback = function(tiddlerFieldsArray) {
 			self.readFileCallback(tiddlerFieldsArray);
-		},
-		getItem = function(type) {
+		};
+	var getItem = function(type) {
 			type = type || "text/plain";
 			return function(str) {
 				// Use the deserializer specified if any
@@ -257,7 +257,7 @@ DropZoneWidget.prototype.handlePasteEvent  = function(event) {
 					readFileCallback([tiddlerFields]);
 				}
 			}
-		}
+		};
 	// Let the browser handle it if we're in a textarea or input box
 	if(["TEXTAREA","INPUT"].indexOf(event.target.tagName) == -1 && !event.target.isContentEditable) {
 		var self = this,


### PR DESCRIPTION
See "vercel" preview links below to find the PR-wikis, where you can test different browsers. At the moment it will create 2 tiddlers

The existing core code has an issue with the `type` variable assigned to the tiddler in [line 267](https://github.com/Jermolene/TiddlyWiki5/blob/73138b79aaaafa32b3a0abf8ba80c96eb3a18d56/core/modules/widgets/dropzone.js#L267) ... It is defined in [line 255](https://github.com/Jermolene/TiddlyWiki5/blob/73138b79aaaafa32b3a0abf8ba80c96eb3a18d56/core/modules/widgets/dropzone.js#L255), which will be defined by the last element in the for loop (line 244)

The `type` variable is passed to the `item.getAsString(function(str) {` **callback function as a closure variable, which is a problem in the existing code.**

The PR fixes that. So the `type` will be correctly assigned to every element, that comes from the clipboard, which in turn makes the behaviour for all desktop browsers I could test consistent. 

@Jermolene ... We need to decide, which element should be imported. ... From my point of view, it should be `text/plain`, since `text/html` creates a lot of overhead, that needs to be manually removed. 

As @saqimtiaz ... pointed out. Using `text/plain` as the default will be different to what Chrome does at the moment. 

It would be possible to check for the browser and "recreate the same behaviour" as it is now. .. But I personally think we should fix the problem in a consistent way.

-------

As shown at issue: **[BUG] pasting content from a webpage creates 2 elements in the "paste" event, TW dropzone overwrites the first one** #6592 

If any content from a webpage is copy / pasted into TW, we get 2 [dataTransfer.items](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/items) 

- One of them is `text/html` and the other one is `text/plain`
- This behaviour is consistent on desktop browsers
- **I did test** FireFox 99.0 Win 11, FF 99.0 Ubuntu 20.40, Edge Version 100.0.1185.36 (Offizielles Build) (64-Bit) Win 11, Edge Version 101.0.1210.10 (Official build) beta (64-bit) on Win 11, Chromium Version 100.0.4896.75 (Official Build) snap (64-bit) Ubuntu 20.04

I did try to test copy / paste on my phone, but I have no idea how to do that. I can't open 2 chrome windows in split screen which would allow drag & drop copy paste. 

FF for Android doesn't create  draggable content. 

Copying from other Android apps eg: Free-mail email-client seems to create `text/plain` elements only. 
