### PR TITLE
Improve Contributors Section in Release Tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/system/doc-macros.tid
+++ b/editions/tw5.com/tiddlers/system/doc-macros.tid
@@ -172,13 +172,11 @@ $credit$
 \end
 
 \define .contributors(usernames)
-<ol class="doc-github-contributors">
+<section class="doc-github-contributors">
 <$list filter="[enlist<__usernames__>sort[]]" variable="username">
-<li>
-<a href={{{ [[https://github.com/]addsuffix<username>] }}} class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><img src={{{ [[https://github.com/]addsuffix<username>addsuffix[.png?size=24]] }}} width="24" height="24"/><span class="doc-github-contributor-username"> @<$text text=<<username>>/></span></a>
-</li>
+<a href={{{ [[https://github.com/]addsuffix<username>] }}} class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><img src={{{ [[https://github.com/]addsuffix<username>addsuffix[.png?size=64]] }}} width="64" height="64"/><span class="doc-github-contributor-username">@<$text text=<<username>>/></span></a>
 </$list>
-</ol>
+</section>
 \end
 
 <pre><$view field="text"/></pre>

--- a/editions/tw5.com/tiddlers/system/doc-macros.tid
+++ b/editions/tw5.com/tiddlers/system/doc-macros.tid
@@ -172,11 +172,13 @@ $credit$
 \end
 
 \define .contributors(usernames)
-<section class="doc-github-contributors">
+<ol class="doc-github-contributors">
 <$list filter="[enlist<__usernames__>sort[]]" variable="username">
+<li>
 <a href={{{ [[https://github.com/]addsuffix<username>] }}} class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><img src={{{ [[https://github.com/]addsuffix<username>addsuffix[.png?size=64]] }}} width="64" height="64"/><span class="doc-github-contributor-username">@<$text text=<<username>>/></span></a>
+</li>
 </$list>
-</section>
+</ol>
 \end
 
 <pre><$view field="text"/></pre>

--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -252,19 +252,31 @@ a.doc-deprecated-version.tc-tiddlylink {
 		<<box-shadow "1px 1px 6px rgba(0, 0, 0, 0.6)">>
 	}
 }
-
-.doc-github-contributors {
-	list-style: none;
+.doc-github-contributors{
+display: flex;
+flex-wrap: wrap;
 }
-
 .doc-github-contributors a {
-	text-decoration: none;
-	font-size: 14px;
-	line-height: 18px;
-	vertical-align: baseline;
+display: flex;
+justify-content: center;
+align-items: center;
+flex-direction:column;
+width:82px;
+height:82px;
+margin:3px 3px 10px 3px;
+text-decoration:none;
+}
+.doc-github-contributors a img{ 
+border-radius: 50%; 
+background:#eee;
+}
+.doc-github-contributors a .doc-github-contributor-username {
+font-size:12px;
+font-weight:500;
+text-align:center;
+width:75px;
+white-space: nowrap;
+overflow: hidden;
+text-overflow: ellipsis;
 }
 
-.doc-github-contributors a img,
-.doc-github-contributors a .doc-github-contributor-username {
-	vertical-align: middle;
-}

--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -252,31 +252,33 @@ a.doc-deprecated-version.tc-tiddlylink {
 		<<box-shadow "1px 1px 6px rgba(0, 0, 0, 0.6)">>
 	}
 }
-.doc-github-contributors{
-display: flex;
-flex-wrap: wrap;
+.doc-github-contributors {
+	list-style: none;
+	display: flex;
+	flex-wrap: wrap;
 }
-.doc-github-contributors a {
-display: flex;
-justify-content: center;
-align-items: center;
-flex-direction:column;
-width:82px;
-height:82px;
-margin:3px 3px 10px 3px;
-text-decoration:none;
+ol.doc-github-contributors li {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction:column;
+	width:82px;
+	height:82px;
+	margin:3px 3px 10px 3px;
+	text-decoration:none;
 }
-.doc-github-contributors a img{ 
-border-radius: 50%; 
-background:#eee;
+.doc-github-contributors a img { 
+	border-radius: 50%; 
+	background:#eee;
 }
-.doc-github-contributors a .doc-github-contributor-username {
-font-size:12px;
-font-weight:500;
-text-align:center;
-width:75px;
-white-space: nowrap;
-overflow: hidden;
-text-overflow: ellipsis;
+.doc-github-contributor-username {
+	display:inline-block;
+	font-size:12px;
+	font-weight:500;
+	text-align:center;
+	width:75px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
This PR addresses the issue https://github.com/Jermolene/TiddlyWiki5/issues/6784
for a contributor section to looks more professional 

I tried to use the smallest CSS and do not touch the macro as much as possible.
For example I did not added a div, but used `a` as a block element.