### PR TITLE
Fix: new field no longer got focus after adding a field

### DIFF
--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -137,7 +137,7 @@ $value={{{ [<newFieldValueTiddler>get<name>] }}}/>
 </div>
 <$let currentTiddler=<<newFieldValueTiddler>> currentField={{{ [<newFieldNameTiddler>get[text]] }}}>
 <span class="tc-edit-field-add-value tc-small-gap-right">
-<$set name="currentTiddlerCSSescaped" value={{{ [<currentTiddler>escapecss[]] }}}>
+<$set name="currentTiddlerCSSescaped" value={{{ [<storyTiddler>escapecss[]] }}}>
 <$keyboard key="((add-field))" actions=<<new-field-actions>>>
 <$transclude tiddler={{{ [<currentField>] :cascade[all[shadows+tiddlers]tag[$:/tags/FieldEditorFilter]!is[draft]get[text]] :and[!is[blank]else{$:/core/ui/EditTemplate/fieldEditor/default}] }}} />
 </$keyboard>


### PR DESCRIPTION
When hitting enter in a new-field value the field gets added and it's supposed to focus the field-name input of the new field
This PR restores that behavior