### PR TITLE
Give plugin authors the chance to extend a palette

### DIFF
--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -2,6 +2,7 @@ title: $:/core/macros/CSS
 tags: $:/tags/Macro
 
 \define colour(name)
+\whitespace trim
 <$transclude tiddler={{$:/palette}} index=<<__name__>>>
 <$transclude tiddler="$:/palettes/Vanilla" index=<<__name__>>>
 <$transclude tiddler={{{ [[$:/config/DefaultColourPaletteMappings/]addsuffix<__palette__>addsuffix[/]addsuffix<__name__>] }}}/>

--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -2,10 +2,10 @@ title: $:/core/macros/CSS
 tags: $:/tags/Macro
 
 \define colour(name)
-<$transclude tiddler={{$:/palette}} index="$name$">
-<$transclude tiddler="$:/palettes/Vanilla" index="$name$">
+<$transclude tiddler={{$:/palette}} index=<<__name__>>>
+<$transclude tiddler="$:/palettes/Vanilla" index=<<__name__>>>
 <$transclude tiddler={{{ [[$:/config/DefaultColourPaletteMappings/]addsuffix<__palette__>addsuffix[/]addsuffix<__name__>] }}}/>
-<$transclude tiddler="$:/config/DefaultColourMappings/$name$"/>
+<$transclude tiddler={{{ [[$:/config/DefaultColourMappings/]addsuffix<__name__>] }}}/>
 </$transclude>
 </$transclude>
 </$transclude>

--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -2,7 +2,13 @@ title: $:/core/macros/CSS
 tags: $:/tags/Macro
 
 \define colour(name)
-<$transclude tiddler={{$:/palette}} index="$name$"><$transclude tiddler={{{ [{$:/palette}addsuffix[/extension]] }}} index="$name$"><$transclude tiddler="$:/palettes/Vanilla" index="$name$"><$transclude tiddler="$:/config/DefaultColourMappings/$name$"/></$transclude></$transclude></$transclude>
+<$transclude tiddler={{$:/palette}} index="$name$">
+<$transclude tiddler="$:/palettes/Vanilla" index="$name$">
+<$transclude tiddler={{{ [[$:/config/DefaultColourPaletteMappings/]addsuffix<__palette__>addsuffix[/]addsuffix<__name__>] }}}/>
+<$transclude tiddler="$:/config/DefaultColourMappings/$name$"/>
+</$transclude>
+</$transclude>
+</$transclude>
 \end
 
 \define color(name)

--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -2,7 +2,7 @@ title: $:/core/macros/CSS
 tags: $:/tags/Macro
 
 \define colour(name)
-<$transclude tiddler={{$:/palette}} index="$name$"><$transclude tiddler="$:/palettes/Vanilla" index="$name$"><$transclude tiddler="$:/config/DefaultColourMappings/$name$"/></$transclude></$transclude>
+<$transclude tiddler={{$:/palette}} index="$name$"><$transclude tiddler={{{ [{$:/palette}addsuffix[/extension]] }}} index="$name$"><$transclude tiddler="$:/palettes/Vanilla" index="$name$"><$transclude tiddler="$:/config/DefaultColourMappings/$name$"/></$transclude></$transclude></$transclude>
 \end
 
 \define color(name)

--- a/editions/tw5.com/tiddlers/macros/ColourMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/ColourMacro.tid
@@ -7,7 +7,7 @@ caption: colour
 
 The <<.def colour>> (or <<.def color>>) [[macro|Macros]] returns the [[CSS|Cascading Style Sheets]] value of one the colours in the current [[palette|ColourPalettes]].
 
-If no such entry exists in the current palette, the [[vanilla palette|$:/palettes/Vanilla]] is used instead. If no such entry exists in the vanilla palette, the system looks for a configuration tiddler with the title `$:/config/DefaultColourMappings/<colour-name>` and transcludes the colour from the text field. This enables to plugins to ship defaults for colours that are not present in the core palettes.
+If no such entry exists in the current palette, the system looks for a configuration tiddler with the title `$:/config/DefaultColourMappings/<palette>/<colour-name>` and transcludes the colour from the text field. If no such entry exists, the [[vanilla palette|$:/palettes/Vanilla]] is used instead. If no such entry exists in the vanilla palette, the system looks for a configuration tiddler with the title `$:/config/DefaultColourMappings/<colour-name>` and transcludes the colour from the text field. This enables to plugins to ship defaults for colours that are not present in the core palettes.
 
 !! Parameters
 

--- a/editions/tw5.com/tiddlers/macros/ColourMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/ColourMacro.tid
@@ -1,5 +1,5 @@
 created: 20150221154058000
-modified: 20200228142855357
+modified: 20220416090558106
 tags: Macros [[Core Macros]]
 title: colour Macro
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
This PR changes the `colour` macro so, that it transcludes a tiddler with the name of the current palette but with the suffix `/extension` on the second position

This gives plugin authors the chance to extend palettes