### PR TITLE
fix #6782, remove hardcoded spaces and replace with SPAN and proper class

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -3,11 +3,13 @@ tags: $:/tags/Macro
 
 \define toc-caption()
 \whitespace trim
+<span class="tc-toc-caption tc-tiny-gap-left">
 <$set name="tv-wikilinks" value="no">
   <$transclude field="caption">
     <$view field="title"/>
   </$transclude>
 </$set>
+</span>
 \end
 
 \define toc-body(tag,sort:"",itemClassFilter,exclude,path)
@@ -51,7 +53,6 @@ tags: $:/tags/Macro
           {{$:/core/images/down-arrow}}
         </$button>
       </$reveal>
-      &#32;
       <<toc-caption>>
     </$link>
     <$reveal type="match" stateTitle=<<toc-state>> text="open">
@@ -71,14 +72,12 @@ tags: $:/tags/Macro
       <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
         <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
           {{$:/core/images/right-arrow}}
-          &#32;
           <<toc-caption>>
         </$button>
       </$reveal>
       <$reveal type="match" stateTitle=<<toc-state>> text="open">
         <$button setTitle=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
           {{$:/core/images/down-arrow}}
-          &#32;
           <<toc-caption>>
         </$button>
       </$reveal>
@@ -127,7 +126,6 @@ tags: $:/tags/Macro
             </$button>
           </$reveal>
         </$list>
-        &#32;
         <<toc-caption>>
       </$link>
       <$reveal type="match" stateTitle=<<toc-state>> text="open">
@@ -147,14 +145,12 @@ tags: $:/tags/Macro
         <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
           <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
             {{$:/core/images/right-arrow}}
-            &#32;
             <<toc-caption>>
           </$button>
         </$reveal>
         <$reveal type="match" stateTitle=<<toc-state>> text="open">
           <$button setTitle=<<toc-state>> setTo="close" class="tc-btn-invisible tc-popup-keep">
             {{$:/core/images/down-arrow}}
-            &#32;
             <<toc-caption>>
           </$button>
         </$reveal>


### PR DESCRIPTION
fix #6782

The issue was first raised at Talk: https://talk.tiddlywiki.org/t/tiddler-link-underline-too-long/3913 ... Since the toc-macros have already been changed since 5.2.2, the fix is different to what was suggested at Talk. ... It's actually simpler now. 

- The PR removes hardcoded spaces and replaces them with SPAN and a proper class `tc-tiny-gap-left`
- The PR also adds a `tc-toc-caption` class, which didn't exist yet. So users have a class, they can use to style the caption if needed. 
- The PR also improves the possibility to copy-paste tiddler titles from the TOC since there will be no leading space in the clipboard, which can cause problems when pasted 

Before

![image](https://user-images.githubusercontent.com/374655/180792617-78c2b65f-6169-4603-8484-4bfd768d67da.png)


After

![image](https://user-images.githubusercontent.com/374655/180792804-cc79fe5c-f19e-49f1-9bc5-1d2605517df0.png)
