### PR TITLE
Change title 'Upgrading' to 'Upgrading/Updating'

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/Upgrading_Updating.tid
+++ b/editions/tw5.com/tiddlers/howtos/Upgrading_Updating.tid
@@ -1,7 +1,7 @@
 created: 20131202102427114
-modified: 20160617105124677
+modified: 20220423195747212
 tags: Features [[Working with TiddlyWiki]]
-title: Upgrading
+title: Upgrading/Updating
 type: text/vnd.tiddlywiki
 
 There are regular releases of TiddlyWiki with bug fixes and improvements. It's a good idea to keep up to date by regularly upgrading to the latest version.

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.1.12.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.1.12.tid
@@ -1,10 +1,10 @@
 caption: 5.1.12
 created: 20160713104714652
-modified: 20160713104714652
+modified: 20220423193922258
+released: 20160713104714652
 tags: ReleaseNotes
 title: Release 5.1.12
 type: text/vnd.tiddlywiki
-released: 20160713104714652
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.1.11...v5.1.12]]//
 
@@ -34,7 +34,7 @@ The bitmap editor has been enhanced with a toolbar supporting:
 
 !! Improved Plugins
 
-Several of the official plugins available in the plugin library have been updated for this release. [[Upgrading]] will automatically update any installed plugins.
+Several of the official plugins available in the plugin library have been updated for this release. [[Upgrading/Updating]] will automatically update any installed plugins.
 
 * The KaTeX plugin has been updated to [[version v0.60.0|https://github.com/Khan/KaTeX/releases/tag/v0.6.0]]
 * The CodeMirror plugin has been updated to version 5.13.2, and integrated with the new editor toolbars. The default configuration has been updated to include syntax highlighting for HTML, ~JavaScript, CSS, XML, TiddlyWiki Classic and Markdown.

--- a/editions/tw5.com/tiddlers/releasenotes/alpha/Release 5.0.1alpha.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/alpha/Release 5.0.1alpha.tid
@@ -1,16 +1,16 @@
+caption: 5.0.1-alpha
 created: 20131201132300007
-modified: 20131206161343895
+modified: 20220423193922258
+released: 201312061753
 tags: AlphaReleaseNotes
 title: Release 5.0.1-alpha
 type: text/vnd.tiddlywiki
-released: 201312061753
-caption: 5.0.1-alpha
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.0.0-alpha.17...v5.0.1-alpha]]//
 
 !! Improvements
 
-* Changes to the importing process to enable a smoother [[Upgrading]] process
+* Changes to the importing process to enable a smoother [[Upgrading/Updating]] process
 ** Ignores attempts to import plugins that are older than currently installed plugins
 ** System tiddlers are now imported as usual
 * If `$:/theme` isn't defined or refers to a missing tiddler, then fallback through ''Snow White'' to ''Vanilla''. This means that `empty.html` now defaults to ''Snow White''

--- a/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
@@ -5,7 +5,7 @@ created: 20130825213500000
 delivery: Service
 description: Online TiddlyWiki hosting. (Deprecated in favour of TiddlyHost)
 method: save
-modified: 20210423004027196
+modified: 20220423193922258
 tags: Android Chrome Firefox [[Internet Explorer]] Linux Mac Opera PHP Safari Saving Windows iOS Edge
 title: Saving on TiddlySpot
 type: text/vnd.tiddlywiki
@@ -39,8 +39,8 @@ Error: NS_ERROR_DOM_BAD_URI: Access to restricted URI denied
 
 The upgrade operation falls foul of a security restriction in Firefox. Until this can be resolved, we suggest using Chrome.
 
-* Use Chrome to open the local TiddlyWiki document you want to upload to ~TiddlySpot and follow the steps 1 through 5 described at [[Upgrading]].
+* Use Chrome to open the local TiddlyWiki document you want to upload to ~TiddlySpot and follow the steps 1 through 5 described at [[Upgrading/Updating]].
 * Once you've checked the ~TiddlySpot-hosted TiddlyWiki loads properly in Chrome, you should be able to access, edit and [[save using TiddlyFox|Saving with TiddlyFox]] again.
 * After you've uploaded your local document once, further editing and saving of the online version hosted on ~TiddlySpot should work with any modern browser of your choice. (Don't forget to fill in the ~TiddlySpot password in your ~TiddlySpot TiddlyWiki control panel for any new browser you want to use for saving changes.)
 
