### PR TITLE
action-setfield shouldn't write to the current tiddler if the $tiddler attribute is present but has evaluated to a missing attribute

### DIFF
--- a/core/modules/widgets/action-setfield.js
+++ b/core/modules/widgets/action-setfield.js
@@ -35,7 +35,7 @@ SetFieldWidget.prototype.render = function(parent,nextSibling) {
 Compute the internal state of the widget
 */
 SetFieldWidget.prototype.execute = function() {
-	this.actionTiddler = this.getAttribute("$tiddler",this.getVariable("currentTiddler"));
+	this.actionTiddler = this.getAttribute("$tiddler") || (!this.hasParseTreeNodeAttribute("$tiddler") && this.getVariable("currentTiddler"));
 	this.actionField = this.getAttribute("$field");
 	this.actionIndex = this.getAttribute("$index");
 	this.actionValue = this.getAttribute("$value");
@@ -46,11 +46,7 @@ SetFieldWidget.prototype.execute = function() {
 Refresh the widget by ensuring our attributes are up to date
 */
 SetFieldWidget.prototype.refresh = function(changedTiddlers) {
-	var changedAttributes = this.computeAttributes();
-	if(changedAttributes["$tiddler"] || changedAttributes["$field"] || changedAttributes["$index"] || changedAttributes["$value"]) {
-		this.refreshSelf();
-		return true;
-	}
+	// Nothing to refresh
 	return this.refreshChildren(changedTiddlers);
 };
 
@@ -60,15 +56,17 @@ Invoke the action associated with this widget
 SetFieldWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var self = this,
 		options = {};
-	options.suppressTimestamp = !this.actionTimestamp;
-	if((typeof this.actionField == "string") || (typeof this.actionIndex == "string")  || (typeof this.actionValue == "string")) {
-		this.wiki.setText(this.actionTiddler,this.actionField,this.actionIndex,this.actionValue,options);
-	}
-	$tw.utils.each(this.attributes,function(attribute,name) {
-		if(name.charAt(0) !== "$") {
-			self.wiki.setText(self.actionTiddler,name,undefined,attribute,options);
+	if(this.actionTiddler) {
+		options.suppressTimestamp = !this.actionTimestamp;
+		if((typeof this.actionField == "string") || (typeof this.actionIndex == "string")  || (typeof this.actionValue == "string")) {
+			this.wiki.setText(this.actionTiddler,this.actionField,this.actionIndex,this.actionValue,options);
 		}
-	});
+		$tw.utils.each(this.attributes,function(attribute,name) {
+			if(name.charAt(0) !== "$") {
+				self.wiki.setText(self.actionTiddler,name,undefined,attribute,options);
+			}
+		});
+	}
 	return true; // Action was invoked
 };
 

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -289,10 +289,17 @@ Widget.prototype.computeAttribute = function(attribute) {
 };
 
 /*
-Check for the presence of an attribute
+Check for the presence of an evaluated attribute on the widget. Note that attributes set to a missing variable (ie attr=<<missing>>) will be treated as missing
 */
 Widget.prototype.hasAttribute = function(name) {
 	return $tw.utils.hop(this.attributes,name);
+};
+
+/*
+Check for the presence of a raw attribute on the widget parse tree node. Note that attributes set to a missing variable (ie attr=<<missing>>) will NOT be treated as missing
+*/
+Widget.prototype.hasParseTreeNodeAttribute = function(name) {
+	return $tw.utils.hop(this.parseTreeNode.attributes,name);
 };
 
 /*

--- a/editions/test/tiddlers/tests/test-action-widgets.js
+++ b/editions/test/tiddlers/tests/test-action-widgets.js
@@ -36,6 +36,49 @@ function setupWiki(wikiOptions) {
 	};
 }
 
+it("should handle the action-setfield widget", function() {
+	var info = setupWiki();
+	var invokeActions = function(actions) {
+		info.widgetNode.invokeActionString(actions,info.widgetNode,null,{});
+	};
+	var resetTiddlers = function() {
+		info.wiki.addTiddlers([
+			{
+				title: "Output",
+				text: "Elephants!"
+			},{
+				title: "Root",
+				text: "Eagles!"
+			}
+		]);
+	};
+	// Start with a reset
+	resetTiddlers();
+	// Check it
+	expect(info.wiki.getTiddlerText("Output")).toBe("Elephants!");
+	expect(info.wiki.getTiddlerText("Root")).toBe("Eagles!");
+	// Missing $tiddler attribute
+	resetTiddlers();
+	invokeActions("<$tiddler tiddler='Root'><$action-setfield $field='text' $value='Hippos!'/></$tiddler>");
+	expect(info.wiki.getTiddlerText("Output")).toBe("Elephants!");
+	expect(info.wiki.getTiddlerText("Root")).toBe("Hippos!");
+	// Blank $tiddler attribute
+	resetTiddlers();
+	invokeActions("<$tiddler tiddler='Root'><$action-setfield $tiddler='' $field='text' $value='Koalas!'/></$tiddler>");
+	expect(info.wiki.getTiddlerText("Output")).toBe("Elephants!");
+	expect(info.wiki.getTiddlerText("Root")).toBe("Eagles!");
+	// Empty $tiddler attribute
+	resetTiddlers();
+	invokeActions("<$tiddler tiddler='Root'><$action-setfield $tiddler={{{}}} $field='text' $value='Sharks!'/></$tiddler>");
+	expect(info.wiki.getTiddlerText("Output")).toBe("Elephants!");
+	expect(info.wiki.getTiddlerText("Root")).toBe("Eagles!");
+	// Missing variable attribute
+	resetTiddlers();
+	invokeActions("<$tiddler tiddler='Root'><$action-setfield $tiddler=<<missing>> $field='text' $value='Tigers!'/></$tiddler>");
+	expect(info.wiki.getTiddlerText("Output")).toBe("Elephants!");
+	expect(info.wiki.getTiddlerText("Root")).toBe("Eagles!");
+});
+
 it("should handle the action-listops widget", function() {
 	var info = setupWiki();
 	var invokeActions = function(actions) {


### PR DESCRIPTION
Fixes #5916