### PR TITLE
Parameterised transclusions

### DIFF
--- a/core/modules/parsers/binaryparser.js
+++ b/core/modules/parsers/binaryparser.js
@@ -21,9 +21,9 @@ var BinaryParser = function(type,text,options) {
 		type: "element",
 		tag: "p",
 		children: [{
-			type: "transclude",
+			type: "ubertransclude",
 			attributes: {
-				tiddler: {type: "string", value: BINARY_WARNING_MESSAGE}
+				"$tiddler": {type: "string", value: BINARY_WARNING_MESSAGE}
 			}
 		}]
 	};
@@ -36,9 +36,9 @@ var BinaryParser = function(type,text,options) {
 			download: {type: "indirect", textReference: "!!title"}
 		},
 		children: [{
-			type: "transclude",
+			type: "ubertransclude",
 			attributes: {
-				tiddler: {type: "string", value: EXPORT_BUTTON_IMAGE}
+				"$tiddler": {type: "string", value: EXPORT_BUTTON_IMAGE}
 			}
 		}]
 	};

--- a/core/modules/parsers/wikiparser/rules/transcludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeblock.js
@@ -34,7 +34,7 @@ exports.parse = function() {
 		textRef = $tw.utils.trim(this.match[1]);
 	// Prepare the transclude widget
 	var transcludeNode = {
-			type: "transclude",
+			type: "ubertransclude",
 			attributes: {},
 			isBlock: true
 		};
@@ -55,7 +55,7 @@ exports.parse = function() {
 		};
 	}
 	if(template) {
-		transcludeNode.attributes.tiddler = {type: "string", value: template};
+		transcludeNode.attributes["$tiddler"] = {type: "string", value: template};
 		if(textRef) {
 			return [tiddlerNode];
 		} else {
@@ -63,12 +63,12 @@ exports.parse = function() {
 		}
 	} else {
 		if(textRef) {
-			transcludeNode.attributes.tiddler = {type: "string", value: targetTitle};
+			transcludeNode.attributes["$tiddler"] = {type: "string", value: targetTitle};
 			if(targetField) {
-				transcludeNode.attributes.field = {type: "string", value: targetField};
+				transcludeNode.attributes["$field"] = {type: "string", value: targetField};
 			}
 			if(targetIndex) {
-				transcludeNode.attributes.index = {type: "string", value: targetIndex};
+				transcludeNode.attributes["$index"] = {type: "string", value: targetIndex};
 			}
 			return [tiddlerNode];
 		} else {

--- a/core/modules/parsers/wikiparser/rules/transcludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeinline.js
@@ -34,7 +34,7 @@ exports.parse = function() {
 		textRef = $tw.utils.trim(this.match[1]);
 	// Prepare the transclude widget
 	var transcludeNode = {
-			type: "transclude",
+			type: "ubertransclude",
 			attributes: {}
 		};
 	// Prepare the tiddler widget
@@ -53,7 +53,7 @@ exports.parse = function() {
 		};
 	}
 	if(template) {
-		transcludeNode.attributes.tiddler = {type: "string", value: template};
+		transcludeNode.attributes["$tiddler"] = {type: "string", value: template};
 		if(textRef) {
 			return [tiddlerNode];
 		} else {
@@ -61,12 +61,12 @@ exports.parse = function() {
 		}
 	} else {
 		if(textRef) {
-			transcludeNode.attributes.tiddler = {type: "string", value: targetTitle};
+			transcludeNode.attributes["$tiddler"] = {type: "string", value: targetTitle};
 			if(targetField) {
-				transcludeNode.attributes.field = {type: "string", value: targetField};
+				transcludeNode.attributes["$field"] = {type: "string", value: targetField};
 			}
 			if(targetIndex) {
-				transcludeNode.attributes.index = {type: "string", value: targetIndex};
+				transcludeNode.attributes["$index"] = {type: "string", value: targetIndex};
 			}
 			return [tiddlerNode];
 		} else {

--- a/core/modules/widgets/parameters.js
+++ b/core/modules/widgets/parameters.js
@@ -1,0 +1,74 @@
+/*\
+title: $:/core/modules/widgets/parameters.js
+type: application/javascript
+module-type: widget
+
+Widget for definition of transclusion parameters
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget,
+	UberTranscludeWidget = require("$:/core/modules/widgets/ubertransclude.js").ubertransclude;
+
+var ParametersWidget = function(parseTreeNode,options) {
+	// Initialise
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+ParametersWidget.prototype = Object.create(Widget.prototype);
+
+/*
+Render this widget into the DOM
+*/
+ParametersWidget.prototype.render = function(parent,nextSibling) {
+	// Call the constructor
+	Widget.call(this);
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
+	this.renderChildren(parent,nextSibling);
+};
+
+/*
+Compute the internal state of the widget
+*/
+ParametersWidget.prototype.execute = function() {
+	var self = this;
+	// Find the parent transclusion
+	var transclusionWidget = this.parentWidget;
+	while(transclusionWidget && !(transclusionWidget instanceof UberTranscludeWidget)) {
+		transclusionWidget = transclusionWidget.parentWidget;
+	}
+	// Process each parameter
+	if(transclusionWidget) {
+		$tw.utils.each(this.attributes,function(value,name) {
+			self.setVariable(name,transclusionWidget.getTransclusionParameter(name,value));
+		});	
+	}
+	// Construct the child widgets
+	this.makeChildWidgets();
+};
+
+/*
+Refresh the widget by ensuring our attributes are up to date
+*/
+ParametersWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if(Object.keys(changedAttributes).length) {
+		this.refreshSelf();
+		return true;
+	}
+	return this.refreshChildren(changedTiddlers);
+};
+
+exports.parameters = ParametersWidget;
+
+})();

--- a/core/modules/widgets/slot.js
+++ b/core/modules/widgets/slot.js
@@ -1,0 +1,71 @@
+/*\
+title: $:/core/modules/widgets/slot.js
+type: application/javascript
+module-type: widget
+
+Widget for definition of slots within transcluded content. The values provided by the translusion are passed to the slot.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget,
+	UberTranscludeWidget = require("$:/core/modules/widgets/ubertransclude.js").ubertransclude;
+
+var SlotWidget = function(parseTreeNode,options) {
+	// Initialise
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+SlotWidget.prototype = Object.create(Widget.prototype);
+
+/*
+Render this widget into the DOM
+*/
+SlotWidget.prototype.render = function(parent,nextSibling) {
+	// Call the constructor
+	Widget.call(this);
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
+	this.renderChildren(parent,nextSibling);
+};
+
+/*
+Compute the internal state of the widget
+*/
+SlotWidget.prototype.execute = function() {
+	var self = this;
+	this.slotName = this.getAttribute("$name");
+	// Find the parent transclusion
+	var transclusionWidget = this.parentWidget;
+	while(transclusionWidget && !(transclusionWidget instanceof UberTranscludeWidget)) {
+		transclusionWidget = transclusionWidget.parentWidget;
+	}
+	// Get the parse tree nodes comprising the slot contents
+	var parseTreeNodes = transclusionWidget.getTransclusionSlotValue(this.slotName,this.parseTreeNode.children);
+	// Construct the child widgets
+	this.makeChildWidgets(parseTreeNodes);
+};
+
+/*
+Refresh the widget by ensuring our attributes are up to date
+*/
+SlotWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if(changedAttributes["$name"]) {
+		this.refreshSelf();
+		return true;
+	}
+	return this.refreshChildren(changedTiddlers);
+};
+
+exports.slot = SlotWidget;
+
+})();

