### PR TITLE
fix headings in wikitext example code

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
@@ -1,6 +1,6 @@
 caption: transclude
 created: 20130824142500000
-modified: 20220122190609396
+modified: 20220513114759336
 tags: Widgets
 title: TranscludeWidget
 type: text/vnd.tiddlywiki
@@ -65,7 +65,4 @@ The transclude widget allows access to the individual tiddlers stored within a [
 
 The following example will transclude the core version of the tiddler [[$:/DefaultTiddlers]] even if it has been overridden:
 
-<<wikitext-example-without-html '
-<$transclude tiddler="$:/core" subtiddler="$:/DefaultTiddlers"/>
-
-'>>
+<<wikitext-example-without-html """<$transclude tiddler="$:/core" subtiddler="$:/DefaultTiddlers"/>""">>

--- a/editions/tw5.com/tiddlers/wikitext/Code Blocks in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Code Blocks in WikiText.tid
@@ -1,14 +1,13 @@
 caption: Code Blocks
 created: 20131205160047557
-modified: 20160606140326254
+modified: 20220513120302826
 tags: WikiText
 title: Code Blocks in WikiText
 type: text/vnd.tiddlywiki
 
 You can use triple backticks <code>&#96;&#96;&#96;</code> to mark code blocks (<<.icon $:/core/images/mono-block>>):
 
-<pre>
-&#96;&#96;&#96;
+<pre>&#96;&#96;&#96;
 This will be monospaced
 &#96;&#96;&#96;
 </pre>
@@ -23,8 +22,7 @@ To be interpreted correctly, the three backticks need to be at the start of the 
 
 Be aware that any preceding paragraph content should be properly terminated with a double line break, too. So, this example is wrong:
 
-<pre>
-This is an ordinary paragraph
+<pre>This is an ordinary paragraph
 &#96;&#96;&#96;
 This will be monospaced
 &#96;&#96;&#96;
@@ -32,8 +30,7 @@ This will be monospaced
 
 The correct version is:
 
-<pre>
-This is an ordinary paragraph
+<pre>This is an ordinary paragraph
 
 &#96;&#96;&#96;
 This will be monospaced

--- a/editions/tw5.com/tiddlers/wikitext/Dashes in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Dashes in WikiText.tid
@@ -1,8 +1,12 @@
+caption: Dashes
 created: 20131205160641986
-modified: 20131205160653909
+modified: 20220513111920644
+revision: 0
 tags: WikiText
 title: Dashes in WikiText
 type: text/vnd.tiddlywiki
-caption: Dashes
 
-You can create an n-dash with a double hyphen `--` and an m-dash with a triple hyphen `---`. For example -- this is an example --- and so is this
+You can create an n-dash with a double hyphen -- and an m-dash with a triple hyphen `---`.
+
+<<wikitext-example src:"""* -- n-dash example 
+* --- m-dash example --- have fun!""">>

--- a/editions/tw5.com/tiddlers/wikitext/Formatting in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Formatting in WikiText.tid
@@ -1,6 +1,6 @@
 caption: Formatting
 created: 20131205155959399
-modified: 20160606135946509
+modified: 20220513120211686
 tags: WikiText
 title: Formatting in WikiText
 type: text/vnd.tiddlywiki
@@ -8,12 +8,12 @@ type: text/vnd.tiddlywiki
 Available character formatting includes:
 
 * <code>&#96;backticks&#96;</code> for `code` (<<.icon $:/core/images/mono-line>>)
-** Alternatively, <code>&#96;&#96;double backticks allows &#96;embedded&#96; backticks&#96;&#96;</code>
-* `''bold''` for ''bold text'' (<<.icon $:/core/images/bold>>)
-* `//italic//` for //italic text// (<<.icon $:/core/images/italic>>)
-* `__underscore__` for __underscored text__ (<<.icon $:/core/images/underline>>)
-* `^^superscript^^` for ^^superscripted^^ text (<<.icon $:/core/images/superscript>>)
-* `,,subscript,,` for ,,subscripted,, text (<<.icon $:/core/images/subscript>>)
+** Alternatively, <code>&#96;&#96;double backticks allows &#96;embedded&#96; backticks&#96;&#96;</code><br><br>
+* `''bold''` for ''bold text'' (<<.icon $:/core/images/bold>>)<br><br>
+* `//italic//` for //italic text// (<<.icon $:/core/images/italic>>)<br><br>
+* `__underscore__` for __underscored text__ (<<.icon $:/core/images/underline>>)<br><br>
+* `^^superscript^^` for ^^superscripted^^ text (<<.icon $:/core/images/superscript>>)<br><br>
+* `,,subscript,,` for ,,subscripted,, text (<<.icon $:/core/images/subscript>>)<br><br>
 * `~~strikethrough~~` for ~~strikethrough~~ text (<<.icon $:/core/images/strikethrough>>)
 
 See also: [[Code Blocks in WikiText]]

--- a/editions/tw5.com/tiddlers/wikitext/Headings in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Headings in WikiText.tid
@@ -1,9 +1,9 @@
+caption: Headings
 created: 20131205161234909
-modified: 20190412000000000
+modified: 20220513110830487
 tags: WikiText
 title: Headings in WikiText
 type: text/vnd.tiddlywiki
-caption: Headings
 
 Headings are specified with one up to six leading `!` characters:
 
@@ -17,4 +17,4 @@ Headings are specified with one up to six leading `!` characters:
 
 CSS classes can be assigned to individual headings like this:
 
-<<wikitext-example src:"" "!!.myStyle This heading has the class `myStyle`">>
+<<wikitext-example src:"""!!.myStyle This heading has the class `myStyle`""">>

--- a/editions/tw5.com/tiddlers/wikitext/Horizontal Rules in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Horizontal Rules in WikiText.tid
@@ -1,12 +1,10 @@
+caption: Horizontal Rules
 created: 20131205160706975
-modified: 20131205160719633
+modified: 20220513111257531
 tags: WikiText
 title: Horizontal Rules in WikiText
 type: text/vnd.tiddlywiki
-caption: Horizontal Rules
 
 You can include a horizontal rule with three or more dashes on their own on a line:
 
-<<wikitext-example src:"
----
-">>
+<<wikitext-example src:"---">>

--- a/editions/tw5.com/tiddlers/wikitext/Tables in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Tables in WikiText.tid
@@ -1,41 +1,31 @@
+caption: Tables
 created: 20130914132100000
-modified: 20140125144616046
+modified: 20220513115945053
 tags: WikiText
 title: Tables in WikiText
 type: text/vnd.tiddlywiki
-caption: Tables
 
 ! Basics
 
-TiddlyWiki5 formats tables using vertical bar characters like so:
+TiddlyWiki5 formats tables using vertical bar `|` characters. Exclamation marks `!` are used to indicate header cells.
 
-```
-|!Cell1 |!Cell2 |
+<<wikitext-example-without-html src:"""|!Cell1 |!Cell2 |
 |Cell3 |Cell3 |
-```
+""">>
 
-Exclamation marks are used to indicate header cells. The example renders as:
 
-|!Cell1 |!Cell2 |
-|Cell3 |Cell3 |
 
 ! Cell Alignment
 
 Table cell alignment is controlled by inserting space characters before and/or after the cell content. For example:
 
-```
-|Left aligned content |
+<<wikitext-example-without-html src:"""|Left aligned content |
 | Right aligned content|
 | Centred content |
 |+++ a very wide column so we can see the alignment +++|
-```
+""">>
 
-The example renders as:
 
-|Left aligned content |
-| Right aligned content|
-| Centred content |
-|+++ a very wide column so we can see the alignment +++|
 
 ! Cell vertical Alignment
 
@@ -60,23 +50,19 @@ If you need to have a `^`or a `,` as the first character of a left aligned cell,
 | `^` | &amp;#94; |
 | `,` | &amp;#44; |
 
+
+
 ! Cell Merging
 
 To merge a table cell with the one above, use the special cell text `~`. To merge a cell with the one to its left use the text `<`. To merge one to its right use `>`. For example:
 
-```
-|Cell1 |Cell2 |Cell3 |Cell4 |
+<<wikitext-example-without-html src:"""|Cell1 |Cell2 |Cell3 |Cell4 |
 |Cell5 |Cell6 |Cell7 |<|
 |Cell5 |~|Cell7 |Cell8 |
 |>|Cell9 |Cell10 |Cell11 |
-```
+""">>
 
-Renders as:
 
-|Cell1 |Cell2 |Cell3 |Cell4 |
-|Cell5 |Cell6 |Cell7 |<|
-|Cell5 |~|Cell7 |Cell8 |
-|>|Cell9 |Cell10 |Cell11 |
 
 ! Table Classes, Captions, Headers and Footers
 
@@ -87,20 +73,10 @@ Table CSS classes, captions, headers and footers can be specified as special pse
 * adds a header row of cells with the text "Header"
 * adds a footer row of cells with the text "Footer"
 
-```
-|myclass anotherClass|k
+<<wikitext-example-without-html src:"""|myclass anotherClass|k
 |This is a caption |c
 |Cell1 |Cell2 |
 |Cell3 |Cell3 |
 |Header|Header|h
 |Footer|Footer|f
-```
-
-Renders as:
-
-|myclass anotherClass|k
-|This is a caption |c
-|Cell1 |Cell2 |
-|Cell3 |Cell3 |
-|Header|Header|h
-|Footer|Footer|f
+""">>

--- a/editions/tw5.com/tiddlers/wikitext/Widgets in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Widgets in WikiText.tid
@@ -1,15 +1,15 @@
 caption: Widgets
 created: 20131205160840915
-modified: 20220122193129241
+modified: 20220513113347606
 tags: WikiText
 title: Widgets in WikiText
 type: text/vnd.tiddlywiki
 
 Widgets provide rich functionality within WikiText. They have the same syntax as [[HTML elements|HTML in WikiText]], but the tag name always starts with `$`. For example:
 
-```
-<$button message="tm-close-tiddler">Close Me!</$button>
-```
+<$macrocall $name=".example" n="1"
+eg="""<$button message="tm-navigate" to="HelloThere">Open ~HelloThere</$button>
+"""/>
 
 Note that widgets inherit all the features of [[HTML in WikiText]]:
 

--- a/editions/tw5.com/tiddlers/wikitext/parser/WikiText Parser Modes.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/WikiText Parser Modes.tid
@@ -1,5 +1,5 @@
 created: 20220110233944530
-modified: 20220202022415581
+modified: 20220513112653029
 tags: WikiText
 title: WikiText Parser Modes
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
- fix headings in wikitext example code 
- improve "copy to clipboard" functions
- improve readability for some inline rules