### PR TITLE
Write the right "color-scheme" meta tag to the iframe of the framed text-editor

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -34,8 +34,10 @@ function FramedEngine(options) {
 	this.parentNode.insertBefore(this.iframeNode,this.nextSibling);
 	this.iframeDoc = this.iframeNode.contentWindow.document;
 	// (Firefox requires us to put some empty content in the iframe)
+	var paletteTitle = this.widget.getTiddlerText("$:/palette");
+	var colorScheme = paletteTitle.fields["color-scheme"];
 	this.iframeDoc.open();
-	this.iframeDoc.write("");
+	this.iframeDoc.write("<meta name='color-scheme' content='" + colorScheme ? colorScheme : "light" + "'>'");
 	this.iframeDoc.close();
 	// Style the iframe
 	this.iframeNode.className = this.dummyTextArea.className;

--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -35,9 +35,9 @@ function FramedEngine(options) {
 	this.iframeDoc = this.iframeNode.contentWindow.document;
 	// (Firefox requires us to put some empty content in the iframe)
 	var paletteTitle = this.widget.getTiddlerText("$:/palette");
-	var colorScheme = paletteTitle.fields["color-scheme"];
+	var colorScheme = paletteTitle.fields["color-scheme"] || "light";
 	this.iframeDoc.open();
-	this.iframeDoc.write("<meta name='color-scheme' content='" + colorScheme ? colorScheme : "light" + "'>'");
+	this.iframeDoc.write("<meta name='color-scheme' content='" + colorScheme + "'>");
 	this.iframeDoc.close();
 	// Style the iframe
 	this.iframeNode.className = this.dummyTextArea.className;


### PR DESCRIPTION
This PR writes the `color-scheme` **meta-tag** to the framed text-editor, corresponding to the `color-scheme` field of the currently selected palette.

This then enables us to set the following in CSS:

```
:root {
color-scheme: dark/light (corresponding to palette);
}
```