### PR TITLE
Fix toggling of the numbered list prefix in Markdown tiddlers

### DIFF
--- a/core/modules/editor/operations/text/prefix-lines.js
+++ b/core/modules/editor/operations/text/prefix-lines.js
@@ -25,7 +25,7 @@ exports["prefix-lines"] = function(event,operation) {
 	$tw.utils.each(lines,function(line,index) {
 		// Remove and count any existing prefix characters
 		var count = 0;
-		while(line.startsWith(event.paramObject.character)) {
+		while($tw.utils.startsWith(line,event.paramObject.character)) {
 			line = line.substring(event.paramObject.character.length);
 			count++;
 		}

--- a/core/modules/editor/operations/text/prefix-lines.js
+++ b/core/modules/editor/operations/text/prefix-lines.js
@@ -25,8 +25,8 @@ exports["prefix-lines"] = function(event,operation) {
 	$tw.utils.each(lines,function(line,index) {
 		// Remove and count any existing prefix characters
 		var count = 0;
-		while(line.charAt(0) === event.paramObject.character) {
-			line = line.substring(1);
+		while(line.startsWith(event.paramObject.character)) {
+			line = line.substring(event.paramObject.character.length);
 			count++;
 		}
 		// Remove any whitespace


### PR DESCRIPTION
Whenever you use a button/shortcut that calls the function [prefix-lines.js](https://github.com/Jermolene/TiddlyWiki5/blob/master/core/modules/editor/operations/text/prefix-lines.js), the line prefix is added when there was none or it's removed when it was already there. (Examples: bulleted list, numbered list, heading).

The only exception is numbered lists in Markdown tiddlers. When you press the according button multiple times, the prefixes add up:

```markdown
1. 1. 1. item
```

The reason is that the `prefix-lines` function expects the prefix parameter to be a single character (which is true for all prefixes except for the [Markdown numbered list prefix](https://github.com/Jermolene/TiddlyWiki5/blob/master/plugins/tiddlywiki/markdown/EditorToolbar/list-number.tid)). This pull request makes `prefix-lines` work for multi-character prefixes, too.