### PR TITLE
Allow toggling wrap-lines text operations (like mono block)

### DIFF
--- a/core/modules/editor/operations/text/wrap-lines.js
+++ b/core/modules/editor/operations/text/wrap-lines.js
@@ -15,16 +15,33 @@ Text editor operation to wrap the selected lines with a prefix and suffix
 exports["wrap-lines"] = function(event,operation) {
 	var prefix = event.paramObject.prefix || "",
 		suffix = event.paramObject.suffix || "";
-	// Cut just past the preceding line break, or the start of the text
-	operation.cutStart = $tw.utils.findPrecedingLineBreak(operation.text,operation.selStart);
-	// Cut to just past the following line break, or to the end of the text
-	operation.cutEnd = $tw.utils.findFollowingLineBreak(operation.text,operation.selEnd);
-	// Add the prefix and suffix
-	operation.replacement = prefix + "\n" +
-				operation.text.substring(operation.cutStart,operation.cutEnd) + "\n" +
-				suffix + "\n";
-	operation.newSelStart = operation.cutStart + prefix.length + 1;
-	operation.newSelEnd = operation.newSelStart + (operation.cutEnd - operation.cutStart);
+	if($tw.utils.endsWith(operation.text.substring(0,operation.selStart), prefix + "\n") &&
+			$tw.utils.startsWith(operation.text.substring(operation.selEnd), "\n" + suffix)) {
+		// Selected text is already surrounded by prefix and suffix: Remove them
+		// Cut selected text plus prefix and suffix
+		operation.cutStart = operation.selStart - (prefix.length + 1);
+		operation.cutEnd = operation.selEnd + suffix.length + 1;
+		// Also cut the following newline (if there is any)
+		if (operation.text[operation.cutEnd] === "\n") {
+			operation.cutEnd++;
+		}
+		// Replace with selection
+		operation.replacement = operation.text.substring(operation.selStart,operation.selEnd);
+		// Select text that was in between prefix and suffix
+		operation.newSelStart = operation.cutStart;
+		operation.newSelEnd = operation.selEnd - (prefix.length + 1);
+	} else {
+		// Cut just past the preceding line break, or the start of the text
+		operation.cutStart = $tw.utils.findPrecedingLineBreak(operation.text,operation.selStart);
+		// Cut to just past the following line break, or to the end of the text
+		operation.cutEnd = $tw.utils.findFollowingLineBreak(operation.text,operation.selEnd);
+		// Add the prefix and suffix
+		operation.replacement = prefix + "\n" +
+					operation.text.substring(operation.cutStart,operation.cutEnd) + "\n" +
+					suffix + "\n";
+		operation.newSelStart = operation.cutStart + prefix.length + 1;
+		operation.newSelEnd = operation.newSelStart + (operation.cutEnd - operation.cutStart);
+	}
 };
 
 })();

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -96,6 +96,20 @@ exports.repeat = function(str,count) {
 };
 
 /*
+Check if a string starts with another string
+*/
+exports.startsWith = function(str,search) {
+	return str.substring(0, search.length) === search;
+};
+
+/*
+Check if a string ends with another string
+*/
+exports.endsWith = function(str,search) {
+	return str.substring(str.length - search.length) === search;
+};
+
+/*
 Trim whitespace from the start and end of a string
 Thanks to Steven Levithan, http://blog.stevenlevithan.com/archives/faster-trim-javascript
 */


### PR DESCRIPTION
Whenever I apply a "wrap-lines" text operation (like a code/monospace block or a block quote) by accident (p.e. a line is missing in the selection), I can't easily undo it. **ctrl-Z** does not work. And using the (p.e. block quote) shortcut again results in multiple nested blocks quotes:

![image](https://user-images.githubusercontent.com/13970628/168885562-51c36f77-508a-4fdb-9c33-a7154c02ce65.png)

With this pull request merged, you can just undo such an operation by pressing the same button again (or using the same shortcut again).

![TiddlyWiki toggle block quote](https://user-images.githubusercontent.com/13970628/168886462-1ab2b70e-9673-475b-bea9-824897cbe9d8.gif)