### PR TITLE
feat: support arbitrary DOM attributes on DOM nodes generated by widgets

### DIFF
--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -40,6 +40,7 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 		tag = this.buttonTag;
 	}
 	domNode = this.document.createElement(tag);
+	this.assignAttributes(domNode,{requirePrefix: "dom-"});
 	this.domNode = domNode;
 	// Assign classes
 	var classes = this["class"].split(" ") || [],

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -317,14 +317,23 @@ Widget.prototype.getAttribute = function(name,defaultText) {
 Assign the computed attributes of the widget to a domNode
 options include:
 excludeEventAttributes: ignores attributes whose name begins with "on"
+requirePrefix: specifies a prefix that attributes to be assigned must match
 */
 Widget.prototype.assignAttributes = function(domNode,options) {
 	options = options || {};
-	var self = this;
+	var self = this,
+		prefix = options.requirePrefix;
 	var assignAttribute = function(name,value) {
 		// Check for excluded attribute names
 		if(options.excludeEventAttributes && name.substr(0,2) === "on") {
 			value = undefined;
+		}
+		if(prefix) {
+			if(!$tw.utils.startsWith(name,prefix)) {
+				value = undefined;			
+			} else {
+				name = name.substr(prefix.length);
+			}
 		}
 		if(value !== undefined) {
 			// Handle the xlink: namespace


### PR DESCRIPTION
This PR is a proof of concept to facilitate discussion of a new affordance to specify DOM node attributes on DOM nodes generated by widgets.

Any attributes prefixed with `dom-` would be assigned to the DOM node after removal of the `dom-` prefix.

`<$button tag="div" dom-data-item="abc" dom-style.border="1px solid red" dom-style.height="500px"/>`

renders as:
`<div data-item="abc" class="" style="border: 1px solid red; height: 500px;"></div>`

_Note that attributes prefixed with `dom-style.` are being treated as we do `style.` prefixed attributes on HTML elements. This support could be omitted, or made consistent with the implementation for HTML elements._

**Salient code changes**:
* extends `Widget.prototype.assignAttributes` with the option to only assign attributes with a specified prefix
* extends ButtonWidget as an example of using `widget.assignAttributes` to assign attributes to the DOM node generated.
* any attributes assigned by explicit widget attributes take priority.


Widgets such as `$scrollable` that generate more than one DOM node can choose to use different prefixes to support attributes on each DOM node.
