### PR TITLE
Image lazy loading

### DIFF
--- a/core/modules/widgets/image.js
+++ b/core/modules/widgets/image.js
@@ -111,6 +111,9 @@ ImageWidget.prototype.render = function(parent,nextSibling) {
 	if(this.imageAlt) {
 		domNode.setAttribute("alt",this.imageAlt);
 	}
+	if(this.lazyLoading && tag === "img") {
+		domNode.setAttribute("loading",this.lazyLoading);
+	}
 	// Add classes when the image loads or fails
 	$tw.utils.addClass(domNode,"tc-image-loading");
 	domNode.addEventListener("load",function() {
@@ -137,6 +140,7 @@ ImageWidget.prototype.execute = function() {
 	this.imageClass = this.getAttribute("class");
 	this.imageTooltip = this.getAttribute("tooltip");
 	this.imageAlt = this.getAttribute("alt");
+	this.lazyLoading = this.getAttribute("loading");
 };
 
 /*

--- a/editions/tw5.com/tiddlers/widgets/ImageWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ImageWidget.tid
@@ -1,8 +1,9 @@
-title: ImageWidget
-created: 20140416160234142
-modified: 20220101205921813
-tags: Widgets
 caption: image
+created: 20140416160234142
+modified: 20220721101822882
+tags: Widgets
+title: ImageWidget
+type: text/vnd.tiddlywiki
 
 ! Introduction
 
@@ -19,6 +20,7 @@ Any content of the `<$image>` widget is ignored.
 |tooltip |The tooltip to be displayed over the image |
 |alt |The alternative text to be associated with the image |
 |class |CSS classes to be assigned to the `<img>` element |
+|loading|Optional. Set to `lazy` to enable lazy loading of images loaded from an external URI |
 
 The width and the height can be specified as pixel values (eg "23" or "23px") or percentages (eg "23%"). They are both optional; if not provided the browser will use CSS rules to size the image.
 

--- a/editions/tw5.com/tiddlers/widgets/ImageWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ImageWidget.tid
@@ -1,6 +1,6 @@
 caption: image
 created: 20140416160234142
-modified: 20220721101822882
+modified: 20220721102303815
 tags: Widgets
 title: ImageWidget
 type: text/vnd.tiddlywiki
@@ -20,7 +20,7 @@ Any content of the `<$image>` widget is ignored.
 |tooltip |The tooltip to be displayed over the image |
 |alt |The alternative text to be associated with the image |
 |class |CSS classes to be assigned to the `<img>` element |
-|loading|Optional. Set to `lazy` to enable lazy loading of images loaded from an external URI |
+|loading|<<.from-version "5.2.3">>Optional. Set to `lazy` to enable lazy loading of images loaded from an external URI |
 
 The width and the height can be specified as pixel values (eg "23" or "23px") or percentages (eg "23%"). They are both optional; if not provided the browser will use CSS rules to size the image.
 


### PR DESCRIPTION
This PR extends the $image widget with support for the attribute `loading` which can be set to `lazy` to enable browser based lazy loading for images loaded from an external URI.

Unfortunately lazy loading does not seem to work for embedded base64 images.