-//See also: [[Upgrading]]//
+//See also: [[Upgrading/Updating]]//

--- a/editions/tw5.com/tiddlers/saving/Saving via WebDAV.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving via WebDAV.tid
@@ -4,12 +4,12 @@ created: 20160216191710789
 delivery: Protocol
 description: Standard web protocol available on products such as Sharepoint
 method: save
-modified: 20220222190056634
+modified: 20220423193922258
 tags: Android Chrome Firefox [[Internet Explorer]] Linux Mac Opera PHP Safari Saving Windows iOS Edge
 title: Saving via WebDAV
 type: text/vnd.tiddlywiki
 
-If hosted on a [[WebDAV|https://en.wikipedia.org/wiki/WebDAV]]-enabled server, TiddlyWiki will automatically save changes via HTTP for TiddlyWiki's created after 2016. If you created your wiki before Feb 16 2016  you'll need to [[Upgrade|Upgrading]] to enable ~WebDAV.
+If hosted on a [[WebDAV|https://en.wikipedia.org/wiki/WebDAV]]-enabled server, TiddlyWiki will automatically save changes via HTTP for TiddlyWiki's created after 2016. If you created your wiki before Feb 16 2016  you'll need to [[Upgrade|Upgrading/Updating]] to enable ~WebDAV.
 
 
 

--- a/editions/tw5.com/tiddlers/webserver/Using the external JavaScript template.tid
+++ b/editions/tw5.com/tiddlers/webserver/Using the external JavaScript template.tid
@@ -1,5 +1,5 @@
 created: 20180905075846391
-modified: 20210611055708739
+modified: 20220423193922258
 tags: [[WebServer Guides]]
 title: Using the external JavaScript template
 type: text/vnd.tiddlywiki
@@ -89,7 +89,7 @@ tiddlywiki YOUR_WIKI_FOLDER --build tiddlywikicore
 
 Before you proceed, backup your wiki first! Follow the steps below to upgrade a single-file wiki with the external JavaScript template:
 
-# Proceed with the [[Upgrade Process for Standalone TiddlyWikis|Upgrading]]. Your wiki will be converted to a full standalone HTML.
+# Proceed with the [[Upgrade Process for Standalone TiddlyWikis|Upgrading/Updating]]. Your wiki will be converted to a full standalone HTML.
 
 # Open your upgraded wiki in the browser. If you'd like to revert to using the regular template, restore the original shadow tiddler `$:/config/SaveWikiButton/Template` by deleting any custom copy. Save your wiki and you are done. 
 

--- a/editions/tw5.com/tiddlers/workingwithtw/Working with TiddlyWiki.tid
+++ b/editions/tw5.com/tiddlers/workingwithtw/Working with TiddlyWiki.tid
@@ -1,6 +1,6 @@
 created: 20140904101100000
-list: [[The First Rule of Using TiddlyWiki]] GettingStarted [[Getting Started Video]] Upgrading [[Navigating between open tiddlers]] [[Using links to navigate between tiddlers]] [[Searching in TiddlyWiki]] [[Creating and editing tiddlers]] [[Creating journal tiddlers]] Saving [[Formatting text in TiddlyWiki]] [[Structuring TiddlyWiki]] Tagging [[Images in WikiText]] KeyboardShortcuts Encryption
-modified: 20140919191122898
+list: [[The First Rule of Using TiddlyWiki]] GettingStarted [[Getting Started Video]] Upgrading/Updating [[Navigating between open tiddlers]] [[Using links to navigate between tiddlers]] [[Searching in TiddlyWiki]] [[Creating and editing tiddlers]] [[Creating journal tiddlers]] Saving [[Formatting text in TiddlyWiki]] [[Structuring TiddlyWiki]] Tagging [[Images in WikiText]] KeyboardShortcuts Encryption
+modified: 20220423193922258
 tags: TableOfContents
 title: Working with TiddlyWiki
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
On a regular basis people ask for help Upgrading. This is because they are looking for the term 'Updating'. Unfortunately, simply adding search terms to the tiddler 'Upgrading' is insufficient, since there are 70 hits when you type 'Updat', and those all occur at the end of the search list. This PR changes the tiddler to "Upgrading/Updating" and also changes the tiddlers that were linked to the tiddler. 