--- a/core/modules/widgets/ubertransclude.js
+++ b/core/modules/widgets/ubertransclude.js
@@ -88,8 +88,15 @@ UberTranscludeWidget.prototype.execute = function() {
 			});
 	}
 	var parseTreeNodes = parser ? parser.tree : (this.slotValueParseTrees["missing"] || []);
-	this.sourceText = parser ? parser.source : null;
-	this.parserType = parser? parser.type : null;
+	this.sourceText = parser ? parser.source : undefined;
+	this.parserType = parser? parser.type : undefined;
+	// Wrap the transcluded content if required
+	if(this.slotValueParseTrees["wrapper"]) {
+		this.slotValueParseTrees["wrapped"] = parseTreeNodes;
+		parseTreeNodes = this.slotValueParseTrees["wrapper"];
+		this.sourceTest = undefined;
+		this.sourceType = undefined;
+	}
 	// Set context variables for recursion detection
 	var recursionMarker = this.makeRecursionMarker();
 	if(this.recursionMarker === "yes") {

--- a/core/modules/widgets/ubertransclude.js
+++ b/core/modules/widgets/ubertransclude.js
@@ -1,0 +1,168 @@
+/*\
+title: $:/core/modules/widgets/ubertransclude.js
+type: application/javascript
+module-type: widget
+
+Ubertransclude widget
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var UberTranscludeWidget = function(parseTreeNode,options) {
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+UberTranscludeWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+UberTranscludeWidget.prototype.render = function(parent,nextSibling) {
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
+	this.renderChildren(parent,nextSibling);
+};
+
+/*
+Compute the internal state of the widget
+*/
+UberTranscludeWidget.prototype.execute = function() {
+	var self = this;
+	// Get our parameters
+	this.transcludeVariable = this.getAttribute("$variable");
+	this.transcludeType = this.getAttribute("$type");
+	this.transcludeTitle = this.getAttribute("$tiddler",this.getVariable("currentTiddler"));
+	this.transcludeSubTiddler = this.getAttribute("$subtiddler");
+	this.transcludeField = this.getAttribute("$field");
+	this.transcludeIndex = this.getAttribute("$index");
+	this.transcludeMode = this.getAttribute("$mode");
+	this.recursionMarker = this.getAttribute("$recursionMarker","yes");
+	// Find the value widgets in our parse tree
+	this.slotValueParseTrees = Object.create(null);
+	this.slotValueParseTrees.missing = this.parseTreeNode.children;
+	var searchParseTreeNodes = function(nodes) {
+		$tw.utils.each(nodes,function(node) {
+			if(node.type === "value" && node.tag === "$value") {
+				if(node.attributes["$name"] && node.attributes["$name"].type === "string") {
+					var slotValueName = node.attributes["$name"].value;
+					self.slotValueParseTrees[slotValueName] = node.children;
+				}
+			} else {
+				searchParseTreeNodes(node.children);
+			}
+		});
+	};
+	searchParseTreeNodes(this.parseTreeNode.children);
+	// Parse the text reference
+	var parseAsInline = !this.parseTreeNode.isBlock;
+	if(this.transcludeMode === "inline") {
+		parseAsInline = true;
+	} else if(this.transcludeMode === "block") {
+		parseAsInline = false;
+	}
+	var parser;
+	if(this.transcludeVariable) {
+		parser = this.wiki.parseText(this.transcludeType,this.getVariable(this.transcludeVariable,""),{parseAsInline: !this.parseTreeNode.isBlock});
+	} else {
+		parser = this.wiki.parseTextReference(
+			this.transcludeTitle,
+			this.transcludeField,
+			this.transcludeIndex,
+			{
+				parseAsInline: parseAsInline,
+				subTiddler: this.transcludeSubTiddler
+			});
+	}
+	var parseTreeNodes = parser ? parser.tree : this.parseTreeNode.children;
+	this.sourceText = parser ? parser.source : null;
+	this.parserType = parser? parser.type : null;
+	// Set context variables for recursion detection
+	var recursionMarker = this.makeRecursionMarker();
+	if(this.recursionMarker === "yes") {
+		this.setVariable("ubertransclusion",recursionMarker);
+	}
+	// Check for recursion
+	if(parser) {
+		if(this.parentWidget && this.parentWidget.hasVariable("ubertransclusion",recursionMarker)) {
+			parseTreeNodes = [{type: "element", tag: "span", attributes: {
+				"class": {type: "string", value: "tc-error"}
+			}, children: [
+				{type: "text", text: $tw.language.getString("Error/RecursiveTransclusion")}
+			]}];
+		}
+	}
+	// Construct the child widgets
+	this.makeChildWidgets(parseTreeNodes);
+};
+
+/*
+Fetch the value of a parameter
+*/
+UberTranscludeWidget.prototype.getTransclusionParameter = function(name,defaultValue) {
+	if(name.charAt(0) === "$") {
+		name = "$" + name;
+	}
+	return this.getAttribute(name,defaultValue);
+};
+
+/*
+Fetch the value of a slot
+*/
+UberTranscludeWidget.prototype.getTransclusionSlotValue = function(name,defaultParseTreeNodes) {
+	if(name && this.slotValueParseTrees[name]) {
+		return this.slotValueParseTrees[name];
+	} else {
+		return defaultParseTreeNodes || [];
+	}
+};
+
+/*
+Compose a string comprising the title, field and/or index to identify this transclusion for recursion detection
+*/
+UberTranscludeWidget.prototype.makeRecursionMarker = function() {
+	var output = [];
+	output.push("{");
+	output.push(this.getVariable("currentTiddler",{defaultValue: ""}));
+	output.push("|");
+	output.push(this.transcludeTitle || "");
+	output.push("|");
+	output.push(this.transcludeField || "");
+	output.push("|");
+	output.push(this.transcludeIndex || "");
+	output.push("|");
+	output.push(this.transcludeSubTiddler || "");
+	output.push("}");
+	return output.join("");
+};
+
+UberTranscludeWidget.prototype.parserNeedsRefresh = function() {
+	var parserInfo = this.wiki.getTextReferenceParserInfo(this.transcludeTitle,this.transcludeField,this.transcludeIndex,{subTiddler:this.transcludeSubTiddler});
+	return (this.sourceText === undefined || parserInfo.sourceText !== this.sourceText || parserInfo.parserType !== this.parserType)
+};
+
+/*
+Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+*/
+UberTranscludeWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if(($tw.utils.count(changedAttributes) > 0) || (changedTiddlers[this.transcludeTitle] && this.parserNeedsRefresh())) {
+		this.refreshSelf();
+		return true;
+	} else {
+		return this.refreshChildren(changedTiddlers);
+	}
+};
+
+exports.ubertransclude = UberTranscludeWidget;
+
+})();

