### PR TITLE
Add additional example of tm-new-tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-new-tiddler.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-new-tiddler.tid
@@ -36,3 +36,12 @@ To create a new tiddler with given attributes rather than from a template:
 New Tiddler
 </$button>
 ```
+
+To create a new tiddler from a template with additional attributes:
+
+```
+<$button>
+<$action-sendmessage $message="tm-new-tiddler" $param=<<currentTiddler>> fieldname="field value" />
+New Tiddler
+</$button>
+```


### PR DESCRIPTION
Add additional example to create a new tiddler from a template with additional attributes:

Stemmed from this discussion "Cloning a tiddler" https://talk.tiddlywiki.org/t/cloning-a-tiddler/3301/4?u=tw_tones 

Unless documented users may feel forced to move to using the ActionCreateTiddlerWidget when in fact tm-new-tiddler permits a clone to include additional parameters to be specified. I just tested this with the above example on tiddlywiki.com v5.2.2 in a tiddler tagged $:/tags/ViewTemplate 

I just provided an additional example using the existing format.