### PR TITLE
Fix svg foreignObject that contains DIVs

### DIFF
--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -51,7 +51,12 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	if(this.namespace) {
 		this.setVariable("namespace",this.namespace);
 	} else {
-		this.namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"});
+		if (this.attributes.xmlns) {
+			this.namespace = this.attributes.xmlns;
+			this.setVariable("namespace",this.namespace);
+		} else {
+			this.namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"});
+		}
 	}
 	// Invoke the th-rendering-element hook
 	var parseTreeNodes = $tw.hooks.invokeHook("th-rendering-element",null,this);

--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -55,7 +55,7 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 			this.namespace = this.attributes.xmlns;
 			this.setVariable("namespace",this.namespace);
 		} else {
-			this.namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"});
+			this.namespace = this.getVariable("namespace",{defaultValue: tagNamespaces.body});
 		}
 	}
 	// Invoke the th-rendering-element hook


### PR DESCRIPTION
The existing v5.2.2 code checks if a `svg, math or body` element are created and sets a `namespace` variable accordingly. This value is then inherited by _all_ child elements. It doesn't check, if any child element contains a "xmlns" attribute that tries to switch the `namespace`. 

The new code checks, if any child element (DIV) of the eg: `foreignObject` contains a `xmlns` attribute. If this attribute is found it is used and the variable `namespace` is set accordingly, to cover nested html elements. 

With the new code the `xmlns` attribute will take precedence. 

There will be a second PR, with the new tests, that test _all_ the nested IF code paths and makes sure that future changes will be tested. 

I did test the new code with Windows 11 FF 102 and Edge Version 103.0.1264.44

To reproduce with TW v5.2.2

- Create a new tiddler with the following  code
- Click the "preview" button or "done"

```
<svg width="260px" height="260px"><circle cx="150" cy="150" r="100" fill="lightblue" stoke="red"/><foreignObject x="70" y="110" width="150" height="180"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a [[link to a tiddler|HelloThere]].</div></foreignObject><circle cx="250" cy="150" r="10" fill="blue" stoke="red"/></svg>
```

It looks like this: 

![image](https://user-images.githubusercontent.com/374655/177328361-8557e2c5-72c3-4198-96e7-7b504df3051a.png)

After the PR is merged it looks like this as it should be. 

![image](https://user-images.githubusercontent.com/374655/177328610-8fbee72d-caba-4ec9-8ae8-684c5222f3b7.png)