--- a/core/modules/widgets/ubertransclude.js
+++ b/core/modules/widgets/ubertransclude.js
@@ -134,17 +134,15 @@ UberTranscludeWidget.prototype.getTransclusionSlotValue = function(name,defaultP
 Compose a string comprising the title, field and/or index to identify this transclusion for recursion detection
 */
 UberTranscludeWidget.prototype.makeRecursionMarker = function() {
+	var attributes = Object.create(null);
+	$tw.utils.each(this.attributes,function(value,name) {
+		attributes[name] = value;
+	});
 	var output = [];
 	output.push("{");
 	output.push(this.getVariable("currentTiddler",{defaultValue: ""}));
 	output.push("|");
-	output.push(this.transcludeTitle || "");
-	output.push("|");
-	output.push(this.transcludeField || "");
-	output.push("|");
-	output.push(this.transcludeIndex || "");
-	output.push("|");
-	output.push(this.transcludeSubTiddler || "");
+	output.push(JSON.stringify(attributes));
 	output.push("}");
 	return output.join("");
 };

--- a/core/modules/widgets/ubertransclude.js
+++ b/core/modules/widgets/ubertransclude.js
@@ -65,7 +65,7 @@ UberTranscludeWidget.prototype.execute = function() {
 	};
 	searchParseTreeNodes(this.parseTreeNode.children);
 	if(noValueWidgetsFound) {
-		this.slotValueParseTrees["missing"] = this.parseTreeNode.children;
+		this.slotValueParseTrees["ts-missing"] = this.parseTreeNode.children;
 	}
 	// Parse the text reference
 	var parseAsInline = !this.parseTreeNode.isBlock;
@@ -87,13 +87,13 @@ UberTranscludeWidget.prototype.execute = function() {
 				subTiddler: this.transcludeSubTiddler
 			});
 	}
-	var parseTreeNodes = parser ? parser.tree : (this.slotValueParseTrees["missing"] || []);
+	var parseTreeNodes = parser ? parser.tree : (this.slotValueParseTrees["ts-missing"] || []);
 	this.sourceText = parser ? parser.source : undefined;
 	this.parserType = parser? parser.type : undefined;
 	// Wrap the transcluded content if required
