### PR TITLE
feat: inform child widget to do some custom cleanup

### DIFF
--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -80,7 +80,7 @@ ClassicStoryView.prototype.remove = function(widget) {
 	if(duration) {
 		var targetElement = widget.findFirstDomNode(),
 			removeElement = function() {
-				widget.removeChildDomNodes();
+				widget.destroy();
 			};
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
 		if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
@@ -112,7 +112,7 @@ ClassicStoryView.prototype.remove = function(widget) {
 			{opacity: "0.0"}
 		]);
 	} else {
-		widget.removeChildDomNodes();
+		widget.destroy();
 	}
 };
 

--- a/core/modules/storyviews/pop.js
+++ b/core/modules/storyviews/pop.js
@@ -73,7 +73,7 @@ PopStoryView.prototype.remove = function(widget) {
 		duration = $tw.utils.getAnimationDuration(),
 		removeElement = function() {
 			if(targetElement && targetElement.parentNode) {
-				widget.removeChildDomNodes();
+				widget.destroy();
 			}
 		};
 	// Abandon if the list entry isn't a DOM element (it might be a text node)

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -144,7 +144,7 @@ ZoominListView.prototype.remove = function(widget) {
 	var targetElement = widget.findFirstDomNode(),
 		duration = $tw.utils.getAnimationDuration(),
 		removeElement = function() {
-			widget.removeChildDomNodes();
+			widget.destroy();
 		};
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
 	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {

--- a/core/modules/widgets/importvariables.js
+++ b/core/modules/widgets/importvariables.js
@@ -116,7 +116,7 @@ ImportVariablesWidget.prototype.refresh = function(changedTiddlers) {
 	}
 	if(changedAttributes.filter || !$tw.utils.isArrayEqual(this.tiddlerList,tiddlerList) || haveListedTiddlersChanged()) {
 		// Compute the filter
-		this.removeChildDomNodes();
+		this.destroy();
 		this.execute(tiddlerList);
 		this.renderChildren(this.parentDomNode,this.findNextSiblingDomNode());
 		return true;

--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -219,7 +219,7 @@ ListWidget.prototype.handleListChanges = function(changedTiddlers) {
 	} else {
 		// If the list was empty then we need to remove the empty message
 		if(prevList.length === 0) {
-			this.removeChildDomNodes();
+			this.destroy();
 			this.children = [];
 		}
 		// If we are providing an counter variable then we must refresh the items, otherwise we can rearrange them
@@ -312,7 +312,7 @@ ListWidget.prototype.removeListItem = function(index) {
 	if(this.storyview && this.storyview.remove) {
 		this.storyview.remove(widget);
 	} else {
-		widget.removeChildDomNodes();
+		widget.destroy();
 	}
 	// Remove the child widget
 	this.children.splice(index,1);

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -615,7 +615,8 @@ Widget.prototype.removeChildDomNodes = function() {
 Inform widget that extends this widget and children widgets that widget tree is about to destroy, and dom nodes are being unmounted from the document.
 */
 Widget.prototype.destroy = function(options) {
-	var removeDom = options && options.removeDom
+	// removeDom by default
+	var removeDom = (options && options.removeDom) || true;
 	if (removeDom) {
 		// prepare options for children, if we have removed the dom, child don't need to remove their dom
 		removeDom = !this.removeChildDomNodes();

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -599,21 +599,19 @@ Widget.prototype.findFirstDomNode = function() {
 /*
 Remove any DOM nodes created by this widget or its children
 */
-Widget.prototype.removeChildDomNodes = function(parentRemoved) {
+Widget.prototype.removeChildDomNodes = function() {
 	// If this widget has directly created DOM nodes, delete them and exit. This assumes that any child widgets are contained within the created DOM nodes, which would normally be the case
-	// If parent has already detatch its dom node from the document, we don't need to do it again.
-	if(this.domNodes.length > 0 && !parentRemoved) {
+	if(this.domNodes.length > 0) {
 		$tw.utils.each(this.domNodes,function(domNode) {
 			domNode.parentNode.removeChild(domNode);
 		});
 		this.domNodes = [];
-		// inform child widget to do some custom cleanup in a override sub-class method, and tell child widget that parent has already done the update, so children don't need to do anything.
-		parentRemoved = true;
+	} else {
+		// Otherwise, ask the child widgets to delete their DOM nodes
+		$tw.utils.each(this.children,function(childWidget) {
+			childWidget.removeChildDomNodes();
+		});
 	}
-	// If parentRemoved is unset or false, will ask the child widgets to delete their DOM nodes
-	$tw.utils.each(this.children,function(childWidget) {
-		childWidget.removeChildDomNodes(parentRemoved);
-	});
 };
 
 /*

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -621,7 +621,7 @@ Widget.prototype.removeChildDomNodes = function(options) {
 };
 
 /*
-Inform widget that extends this widget and children widgets that widget tree is about to destroy, and dom nodes are being unmounted from the document.
+Inform widget subclass that extends this widget and children widgets of this widget. Let them know this widget tree is about to destroy, and dom nodes are being unmounted from the document.
 */
 Widget.prototype.destroy = function(options) {
 	// removeDom by default

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -606,12 +606,24 @@ Widget.prototype.removeChildDomNodes = function() {
 			domNode.parentNode.removeChild(domNode);
 		});
 		this.domNodes = [];
+		this.destroy();
 	} else {
 		// Otherwise, ask the child widgets to delete their DOM nodes
 		$tw.utils.each(this.children,function(childWidget) {
 			childWidget.removeChildDomNodes();
 		});
 	}
+};
+
+/*
+Inform widget that extends this widget and children widgets that widget tree is about to destroy, and dom nodes are being unmounted from the document.
+*/
+Widget.prototype.destroy = function() {
+	// nothing need to do, as dom is already removed in the removeChildDomNodes
+	// we just need to inform the children
+	$tw.utils.each(this.children,function(childWidget) {
+		childWidget.destroy();
+	});
 };
 
 /*

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -534,7 +534,7 @@ Rebuild a previously rendered widget
 */
 Widget.prototype.refreshSelf = function() {
 	var nextSibling = this.findNextSiblingDomNode();
-	this.removeChildDomNodes();
+	this.destroy();
 	this.render(this.parentDomNode,nextSibling);
 };
 
@@ -606,23 +606,24 @@ Widget.prototype.removeChildDomNodes = function() {
 			domNode.parentNode.removeChild(domNode);
 		});
 		this.domNodes = [];
-		this.destroy();
-	} else {
-		// Otherwise, ask the child widgets to delete their DOM nodes
-		$tw.utils.each(this.children,function(childWidget) {
-			childWidget.removeChildDomNodes();
-		});
+		return true;
 	}
+	return false
 };
 
 /*
 Inform widget that extends this widget and children widgets that widget tree is about to destroy, and dom nodes are being unmounted from the document.
 */
-Widget.prototype.destroy = function() {
+Widget.prototype.destroy = function(options) {
+	var removeDom = options && options.removeDom
+	if (removeDom) {
+		// prepare options for children, if we have removed the dom, child don't need to remove their dom
+		removeDom = !this.removeChildDomNodes();
+	}
 	// nothing need to do, as dom is already removed in the removeChildDomNodes
 	// we just need to inform the children
 	$tw.utils.each(this.children,function(childWidget) {
-		childWidget.destroy();
+		childWidget.destroy({ removeDom: removeDom });
 	});
 };
 

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -534,7 +534,7 @@ Rebuild a previously rendered widget
 */
 Widget.prototype.refreshSelf = function() {
 	var nextSibling = this.findNextSiblingDomNode();
-	this.destroy();
+	this.removeChildDomNodes({ recursive: true });
 	this.render(this.parentDomNode,nextSibling);
 };
 
@@ -599,7 +599,8 @@ Widget.prototype.findFirstDomNode = function() {
 /*
 Remove any DOM nodes created by this widget or its children
 */
-Widget.prototype.removeChildDomNodes = function() {
+Widget.prototype.removeChildDomNodes = function(options) {
+	const recursive = options && options.recursive;
 	// If this widget has directly created DOM nodes, delete them and exit. This assumes that any child widgets are contained within the created DOM nodes, which would normally be the case
 	if(this.domNodes.length > 0) {
 		$tw.utils.each(this.domNodes,function(domNode) {
@@ -607,6 +608,11 @@ Widget.prototype.removeChildDomNodes = function() {
 		});
 		this.domNodes = [];
 		return true;
+	} else if(recursive) {
+		// Otherwise, ask the child widgets to delete their DOM nodes
+		$tw.utils.each(this.children,function(childWidget) {
+			childWidget.removeChildDomNodes(options);
+		});
 	}
 	return false
 };

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -600,8 +600,11 @@ Widget.prototype.findFirstDomNode = function() {
 Remove any DOM nodes created by this widget or its children
 */
 Widget.prototype.removeChildDomNodes = function(options) {
-	const recursive = options && options.recursive;
-	// If this widget has directly created DOM nodes, delete them and exit. This assumes that any child widgets are contained within the created DOM nodes, which would normally be the case
+	var recursive = options && options.recursive;
+	/**
+	 * If this widget has directly created DOM nodes, delete them and exit.
+	 * This assumes that any child widgets are contained within the created DOM nodes, which would normally be the case
+	 */
 	if(this.domNodes.length > 0) {
 		$tw.utils.each(this.domNodes,function(domNode) {
 			domNode.parentNode.removeChild(domNode);

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -607,7 +607,7 @@ Widget.prototype.removeChildDomNodes = function(parentRemoved) {
 			domNode.parentNode.removeChild(domNode);
 		});
 		this.domNodes = [];
-		// inform child widget to do some custom cleanup in a overrided sub-class method, and tell child widget that parent has already done the update, so children don't need to do anything.
+		// inform child widget to do some custom cleanup in a override sub-class method, and tell child widget that parent has already done the update, so children don't need to do anything.
 		parentRemoved = true;
 	}
 	// If parentRemoved is unset or false, will ask the child widgets to delete their DOM nodes

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -599,19 +599,21 @@ Widget.prototype.findFirstDomNode = function() {
 /*
 Remove any DOM nodes created by this widget or its children
 */
-Widget.prototype.removeChildDomNodes = function() {
+Widget.prototype.removeChildDomNodes = function(parentRemoved) {
 	// If this widget has directly created DOM nodes, delete them and exit. This assumes that any child widgets are contained within the created DOM nodes, which would normally be the case
-	if(this.domNodes.length > 0) {
+	// If parent has already detatch its dom node from the document, we don't need to do it again.
+	if(this.domNodes.length > 0 && !parentRemoved) {
 		$tw.utils.each(this.domNodes,function(domNode) {
 			domNode.parentNode.removeChild(domNode);
 		});
 		this.domNodes = [];
-	} else {
-		// Otherwise, ask the child widgets to delete their DOM nodes
-		$tw.utils.each(this.children,function(childWidget) {
-			childWidget.removeChildDomNodes();
-		});
+		// inform child widget to do some custom cleanup in a overrided sub-class method, and tell child widget that parent has already done the update, so children don't need to do anything.
+		parentRemoved = true;
 	}
+	// If parentRemoved is unset or false, will ask the child widgets to delete their DOM nodes
+	$tw.utils.each(this.children,function(childWidget) {
+		childWidget.removeChildDomNodes(parentRemoved);
+	});
 };
 
 /*

--- a/plugins/tiddlywiki/cecily/cecily.js
+++ b/plugins/tiddlywiki/cecily/cecily.js
@@ -62,7 +62,7 @@ CecilyStoryView.prototype.remove = function(widget) {
 		duration = $tw.utils.getAnimationDuration();
 	// Remove the widget at the end of the transition
 	setTimeout(function() {
-		widget.removeChildDomNodes();
+		widget.destroy();
 	},duration);
 	// Animate the closure
 	$tw.utils.setStyle(targetElement,[

--- a/plugins/tiddlywiki/stacked-view/stacked.js
+++ b/plugins/tiddlywiki/stacked-view/stacked.js
@@ -80,7 +80,7 @@ StackedListView.prototype.insert = function(widget) {
 };
 
 StackedListView.prototype.remove = function(widget) {
-	widget.removeChildDomNodes();
+	widget.destroy();
 };
 
 exports.stacked = StackedListView;


### PR DESCRIPTION
Implements for [https://github.com/Jermolene/TiddlyWiki5/discussions/5945](https://github.com/Jermolene/TiddlyWiki5/discussions/5945)

After this, we can do:

```ts
class SomeReactWidget extends Widget {
  destroy() {
    super.destroy();
    this.reactRoot?.unmount?.();
  }
```

TLDR: use `destroy()` instead of `removeChildDomNodes()` in your widgets.

The Problem: The parent widget (in this case is the storyriver's list widget, maybe) will directly remove child dom node from itself's childlist, and won't inform child widget, and just wait for GC. So event listeners and ReactJS instances will still exist on old child dom nodes, causing problems.

In this PR: A change to `removeChildDomNodes` has been made. So it is non-recursive by default. (You can pass an option like `this.removeChildDomNodes({ recursive: true })` to get old behavior).

**This will only break plugins with widget that doesn't have any dom node, but want to help child widgets do the `removeChildDomNodes`. This is very rare**, because normally every widget has its own dom node, and its child widget will attach the child dom node to the parent dom node.

And it is recommended to use the new `destroy()` method that will call `removeChildDomNodes()` only once, and it will recursively inform children about "parent has unmounted, you don't need to do anything but you can clean yourself up".
