### PR TITLE
Add tv-widgetnode-width and tv-widgetnode-height

### DIFF
--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -304,6 +304,11 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 			variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
 		}
 	}
+	
+	if(domNode && domNode.offsetWidth) {
+		variables["tv-widgetnode-width"] = domNode.offsetWidth.toString();
+		variables["tv-widgetnode-height"] = domNode.offsetHeight.toString();
+	}
 
 	if(event && event.clientX && event.clientY) {
 		if(selectedNode) {

--- a/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
@@ -48,6 +48,8 @@ The following variables are made available to the actions:
 |`event-type` |The type property of the JavaScript event |
 |`event-detail-*` |Any properties in the detail attribute of the event are made available with the prefix `event-detail-` |
 |`tv-popup-coords` |A co-ordinate string that can be used with the ActionPopupWidget to trigger a popup at the DOM node matching the selector where the event originated |
+|`tv-widgetnode-width` |<<.from-version "5.2.3">> `offsetWidth` of the DOM node created by the eventcatcher widget |
+|`tv-widgetnode-height` |<<.from-version "5.2.3">> 
 |`tv-selectednode-posx` |`x` offset position of the selected DOM node |
 |`tv-selectednode-posy` |`y` offset position of the selected DOM node  |
 |`tv-selectednode-width` |`offsetWidth` of the selected DOM node |

--- a/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
@@ -49,7 +49,7 @@ The following variables are made available to the actions:
 |`event-detail-*` |Any properties in the detail attribute of the event are made available with the prefix `event-detail-` |
 |`tv-popup-coords` |A co-ordinate string that can be used with the ActionPopupWidget to trigger a popup at the DOM node matching the selector where the event originated |
 |`tv-widgetnode-width` |<<.from-version "5.2.3">> `offsetWidth` of the DOM node created by the eventcatcher widget |
-|`tv-widgetnode-height` |<<.from-version "5.2.3">> 
+|`tv-widgetnode-height` |<<.from-version "5.2.3">> `offsetHeight` of the DOM node created by the eventcatcher widget |
 |`tv-selectednode-posx` |`x` offset position of the selected DOM node |
 |`tv-selectednode-posy` |`y` offset position of the selected DOM node  |
 |`tv-selectednode-width` |`offsetWidth` of the selected DOM node |

--- a/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
@@ -1,5 +1,5 @@
 created: 20201123113532200
-modified: 20220311154749139
+modified: 20220507184043398
 tags: Widgets TriggeringWidgets
 title: EventCatcherWidget
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
This PR adds `tv-widgetnode-width` and `tv-widgetnode-height` variables to `collectDOMVariables` in dom.js, so that in the variables of the eventcatcher widget we have access to those.

Docs are added.