### PR TITLE
Fix copy-and-paste mistake in insertafter docs

### DIFF
--- a/editions/tw5.com/tiddlers/filters/insertafter Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/insertafter Operator.tid
@@ -14,7 +14,7 @@ type: text/vnd.tiddlywiki
 
 The <<.op insertafter>> operator requires at least one parameter which specifies the title to insert into the input list. A second parameter can be used to specify the title after which the new title should be inserted.
 
-A suffix can also be used to specify <<.place A>>, the title after which the new title should be inserted, but this form is deprecated. Instead, the two-parameter form is recommended. If the two-parameter form is used, the suffixes ''start'' and ''end'' can be used to specify where the item should be inserted if <<.place B>> is not found.
+A suffix can also be used to specify <<.place A>>, the title after which the new title should be inserted, but this form is deprecated. Instead, the two-parameter form is recommended. If the two-parameter form is used, the suffixes ''start'' and ''end'' can be used to specify where the item should be inserted if <<.place A>> is not found.
 
 ```
 insertafter:<after-title-variable>[<title>]


### PR DESCRIPTION
In #6801 I copied a section of text from the `insertbefore` operator to use in the `insertafter` docs, and in *most* of the copied text I replaced `.place B` with `.place A` since in `insertafter`, the parameter is called A rather than B. But I just noticed that there's one that I missed; this PR fixes that.