### PR TITLE
allow global keyboard shortcuts to override all other shortcuts by providing a special field

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -196,7 +196,7 @@ FramedEngine.prototype.handleFocusEvent = function(event) {
 Handle a keydown event
  */
 FramedEngine.prototype.handleKeydownEvent = function(event) {
-	if ($tw.keyboardManager.handleKeydownEvent(event, true)) {
+	if ($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
 		return true;
 	}
 

--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -84,13 +84,10 @@ function FramedEngine(options) {
 	// Copy the styles from the dummy textarea
 	this.copyStyles();
 	// Add event listeners
-	$tw.utils.addEventListeners(this.iframeDoc, [
-		{name: "keydown",handlerObject: $tw.keyboardManager,handlerMethod: "handlePrimaryKeydownEvent", capture: true},
-	]);
 	$tw.utils.addEventListeners(this.domNode,[
 		{name: "click",handlerObject: this,handlerMethod: "handleClickEvent"},
 		{name: "input",handlerObject: this,handlerMethod: "handleInputEvent"},
-		{name: "keydown",handlerObject: this.widget,handlerMethod: "handleKeydownEvent"},
+		{name: "keydown",handlerObject: this,handlerMethod: "handleKeydownEvent"},
 		{name: "focus",handlerObject: this,handlerMethod: "handleFocusEvent"}
 	]);
 	// Add drag and drop event listeners if fileDrop is enabled
@@ -193,6 +190,17 @@ FramedEngine.prototype.handleFocusEvent = function(event) {
 	if(this.widget.editCancelPopups) {
 		$tw.popup.cancel(0);
 	}
+};
+
+/*
+Handle a keydown event
+ */
+FramedEngine.prototype.handleKeydownEvent = function(event) {
+	if ($tw.keyboardManager.handleKeydownEvent(event, true)) {
+		return true;
+	}
+
+	return this.widget.handleKeydownEvent(event);
 };
 
 /*

--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -84,6 +84,9 @@ function FramedEngine(options) {
 	// Copy the styles from the dummy textarea
 	this.copyStyles();
 	// Add event listeners
+	$tw.utils.addEventListeners(this.iframeDoc, [
+		{name: "keydown",handlerObject: $tw.keyboardManager,handlerMethod: "handlePrimaryKeydownEvent", capture: true},
+	]);
 	$tw.utils.addEventListeners(this.domNode,[
 		{name: "click",handlerObject: this,handlerMethod: "handleClickEvent"},
 		{name: "input",handlerObject: this,handlerMethod: "handleInputEvent"},

--- a/core/modules/keyboard.js
+++ b/core/modules/keyboard.js
@@ -141,6 +141,7 @@ function KeyboardManager(options) {
 	this.shortcutKeysList = [], // Stores the shortcut-key descriptors
 	this.shortcutActionList = [], // Stores the corresponding action strings
 	this.shortcutParsedList = []; // Stores the parsed key descriptors
+	this.shortcutPriorityList = []; // Stores the parsed shortcut priority
 	this.lookupNames = ["shortcuts"];
 	this.lookupNames.push($tw.platform.isMac ? "shortcuts-mac" : "shortcuts-not-mac")
 	this.lookupNames.push($tw.platform.isWindows ? "shortcuts-windows" : "shortcuts-not-windows");
@@ -318,25 +319,17 @@ KeyboardManager.prototype.updateShortcutLists = function(tiddlerList) {
 		this.shortcutKeysList[i] = tiddlerFields.key !== undefined ? tiddlerFields.key : undefined;
 		this.shortcutActionList[i] = tiddlerFields.text;
 		this.shortcutParsedList[i] = this.shortcutKeysList[i] !== undefined ? this.parseKeyDescriptors(this.shortcutKeysList[i]) : undefined;
+		this.shortcutPriorityList[i] = tiddlerFields.priority === "yes" ? true : false;
 	}
 };
 
-KeyboardManager.prototype.handleKeydownEvent = function(event) {
-	return this.handleKeydownEventInternal(event, false);
-}
-
-KeyboardManager.prototype.handlePrimaryKeydownEvent = function(event) {
-	return this.handleKeydownEventInternal(event, true);
-}
-
-KeyboardManager.prototype.handleKeydownEventInternal = function(event, onlyPrimary) {
+KeyboardManager.prototype.handleKeydownEvent = function(event, onlyPriority) {
 	var key, action;
 	for(var i=0; i<this.shortcutTiddlers.length; i++) {
-		var tiddler = $tw.wiki.getTiddler(this.shortcutTiddlers[i]);
-		if (onlyPrimary && !tiddler.fields.primary) {
+		if(onlyPriority && this.shortcutPriorityList[i] !== true) {
 			continue;
 		}
-		
+
 		if(this.shortcutParsedList[i] !== undefined && this.checkKeyDescriptors(event,this.shortcutParsedList[i])) {
 			key = this.shortcutParsedList[i];
 			action = this.shortcutActionList[i];

--- a/core/modules/keyboard.js
+++ b/core/modules/keyboard.js
@@ -322,8 +322,21 @@ KeyboardManager.prototype.updateShortcutLists = function(tiddlerList) {
 };
 
 KeyboardManager.prototype.handleKeydownEvent = function(event) {
+	return this.handleKeydownEventInternal(event, false);
+}
+
+KeyboardManager.prototype.handlePrimaryKeydownEvent = function(event) {
+	return this.handleKeydownEventInternal(event, true);
+}
+
+KeyboardManager.prototype.handleKeydownEventInternal = function(event, onlyPrimary) {
 	var key, action;
 	for(var i=0; i<this.shortcutTiddlers.length; i++) {
+		var tiddler = $tw.wiki.getTiddler(this.shortcutTiddlers[i]);
+		if (onlyPrimary && !tiddler.fields.primary) {
+			continue;
+		}
+		
 		if(this.shortcutParsedList[i] !== undefined && this.checkKeyDescriptors(event,this.shortcutParsedList[i])) {
 			key = this.shortcutParsedList[i];
 			action = this.shortcutActionList[i];

--- a/core/modules/keyboard.js
+++ b/core/modules/keyboard.js
@@ -323,10 +323,16 @@ KeyboardManager.prototype.updateShortcutLists = function(tiddlerList) {
 	}
 };
 
-KeyboardManager.prototype.handleKeydownEvent = function(event, onlyPriority) {
+/*
+event: the keyboard event object
+options:
+	onlyPriority: true if only priority global shortcuts should be invoked
+*/
+KeyboardManager.prototype.handleKeydownEvent = function(event, options) {
+	options = options || {};
 	var key, action;
 	for(var i=0; i<this.shortcutTiddlers.length; i++) {
-		if(onlyPriority && this.shortcutPriorityList[i] !== true) {
+		if(options.onlyPriority && this.shortcutPriorityList[i] !== true) {
 			continue;
 		}
 

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -213,7 +213,7 @@ exports.addEventListeners = function(domNode,events) {
 				handler = eventInfo.handlerObject;
 			}
 		}
-		domNode.addEventListener(eventInfo.name,handler,false);
+		domNode.addEventListener(eventInfo.name,handler,!!eventInfo.capture);
 	});
 };
 

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -213,7 +213,7 @@ exports.addEventListeners = function(domNode,events) {
 				handler = eventInfo.handlerObject;
 			}
 		}
-		domNode.addEventListener(eventInfo.name,handler,!!eventInfo.capture);
+		domNode.addEventListener(eventInfo.name,handler,false);
 	});
 };
 

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -53,6 +53,10 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 };
 
 KeyboardWidget.prototype.handleChangeEvent = function(event) {
+	if ($tw.keyboardManager.handlePrimaryKeydownEvent(event)) {
+		return true;
+	}
+	
 	var keyInfo = $tw.keyboardManager.getMatchingKeyDescriptor(event,this.keyInfoArray);
 	if(keyInfo) {
 		var handled = this.invokeActions(this,event);

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -53,7 +53,7 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 };
 
 KeyboardWidget.prototype.handleChangeEvent = function(event) {
-	if ($tw.keyboardManager.handleKeydownEvent(event, true)) {
+	if ($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
 		return true;
 	}
 

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -53,10 +53,10 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 };
 
 KeyboardWidget.prototype.handleChangeEvent = function(event) {
-	if ($tw.keyboardManager.handlePrimaryKeydownEvent(event)) {
+	if ($tw.keyboardManager.handleKeydownEvent(event, true)) {
 		return true;
 	}
-	
+
 	var keyInfo = $tw.keyboardManager.getMatchingKeyDescriptor(event,this.keyInfoArray);
 	if(keyInfo) {
 		var handled = this.invokeActions(this,event);

--- a/editions/tw5.com/tiddlers/concepts/KeyboardShortcutTiddler.tid
+++ b/editions/tw5.com/tiddlers/concepts/KeyboardShortcutTiddler.tid
@@ -7,6 +7,8 @@ A ''Keyboard Shortcut Tiddler'' is made of three parts:
 * The ''field'' `key` with a [[Keyboard Shortcut Descriptor]] as its ''value''
 * Actions in its ''text'' field
 
+<<.tip """<<.from-version "5.2.3">> By default <<.wlink KeyboardWidget>> and text editor shortcuts take priority, which can be circumvented by setting the ''field'' `priority` to `yes`.""">>
+
 If the [[Keyboard Shortcut Descriptor]] has the form `((my-shortcut))` it's a ''reference'' to a ''configuration Tiddler'' that stores the corresponding [[Keyboard Shortcut|KeyboardShortcuts]]
 
 In order to make a ''shortcut'' editable through the <<.controlpanel-tab KeyboardShortcuts>> Tab in the $:/ControlPanel it's sufficient to create a tiddler `$:/config/ShortcutInfo/my-shortcut`, where the ''suffix'' is the ''reference'' used for the [[Keyboard Shortcut|KeyboardShortcuts]]

--- a/editions/tw5.com/tiddlers/concepts/KeyboardShortcutTiddler.tid
+++ b/editions/tw5.com/tiddlers/concepts/KeyboardShortcutTiddler.tid
@@ -7,7 +7,7 @@ A ''Keyboard Shortcut Tiddler'' is made of three parts:
 * The ''field'' `key` with a [[Keyboard Shortcut Descriptor]] as its ''value''
 * Actions in its ''text'' field
 
-<<.tip """<<.from-version "5.2.3">> By default <<.wlink KeyboardWidget>> and text editor shortcuts take priority, which can be circumvented by setting the ''field'' `priority` to `yes`.""">>
+<<.tip """<<.from-version "5.2.4">> By default <<.wlink KeyboardWidget>> and text editor shortcuts take priority, which can be circumvented by setting the ''field'' `priority` to `yes`.""">>
 
 If the [[Keyboard Shortcut Descriptor]] has the form `((my-shortcut))` it's a ''reference'' to a ''configuration Tiddler'' that stores the corresponding [[Keyboard Shortcut|KeyboardShortcuts]]
 

--- a/editions/tw5.com/tiddlers/howtos/How to create keyboard shortcuts.tid
+++ b/editions/tw5.com/tiddlers/howtos/How to create keyboard shortcuts.tid
@@ -66,6 +66,8 @@ In the [[Keyboard Shortcuts Tab|$:/core/ui/ControlPanel/KeyboardShortcuts]] the 
 
 !! Using global Keyboard Shortcuts
 
+> See [[Keyboard Shortcut Tiddler]] for detailed information about creating new global keyboard shortcuts.
+
 > The actions for ''global'' keyboard shortcuts are stored in the ''text'' field of tiddlers tagged with <<tag $:/tags/KeyboardShortcut>>
 
 > The ''key field'' connects an action-tiddler with the corresponding shortcut through the `((my-shortcut))` syntax, called [[Keyboard Shortcut Descriptor]]

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -186,6 +186,10 @@ function CodeMirrorEngine(options) {
 		return false;
 	});
 	this.cm.on("keydown",function(cm,event) {
+		if ($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
+			return true;
+		}
+	
 		return self.widget.handleKeydownEvent.call(self.widget,event);
 	});
 	this.cm.on("focus",function(cm,event) {


### PR DESCRIPTION
Here is my proposed alternate solution to #6705. 

In order to make a global shortcut override other shortcuts add a field `priority` and set it to `yes`.

## Todo:

 - [x] Update the documentation for global keyboard shortcut
 - [x] Ensure it works with `simple` editor
 - [x] Ensure it works with `codemirror` editor

# Testing:

Below is info about what scenarios I checked and with what tiddlers

## Test Tiddlers:

```
title: Shortcut
tags: $:/tags/KeyboardShortcut
key: ctrl+l

<$action-log $$message="global"/>
<$checkbox field="priority" checked="yes" unchecked=""/> Priority = {{!!priority}}
```

```
title: test

<$keyboard actions="""<$action-log $$message="widget"/>""" key="ctrl+l">
<$edit-text field="test" placeholder="Has keyboard action"/>
</$keyboard>
<$edit-text field="test" placeholder="No keyboard action"/>
```

The shortcut is `Ctrl+L`. Clicking the checkbox in shortcut tiddler toggles priority between `yes` and an empty value.

## Test cases:

 * With `priority = ""` pressing `Ctrl+L`:
     * [x] **Nothing focused:** logs `global` in the console
     * [x] **EditText widget without KeyboardWidget focused:** logs `global` in the console
     * [x] **EditText widget with a KeyboardWidget focused:** logs `widget` in the console
     * [x] **Framed editor focused:** Opens _Create wikitext link_ dialog
     * [x] **Simple editor focused:** ~~Opens _Create wikitext link_ dialog~~ logs `global` in the console (that's actually how it worked before `priority` was introduced)
     * [x] **CodeMirror editor focused:** Opens _Create wikitext link_ dialog
 * With `priority = "yes"` pressing `Ctrl+L`:
     * [x] **Nothing focused:** logs `global` in the console
     * [x] **EditText widget without KeyboardWidget focused:** logs `global` in the console
     * [x] **EditText widget with a KeyboardWidget focused:** logs `global` in the console
     * [x] **Framed editor focused:** logs `global` in the console
     * [x] **Simple editor focused:** logs `global` in the console
     * [x] **CodeMirror editor focused:** logs `global` in the console