### PR TITLE
Add tiddler 'How to update ...'

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/How to update TiddlyWiki to the latest version.tid
+++ b/editions/tw5.com/tiddlers/howtos/How to update TiddlyWiki to the latest version.tid
@@ -1,0 +1,7 @@
+created: 20220426221124514
+modified: 20220426221240671
+tags: [[Working with TiddlyWiki]]
+title: How to update TiddlyWiki to the latest version
+type: text/vnd.tiddlywiki
+
+{{Upgrading}}


### PR DESCRIPTION
Adding tiddler 'How to update TiddlyWiki to the latest version' which transcludes the existing tiddler 'Upgrading'. 
Some people search for term 'update' instead of 'upgrade' .