### PR TITLE
Add tiddly-wiki-server to TiddlyWeb implementors

### DIFF
--- a/editions/tw5.com/tiddlers/definitions/TiddlyWeb.tid
+++ b/editions/tw5.com/tiddlers/definitions/TiddlyWeb.tid
@@ -15,5 +15,6 @@ Other implementations of the API include:
 
 * [[TiddlyWiki App Engine Server|https://github.com/rsc/tiddly]], a 300-line Go implementation from Russ Cox
 * [[TiddlyWiki 5 server module|https://github.com/Jermolene/TiddlyWiki5/blob/master/core/modules/commands/server.js]], the bare-bones subset of the API implemented in TiddlyWiki version 5 for Node.js
+* [[tiddly-wiki-server|https://github.com/nathanielknight/tiddly-wiki-server]], an implementation based on Rust and SQLite
 
 As of early 2017, none is currently as complete as TiddlyWeb itself.


### PR DESCRIPTION
Add [tiddly-wiki-server](https://github.com/nathanielknight/tiddly-wiki-server) to the [list of TiddlyWeb](https://tiddlywiki.com/#TiddlyWeb) implementors.

Tiddly-Wiki server uses SQLite as a backing datastore and is implemented in Rust. It's designed to have a much smaller memory footprint than the existing NodeJS based back-end; as one might expect, it compromises on some other features.