### PR TITLE
Allow global keyboard shortcuts to work in framed editor

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -84,6 +84,9 @@ function FramedEngine(options) {
 	// Copy the styles from the dummy textarea
 	this.copyStyles();
 	// Add event listeners
+	$tw.utils.addEventListeners(this.iframeDoc, [
+		{name: "keydown",handlerObject: $tw.keyboardManager,handlerMethod: "handleKeydownEvent", capture: true},
+	]);
 	$tw.utils.addEventListeners(this.domNode,[
 		{name: "click",handlerObject: this,handlerMethod: "handleClickEvent"},
 		{name: "input",handlerObject: this,handlerMethod: "handleInputEvent"},

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -198,6 +198,7 @@ Each entry in the events array is an object with these properties:
 handlerFunction: optional event handler function
 handlerObject: optional event handler object
 handlerMethod: optionally specifies object handler method name (defaults to `handleEvent`)
+capture: optionally specifies the listener should use capture (defaults to `false`)
 */
 exports.addEventListeners = function(domNode,events) {
 	$tw.utils.each(events,function(eventInfo) {
@@ -213,7 +214,7 @@ exports.addEventListeners = function(domNode,events) {
 				handler = eventInfo.handlerObject;
 			}
 		}
-		domNode.addEventListener(eventInfo.name,handler,false);
+		domNode.addEventListener(eventInfo.name,handler,!!eventInfo.capture);
 	});
 };
 


### PR DESCRIPTION
I've been adding some keyboard navigation to my personal Wikis and I noticed one thing that annoyed the end of me - if I am in the middle of editing a tiddler I need to click away with the mouse for the shortcuts to work.

## What changes:

 * Shortcuts defined with tag `$:/tags/KeyboardShortcut` will now work even if the focus is in the tiddler editor when using the toolbar (ie. framed editor is used).
 * And these shortcuts take priority over the styling shortcuts already defined in the editor.

## What changes (technically):

The reason is that the framed editor uses an iframe, and thus the keyboard events don't reach the host's `document` in the first place. I've distilled the solution to two changes:

 * `$tw.utils.addEventListeners()` now supports registering the event to listen in capture phase.
 * `framed.js` adds the listener that listens to the global shortcuts defined with `$:/tags/KeyboardShortcuts` to the iframe document.

Thus what happens is that if define a global keyboard shortcut for, say, `Ctrl+L`, if you have focus on the framed editor the capture phase listener will detect the keypress, run the shortcut and stop propagation, preventing **Create wikitext link** from running. On the other hand if there is no global keyboard shortcut it'll happily continue.

## Older solution:

At first I made two different changes:
 * `framed.js` added a listener to global shortcuts directly in `this.domNode`
 * `keyboard.js` replaced `stopPropagation()` with `stopImmediatePropagation()` to prevent the framed editor's shortcuts to also trigger

But this introduced a potential problem, where if you had a situation where these callbacks were used but you also wanted the underlying events to trigger, they wouldn't. Or if you had multiple listeners in the document.

## Possible problems:

I don't see any, but also I am not that knowledgable with TW.  