### PR TITLE
Expose isMobile to info

### DIFF
--- a/plugins/tiddlywiki/browser-sniff/browser.js
+++ b/plugins/tiddlywiki/browser-sniff/browser.js
@@ -42,7 +42,8 @@ exports.getInfoTiddlerFields = function() {
 				["is/sailfish","sailfish"],
 				["is/android","android"],
 				["is/windowsphone","windowsphone"],
-				["is/firefoxos","firefoxos"]
+				["is/firefoxos","firefoxos"],
+				["is/mobile","mobile"]
 			];
 		$tw.utils.each(mappings,function(mapping) {
 			var value = bowser.browser[mapping[1]];

--- a/plugins/tiddlywiki/browser-sniff/browser.js
+++ b/plugins/tiddlywiki/browser-sniff/browser.js
@@ -45,7 +45,7 @@ exports.getInfoTiddlerFields = function() {
 				["is/firefoxos","firefoxos"],
 				["is/mobile","mobile"]
 			];
-		$tw.browser = $tw.utils.extend($tw.browser, bowser);
+		$tw.browser = $tw.utils.extend($tw.browser, bowser.browser);
 		$tw.utils.each(mappings,function(mapping) {
 			var value = bowser.browser[mapping[1]];
 			if(value === undefined) {

--- a/plugins/tiddlywiki/browser-sniff/browser.js
+++ b/plugins/tiddlywiki/browser-sniff/browser.js
@@ -45,7 +45,9 @@ exports.getInfoTiddlerFields = function() {
 				["is/firefoxos","firefoxos"],
 				["is/mobile","mobile"]
 			];
-		$tw.browser = $tw.utils.extend($tw.browser, bowser.browser);
+		$tw.browser = $tw.utils.extend($tw.browser, {
+			mobile: bowser.browser.mobile,
+		});
 		$tw.utils.each(mappings,function(mapping) {
 			var value = bowser.browser[mapping[1]];
 			if(value === undefined) {

--- a/plugins/tiddlywiki/browser-sniff/browser.js
+++ b/plugins/tiddlywiki/browser-sniff/browser.js
@@ -46,7 +46,7 @@ exports.getInfoTiddlerFields = function() {
 				["is/mobile","mobile"]
 			];
 		$tw.browser = $tw.utils.extend($tw.browser, {
-			mobile: bowser.browser.mobile,
+			is: bowser.browser,
 		});
 		$tw.utils.each(mappings,function(mapping) {
 			var value = bowser.browser[mapping[1]];

--- a/plugins/tiddlywiki/browser-sniff/browser.js
+++ b/plugins/tiddlywiki/browser-sniff/browser.js
@@ -45,6 +45,7 @@ exports.getInfoTiddlerFields = function() {
 				["is/firefoxos","firefoxos"],
 				["is/mobile","mobile"]
 			];
+		$tw.browser = $tw.utils.extend($tw.browser, bowser);
 		$tw.utils.each(mappings,function(mapping) {
 			var value = bowser.browser[mapping[1]];
 			if(value === undefined) {


### PR DESCRIPTION
Allow knowing if the user is on a mobile phone.

![](https://user-images.githubusercontent.com/3746270/166644215-017d8462-71e7-4ed2-86c8-fe469004889b.png)

![截屏2022-05-04 16 28 47](https://user-images.githubusercontent.com/3746270/166647064-7932e4f4-1f9b-4192-b469-d1299d85b520.png)


I personally more and more using tw on a phone, so need this to make changes to some of my plugins. Useful in places like 

https://github.com/NicolasPetton/Notebook/blob/465c832c885894ee3c97be76449cc524e1252eb0/plugins/notebook-mobile/js/notebookSidebarNav.js#L15-L18