### PR TITLE
Show stylesheets as rendered plain text

### DIFF
--- a/core/ui/ViewTemplate/body/rendered-plain-text.tid
+++ b/core/ui/ViewTemplate/body/rendered-plain-text.tid
@@ -1,0 +1,10 @@
+title: $:/core/ui/ViewTemplate/body/rendered-plain-text
+
+\whitespace trim
+<$wikify name="text" text={{!!text}} type={{!!type}}>
+<pre>
+<code>
+<$text text=<<text>>/>
+</code>
+</pre>
+</$wikify>

--- a/core/wiki/config/ViewTemplateBodyFilters.multids
+++ b/core/wiki/config/ViewTemplateBodyFilters.multids
@@ -1,6 +1,7 @@
 title: $:/config/ViewTemplateBodyFilters/
 tags: $:/tags/ViewTemplateBodyFilter
 
+stylesheet: [tag[$:/tags/Stylesheet]then[$:/core/ui/ViewTemplate/body/rendered-plain-text]]
 system: [prefix[$:/boot/]] [prefix[$:/config/]] [prefix[$:/core/macros]] [prefix[$:/core/save/]] [prefix[$:/core/templates/]] [prefix[$:/core/ui/]split[/]count[]compare:number:eq[4]] [prefix[$:/info/]] [prefix[$:/language/]] [prefix[$:/languages/]] [prefix[$:/snippets/]] [prefix[$:/state/]] [prefix[$:/status/]] [prefix[$:/info/]] [prefix[$:/temp/]] +[!is[image]limit[1]then[$:/core/ui/ViewTemplate/body/code]]
 code-body: [field:code-body[yes]then[$:/core/ui/ViewTemplate/body/code]]
 import: [field:plugin-type[import]then[$:/core/ui/ViewTemplate/body/import]]

--- a/core/wiki/tags/ViewTemplateBodyFilter.tid
+++ b/core/wiki/tags/ViewTemplateBodyFilter.tid
@@ -1,3 +1,3 @@
 title: $:/tags/ViewTemplateBodyFilter
-list: $:/config/ViewTemplateBodyFilters/system $:/config/ViewTemplateBodyFilters/code-body $:/config/ViewTemplateBodyFilters/import $:/config/ViewTemplateBodyFilters/plugin $:/config/ViewTemplateBodyFilters/hide-body $:/config/ViewTemplateBodyFilters/default
+list: $:/config/ViewTemplateBodyFilters/stylesheet $:/config/ViewTemplateBodyFilters/system $:/config/ViewTemplateBodyFilters/code-body $:/config/ViewTemplateBodyFilters/import $:/config/ViewTemplateBodyFilters/plugin $:/config/ViewTemplateBodyFilters/hide-body $:/config/ViewTemplateBodyFilters/default
 

--- a/editions/tw5.com/tiddlers/_tw_shared/styles.tid
+++ b/editions/tw5.com/tiddlers/_tw_shared/styles.tid
@@ -1,6 +1,5 @@
 title: $:/_tw_shared/styles
 tags: $:/tags/Stylesheet TiddlyWikiSitesMenu
-code-body: yes
 
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock
 

--- a/editions/tw5.com/tiddlers/demonstrations/CustomStoryTiddlerTemplateDemo.tid/Styles.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/CustomStoryTiddlerTemplateDemo.tid/Styles.tid
@@ -1,6 +1,5 @@
 title: $:/_tw5.com/CustomStoryTiddlerTemplateDemo/Styles
 tags: $:/tags/Stylesheet
-code-body: yes
 
 .tc-custom-tiddler-template {
 	border: 3px solid <<colour muted-foreground>>;

--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -1,4 +1,3 @@
-code-body: yes
 created: 20150117152612000
 modified: 20220617125128201
 tags: $:/tags/Stylesheet

--- a/plugins/tiddlywiki/katex/styles.tid
+++ b/plugins/tiddlywiki/katex/styles.tid
@@ -1,6 +1,5 @@
 title: $:/plugins/tiddlywiki/katex/styles
 tags: [[$:/tags/Stylesheet]]
-code-body: yes
 
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline
 


### PR DESCRIPTION
As discussed [here](https://github.com/Jermolene/TiddlyWiki5/discussions/6772#discussioncomment-3138205), it is proposed to change the default view template body for stylesheets to show their rendered output as plain text.

At the moment, the raw text of stylesheets is displayed (ie including macros and other wikitext):

<img width="944" alt="image" src="https://user-images.githubusercontent.com/174761/178764045-891a8001-7142-4ea3-842d-ae0164bd426a.png">

With this PR, the same stylesheet looks like this:

<img width="843" alt="image" src="https://user-images.githubusercontent.com/174761/178764262-28f2092c-61c5-45f0-9af1-6beef9936a3e.png">

This is the same display format that is used in control panel -> info -> advanced -> stylesheets.

I think that the rendered view is useful because it makes it easier to see what the browser is actually seeing, but I recognise that it is non-backwards compatible change so I've prepared this PR for discussion.

