### PR TITLE
Add storyTiddler to render command

### DIFF
--- a/core/modules/commands/render.js
+++ b/core/modules/commands/render.js
@@ -50,7 +50,7 @@ Render individual tiddlers and save the results to the specified files
 				console.log("Rendering \"" + title + "\" to \"" + filepath + "\"");
 			}
 			var parser = wiki.parseTiddler(template || title),
-				widgetNode = wiki.makeWidget(parser,{variables: $tw.utils.extend({},variables,{currentTiddler: title})}),
+				widgetNode = wiki.makeWidget(parser,{variables: $tw.utils.extend({},variables,{currentTiddler: title,storyTiddler: title})}),
 				container = $tw.fakeDocument.createElement("div");
 			widgetNode.render(container,null);
 			var text = type === "text/html" ? container.innerHTML : container.textContent;

--- a/core/modules/commands/rendertiddler.js
+++ b/core/modules/commands/rendertiddler.js
@@ -40,6 +40,7 @@ Command.prototype.execute = function() {
 	$tw.utils.createFileDirectories(filename);
 	if(template) {
 		variables.currentTiddler = title;
+		variables.storyTiddler = title;
 		title = template;
 	}
 	if(name && value) {

--- a/core/modules/commands/rendertiddlers.js
+++ b/core/modules/commands/rendertiddlers.js
@@ -46,7 +46,7 @@ Command.prototype.execute = function() {
 	}
 	$tw.utils.each(tiddlers,function(title) {
 		var parser = wiki.parseTiddler(template),
-			widgetNode = wiki.makeWidget(parser,{variables: {currentTiddler: title}}),
+			widgetNode = wiki.makeWidget(parser,{variables: {currentTiddler: title, storyTiddler: title}}),
 			container = $tw.fakeDocument.createElement("div");
 		widgetNode.render(container,null);
 		var text = type === "text/html" ? container.innerHTML : container.textContent,


### PR DESCRIPTION
Enable transclusion to get the title of the currently rendered Tiddler, for example, it can be used on the banner of TiddlyWiki static pages to jump to specific pages. Of course I can implement this if needed.