### PR TITLE
Fix 6731 tag and field name trim

### DIFF
--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -11,7 +11,7 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 \whitespace trim
 <$set name="tag" value={{{ [<__tiddler__>get[text]] }}}>
 <$list filter="[<saveTiddler>!contains:$tagField$<tag>!match[]]" variable="ignore" emptyMessage="<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter='-[<tag>]'/>">
-<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>]"/>
+<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
 $actions$
 </$list>
 </$set>
@@ -52,7 +52,7 @@ $actions$
 </span><$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button><$reveal state=<<storeTitle>> type="nomatch" text=""><$button class="tc-btn-invisible tc-small-gap tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/ClearInput/Hint}} aria-label={{$:/language/EditTemplate/Tags/ClearInput/Caption}}>{{$:/core/images/close-button}}<<delete-tag-state-tiddlers>></$button></$reveal><span class="tc-add-tag-button tc-small-gap-left">
 <$set name="tag" value={{{ [<newTagNameTiddler>get[text]] }}}>
 <$button set=<<newTagNameTiddler>> setTo="" class="">
-<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>]"/>
+<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
 $actions$
 <$set name="currentTiddlerCSSEscaped" value={{{ [<saveTiddler>escapecss[]] }}}>
 <<delete-tag-state-tiddlers>><$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>>/>

--- a/core/wiki/macros/tag.tid
+++ b/core/wiki/macros/tag.tid
@@ -16,7 +16,7 @@ color:$(foregroundColor)$;
 	$element-attributes$
 	class="tc-tag-label tc-btn-invisible"
 	style=<<tag-pill-styles>>
->$actions$<$transclude tiddler="""$icon$"""/><$view tiddler=<<__tag__>> field="title" format="text" />
+>$actions$<$transclude tiddler="""$icon$"""/><$view tiddler=<<__tag__>> field="title" format="text" /></$element-tag$>
 \end
 
 \define tag-pill-body(tag,icon,colour,palette,element-tag,element-attributes,actions)

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -738,7 +738,7 @@ button.tc-tag-label, span.tc-tag-label {
 	font-weight: normal;
 	line-height: 1.2em;
 	color: <<colour tag-foreground>>;
-	white-space: nowrap;
+	white-space: break-spaces;
 	vertical-align: baseline;
 	background-color: <<colour tag-background>>;
 	border-radius: 1em;
@@ -775,7 +775,6 @@ button.tc-untagged-label {
 }
 
 .tc-tag-manager-table .tc-tag-label {
-	white-space: normal;
 }
 
 .tc-tag-manager-tag {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2157,6 +2157,10 @@ html body.tc-body.tc-single-tiddler-window {
 	margin: 0.5em 0;
 }
 
+.tc-manager-control select {
+	max-width: 100%;
+}
+
 .tc-manager-list {
 	width: 100%;
 	border-top: 1px solid <<colour muted-foreground>>;


### PR DESCRIPTION
This PR contains 3 commits that fix [#6731 ](https://github.com/Jermolene/TiddlyWiki5/issues/6731)

- 3dee2704ab917f46b74fce126567c2b31eca1706 adds 2 trims to the UI
- da99b265cc0e2d65877f76b6d6a95741beedb64f increases the chance, that users will spot future problems more easily. 
  - also see your commit message from 002d47b4d91f81b91bb9025a438c7f46c9ab3fe1
  - > Now long tags wrap onto multiple lines. I think they look quite good,
and we may want to consider using the same technique in the view
template.
- 02edf8580522ae3690085a52ee734c5e00696bfb adds an HTML end-tag, that was missing. 

Tested with FF on windows. 

![image](https://user-images.githubusercontent.com/374655/175561531-e2f62072-e73b-4351-9298-b27bc0f6409d.png)


Also tested with Edge on Windows

<details><summary>Click me -- Spaces are more visible now</summary>

![image](https://user-images.githubusercontent.com/374655/175561245-a943962a-b78e-431c-a77f-09d1dd57c710.png)

</details>


