### PR TITLE
Svg foreign object failing test

### DIFF
--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -172,7 +172,7 @@ describe("Widget module", function() {
 		expect(wrapper.firstChild.namespaceURI).toBe("http://www.w3.org/2000/svg");
 	});
 
-	it("should deal with foreignObject in SVG elements", function() {
+	it("should deal with foreignObject in SVG elements defined in elements.js", function() {
 		var wiki = new $tw.Wiki();
 		// Construct the widget node
 		var text = '<svg width="260px" height="260px"><circle cx="150" cy="150" r="100" fill="lightblue" stoke="red"/><foreignObject x="70" y="110" width="150" height="180"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a [[link to a tiddler|HelloThere]].</div></foreignObject></svg>\n';
@@ -181,9 +181,27 @@ describe("Widget module", function() {
 		var wrapper = renderWidgetNode(widgetNode);
 		// Test the rendering
 		expect(wrapper.innerHTML).toBe('<svg height="260px" width="260px"><circle cx="150" cy="150" fill="lightblue" r="100" stoke="red"></circle><foreignObject height="180" width="150" x="70" y="110"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a <a class="tc-tiddlylink tc-tiddlylink-missing" href="#HelloThere">link to a tiddler</a>.</div></foreignObject></svg>\n');
-		expect(wrapper.firstChild.namespaceURI).toBe("http://www.w3.org/2000/svg");
-		// first DIV in foreignObject needs to be HTML NS
-		expect(wrapper.firstChild.children[1].firstChild.namespaceURI).toBe("http://www.w3.org/1999/xhtml");
+
+		var SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+		var HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+
+		// SVG is the first child of the wrapper element. The namespace is defined by element.js widget code
+		expect(wrapper.firstChild.tag).toBe("svg");
+		expect(wrapper.firstChild.namespaceURI).toBe(SVG_NAMESPACE);
+
+		// child 0 should be "circle" and it should inherit namespaceURI from SVG parent
+		// code-path with `this.getVariable("namespace",` is tested
+		expect(wrapper.firstChild.children[0].tag).toBe("circle");
+		expect(wrapper.firstChild.children[0].namespaceURI).toBe(SVG_NAMESPACE);
+		
+		// child 1 should be "foreignObject" and it should inherit namespaceURI from SVG parent
+		expect(wrapper.firstChild.children[1].tag).toBe("foreignObject");
+		expect(wrapper.firstChild.children[1].namespaceURI).toBe(SVG_NAMESPACE);
+		
+		// first DIV in foreignObject needs to be HTML NS because of its XMLNS attribute
+		// fixed in v5.2.3
+		expect(wrapper.firstChild.children[1].firstChild.tag).toBe("div");
+		expect(wrapper.firstChild.children[1].firstChild.namespaceURI).toBe(HTML_NAMESPACE);
 	});
 
 	it("should parse and render transclusions", function() {

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -172,6 +172,20 @@ describe("Widget module", function() {
 		expect(wrapper.firstChild.namespaceURI).toBe("http://www.w3.org/2000/svg");
 	});
 
+	it("should deal with foreignObject in SVG elements", function() {
+		var wiki = new $tw.Wiki();
+		// Construct the widget node
+		var text = '<svg width="260px" height="260px"><circle cx="150" cy="150" r="100" fill="lightblue" stoke="red"/><foreignObject x="70" y="110" width="150" height="180"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a [[link to a tiddler|HelloThere]].</div></foreignObject></svg>\n';
+		var widgetNode = createWidgetNode(parseText(text,wiki,{parseAsInline:true}),wiki);
+		// Render the widget node to the DOM
+		var wrapper = renderWidgetNode(widgetNode);
+		// Test the rendering
+		expect(wrapper.innerHTML).toBe('<svg height="260px" width="260px"><circle cx="150" cy="150" fill="lightblue" r="100" stoke="red"></circle><foreignObject height="180" width="150" x="70" y="110"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a <a class="tc-tiddlylink tc-tiddlylink-missing" href="#HelloThere">link to a tiddler</a>.</div></foreignObject></svg>\n');
+		expect(wrapper.firstChild.namespaceURI).toBe("http://www.w3.org/2000/svg");
+		// first DIV in foreignObject needs to be HTML NS
+		expect(wrapper.firstChild.children[1].firstChild.namespaceURI).toBe("http://www.w3.org/1999/xhtml");
+	});
+
 	it("should parse and render transclusions", function() {
 		var wiki = new $tw.Wiki();
 		// Add a tiddler

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -175,12 +175,12 @@ describe("Widget module", function() {
 	it("should deal with foreignObject in SVG elements defined in elements.js", function() {
 		var wiki = new $tw.Wiki();
 		// Construct the widget node
-		var text = '<svg width="260px" height="260px"><circle cx="150" cy="150" r="100" fill="lightblue" stoke="red"/><foreignObject x="70" y="110" width="150" height="180"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a [[link to a tiddler|HelloThere]].</div></foreignObject><circle cx="250" cy="150" r="10" fill="blue" stoke="red"/></svg>\n';
+		var text = '<svg width="260px" height="260px"><circle cx="150" cy="150" r="100" fill="lightblue" stoke="red"/><foreignObject x="70" y="110" width="150" height="180"><div xmlns="http://www.w3.org/1999/xhtml">A [[link to a tiddler|HelloThere]].</div></foreignObject><circle cx="250" cy="150" r="10" fill="blue" stoke="red"/></svg>\n';
 		var widgetNode = createWidgetNode(parseText(text,wiki,{parseAsInline:true}),wiki);
 		// Render the widget node to the DOM
 		var wrapper = renderWidgetNode(widgetNode);
 		// Test the rendering
-		expect(wrapper.innerHTML).toBe('<svg height="260px" width="260px"><circle cx="150" cy="150" fill="lightblue" r="100" stoke="red"></circle><foreignObject height="180" width="150" x="70" y="110"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a <a class="tc-tiddlylink tc-tiddlylink-missing" href="#HelloThere">link to a tiddler</a>.</div></foreignObject><circle cx="250" cy="150" fill="blue" r="10" stoke="red"></circle></svg>\n');
+		expect(wrapper.innerHTML).toBe('<svg height="260px" width="260px"><circle cx="150" cy="150" fill="lightblue" r="100" stoke="red"></circle><foreignObject height="180" width="150" x="70" y="110"><div xmlns="http://www.w3.org/1999/xhtml">A <a class="tc-tiddlylink tc-tiddlylink-missing" href="#HelloThere">link to a tiddler</a>.</div></foreignObject><circle cx="250" cy="150" fill="blue" r="10" stoke="red"></circle></svg>\n');
 
 		var SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 		var HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -175,12 +175,12 @@ describe("Widget module", function() {
 	it("should deal with foreignObject in SVG elements defined in elements.js", function() {
 		var wiki = new $tw.Wiki();
 		// Construct the widget node
-		var text = '<svg width="260px" height="260px"><circle cx="150" cy="150" r="100" fill="lightblue" stoke="red"/><foreignObject x="70" y="110" width="150" height="180"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a [[link to a tiddler|HelloThere]].</div></foreignObject></svg>\n';
+		var text = '<svg width="260px" height="260px"><circle cx="150" cy="150" r="100" fill="lightblue" stoke="red"/><foreignObject x="70" y="110" width="150" height="180"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a [[link to a tiddler|HelloThere]].</div></foreignObject><circle cx="250" cy="150" r="10" fill="blue" stoke="red"/></svg>\n';
 		var widgetNode = createWidgetNode(parseText(text,wiki,{parseAsInline:true}),wiki);
 		// Render the widget node to the DOM
 		var wrapper = renderWidgetNode(widgetNode);
 		// Test the rendering
-		expect(wrapper.innerHTML).toBe('<svg height="260px" width="260px"><circle cx="150" cy="150" fill="lightblue" r="100" stoke="red"></circle><foreignObject height="180" width="150" x="70" y="110"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a <a class="tc-tiddlylink tc-tiddlylink-missing" href="#HelloThere">link to a tiddler</a>.</div></foreignObject></svg>\n');
+		expect(wrapper.innerHTML).toBe('<svg height="260px" width="260px"><circle cx="150" cy="150" fill="lightblue" r="100" stoke="red"></circle><foreignObject height="180" width="150" x="70" y="110"><div xmlns="http://www.w3.org/1999/xhtml">Here is some text that requires a word wrap, and includes a <a class="tc-tiddlylink tc-tiddlylink-missing" href="#HelloThere">link to a tiddler</a>.</div></foreignObject><circle cx="250" cy="150" fill="blue" r="10" stoke="red"></circle></svg>\n');
 
 		var SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 		var HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
@@ -198,10 +198,16 @@ describe("Widget module", function() {
 		expect(wrapper.firstChild.children[1].tag).toBe("foreignObject");
 		expect(wrapper.firstChild.children[1].namespaceURI).toBe(SVG_NAMESPACE);
 		
-		// first DIV in foreignObject needs to be HTML NS because of its XMLNS attribute
-		// fixed in v5.2.3
-		expect(wrapper.firstChild.children[1].firstChild.tag).toBe("div");
-		expect(wrapper.firstChild.children[1].firstChild.namespaceURI).toBe(HTML_NAMESPACE);
+			// first DIV in foreignObject needs to be HTML NS because of its XMLNS attribute
+			// fixed in v5.2.3
+			expect(wrapper.firstChild.children[1].firstChild.tag).toBe("div");
+			expect(wrapper.firstChild.children[1].firstChild.namespaceURI).toBe(HTML_NAMESPACE);
+
+		// child 2 should be second "circle" and it should inherit namespaceURI from SVG parent
+		// Just to be sure, that no namespace variables leak
+		expect(wrapper.firstChild.children[2].tag).toBe("circle");
+		expect(wrapper.firstChild.children[2].namespaceURI).toBe(SVG_NAMESPACE);
+
 	});
 
 	it("should parse and render transclusions", function() {


### PR DESCRIPTION
This PR is related to:  Fix svg foreignObject that contains DIVs #6755 

This test **fails** if it is used with TW **v5.2.2**. ... It passes if the code from PR #6755 is active

It fails with 

```
Failures:
1) Widget module should deal with foreignObject in SVG elements defined in elements.js
  Message:
    Expected 'http://www.w3.org/2000/svg' to be 'http://www.w3.org/1999/xhtml'.
  Stack:
```

because the `<div xmlns="http://www.w3.org/1999/xhtml" ... >`  is ignored with v5.2.2 code. 

The new tests will make sure that all `if` code paths are executed 