### PR TITLE
Add emptyMessage to list-links-draggable and correct docs

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -22,12 +22,12 @@ tags: $:/tags/Macro
 <$action-listops $tiddler=<<targetTiddler>> $field=<<targetField>> $subfilter="+[insertbefore<actionTiddler>,<currentTiddler>]"/>
 \end
 
-\define list-links-draggable(tiddler,field:"list",type:"ul",subtype:"li",class:"",itemTemplate)
+\define list-links-draggable(tiddler,field:"list",emptyMessage,type:"ul",subtype:"li",class:"",itemTemplate)
 \whitespace trim
 <span class="tc-links-draggable-list">
 <$vars targetTiddler="""$tiddler$""" targetField="""$field$""">
 <$type$ class="$class$">
-<$list filter="[list[$tiddler$!!$field$]]">
+<$list filter="[list[$tiddler$!!$field$]]" emptyMessage=<<__emptyMessage__>>>
 <$droppable actions=<<list-links-draggable-drop-actions>> tag="""$subtype$""" enable=<<tv-enable-drag-and-drop>>>
 <div class="tc-droppable-placeholder"/>
 <div>

--- a/editions/tw5.com/tiddlers/macros/list-links-draggable Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/list-links-draggable Macro.tid
@@ -13,6 +13,8 @@ The <<.def list-links-draggable>> [[macro|Macros]] renders the ListField of a ti
 : The title of the tiddler containing the list
 ;field
 : The name of the field containing the list (defaults to `list`)
+;emptyMessage
+: Optional wikitext to display if there is no output (tiddler is not existed, field is not existed or empty)
 ;type
 : The element tag to use for the list wrapper (defaults to `ul`)
 ;subtype


### PR DESCRIPTION
This PR fixes the issue https://github.com/Jermolene/TiddlyWiki5/issues/6458.

To be included in #6765 and merged in TW5.2.3 release.