### PR TITLE
Add description and examples comparing :map vs. :map:flat

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210618134753828
-modified: 20220720191457421
+modified: 20220723142748506
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Map Filter Run Prefix]]
 title: Map Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -20,12 +20,24 @@ Get the tags of all tiddlers tagged `Widget:`
 <<.operator-example 3 "[tag[Widgets]] :map:flat[tagging[]] :and[!is[blank]unique[]]">>
 <<.tip "Without the `flat` suffix the `:map` filter run only returns the first result for each input title">>
 
+!! Comparison between `:map` and `:map:flat` filter run prefixes
+
+The `:map` filter run prefix provides a subset of the `:map:flat` functionality. The `:map` filter run behaves as if a call to the [[first operator|first Operator]] is automatically added to the end of a `:map:flat` filter run. The `:map` run will always have the same number of outputs as inputs. Within the run the number of items can increase, but only the first item will be returned as output. The `:map:flat` run will always return at least as many outputs as inputs. However, since it does not have the implicit call to [[first|first Operator]] it can increase the number of outputs compared to the number of inputs.
+
+| `:map:flat` | `:map` |
+|^<<.operator-example m1.1 "[range[4]] :map:flat[range<currentTiddler>]">>|^<<.operator-example m1.2 "[range[4]] :map[range<currentTiddler>]">>|
+|^<<.operator-example m2.1 "[range[4]] :map:flat[range<currentTiddler>first[]]">>|^<<.operator-example m2.2 "[range[4]] :map[range<currentTiddler>]">>|
+|^<<.operator-example m3.1 "[range[4]] :map:flat[range<currentTiddler>sum[]]">>|^<<.operator-example m3.2 "[range[4]] :map[range<currentTiddler>sum[]]">>|
+|^<<.operator-example m4.1 "[[1,2,3]] [[4,5]] :map:flat[split[,]]">>|^<<.operator-example m4.2 "[[1,2,3]] [[4,5]] :map[split[,]]">>|
+|^<<.operator-example m5.1 "[[1,2,3]] [[4,5]] :map:flat[split[,]first[]]">>|^<<.operator-example m5.2 "[[1,2,3]] [[4,5]] :map[split[,]]">>|
+
+
 !! Comparison between `:map` and `:and`/`+` filter run prefixes
 
 The functionality of the `:map` filter run prefix has some overlap with the `:and` prefix (alias `+`). They will sometimes return the same results as each other. In at least these cases, the results will be different:
 
 # The `:and` filter run can modify the number of items (either increase or decrease). The `:map` run will never alter the number of items.
-# The number of items in the `:and` filter run will also decrease due to de-duplication. The `:map` run will not de-duplicate.
+# The number of items in the `:and` filter run will also decrease due to [[de-duplication|Dominant Append]]. The `:map` run will not [[de-duplicate|Dominant Append]].
 # Explicit references to the "currentTiddler" variable will behave differently
 # Implicit references to the "currentTiddler" using TextReference will behave differently.
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210618134753828
-modified: 20220724133254215
+modified: 20220724162340642
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Map Filter Run Prefix]]
 title: Map Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -23,8 +23,6 @@ Get the tags of all tiddlers tagged `Widget:`
 !! Comparison between `:map` with and without the `flat` suffix
 
 The `:map` filter run will return at least as many outputs as given in the input.  By default one input item will result in exactly one output item. When the filter run transforms an input item into an empty result, the output for that item will be an empty string. When the filter run transforms an input item into multiple items, only the first item will appear in the output. This behavior can be overridden by providing the `flat` suffix. The `flat` suffix will cause all the items to appear in the output.
-
-Any `:map` filter run can be expressed with `:map:flat` by adding a call to the [[first operator|first Operator]] at the end of the filter run.
 
 | `:map` | `:map:flat` |
 |^<<.operator-example m0.1 "[range[4]] :map[match[this matches nothing]]">>|^<<.operator-example m0.2 "[range[4]] :map:flat[match[this matches nothing]]">>|

--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210618134753828
-modified: 20220724132428241
+modified: 20220724133254215
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Map Filter Run Prefix]]
 title: Map Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -26,13 +26,13 @@ The `:map` filter run will return at least as many outputs as given in the input
 
 Any `:map` filter run can be expressed with `:map:flat` by adding a call to the [[first operator|first Operator]] at the end of the filter run.
 
