### PR TITLE
Markdown: Add code block button + enable shortcut

### DIFF
--- a/plugins/tiddlywiki/markdown/EditorToolbar/mono-block.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/mono-block.tid
@@ -1,0 +1,17 @@
+title: $:/plugins/tiddlywiki/markdown/EditorToolbar/mono-block
+list-after: $:/core/ui/EditorToolbar/mono-block
+tags: $:/tags/EditorToolbar
+icon: $:/core/images/mono-block
+caption: {{$:/language/Buttons/MonoBlock/Caption}} (Markdown)
+description: {{$:/language/Buttons/MonoBlock/Hint}}
+condition: [<targetTiddler>type[text/x-markdown]]
+button-classes: tc-text-editor-toolbar-item-start-group
+shortcuts: ((mono-block))
+
+<$action-sendmessage
+	$message="tm-edit-text-operation"
+	$param="wrap-lines"
+	prefix="
+```"
+	suffix="```"
+/>

--- a/plugins/tiddlywiki/markdown/EditorToolbar/mono-block.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/mono-block.tid
@@ -4,7 +4,7 @@ tags: $:/tags/EditorToolbar
 icon: $:/core/images/mono-block
 caption: {{$:/language/Buttons/MonoBlock/Caption}} (Markdown)
 description: {{$:/language/Buttons/MonoBlock/Hint}}
-condition: [<targetTiddler>type[text/x-markdown]]
+condition: [<targetTiddler>type[text/x-markdown]] [<targetTiddler>type[text/markdown]]
 button-classes: tc-text-editor-toolbar-item-start-group
 shortcuts: ((mono-block))
 


### PR DESCRIPTION
When using the markdown plugin, you can enter fenced code blocks in markdown tiddlers but there is no button in the editor toolbar and the usual shortcut (**ctrl-shift-M**) doesn't work either.

This pull requests adds a code block button (same as for regular tiddlers) and by that, the shortcut works without further code changes.