### PR TITLE
fix-6678-title-indent problem

### DIFF
--- a/core/ui/ViewTemplate/title.tid
+++ b/core/ui/ViewTemplate/title.tid
@@ -12,10 +12,14 @@ fill:$(foregroundColor)$;
 </span>
 <$set name="tv-wikilinks" value={{$:/config/Tiddlers/TitleLinks}}>
 <$link>
+<$let tiddlerIcon={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] }}}>
+<$list filter="[<tiddlerIcon>!is[blank]]" variable="ignore">
 <$let foregroundColor={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}}>
 <span class="tc-tiddler-title-icon" style=<<title-styles>>>
 {{||$:/core/ui/TiddlerIcon}}
 </span>
+</$let>
+</$list>
 </$let>
 <$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/ViewTemplateTitleFilter]!is[draft]get[text]] :and[!is[blank]else[$:/core/ui/ViewTemplate/title/default]] }}} />
 </$link>


### PR DESCRIPTION
This PR fixes #6678 [BUG] tiddler title alignment is off - again

Images tested with new code. 

<details><summary>Title without an icon</summary>

![image](https://user-images.githubusercontent.com/374655/166928819-2cc4dd07-0b31-44f2-a761-84c2c94cc2a4.png)
</details>

<details><summary>Title with icon</summary>

![image](https://user-images.githubusercontent.com/374655/166928588-f696823e-8bb4-47ec-bdc8-f5a92cc858ac.png)
</details>

