### PR TITLE
Fix: restore drag and drop on mobile chrome

### DIFF
--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -107,8 +107,9 @@ exports.makeDraggable = function(options) {
 					dataTransfer.setData("text/vnd.tiddler",jsonData);
 					dataTransfer.setData("text/plain",titleString);
 					dataTransfer.setData("text/x-moz-url","data:text/vnd.tiddler," + encodeURIComponent(jsonData));
+				} else {
+					dataTransfer.setData("URL","data:text/vnd.tiddler," + encodeURIComponent(jsonData));
 				}
-				dataTransfer.setData("URL","data:text/vnd.tiddler," + encodeURIComponent(jsonData));
 				dataTransfer.setData("Text",titleString);
 				event.stopPropagation();
 			}


### PR DESCRIPTION
This PR restores drag and drop behaviour in mobile Chrome by only assigning the URL data type on IE.

Tested on:
* Ubuntu and Windows 10 with the latest Firefox, Chrome and IE11
* OSX with Safari and Chrome
* iPhone and the latest Chrome and Safari

**Some iPad testing would be appreciated.** 

Test file:
https://saqimtiaz.github.io/sq-tw/temp/dnd-fix.html

Fixes #6617 