-| `:map:flat` | `:map` |
-|^<<.operator-example m0.1 "[range[4]] :map:flat[match[this matches nothing]]">>|^<<.operator-example m0.2 "[range[4]] :map[match[this matches nothing]]">>|
-|^<<.operator-example m1.1 "[range[4]] :map:flat[range<currentTiddler>]">>|^<<.operator-example m1.2 "[range[4]] :map[range<currentTiddler>]">>|
-|^<<.operator-example m2.1 "[range[4]] :map:flat[range<currentTiddler>first[]]">>|^<<.operator-example m2.2 "[range[4]] :map[range<currentTiddler>]">>|
-|^<<.operator-example m3.1 "[range[4]] :map:flat[range<currentTiddler>sum[]]">>|^<<.operator-example m3.2 "[range[4]] :map[range<currentTiddler>sum[]]">>|
-|^<<.operator-example m4.1 "[[1,2,3]] [[4,5]] :map:flat[split[,]]">>|^<<.operator-example m4.2 "[[1,2,3]] [[4,5]] :map[split[,]]">>|
-|^<<.operator-example m5.1 "[[1,2,3]] [[4,5]] :map:flat[split[,]first[]]">>|^<<.operator-example m5.2 "[[1,2,3]] [[4,5]] :map[split[,]]">>|
+| `:map` | `:map:flat` |
+|^<<.operator-example m0.1 "[range[4]] :map[match[this matches nothing]]">>|^<<.operator-example m0.2 "[range[4]] :map:flat[match[this matches nothing]]">>|
+|^<<.operator-example m1.1 "[range[4]] :map[range<currentTiddler>]">>|^<<.operator-example m1.2 "[range[4]] :map:flat[range<currentTiddler>]">>|
+|^<<.operator-example m2.1 "[range[4]] :map[range<currentTiddler>]">>|^<<.operator-example m2.2 "[range[4]] :map:flat[range<currentTiddler>first[]]">>|
+|^<<.operator-example m3.1 "[range[4]] :map[range<currentTiddler>sum[]]">>|^<<.operator-example m3.2 "[range[4]] :map:flat[range<currentTiddler>sum[]]">>|
+|^<<.operator-example m4.1 "[[1,2,3]] [[4,5]] :map[split[,]]">>|^<<.operator-example m4.2 "[[1,2,3]] [[4,5]] :map:flat[split[,]]">>|
+|^<<.operator-example m5.1 "[[1,2,3]] [[4,5]] :map[split[,]]">>|^<<.operator-example m5.2 "[[1,2,3]] [[4,5]] :map:flat[split[,]first[]]">>|
 
 
 !! Comparison between `:map` and `:and`/`+` filter run prefixes

--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210618134753828
-modified: 20220723142748506
+modified: 20220723173623786
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Map Filter Run Prefix]]
 title: Map Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -20,11 +20,16 @@ Get the tags of all tiddlers tagged `Widget:`
 <<.operator-example 3 "[tag[Widgets]] :map:flat[tagging[]] :and[!is[blank]unique[]]">>
 <<.tip "Without the `flat` suffix the `:map` filter run only returns the first result for each input title">>
 
-!! Comparison between `:map` and `:map:flat` filter run prefixes
+!! Comparison between `:map` with and without the `flat` suffix
 
-The `:map` filter run prefix provides a subset of the `:map:flat` functionality. The `:map` filter run behaves as if a call to the [[first operator|first Operator]] is automatically added to the end of a `:map:flat` filter run. The `:map` run will always have the same number of outputs as inputs. Within the run the number of items can increase, but only the first item will be returned as output. The `:map:flat` run will always return at least as many outputs as inputs. However, since it does not have the implicit call to [[first|first Operator]] it can increase the number of outputs compared to the number of inputs.
+The default `:map` filter run prefix behavior is a subset of the functionality provided when the `flat` suffix is used. In both cases at least as many outputs as given in the input will be returned. If the run transforms the input into something blank, that blank item will still be preserved in the output.
+
+Without the suffix, `:map` filter behaves as if a call to the [[first operator|first Operator]] is automatically added to the end. Within the run the number of items might increase, but only the first item will be returned in the output.
+
+With the suffix, `:map:flat` does not have the implicit call to the [[first operator|first Operator]]. When the number of items within the run increase, that increase will be preserved in the output.
 
 | `:map:flat` | `:map` |
+|^<<.operator-example m0.1 "[range[4]] :map:flat[match[this matches nothing]]">>|^<<.operator-example m0.2 "[range[4]] :map[match[this matches nothing]]">>|
 |^<<.operator-example m1.1 "[range[4]] :map:flat[range<currentTiddler>]">>|^<<.operator-example m1.2 "[range[4]] :map[range<currentTiddler>]">>|
 |^<<.operator-example m2.1 "[range[4]] :map:flat[range<currentTiddler>first[]]">>|^<<.operator-example m2.2 "[range[4]] :map[range<currentTiddler>]">>|
 |^<<.operator-example m3.1 "[range[4]] :map:flat[range<currentTiddler>sum[]]">>|^<<.operator-example m3.2 "[range[4]] :map[range<currentTiddler>sum[]]">>|

--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210618134753828
-modified: 20220723173623786
+modified: 20220724132428241
 tags: [[Filter Syntax]] [[Filter Run Prefix Examples]] [[Map Filter Run Prefix]]
 title: Map Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -22,11 +22,9 @@ Get the tags of all tiddlers tagged `Widget:`
 
 !! Comparison between `:map` with and without the `flat` suffix
 
-The default `:map` filter run prefix behavior is a subset of the functionality provided when the `flat` suffix is used. In both cases at least as many outputs as given in the input will be returned. If the run transforms the input into something blank, that blank item will still be preserved in the output.
+The `:map` filter run will return at least as many outputs as given in the input.  By default one input item will result in exactly one output item. When the filter run transforms an input item into an empty result, the output for that item will be an empty string. When the filter run transforms an input item into multiple items, only the first item will appear in the output. This behavior can be overridden by providing the `flat` suffix. The `flat` suffix will cause all the items to appear in the output.
 
-Without the suffix, `:map` filter behaves as if a call to the [[first operator|first Operator]] is automatically added to the end. Within the run the number of items might increase, but only the first item will be returned in the output.
-
-With the suffix, `:map:flat` does not have the implicit call to the [[first operator|first Operator]]. When the number of items within the run increase, that increase will be preserved in the output.
+Any `:map` filter run can be expressed with `:map:flat` by adding a call to the [[first operator|first Operator]] at the end of the filter run.
 
 | `:map:flat` | `:map` |
 |^<<.operator-example m0.1 "[range[4]] :map:flat[match[this matches nothing]]">>|^<<.operator-example m0.2 "[range[4]] :map[match[this matches nothing]]">>|


### PR DESCRIPTION
Added more description of how :map compares to :map:flat and added several more examples.

Most of the examples are based on the suggestion by @rmunn in the comments of #6806