-	if(this.slotValueParseTrees["wrapper"]) {
-		this.slotValueParseTrees["wrapped"] = parseTreeNodes;
-		parseTreeNodes = this.slotValueParseTrees["wrapper"];
+	if(this.slotValueParseTrees["ts-wrapper"]) {
+		this.slotValueParseTrees["ts-wrapped"] = parseTreeNodes;
+		parseTreeNodes = this.slotValueParseTrees["ts-wrapper"];
 		this.sourceTest = undefined;
 		this.sourceType = undefined;
 	}

--- a/core/modules/widgets/value.js
+++ b/core/modules/widgets/value.js
@@ -1,0 +1,57 @@
+/*\
+title: $:/core/modules/widgets/value.js
+type: application/javascript
+module-type: widget
+
+Sub-widget used by the ubertransclude widget for specifying values for slots within transcluded content. It doesn't do anything by itself because the ubertransclude widget only ever deals with the parse tree nodes, and doesn't instantiate the widget itself
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var ValueWidget = function(parseTreeNode,options) {
+	// Initialise
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+ValueWidget.prototype = Object.create(Widget.prototype);
+
+/*
+Render this widget into the DOM
+*/
+ValueWidget.prototype.render = function(parent,nextSibling) {
+	// Call the constructor
+	Widget.call(this);
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
+	this.renderChildren(parent,nextSibling);
+};
+
+/*
+Compute the internal state of the widget
+*/
+ValueWidget.prototype.execute = function() {
+	// Construct the child widgets
+	this.makeChildWidgets();
+};
+
+/*
+Refresh the widget by ensuring our attributes are up to date
+*/
+ValueWidget.prototype.refresh = function(changedTiddlers) {
+	return this.refreshChildren(changedTiddlers);
+};
+
+exports.value = ValueWidget;
+
+})();
+	

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -406,6 +406,32 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 						"$name": {name: "$name", type: "string", value: "body"}
 					},
 					children: parseTreeNode.children
+				},
+				{
+					type: "value",
+					tag: "$value",
+					attributes: {
+						"$name": {name: "$name", type: "string", value: "wrapper"}
+					},
+					children: [
+						{
+							type: "setvariable",
+							tag: "$setvariable",
+							attributes: {
+								"name": {name: "name", type: "string", value: variableDefinitionName},
+								"value": {name: "value", type: "string", value: ""}
+							},
+							children: [
+								{
+									type: "slot",
+									tag: "$slot",
+									attributes: {
+										"$name": {name: "$name", type: "string", value: "wrapped"}
+									}
+								}
+							]
+						}
+					]
 				}
 			]
 		};

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -409,9 +409,7 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 				}
 			]
 		};
-		newParseTreeNode.orderedAttributes = [newParseTreeNode.attributes["$variable"]];
-		newParseTreeNode.children[0].orderedAttributes = [newParseTreeNode.children[0].attributes["$name"]];
-		$tw.utils.each(parseTreeNode.orderedAttributes,function(attr) {
+		$tw.utils.each(parseTreeNode.attributes,function(attr) {
 			// If the attribute starts with a dollar then add an extra dollar so that it doesn't clash with the $xxx attributes of ubertransclude
 			var name = attr.name.charAt(0) === "$" ? "$" + attr.name : attr.name,
 				newAttr = {
@@ -420,7 +418,6 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 					value: attr.value
 				};
 			newParseTreeNode.attributes[name] = newAttr;
-			newParseTreeNode.orderedAttributes.push(newAttr);
 		});
 		parseTreeNode = newParseTreeNode;
 	}

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -403,7 +403,7 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 					type: "value",
 					tag: "$value",
 					attributes: {
-						"$name": {name: "$name", type: "string", value: "body"}
+						"$name": {name: "$name", type: "string", value: "ts-body"}
 					},
 					children: parseTreeNode.children
 				},
@@ -411,7 +411,7 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 					type: "value",
 					tag: "$value",
 					attributes: {
-						"$name": {name: "$name", type: "string", value: "wrapper"}
+						"$name": {name: "$name", type: "string", value: "ts-wrapper"}
 					},
 					children: [
 						{
@@ -426,7 +426,7 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 									type: "slot",
 									tag: "$slot",
 									attributes: {
-										"$name": {name: "$name", type: "string", value: "wrapped"}
+										"$name": {name: "$name", type: "string", value: "ts-wrapped"}
 									}
 								}
 							]

--- a/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-ActionWidget.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-ActionWidget.tid
@@ -1,0 +1,28 @@
+title: Ubertransclude/CustomWidget/ActionWidget
+description: Custom widget definition
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$ubertransclude $tiddler='Result'>
+</$ubertransclude>
+_
+title: Actions
+
+\whitespace trim
+<!-- Define the <$action-mywidget> widget by defining a transcludable variable with that name -->
+<$set name="<$action-mywidget>" value="""\whitespace trim
+	<$parameters one='Jaguar'>
+		<$action-setfield $tiddler="Result" $field="text" $value=<<one>>/>
+	</$parameters>"""
+>
+	<$action-mywidget one="Dingo">
+		Crocodile
+	</$action-mywidget>
+</$set>
+_
+title: ExpectedResult
+
+<p>Dingo</p>

--- a/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-OverrideUbertransclude.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-OverrideUbertransclude.tid
@@ -1,0 +1,35 @@
+title: Ubertransclude/CustomWidget/OverrideUbertransclude
+description: Custom widget definition attempting to override ubertransclude
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$ubertransclude $tiddler='TiddlerOne' one='Ferret'>
+</$ubertransclude>
+_
+title: TiddlerZero
+
+Antelope
+_
+title: TiddlerOne
+
+\whitespace trim
+<!-- Redefine the <$ubertransclude> widget by defining a transcludable variable with that name -->
+<$set name="<$ubertransclude>" value="""\whitespace trim
+	<$parameters one='Jaguar'>
+		<$text text=<<one>>/>
+		<$slot $name="body">
+			Whale
+		</$slot>
+	</$parameters>"""
+>
+	<$ubertransclude $tiddler="TiddlerZero">
+		Crocodile
+	</$ubertransclude>
+</$set>
+_
+title: ExpectedResult
+
+<p>Antelope</p>

