### PR TITLE
Update CupertinoDark.tid so that editor-bg-color isn't transparent

### DIFF
--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -87,7 +87,7 @@ tiddler-border: transparent
 tiddler-controls-foreground-hover: <<colour sidebar-controls-foreground-hover>>
 tiddler-controls-foreground-selected: <<colour sidebar-controls-foreground-hover>>
 tiddler-controls-foreground: #48484A
-tiddler-editor-background: transparent
+tiddler-editor-background: <<colour background>>
 tiddler-editor-border-image: 
 tiddler-editor-border: rgba(255, 255, 255, 0.08)
 tiddler-editor-fields-even: rgba(255, 255, 255, 0.1)


### PR DESCRIPTION
This solves a problem if we apply `color-scheme: dark` to the root element by CSS, where the editor bg stays white and no text is visible