### PR TITLE
Fix unit test for formatDateString UTC format

### DIFF
--- a/editions/test/tiddlers/tests/test-utils.js
+++ b/editions/test/tiddlers/tests/test-utils.js
@@ -78,7 +78,11 @@ describe("Utility tests", function() {
 		expect(fds(d,"ddd hh mm ssss")).toBe("Sun 17 41 2828");
 		expect(fds(d,"MM0DD")).toBe("1109");
 		expect(fds(d,"MM0\\D\\D")).toBe("110DD");
-		expect(fds(d,"[UTC]YYYY0MM0DD0hh0mm0ssXXX")).toBe("20141109174128542");
+		const day = d.getUTCDate();
+		const dayStr = ("" + day).padStart(2, '0');
+		const hours = d.getUTCHours();
+		const expectedUtcStr = `201411${dayStr}${hours}4128542`;
+		expect(fds(d,"[UTC]YYYY0MM0DD0hh0mm0ssXXX")).toBe(expectedUtcStr);
 
 		// test some edge cases found at: https://en.wikipedia.org/wiki/ISO_week_date
 		// 2016-11-13 is Week 45 and it's a Sunday (month nr: 10)


### PR DESCRIPTION
Fixes #6707.

Now the test should run correctly in any timezone.