### PR TITLE
docs: mark out-of-box standalone apps

### DIFF
--- a/editions/tw5.com/tiddlers/saving/Saving on Android.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on Android.tid
@@ -6,7 +6,7 @@ delivery: App
 description: Android app for saving changes locally to device storage
 method: save
 modified: 20200507103926292
-tags: Saving Android
+tags: Saving Android [[Standalone App]]
 title: Saving on Android
 type: text/vnd.tiddlywiki
 url: https://github.com/donmor/Tiddloid

--- a/editions/tw5.com/tiddlers/saving/Saving on TidGi.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TidGi.tid
@@ -5,7 +5,7 @@ created: 20220221080637764
 delivery: App
 description: Desktop application for serving and syncing TiddlyWiki
 method: save
-tags: Saving Mac Windows Linux
+tags: Saving Mac Windows Linux [[Standalone App]]
 title: Saving on TidGi Desktop
 type: text/vnd.tiddlywiki
 url: https://github.com/tiddly-gittly/TidGi-Desktop/releases/latest

--- a/editions/tw5.com/tiddlers/saving/Saving on TiddlyDesktop.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TiddlyDesktop.tid
@@ -6,7 +6,7 @@ delivery: App
 description: Custom desktop application for working with TiddlyWiki
 method: save
 modified: 20200507104332791
-tags: Saving Mac Windows Linux
+tags: Saving Mac Windows Linux [[Standalone App]]
 title: Saving on TiddlyDesktop
 type: text/vnd.tiddlywiki
 url: https://github.com/TiddlyWiki/TiddlyDesktop/releases

--- a/editions/tw5.com/tiddlers/saving/Saving on iPad_iPhone.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on iPad_iPhone.tid
@@ -6,7 +6,7 @@ delivery: App
 description: iPad/iPhone app for working with TiddlyWiki
 method: save
 modified: 20201007205336209
-tags: Saving iOS
+tags: Saving iOS [[Standalone App]]
 title: Saving on iPad/iPhone
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/saving/Saving.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving.tid
@@ -1,6 +1,6 @@
 created: 20140912140651119
 modified: 20220401151525812
-saving-browser: Firefox Chrome Edge [[Internet Explorer]] Safari Opera
+saving-browser: Firefox Chrome Edge [[Internet Explorer]] Safari Opera [[Standalone App]]
 saving-os: Windows Mac Linux Android iOS
 tags: [[Working with TiddlyWiki]]
 title: Saving


### PR DESCRIPTION
New users from Obsidian and Notion may want to use a GUI app that is installable and work out-of-box, I add a new tag to mark them and filter them in the Saving tiddler.

I'm not sure \[\[Standalone App\]\] is a good tag, I actually mean GUI app that works like other note-taking apps, and is dedicated for note-taking (not versatile like Beaver browser).