--- a/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-Simple.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-Simple.tid
@@ -16,7 +16,7 @@ title: TiddlerOne
 <$set name="<$mywidget>" value="""\whitespace trim
 	<$parameters one='Jaguar'>
 		<$text text=<<one>>/>
-		<$slot $name="body">
+		<$slot $name="ts-body">
 			Whale
 		</$slot>
 	</$parameters>"""

--- a/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-Simple.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-Simple.tid
@@ -1,0 +1,31 @@
+title: Ubertransclude/CustomWidget/Simple
+description: Custom widget definition
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$ubertransclude $tiddler='TiddlerOne' one='Ferret'>
+</$ubertransclude>
+_
+title: TiddlerOne
+
+\whitespace trim
+<!-- Define the <$mywidget> widget by defining a transcludable variable with that name -->
+<$set name="<$mywidget>" value="""\whitespace trim
+	<$parameters one='Jaguar'>
+		<$text text=<<one>>/>
+		<$slot $name="body">
+			Whale
+		</$slot>
+	</$parameters>"""
+>
+	<$mywidget one="Dingo">
+		Crocodile
+	</$mywidget>
+</$set>
+_
+title: ExpectedResult
+
+<p>DingoCrocodile</p>

--- a/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-TextWidgetOverride.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-TextWidgetOverride.tid
@@ -15,12 +15,10 @@ title: TiddlerOne
 <!-- Redefine the <$text> widget by defining a transcludable variable with that name -->
 <$set name="<$text>" value="""\whitespace trim
 	<$parameters text='Jaguar'>
-		<$set name="<$text>" value="">
-			<$text text=<<text>>/>
-			<$slot $name="body">
-				Whale
-			</$slot>
-		</$set>
+		<$text text=<<text>>/>
+		<$slot $name="body">
+			Whale
+		</$slot>
 	</$parameters>"""
 >
 	<$text text="Dingo">

--- a/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-TextWidgetOverride.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-TextWidgetOverride.tid
@@ -16,7 +16,7 @@ title: TiddlerOne
 <$set name="<$text>" value="""\whitespace trim
 	<$parameters text='Jaguar'>
 		<$text text=<<text>>/>
-		<$slot $name="body">
+		<$slot $name="ts-body">
 			Whale
 		</$slot>
 	</$parameters>"""

--- a/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-TextWidgetOverride.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-TextWidgetOverride.tid
@@ -1,0 +1,33 @@
+title: Ubertransclude/CustomWidget/TextWidgetOverride
+description: Custom widget definition redefining the text widget
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$ubertransclude $tiddler='TiddlerOne'>
+</$ubertransclude>
+_
+title: TiddlerOne
+
+\whitespace trim
+<!-- Redefine the <$text> widget by defining a transcludable variable with that name -->
+<$set name="<$text>" value="""\whitespace trim
+	<$parameters text='Jaguar'>
+		<$set name="<$text>" value="">
+			<$text text=<<text>>/>
+			<$slot $name="body">
+				Whale
+			</$slot>
+		</$set>
+	</$parameters>"""
+>
+	<$text text="Dingo">
+		Crocodile
+	</$text>
+</$set>
+_
+title: ExpectedResult
+
+<p>DingoCrocodile</p>

--- a/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-VariableAttribute.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-VariableAttribute.tid
@@ -1,0 +1,31 @@
+title: Ubertransclude/CustomWidget/VariableAttribute
+description: Custom widget definition using an attribute called $variable
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$ubertransclude $tiddler='TiddlerOne' one='Ferret'>
+</$ubertransclude>
+_
+title: TiddlerOne
+
+\whitespace trim
+<!-- Redefine the <$mywidget> widget by defining a transcludable variable with that name -->
+<$set name="<$mywidget>" value="""\whitespace trim
+	<$parameters $variable='Jaguar'>
+		<$text text=<<$variable>>/>
+		<$slot $name="body">
+			Whale
+		</$slot>
+	</$parameters>"""
+>
+	<$mywidget $variable="Dingo">
+		Crocodile
+	</$mywidget>
+</$set>
+_
+title: ExpectedResult
+
+<p>DingoCrocodile</p>

--- a/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-VariableAttribute.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/CustomWidget-VariableAttribute.tid
@@ -16,7 +16,7 @@ title: TiddlerOne
 <$set name="<$mywidget>" value="""\whitespace trim
 	<$parameters $variable='Jaguar'>
 		<$text text=<<$variable>>/>
-		<$slot $name="body">
+		<$slot $name="ts-body">
 			Whale
 		</$slot>
 	</$parameters>"""

--- a/editions/test/tiddlers/tests/data/ubertransclusion/MissingTarget.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/MissingTarget.tid
@@ -13,7 +13,7 @@ title: Output
 	</$parameters>
 </$ubertransclude>
 <$ubertransclude $tiddler='TiddlerOne' one='Ferret'>
-	<$value $name="missing">
+	<$value $name="ts-missing">
 		<$parameters one='Ferret'>
 			Badger
 			<$text text=<<one>>/>
@@ -27,7 +27,7 @@ title: Output
 	</$parameters>
 </$ubertransclude>
 <$ubertransclude $tiddler='MissingTiddler' one='Ferret'>
-	<$value $name="missing">
+	<$value $name="ts-missing">
 		<$parameters one='Ferret'>
 			Badger
 			<$text text=<<one>>/>

