### PR TITLE
add charcode, jsstirng macros. allow lf, tab, sapce shortcuts in charcode 

### DIFF
--- a/core/modules/config.js
+++ b/core/modules/config.js
@@ -38,4 +38,18 @@ exports.htmlBlockElements = "address,article,aside,audio,blockquote,canvas,dd,de
 
 exports.htmlUnsafeElements = "script".split(",");
 
+// Character code lookups used in charcode operator and macro
+exports.lookup = {
+	"tab": 9,
+	"\\t": 9,
+	"lf": 10,
+	"\\n": 10,
+	"ff": 12,
+	"\\f": 12,
+	"cr": 13,
+	"\\r": 13,
+	"\\_": 32,
+	"space": 32
+}
+
 })();

--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -175,10 +175,12 @@ exports.pad = function(source,operator,options) {
 }
 
 exports.charcode = function(source,operator,options) {
-	var chars = [];
+	var lookup = $tw.config.lookup,
+		chars = [];
 	$tw.utils.each(operator.operands,function(operand) {
-		if(operand !== "") {
-			chars.push(String.fromCharCode($tw.utils.parseInt(operand)));
+		var code = lookup[operand.toLowerCase()] || operand;
+		if(code !== "") {
+			chars.push(String.fromCharCode($tw.utils.parseInt(code)));
 		}
 	});
 	return [chars.join("")];

--- a/core/modules/macros/charcode.js
+++ b/core/modules/macros/charcode.js
@@ -1,0 +1,37 @@
+/*\
+title: $:/core/modules/macros/charcode.js
+type: application/javascript
+module-type: macro
+
+Macro to return characters using the character-codes as input.
+If the code isn't found the character is returned.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.name = "charcode";
+
+exports.params = [
+	{name: "codes"},
+];
+
+exports.run = function(codes) {
+	var lookup = $tw.config.lookup,
+		tokens = codes.trim().split(/\s+/),
+		results = [];
+	tokens.map(function(name) {
+		var code = lookup[name.toLowerCase()];
+		if (code) {
+			results.push(String.fromCharCode(code));
+		} else {
+			results.push(String.fromCharCode($tw.utils.parseInt(name)));
+		}
+	})
+	return results.join("");
+}
+
+})();

--- a/core/modules/macros/jsstring.js
+++ b/core/modules/macros/jsstring.js
@@ -1,0 +1,28 @@
+/*\
+title: $:/core/modules/macros/jsstring.js
+type: application/javascript
+module-type: macro
+
+Macro to return a string. Replaces \r, \n, \t strings with their character codes.
+All existing CRLF's are removed, which allows us to make the wikitext more readable.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.name = "jsstring";
+
+exports.params = [
+	{name: "text"}
+];
+
+// TODO .. may be it should also use the config.js lookup table
+
+exports.run = function(text, mode) {
+		return text.replace(/\\n/g,"\n").replace(/\\r/g,"\r").replace(/\\t/g,"\t");
+}
+
+})();

--- a/editions/tw5.com/tiddlers/$__StoryList.tid
+++ b/editions/tw5.com/tiddlers/$__StoryList.tid
@@ -1,5 +1,3 @@
-created: 20211126104006194
-list: [[Page and tiddler layout customisation]] [[Creating new buttons for the ViewToolbar and page controls]] [[Structuring TiddlyWiki]] Tagging [[Introduction to Lists]] [[Icon Gallery]] [[How to widen tiddlers (aka storyriver)]] [[How to turn off camel case linking]] [[How to put the last modification date in a banner]] [[How to hide the author's and other fields with CSS]] [[How to export tiddlers]] [[How to Customize TiddlyDesktop]] [[Editing Tiddlers with Vim]] [[Concatenating text and variables using macro substitution]] [[Demonstration: keyboard-driven-input Macro]] HelloThere GettingStarted Community
-modified: 20211126111221917
+list: test-jsstring-with-linebreaks test-join-with-charcode-macro test-jsstring-charcode-side-by-side test-jsstring
 title: $:/StoryList
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/$__StoryList.tid
+++ b/editions/tw5.com/tiddlers/$__StoryList.tid
@@ -1,3 +1,3 @@
-list: test-jsstring-with-linebreaks test-join-with-charcode-macro test-jsstring-charcode-side-by-side test-jsstring
+list: test-6284-jeremy test-jsstring-with-linebreaks test-join-with-charcode-macro test-jsstring-charcode-side-by-side test-jsstring
 title: $:/StoryList
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/$__config_ViewToolbarButtons_Visibility_$__core_ui_Buttons_info.tid
+++ b/editions/tw5.com/tiddlers/$__config_ViewToolbarButtons_Visibility_$__core_ui_Buttons_info.tid
@@ -1,0 +1,6 @@
+created: 20220413102320003
+modified: 20220413102320003
+title: $:/config/ViewToolbarButtons/Visibility/$:/core/ui/Buttons/info
+type: text/vnd.tiddlywiki
+
+show

--- a/editions/tw5.com/tiddlers/test-6284-jeremy.tid
+++ b/editions/tw5.com/tiddlers/test-6284-jeremy.tid
@@ -1,0 +1,26 @@
+created: 20220413104641645
+modified: 20220413105228845
+myField: test
+tags: 
+title: test-6284-jeremy
+type: text/vnd.tiddlywiki
+
+
+Value of myField is -> ''{{!!myField}}''
+
+<<wikitext-example-without-html 
+"""{{{ [all[current]get[myField]addprefix<charcode 93>] }}}
+""">>
+
+
+last example from Jeremy `[<currentTiddler>addsuffix<charcode [[>]` can't be done, since "charcode" would convert the input into something completely different. 
+
+So ''jsstrting'' was created:
+
+<<wikitext-example-without-html 
+"""{{{ [<currentTiddler>addsuffix<jsstring "[[">] }}}
+""">>
+
+
+
+

--- a/editions/tw5.com/tiddlers/test-join-with-charcode-macro.tid
+++ b/editions/tw5.com/tiddlers/test-join-with-charcode-macro.tid
@@ -1,0 +1,41 @@
+created: 20211201181012026
+modified: 20220412133425631
+tags: 
+title: test-join-with-charcode-macro
+type: text/vnd.tiddlywiki
+
+Something like this was discussed at GH: [[ [IDEA] String manipulation operators should be able to deal with \n\t .. and others #4697 |https://github.com/Jermolene/TiddlyWiki5/issues/4697]]
+
+
+<<wikitext-example-without-html 
+"""\define action()
+<$action-setfield $tiddler=a text={{{[[go to edit mode to see the linebreaks]split[ ]join<charcode "lf lf">]}}} />
+<$action-sendmessage $message="tm-edit-tiddler" $param="a"/>
+\end
+
+<$button actions=<<action>>>
+click to write new text to tiddler "a"
+</$button>
+""">>
+
+<<wikitext-example-without-html """<$button>
+<$action-setfield $tiddler=a text={{{[[go to edit mode to see the linebreaks]split[ ]join<charcode "10 \n">]}}} />
+<$action-sendmessage $message="tm-edit-tiddler" $param="b"/>
+click to write new text to tiddler "b"
+</$button>
+""">>
+
+
+<<wikitext-example-without-html """<$button>
+<$action-setfield $tiddler=a text={{{[[convert to links]split[ ]addprefix<jsstring "[[">addsuffix<jsstring "]]">join[ ]]}}} />
+<$action-sendmessage $message="tm-edit-tiddler" $param="c"/>
+click to write new text to tiddler "c"
+</$button>
+""">>
+
+<<wikitext-example-without-html """<$button>
+<$action-setfield $tiddler=a text={{{[[convert to links]split[ ]addprefix<jsstring "[[">addsuffix<jsstring "]]\n">join<charcode lf>]}}} />
+<$action-sendmessage $message="tm-edit-tiddler" $param="d"/>
+click to write new text to tiddler "d"
+</$button>
+""">>

--- a/editions/tw5.com/tiddlers/test-jsstring-charcode-side-by-side.tid
+++ b/editions/tw5.com/tiddlers/test-jsstring-charcode-side-by-side.tid
@@ -1,8 +1,10 @@
 created: 20211201182207801
-modified: 20220412124326177
+modified: 20220413105523838
 tags: 
 title: test-jsstring-charcode-side-by-side
 type: text/vnd.tiddlywiki
+
+TODO The following elements will need to be explained in more detail.
 
 The lookup for the "placeholders" looks like this atm
 
@@ -30,7 +32,7 @@ exports.lookup = {
 ]then[matches]else[doesn't match]] }}}  """>>
 
 
-There are 2 possibilities atm `\n  and lf`
+There are 2 possibilities `\n and lf`
 
 <<wikitext-example-without-html """{{{ [<charcode "\n">match[
 ]then[matches]else[doesn't match]] }}}  """>>

--- a/editions/tw5.com/tiddlers/test-jsstring-charcode-side-by-side.tid
+++ b/editions/tw5.com/tiddlers/test-jsstring-charcode-side-by-side.tid
@@ -1,0 +1,47 @@
+created: 20211201182207801
+modified: 20220412124326177
+tags: 
+title: test-jsstring-charcode-side-by-side
+type: text/vnd.tiddlywiki
+
+The lookup for the "placeholders" looks like this atm
+
+```
+// Character code lookups used in charcode filter and macro
+exports.lookup = {
+	"tab": 9,
+	"\\t": 9,
+	"lf": 10,
+	"\\n": 10,
+	"ff": 12,
+	"\\f": 12,
+	"cr": 13,
+	"\\r": 13,
+	"\\_": 32,
+	"space": 32
+}
+```
+
+---
+
+''macros''
+
+<<wikitext-example-without-html """{{{ [<jsstring "\n">match[
+]then[matches]else[doesn't match]] }}}  """>>
+
+
+There are 2 possibilities atm `\n  and lf`
+
+<<wikitext-example-without-html """{{{ [<charcode "\n">match[
+]then[matches]else[doesn't match]] }}}  """>>
+
+<<wikitext-example-without-html """{{{ [<charcode "lf">match[
+]then[matches]else[doesn't match]] }}}  """>>
+
+
+''filter operator''
+
+<<wikitext-example-without-html """{{{ [charcode[lf]match[
+]then[matches]else[doesn't match]] }}}  """>>
+
+<<wikitext-example-without-html """{{{ [charcode[lf]match<charcode "10">then[matches]else[doesn't match]] }}}  """>>

--- a/editions/tw5.com/tiddlers/test-jsstring-with-linebreaks.tid
+++ b/editions/tw5.com/tiddlers/test-jsstring-with-linebreaks.tid
@@ -1,0 +1,9 @@
+created: 20220412134115557
+modified: 20220412134315319
+tags: 
+title: test-jsstring-with-linebreaks
+type: text/vnd.tiddlywiki
+
+<<wikitext-example-without-html 
+"""<<jsstring "<pre>asdf\n\tasdf</pre>">>
+""">>

--- a/editions/tw5.com/tiddlers/test-jsstring-with-linebreaks.tid
+++ b/editions/tw5.com/tiddlers/test-jsstring-with-linebreaks.tid
@@ -1,5 +1,5 @@
 created: 20220412134115557
-modified: 20220412134315319
+modified: 20220413105257324
 tags: 
 title: test-jsstring-with-linebreaks
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/test-jsstring.tid
+++ b/editions/tw5.com/tiddlers/test-jsstring.tid
@@ -1,0 +1,9 @@
+created: 20211201153854223
+modified: 20220412124323242
+tags: 
+title: test-jsstring
+type: text/vnd.tiddlywiki
+
+<<wikitext-example-without-html """<<jsstring "<pre>a\nb</pre>">> """ >>
+ 
+ 


### PR DESCRIPTION
- The PR adds some "lookup config" elements to allow us to use `lf tab space \n \t` which are easier to handle for humans as `10 13`
- It adds a `charcode` **macro**
- It adds a `jsstring` **macro** ... name is up for discussion
- It changes the existing `charcode` **filter** to allow us to use `lf tab \n \t` -- same reason as above

-------

[There are some test-xxx tiddlers in the DEMO to show the possibilities](https://pmario.github.io/kitchensink/6566-charcode-macro.html#test-jsstring-charcode-side-by-side:test-jsstring-charcode-side-by-side%20test-6284-jeremy%20test-jsstring-with-linebreaks%20test-jsstring%20test-join-with-charcode-macro). Those tests should be converted to doc tiddlers in a second step.

This PR should fix:  

- #6566 .. by Saq
   - issue was created because of: https://github.com/Jermolene/TiddlyWiki5/issues/5309#issuecomment-1080522418
- #6284 .. by Jeremy
- #4697 .. by me

It uses the concept from draft PR:  **charcode-jsstring-macros-charcode-operator** #6295 .. by me.  

There are also some discussions at Talk-TiddlyWiki especially stobot's reply: https://talk.tiddlywiki.org/t/more-direct-way-to-insert-and-in-filters/1670/15 ... that imo requests a more generic way to manipulate strings. ... That's what the `jsstring` macro is used for. 

