### PR TITLE
Update version-macros.tid

### DIFF
--- a/editions/tw5.com/tiddlers/system/version-macros.tid
+++ b/editions/tw5.com/tiddlers/system/version-macros.tid
@@ -5,7 +5,7 @@ title: $:/editions/tw5.com/version-macros
 type: text/vnd.tiddlywiki
 
 \define .from-version(version)
-<span class="doc-from-version">{{$:/core/images/warning}} New in: $version$</span>
+<$button to={{{ [[Release $version$]] }}} class="doc-from-version">{{$:/core/images/warning}} New in: $version$</$button>
 \end
 
 \define .deprecated-since(version, superseded:"TODO-Link")


### PR DESCRIPTION
Documentation macro improvement.

Replace the SPAN used in the .from-version macro with the $button widget to navigate to the release notes
to={{{ [[Release $version$]] }}}

This allows one to click the version pill and open the relevant release notes.