### PR TITLE
Wikitext docs overhaul first step

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/WikiText.tid
+++ b/editions/tw5.com/tiddlers/concepts/WikiText.tid
@@ -1,15 +1,23 @@
 created: 20131205155227468
-modified: 20140919191220377
+list: [[Headings in WikiText]] [[Paragraphs in WikiText]] [[Hard Linebreaks in WikiText]] [[Formatting in WikiText]] [[Dashes in WikiText]] [[Block Quotes in WikiText]] [[Lists in WikiText]] [[Definitions in WikiText]] [[Tables in WikiText]] [[Code Blocks in WikiText]] [[Typed Blocks in WikiText]] [[Images in WikiText]] [[Horizontal Rules in WikiText]] [[Linking in WikiText]] [[Variables in WikiText]] [[Macro Definitions in WikiText]] [[Macro Calls in WikiText]] [[Macros in WikiText]] [[Transclusion in WikiText]] [[Transclusion and Substitution]] [[Styles and Classes in WikiText]] [[HTML in WikiText]] [[Widgets in WikiText]] [[WikiText Parser Modes]]
+modified: 20220726132727329
 tags: Concepts Reference
 title: WikiText
 type: text/vnd.tiddlywiki
+
+\define openAll()
+<$set name=wList filter="[[WikiText]] [enlist{WikiText!!list}]">
+<$action-setfield $tiddler="$:/StoryList" list=<<wList>>/>
+\end
 
 ~WikiText is a concise, expressive way of typing a wide range of text formatting, hypertext and interactive features. It allows you to focus on writing without a complex user interface getting in the way. It is designed to be familiar for users of [[MarkDown|http://daringfireball.net/projects/markdown/]], but with more of a focus on linking and the interactive features.
 
 ~WikiText can also be inserted to the text field using the [[Editor toolbar]].
 
-See [[Formatting text in TiddlyWiki]] for an introduction to WikiText.
+The following elements of WikiText syntax are built into the core. 
 
-The following elements of WikiText syntax are built into the core:
+<$button actions=<<openAll>> >Open all tiddlers from the list below</$button>
 
 <<list-links "[tag[WikiText]]">>
+
+Also see [[Formatting text in TiddlyWiki]] for an introduction to WikiText.

--- a/editions/tw5.com/tiddlers/system/$__editions_tw5.com_wikitext-template.tid
+++ b/editions/tw5.com/tiddlers/system/$__editions_tw5.com_wikitext-template.tid
@@ -1,0 +1,13 @@
+code-body: yes
+created: 20220726132935807
+list-after: $:/core/ui/ViewTemplate/body
+modified: 20220726134215137
+tags: $:/tags/ViewTemplate
+title: $:/editions/tw5.com/wikitext-template
+
+<$list filter="[all[current]tag[WikiText]]" variable="listItem">
+
+---
+
+[[All options to format wikitext can be found at WikiText|WikiText]]
+</$list>

--- a/editions/tw5.com/tiddlers/wikitext/Formatting in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Formatting in WikiText.tid
@@ -1,19 +1,34 @@
 caption: Formatting
 created: 20131205155959399
-modified: 20220513120211686
+modified: 20220726132504220
 tags: WikiText
 title: Formatting in WikiText
 type: text/vnd.tiddlywiki
 
+<style>
+.no-code-border > code {
+  border: initial;
+  background-color: initial;
+}
+</style>
 Available character formatting includes:
 
-* <code>&#96;backticks&#96;</code> for `code` (<<.icon $:/core/images/mono-line>>)
-** Alternatively, <code>&#96;&#96;double backticks allows &#96;embedded&#96; backticks&#96;&#96;</code><br><br>
-* `''bold''` for ''bold text'' (<<.icon $:/core/images/bold>>)<br><br>
-* `//italic//` for //italic text// (<<.icon $:/core/images/italic>>)<br><br>
-* `__underscore__` for __underscored text__ (<<.icon $:/core/images/underline>>)<br><br>
-* `^^superscript^^` for ^^superscripted^^ text (<<.icon $:/core/images/superscript>>)<br><br>
-* `,,subscript,,` for ,,subscripted,, text (<<.icon $:/core/images/subscript>>)<br><br>
-* `~~strikethrough~~` for ~~strikethrough~~ text (<<.icon $:/core/images/strikethrough>>)
+<div class="no-code-border">
+
+|Wikitext | Editor Button |HTML |Rendered Output |h
+|```backticks` ``are used for  for code | (<<.icon $:/core/images/mono-line>>) |`<code>backticks</code>` are used for code|`backticks` are used for  for code |
+|2 single hyphens are used for `''bold text''`| (<<.icon $:/core/images/bold>>) |2 single hyphens are used for `<strong>bold text</strong>` |2 single hyphens are used for ''bold text''|
+|2 slashes are used for `//italic text//`| (<<.icon $:/core/images/italic>>) |2 slashes are used for `<em>italic text</em>` |2 slashes are used for //italic text//|
+|2 underscores are used for `__underscored text__`| (<<.icon $:/core/images/underline>>) |2 underscores are used for `<u>underscored text<u>` |2 underscores are used for __underscored text__|
+|2 circumflex accents are used for `^^superscripted^^` text | (<<.icon $:/core/images/superscript>>) |2 circumflex accents are used for `<sup>superscripted</sup>` text |2 circumflex accents are used for ^^superscripted^^ text |
+|2 commas are used for `,,subscripted,,` text | (<<.icon $:/core/images/subscript>>) |2 commas are used for `<sub>subscripted</sub>` text |2 commas are used for ,,subscripted,, text |
+|2 tilde signs are used for `~~strikethrough~~` text | (<<.icon $:/core/images/strikethrough>>) |2 tilde signs are used for `<strike>strikethrough</strike>` text |2 tilde signs are used for ~~strikethrough~~ text |
+
+''Special case to show embedded backticks''
+
+|Wikitext |HTML |Rendered Output|h
+|<code>&#96;&#96;double backticks allows &#96;embedded&#96; backticks&#96;&#96;</code>|``<code>double backticks allows `embedded` backticks</code>`` |``double backticks allows `embedded` backticks``|
+
+</div>
 
 See also: [[Code Blocks in WikiText]]

--- a/editions/tw5.com/tiddlers/wikitext/Headings in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Headings in WikiText.tid
@@ -1,11 +1,11 @@
 caption: Headings
 created: 20131205161234909
-modified: 20220513110830487
+modified: 20220726124722460
 tags: WikiText
 title: Headings in WikiText
 type: text/vnd.tiddlywiki
 
-Headings are specified with one up to six leading `!` characters:
+Headings are specified with one up to six leading exclamation mark `!` characters:
 
 ```
 ! This is a level 1 heading
@@ -15,6 +15,8 @@ Headings are specified with one up to six leading `!` characters:
 !!! This is a level 3 heading
 ```
 
+''User defined  heading classes''
+
 CSS classes can be assigned to individual headings like this:
 
-<<wikitext-example src:"""!!.myStyle This heading has the class `myStyle`""">>
+<<wikitext-example src:"""!!.myStyle This heading has the class myStyle""">>


### PR DESCRIPTION
- The WikiText tag now creates a more logical sort order
- There is a button to open all wikitext rules in the StoryRiver
- Formatting in WikiText uses a table now and has more info
- There is a new wikitext-template tiddler, that adds a footer to every tiddler tagged WikiText. The footer links back to the WikiText tiddler. 

There may be more steps, but this could be a start. This [discussion at Talk](https://talk.tiddlywiki.org/t/a-better-documentation-for-wikitext/4066) triggered the PR.