### PR TITLE
Fix: eventcatcher widget - variables can be undefined

### DIFF
--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -292,14 +292,17 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 		$tw.utils.each(selectedNode.attributes,function(attribute) {
 			variables["dom-" + attribute.name] = attribute.value.toString();
 		});
-		// Add a variable with a popup coordinate string for the selected node
-		variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
+		
+		if(selectedNode.offsetLeft && selectedNode.offsetTop && selectedNode.offsetWidth && selectedNode.offsetHeight) {
+			// Add a variable with a popup coordinate string for the selected node
+			variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
 
-		// Add variables for offset of selected node
-		variables["tv-selectednode-posx"] = selectedNode.offsetLeft.toString();
-		variables["tv-selectednode-posy"] = selectedNode.offsetTop.toString();
-		variables["tv-selectednode-width"] = selectedNode.offsetWidth.toString();
-		variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
+			// Add variables for offset of selected node
+			variables["tv-selectednode-posx"] = selectedNode.offsetLeft.toString();
+			variables["tv-selectednode-posy"] = selectedNode.offsetTop.toString();
+			variables["tv-selectednode-width"] = selectedNode.offsetWidth.toString();
+			variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
+		}
 	}
 
 	if(event && event.clientX && event.clientY) {

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -293,7 +293,7 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 			variables["dom-" + attribute.name] = attribute.value.toString();
 		});
 		
-		if(selectedNode.offsetLeft && selectedNode.offsetTop && selectedNode.offsetWidth && selectedNode.offsetHeight) {
+		if(selectedNode.offsetLeft) {
 			// Add a variable with a popup coordinate string for the selected node
 			variables["tv-popup-coords"] = "(" + selectedNode.offsetLeft + "," + selectedNode.offsetTop +"," + selectedNode.offsetWidth + "," + selectedNode.offsetHeight + ")";
 

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -77,6 +77,9 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 			}
 			// Execute our actions with the variables
 			if(actions) {
+				if(variables === undefined) {
+					variables = $tw.utils.collectDOMVariables(selectedNode,self.domNode,event);
+				}
 				// Add a variable for the modifier key
 				variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
 				// Add a variable for the mouse button

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -52,7 +52,7 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 				selectedNode = event.target,
 				selectedNodeRect,
 				catcherNodeRect,
-				variables;
+				variables = {};
 			// Firefox can fire dragover and dragenter events on text nodes instead of their parents
 			if(selectedNode.nodeType === 3) {
 				selectedNode = selectedNode.parentNode;
@@ -77,9 +77,6 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 			}
 			// Execute our actions with the variables
 			if(actions) {
-				if(variables === undefined) {
-					variables = $tw.utils.collectDOMVariables(selectedNode,self.domNode,event);
-				}
 				// Add a variable for the modifier key
 				variables.modifier = $tw.keyboardManager.getEventModifierKeyDescriptor(event);
 				// Add a variable for the mouse button


### PR DESCRIPTION
This fixes a nasty Bug introduced by myself where the variables can be undefined