### PR TITLE
Add `alert` role to notifications so they're automatically spoken by screen readers.

### DIFF
--- a/core/modules/utils/dom/notifier.js
+++ b/core/modules/utils/dom/notifier.js
@@ -36,8 +36,9 @@ Notifier.prototype.display = function(title,options) {
 	if(!tiddler) {
 		return;
 	}
-	// Add classes
+	// Add classes and roles
 	$tw.utils.addClass(notification,"tc-notification");
+	notification.setAttribute("role","alert");
 	// Create the variables
 	var variables = $tw.utils.extend({currentTiddler: title},options.variables);
 	// Render the body of the notification


### PR DESCRIPTION
Sorry, this probably should have been in my previous PR--I thought it might require an additional DOM element and that the region might not present on first write. It didn't, however.

This just adds the `alert` role so my screen reader automatically speaks save notifications and such.