### PR TITLE
Notes on navigation to Keyboard Shortcut tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/KeyboardShortcutTiddler.tid
+++ b/editions/tw5.com/tiddlers/concepts/KeyboardShortcutTiddler.tid
@@ -10,3 +10,10 @@ A ''Keyboard Shortcut Tiddler'' is made of three parts:
 If the [[Keyboard Shortcut Descriptor]] has the form `((my-shortcut))` it's a ''reference'' to a ''configuration Tiddler'' that stores the corresponding [[Keyboard Shortcut|KeyboardShortcuts]]
 
 In order to make a ''shortcut'' editable through the <<.controlpanel-tab KeyboardShortcuts>> Tab in the $:/ControlPanel it's sufficient to create a tiddler `$:/config/ShortcutInfo/my-shortcut`, where the ''suffix'' is the ''reference'' used for the [[Keyboard Shortcut|KeyboardShortcuts]]
+
+!! Notes on wiki navigation
+
+If you want to create keyboard shortcuts for navigation, there are two things to keep in mind:
+
+ * If your shortcut uses ''Ctrl'', you need to include `$scroll="yes"` in the [[ActionNavigateWidget's|ActionNavigateWidget]] attributes otherwise the action will be ignored.
+ * The actions need to be wrapped in [[NavigatorWidget]] like in this [[New Tiddler keyboard shortcut|$:/core/ui/KeyboardShortcuts/new-tiddler]].


### PR DESCRIPTION
I've been adding some fancy keyboard shortcuts and consistently struggled with two quirks of how navigation interacts with them so I think it'd be great to codify that in the documentation.

Not sure if the way I wrote it is clear enough, perhaps adding a fully-fledged example would be better:

```
<!-- Navigate to the next open tiddler shortcut-->
<!-- The navigate action must be wrapped in <$navigator> so that they are processed -->
<$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
<!-- We need to strip square brackets from tiddler names to avoid navigating to non-existing tiddlers -->
  <$vars prefix="[[" suffix="]]" >
    <$list variable="target" filter="[[$:/HistoryList]get[current-tiddler]next[$:/StoryList]trim<prefix>trim<suffix>]" emptyMessage="""
      <!-- If we are at the last tiddler wrap to the beginning -->
      <$action-navigate $to={{{[list[$:/StoryList]first[]trim<prefix>trim<suffix>]}}}/>
    """>
      <$action-navigate $to=<<target>>/>
    </$list>
  </$vars>
</$navigator>
```