--- a/editions/test/tiddlers/tests/data/ubertransclusion/MissingTarget.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/MissingTarget.tid
@@ -1,0 +1,48 @@
+title: Ubertransclude/MissingTarget
+description: Transcluding a missing target
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$ubertransclude $tiddler='TiddlerOne' one='Ferret'>
+	<$parameters one='Ferret'>
+		Badger
+		<$text text=<<one>>/>
+	</$parameters>
+</$ubertransclude>
+<$ubertransclude $tiddler='TiddlerOne' one='Ferret'>
+	<$value $name="missing">
+		<$parameters one='Ferret'>
+			Badger
+			<$text text=<<one>>/>
+		</$parameters>
+	</$value>
+</$ubertransclude>
+<$ubertransclude $tiddler='MissingTiddler' one='Ferret'>
+	<$parameters one='Ferret'>
+		Badger
+		<$text text=<<one>>/>
+	</$parameters>
+</$ubertransclude>
+<$ubertransclude $tiddler='MissingTiddler' one='Ferret'>
+	<$value $name="missing">
+		<$parameters one='Ferret'>
+			Badger
+			<$text text=<<one>>/>
+		</$parameters>
+	</$value>
+</$ubertransclude>
+_
+title: TiddlerOne
+
+\whitespace trim
+<$parameters one='Kangaroo'>
+	Piranha
+	<$text text=<<one>>/>
+</$parameters>
+_
+title: ExpectedResult
+
+<p>PiranhaFerretPiranhaFerretBadgerFerretBadgerFerret</p>

--- a/editions/test/tiddlers/tests/data/ubertransclusion/Parameterised-Simple.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/Parameterised-Simple.tid
@@ -1,0 +1,21 @@
+title: Ubertransclude/Parameterised/Simple
+description: Simple parameterised transclusion
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$ubertransclude $tiddler='TiddlerOne' one='Ferret'/>
+<$ubertransclude $tiddler='TiddlerOne'/>
+_
+title: TiddlerOne
+
+\whitespace trim
+<$parameters one='Jaguar'>
+	<$text text=<<one>>/>
+</$parameters>
+_
+title: ExpectedResult
+
+<p>FerretJaguar</p>

--- a/editions/test/tiddlers/tests/data/ubertransclusion/Parameterised-Slotted-Missing.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/Parameterised-Slotted-Missing.tid
@@ -1,0 +1,24 @@
+title: Ubertransclude/Parameterised/Slotted/Missing
+description: Parameterised transclusion with slotted missing values
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$ubertransclude $tiddler='TiddlerOne' one='Ferret'>
+</$ubertransclude>
+_
+title: TiddlerOne
+
+\whitespace trim
+<$parameters one='Jaguar'>
+	<$text text=<<one>>/>
+	<$slot $name="content">
+		Whale
+	</$slot>
+</$parameters>
+_
+title: ExpectedResult
+
+<p>FerretWhale</p>

--- a/editions/test/tiddlers/tests/data/ubertransclusion/Parameterised-Slotted.tid
+++ b/editions/test/tiddlers/tests/data/ubertransclusion/Parameterised-Slotted.tid
@@ -1,0 +1,27 @@
+title: Ubertransclude/Parameterised/Slotted
+description: Parameterised transclusion with slotted values
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$ubertransclude $tiddler='TiddlerOne' one='Ferret'>
+	<$value $name="content">
+		Hippopotamus
+	</$value>
+</$ubertransclude>
+_
+title: TiddlerOne
+
+\whitespace trim
+<$parameters one='Jaguar'>
+	<$text text=<<one>>/>
+	<$slot $name="content">
+		Whale
+	</$slot>
+</$parameters>
+_
+title: ExpectedResult
+
+<p>FerretHippopotamus</p>

--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -12,7 +12,7 @@ The main module of the Jasmine test plugin for TiddlyWiki5
 /*global $tw: true */
 "use strict";
 
-var TEST_TIDDLER_FILTER = "[type[application/javascript]tag[$:/tags/test-spec]]";
+var TEST_TIDDLER_FILTER = "[all[tiddlers+shadows]type[application/javascript]tag[$:/tags/test-spec]]";
 
 exports.name = "jasmine";
 // Ensure this startup module is executed in the right order.

