### PR TITLE
Markdown: Add link(ify) button and enable shortcut (ctrl-L)

### DIFF
--- a/plugins/tiddlywiki/markdown/EditorToolbar/link.tid
+++ b/plugins/tiddlywiki/markdown/EditorToolbar/link.tid
@@ -1,0 +1,15 @@
+caption: {{$:/language/Buttons/Link/Caption}} (Markdown)
+condition: [<targetTiddler>type[text/x-markdown]] [<targetTiddler>type[text/markdown]]
+description: {{$:/language/Buttons/Link/Hint}}
+icon: $:/core/images/link
+list-after: $:/core/ui/EditorToolbar/link
+shortcuts: ((link))
+title: $:/plugins/tiddlywiki/markdown/EditorToolbar/link
+tags: $:/tags/EditorToolbar
+
+<$action-sendmessage
+	$message="tm-edit-text-operation"
+	$param="wrap-selection"
+	prefix="["
+	suffix="]()"
+/>


### PR DESCRIPTION
When using the markdown plugin, there is neither a _link_ nor a _linkify_ button in markdown tiddlers. The corresponding shortcuts  (**shift-alt-L** and **ctrl-L**) don't work.

This pull requests adds a _link_ button (same as for regular tiddlers) which works like the _linkify_ button for regular tiddlers but it inserts `[]()` instead of `[[]]`. This enables the default _link_ shortcut **ctrl-L**.

Probably the best solution would be to add both a _linkify_ button (which inserts `[]()`) and a _link_ button (which opens a popup menu in which you can search existing tiddlers). But I don't know how to create an icon (`[*]()`) matching the style of the existing icons (![image](https://user-images.githubusercontent.com/13970628/168132465-5ec6c122-b74f-46fe-8610-05f0c67f10af.png)) nor do I know how I could migrate the popup menu. So this PR is not the perfect solution but nevertheless an improvement of the current situation.