--- a/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js
+++ b/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js
@@ -1,0 +1,96 @@
+/*\
+title: $:/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests the wiki based tests
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var TEST_WIKI_TIDDLER_FILTER = "[type[text/vnd.tiddlywiki-multiple]tag[$:/tags/wiki-test-spec]]";
+
+var widget = require("$:/core/modules/widgets/widget.js");
+
+describe("Wiki-based tests", function() {
+
+	// Step through the test tiddlers
+	var tests = $tw.wiki.filterTiddlers(TEST_WIKI_TIDDLER_FILTER);
+	$tw.utils.each(tests,function(title) {
+		var tiddler = $tw.wiki.getTiddler(title);
+		it(tiddler.fields.title + ": " + tiddler.fields.description, function() {
+			// Add our tiddlers
+			var wiki = new $tw.Wiki();
+			wiki.addTiddlers(readMultipleTiddlersTiddler(title));
+			// Complain if we don't have the ouput and expected results
+			if(!wiki.tiddlerExists("Output")) {
+				throw "Missing 'Output' tiddler";
+			}
+			if(!wiki.tiddlerExists("ExpectedResult")) {
+				throw "Missing 'ExpectedResult' tiddler";
+			}
+			// Construct the widget node
+			var text = "{{Output}}\n\n";
+			var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
+			// Render the widget node to the DOM
+			var wrapper = renderWidgetNode(widgetNode);
+			// Test the rendering
+			expect(wrapper.innerHTML).toBe(wiki.getTiddlerText("ExpectedResult"));
+		});
+	});
+
+	function readMultipleTiddlersTiddler(title) {
+		var rawTiddlers = $tw.wiki.getTiddlerText(title).split("\n_\n");
+		var tiddlers = [];
+		$tw.utils.each(rawTiddlers,function(rawTiddler) {
+			var fields = Object.create(null),
+				split = rawTiddler.split(/\r?\n\r?\n/mg);
+			if(split.length >= 1) {
+				fields = $tw.utils.parseFields(split[0],fields);
+			}
+			if(split.length >= 2) {
+				fields.text = split.slice(1).join("\n\n");
+			}
+			tiddlers.push(fields);
+		});
+		return tiddlers;
+	}
+
+	function createWidgetNode(parseTreeNode,wiki) {
+		return new widget.widget(parseTreeNode,{
+				wiki: wiki,
+				document: $tw.fakeDocument
+			});
+	}
+
+	function parseText(text,wiki,options) {
+		var parser = wiki.parseText("text/vnd.tiddlywiki",text,options);
+		return parser ? {type: "widget", children: parser.tree} : undefined;
+	}
+
+	function renderWidgetNode(widgetNode) {
+		$tw.fakeDocument.setSequenceNumber(0);
+		var wrapper = $tw.fakeDocument.createElement("div");
+		widgetNode.render(wrapper,null);
+// console.log(require("util").inspect(wrapper,{depth: 8}));
+		return wrapper;
+	}
+
+	function refreshWidgetNode(widgetNode,wrapper,changes) {
+		var changedTiddlers = {};
+		if(changes) {
+			$tw.utils.each(changes,function(title) {
+				changedTiddlers[title] = true;
+			});
+		}
+		widgetNode.refresh(changedTiddlers,wrapper,null);
+// console.log(require("util").inspect(wrapper,{depth: 8}));
+	}
+
+});
+
+})();

--- a/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js
+++ b/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js
@@ -38,6 +38,11 @@ describe("Wiki-based tests", function() {
 			var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
 			// Render the widget node to the DOM
 			var wrapper = renderWidgetNode(widgetNode);
+			// Run the actions if provided
+			if(wiki.tiddlerExists("Actions")) {
+				widgetNode.invokeActionString(wiki.getTiddlerText("Actions"));
+				refreshWidgetNode(widgetNode,wrapper);
+			}
 			// Test the rendering
 			expect(wrapper.innerHTML).toBe(wiki.getTiddlerText("ExpectedResult"));
 		});
@@ -80,14 +85,8 @@ describe("Wiki-based tests", function() {
 		return wrapper;
 	}
 
-	function refreshWidgetNode(widgetNode,wrapper,changes) {
-		var changedTiddlers = {};
-		if(changes) {
-			$tw.utils.each(changes,function(title) {
-				changedTiddlers[title] = true;
-			});
-		}
-		widgetNode.refresh(changedTiddlers,wrapper,null);
+	function refreshWidgetNode(widgetNode,wrapper) {
+		widgetNode.refresh(widgetNode.wiki.changedTiddlers,wrapper);
 // console.log(require("util").inspect(wrapper,{depth: 8}));
 	}
 


### PR DESCRIPTION
# Introduction

This PR introduces a redesigned architecture for transclusion in TiddlyWiki with some significant new capabilities:

* The ability to pass parameters to transclusions, with default values for parameters that are not provided
* A simple, clean way to pass wikitext fragments as parameters into transclusions, without having to use triple double quotes
* The ability to define (or redefine) widgets entirely in wikitext

The cost of these improvements is that it may not be possible to take full advantage of these new features without breaking backwards compatibility.

NOTE: This PR currently uses the term “ubertransclude” as a placeholder pending decisions that are discussed in detail below.

# History

TiddlyWiki 5 macros were originally based on the technique we call "textual substitution": the string values of the parameters provided when calling a macro would be plugged into the macro definition before it was wikified in the usual way.

It led to a lot of wikitext that looked like this:

```
\define mymacro(title)
<$codeblock code={{$title$}}/>
\end
```

The technique worked well enough to get the basics of the TW5 user interface up and running, but it was clear from the start that it was annoyingly brittle. For example, the macro above would fail with tiddler titles containing double closing curly braces. Trying to use it with the title `foo}}bar` would lead to the macro being expanded to the following invalid syntax:

```
<$codeblock code={{foo}}bar}}/>
```

As a result, for a long time, the TW5 user interface failed if a variety of combinations of special characters were found in tiddler titles. Long time users will remember a warning that popped up in the edit template whenever a potentially troublesome character was detected.

Over the years we've mitigated almost all of these issues, particularly by providing access to the macro parameters as variables. For backwards compatibility, this was done without affecting the existing syntax, which required us to adopt the clumsy protocol of wrapping the parameter name in double underscores to get the name of the corresponding variable.

This has all worked well enough for us to fix the UI issues with special characters in tiddler titles, but is very inconsistent and complex, requiring users to grasp multiple mutually exclusive conceptual models for what is going on.

Since about 2015, I've been intermittently thinking and making notes to figure out a better approach. Building on the progress we've made in other areas of TiddlyWiki, a new architecture has gradually taken shape that unifies transclusions, macros and widgets into a single, coherent mechanism.

# New Transclusion Architecture

The new architecture includes the following features:

* A new "ubertransclude" widget that can transclude variables as well as tiddler fields/indexes/subtiddlers, subsuming both the existing transclude and macrocall widgets, and the associated wiki text syntax rules
* The ability to pass named string parameters to an ubertransclusion. The transcluded content can access the parameters as ordinary variables, and can also optionally specify default values to be used if the parameter is not provided. The default values are not restricted to fixed strings, any computed value can be used
* The ability to cleanly pass blocks of wikitext as parameters to macros, without having to pack the wikitext into a triple quoted string
* The ability to invoke macros using widget syntax (in other words, the ability to define custom widgets in wikitext)
* The ability to override built-in JavaScript widgets. For example, one could render a tiddler while providing a custom way to render the `<$link>` widgets within it

If we had a blank slate, the ubertransclude widget would replace the existing transclude and macrocall widgets, but for the moment it is implemented as a separate widget to make things easier to understand and explain.

For reasons discussed below, I think that in the end we may well need to make incompatible changes to our existing wikitext syntax to get the best out of the new architecture. That raises lots of questions about the future road map for TiddlyWiki, explicitly raising the possibility of a future version that intentionally breaks backwards compatibility in order to regain simplicity and consistency.

## Parameterised Transclusion

The new syntax for defining a macro closely resembles the existing syntax. The chief difference is that the parameters are only available as wikitext variables, and textual substitution cannot be used.

```
\macro hello(when="afternoon")
<$list filter="[<when>match[morning]]">
	Good morning!
</$list>
<$list filter="[<when>!match[morning]]">
	Good afternoon or evening!
</$list>
\end
```

The syntax for invoking the macro using the `<$ubertransclude>` widget is as follows:

```
<$ubertransclude $variable="hello" when="morning"/>
```

Note that the attributes `$variable`, `$tiddler`, `$field`, `$index` etc. that start with a dollar sign are used to define what to transclude, while the plain attributes are used as parameters to be passed to the macro.

As at present, defining a macro is really a special syntax for assigning the text of the macro to a variable. The special part is that the parameter declaration is handled by wrapping the content of the macro with a `<$parameters>` widget. So, the following is equivalent to the macro definition given above:

```
<$let hello="""
    <$parameters when="afternoon">
        <$list filter="[<when>match[morning]]">
            	Good morning!
        </$list>
        <$list filter="[<when>!match[morning]]">
            	Good afternoon or evening!
        </$list>
    </$parameters>
""">
    <$ubertransclude $variable="hello" when="morning"/>
</$let>
```

## Slotted Parameters

"Slots" provide a way to pass complex structured data to a transclusion instead of the simple string values supported by string parameters.

Slots are named areas that are defined within transcluded text using the `<$slot>` widget. They are replaced with custom content provided by a corresponding `<$value>` widget inside  the transclusion invocation. For example:

```
\macro hello
<div class="frame">
    <$slot $name="greeting"/>
</div>
\end
```

The syntax for invoking the macro using the `<$ubertransclude>` widget uses the `<$value>` widget to pass the content for the slot:

```
<$ubertransclude $variable="hello">
    <$value $name="greeting">
        <h1>A heading</h1>
        <p>A paragraph</p>
    </$value>
</$ubertransclude>
```

The result would be equivalent to:

```
<div class="frame">
    <h1>A heading</h1>
    <p>A paragraph</p>
</div>
```

The contents of the `<$slot>` widget provide the default contents that are used in case a value is not provided for a named slot.

The special named value `missing` is used if the target of the transclusion is missing. For example:

```
\macro hello
<div class="frame">
    <$slot $name="greeting">
        Default text for the named slot "greeting"
    </$slot>
</div>
\end
```

## Invoking Macros via Widget Syntax

Macros whose names conform to a special format can also be invoked via the standard widget syntax. When invoking a widget called `foo` the core looks for a variable called `<$foo>` and if it finds it, transcludes the contents of the variable instead of invoking the widget in the usual way. It also passes the content of the widget as the named slot value `body`.

For example:

```
\macro <$hello>(name)
<div class="greeting">
		<h1>Hello <$text text=<<name>>/></h1>
    <$slot $name="body"/>
</div>
\end
```

The custom widget is invoked in the usual way:

```
<$hello name="Jeremy">
    This is the greeting
</$hello>
```

Would render as:

```
<div class="greeting">
    This is the greeting
</div>
```

# Backwards Compatibility

The current implementation carefully avoids breaking backwards compatibility, but there are challenges to maintaining that position as the work progresses:

The most obvious difficulty is that we need a shortcut syntax for invoking a parameterised transclusion from a variable. This is the equivalent operation to our current `<<macroname>>` syntax, but with the new parameter handling. Options include:

* Reusing the existing `<<macroname param=value>>` syntax
* Adopting a new shortcut syntax. For example, we could use double parenthesis: `((macroname param=value))`

A second difficulty is what to call the new `<$ubertransclude>` widget. The only incompatibility with the existing `<$transclude>` widget is that the attributes `tiddler`, `field` etc. have been renamed `$tiddler`, `$field` etc to avoid clashing with any parameters of the same name. So there are again two options:

* Reuse the existing `<$transclude>` name, thus breaking backwards compatibility
* Adopt a new name for the new widget, making the existing `<$transclude>` widget be an alias with different attribute naming and without the ability to pass parameters

The new transclusion architecture is not sufficient to enable us to fully deprecate the existing textual substitution mechanism for parameter passing. To handle the remaining use cases I propose a new attribute form quoted with backticks that allows for the substitution of variable values. See https://github.com/Jermolene/TiddlyWiki5/issues/6663 for details.

# Progress

This PR is fully functional but incomplete. Some of the examples above use wikitext shortcut syntaxes that have not yet been implemented; the tests included in the PR show those same examples using the underlying raw widget syntax.

- [x] ubertransclude widget
- [x] parameters widget
- [x] slot widget
- [x] values widget
- [x] widget -> ubertransclusion mapping
- [x] use ubertransclude widget for wikitext transclude syntax
- [x] improved framework for wiki-based rendering tests
- [ ] fix and verify recursion detection
- [ ] extend wikitext transclusion syntax with positional parameters
- [ ] wikitext parser rule for new-style `\macro` definitions
- [ ] wikitext parser rule for `\parameters` construction
- [ ] importvariables should skip the parameters widget
- [ ] parse trees for transcluded variables should be cached
- [ ] check that refresh optimisations still work




