### PR TITLE
add default settings for styled inline SPANs

### DIFF
--- a/core/modules/parsers/wikiparser/rules/styleinline.js
+++ b/core/modules/parsers/wikiparser/rules/styleinline.js
@@ -45,12 +45,12 @@ exports.parse = function() {
 	};
 	if(classString) {
 		$tw.utils.addClassToParseTreeNode(node,classString);
-	} else {
-		$tw.utils.addClassToParseTreeNode(node,"tc-inline-style");
 	}
-
 	if(stylesString) {
 		$tw.utils.addAttributeToParseTreeNode(node,"style",stylesString);
+	}
+	if (!classString && !stylesString) {
+		$tw.utils.addClassToParseTreeNode(node,"tc-inline-style");
 	}
 	return [node];
 };

--- a/core/modules/parsers/wikiparser/rules/styleinline.js
+++ b/core/modules/parsers/wikiparser/rules/styleinline.js
@@ -41,14 +41,14 @@ exports.parse = function() {
 	var node = {
 		type: "element",
 		tag: "span",
-		attributes: {
-			"class": {type: "string", value: "tc-inline-style"}
-		},
 		children: tree
 	};
 	if(classString) {
 		$tw.utils.addClassToParseTreeNode(node,classString);
+	} else {
+		$tw.utils.addClassToParseTreeNode(node,"tc-inline-style");
 	}
+
 	if(stylesString) {
 		$tw.utils.addAttributeToParseTreeNode(node,"style",stylesString);
 	}

--- a/core/modules/parsers/wikiparser/rules/styleinline.js
+++ b/core/modules/parsers/wikiparser/rules/styleinline.js
@@ -49,7 +49,7 @@ exports.parse = function() {
 	if(stylesString) {
 		$tw.utils.addAttributeToParseTreeNode(node,"style",stylesString);
 	}
-	if (!classString && !stylesString) {
+	if(!classString && !stylesString) {
 		$tw.utils.addClassToParseTreeNode(node,"tc-inline-style");
 	}
 	return [node];

--- a/core/palettes/Blanca.tid
+++ b/core/palettes/Blanca.tid
@@ -70,6 +70,8 @@ sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #7897f3
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #eeeeee
 tab-border-selected: #cccccc

--- a/core/palettes/Blanca.tid
+++ b/core/palettes/Blanca.tid
@@ -34,6 +34,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
 foreground: #333333
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: #ecf2ff
 message-border: #cfd6e6
 message-foreground: #547599
@@ -70,8 +72,6 @@ sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #7897f3
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #eeeeee
 tab-border-selected: #cccccc

--- a/core/palettes/Blue.tid
+++ b/core/palettes/Blue.tid
@@ -34,6 +34,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
 foreground: #333353
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: #ecf2ff
 message-border: #cfd6e6
 message-foreground: #547599
@@ -70,8 +72,6 @@ sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #5959c0
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: #ccccdd
 tab-border-selected: #ccccdd

--- a/core/palettes/Blue.tid
+++ b/core/palettes/Blue.tid
@@ -70,6 +70,8 @@ sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #5959c0
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: #ccccdd
 tab-border-selected: #ccccdd

--- a/core/palettes/BrightMute.tid
+++ b/core/palettes/BrightMute.tid
@@ -70,6 +70,8 @@ sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #d1d0d2
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #d8d8d8
 tab-border-selected: #d8d8d8

--- a/core/palettes/BrightMute.tid
+++ b/core/palettes/BrightMute.tid
@@ -34,6 +34,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
 foreground: #333333
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: #ecf2ff
 message-border: #cfd6e6
 message-foreground: #547599
@@ -70,8 +72,6 @@ sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #d1d0d2
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #d8d8d8
 tab-border-selected: #d8d8d8

--- a/core/palettes/ContrastDark.tid
+++ b/core/palettes/ContrastDark.tid
@@ -34,6 +34,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
 foreground: #000
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: <<colour foreground>>
 message-border: <<colour background>>
 message-foreground: <<colour background>>
@@ -70,8 +72,6 @@ sidebar-tiddler-link-foreground-hover: <<colour foreground>>
 sidebar-tiddler-link-foreground: <<colour primary>>
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: <<colour foreground>>
 tab-border-selected: <<colour foreground>>

--- a/core/palettes/ContrastDark.tid
+++ b/core/palettes/ContrastDark.tid
@@ -70,6 +70,8 @@ sidebar-tiddler-link-foreground-hover: <<colour foreground>>
 sidebar-tiddler-link-foreground: <<colour primary>>
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: <<colour foreground>>
 tab-border-selected: <<colour foreground>>

--- a/core/palettes/ContrastLight.tid
+++ b/core/palettes/ContrastLight.tid
@@ -34,6 +34,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #00a
 external-link-foreground: #00e
 foreground: #fff
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: <<colour foreground>>
 message-border: <<colour background>>
 message-foreground: <<colour background>>
@@ -70,8 +72,6 @@ sidebar-tiddler-link-foreground-hover: <<colour foreground>>
 sidebar-tiddler-link-foreground: <<colour primary>>
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: <<colour foreground>>
 tab-border-selected: <<colour foreground>>

--- a/core/palettes/ContrastLight.tid
+++ b/core/palettes/ContrastLight.tid
@@ -70,6 +70,8 @@ sidebar-tiddler-link-foreground-hover: <<colour foreground>>
 sidebar-tiddler-link-foreground: <<colour primary>>
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: <<colour foreground>>
 tab-border-selected: <<colour foreground>>

--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -32,6 +32,8 @@ external-link-foreground-hover:
 external-link-foreground-visited: #BF5AF2
 external-link-foreground: #32D74B
 foreground: #FFFFFF
+highlight-background: #ffff78
+highlight-foreground: #000000
 menubar-background: #464646
 menubar-foreground: #ffffff
 message-background: <<colour background>>
@@ -70,8 +72,6 @@ sidebar-tiddler-link-foreground-hover: rgba(255, 255, 255, 0.7)
 sidebar-tiddler-link-foreground: rgba(255, 255, 255, 0.54)
 site-title-foreground: #ffffff
 static-alert-foreground: #B4B4B4
-styled-inline-background: #ffff78
-styled-inline-foreground: #000000
 tab-background-selected: #3F638B
 tab-background: <<colour page-background>>
 tab-border-selected: <<colour page-background>>

--- a/core/palettes/CupertinoDark.tid
+++ b/core/palettes/CupertinoDark.tid
@@ -70,6 +70,8 @@ sidebar-tiddler-link-foreground-hover: rgba(255, 255, 255, 0.7)
 sidebar-tiddler-link-foreground: rgba(255, 255, 255, 0.54)
 site-title-foreground: #ffffff
 static-alert-foreground: #B4B4B4
+styled-inline-background: #ffff78
+styled-inline-foreground: #000000
 tab-background-selected: #3F638B
 tab-background: <<colour page-background>>
 tab-border-selected: <<colour page-background>>

--- a/core/palettes/DarkPhotos.tid
+++ b/core/palettes/DarkPhotos.tid
@@ -72,6 +72,8 @@ sidebar-tiddler-link-foreground-hover: #aaf
 sidebar-tiddler-link-foreground: #ddf
 site-title-foreground: #fff
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #d8d8d8
 tab-border-selected: #d8d8d8

--- a/core/palettes/DarkPhotos.tid
+++ b/core/palettes/DarkPhotos.tid
@@ -36,6 +36,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
 foreground: #333333
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: #ecf2ff
 message-border: #cfd6e6
 message-foreground: #547599
@@ -72,8 +74,6 @@ sidebar-tiddler-link-foreground-hover: #aaf
 sidebar-tiddler-link-foreground: #ddf
 site-title-foreground: #fff
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #d8d8d8
 tab-border-selected: #d8d8d8

--- a/core/palettes/DesertSand.tid
+++ b/core/palettes/DesertSand.tid
@@ -80,6 +80,8 @@ sidebar-tiddler-link-foreground-hover: #433F35
 sidebar-tiddler-link-foreground: #706A58
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #A6A193
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: #E9E0C7
 tab-background: #A6A193
 tab-border-selected: #C3BAA1

--- a/core/palettes/DesertSand.tid
+++ b/core/palettes/DesertSand.tid
@@ -40,6 +40,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #313163
 external-link-foreground: #555592
 foreground: #2D2A23
+highlight-background: #ffff00
+highlight-foreground: #000000
 menubar-background: #CDC2A6
 menubar-foreground: #5A5446
 message-background: #ECE5CF
@@ -80,8 +82,6 @@ sidebar-tiddler-link-foreground-hover: #433F35
 sidebar-tiddler-link-foreground: #706A58
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #A6A193
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: #E9E0C7
 tab-background: #A6A193
 tab-border-selected: #C3BAA1

--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -41,6 +41,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #d3869b
 external-link-foreground: #8ec07c
 foreground: #fbf1c7
+highlight-background: #ffff79
+highlight-foreground: #000000
 menubar-background: #504945
 menubar-foreground: <<colour foreground>>
 message-background: #83a598
@@ -81,8 +83,6 @@ sidebar-tiddler-link-foreground-hover: #458588
 sidebar-tiddler-link-foreground: #98971a
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #B48EAD
-styled-inline-background: #ffff79
-styled-inline-foreground: #000000
 tab-background-selected: #ebdbb2
 tab-background: #665c54
 tab-border-selected: #665c54

--- a/core/palettes/GruvBoxDark.tid
+++ b/core/palettes/GruvBoxDark.tid
@@ -81,6 +81,8 @@ sidebar-tiddler-link-foreground-hover: #458588
 sidebar-tiddler-link-foreground: #98971a
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #B48EAD
+styled-inline-background: #ffff79
+styled-inline-foreground: #000000
 tab-background-selected: #ebdbb2
 tab-background: #665c54
 tab-border-selected: #665c54

--- a/core/palettes/Nord.tid
+++ b/core/palettes/Nord.tid
@@ -41,6 +41,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #5E81AC
 external-link-foreground: #8FBCBB
 foreground: #d8dee9
+highlight-background: #ffff78
+highlight-foreground: #000000
 menubar-background: #2E3440
 menubar-foreground: #d8dee9
 message-background: #2E3440
@@ -81,8 +83,6 @@ sidebar-tiddler-link-foreground-hover: #A3BE8C
 sidebar-tiddler-link-foreground: #81A1C1
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #B48EAD
-styled-inline-background: #ffff78
-styled-inline-foreground: #000000
 tab-background-selected: #ECEFF4
 tab-background: #4C566A
 tab-border-selected: #4C566A

--- a/core/palettes/Nord.tid
+++ b/core/palettes/Nord.tid
@@ -81,6 +81,8 @@ sidebar-tiddler-link-foreground-hover: #A3BE8C
 sidebar-tiddler-link-foreground: #81A1C1
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #B48EAD
+styled-inline-background: #ffff78
+styled-inline-foreground: #000000
 tab-background-selected: #ECEFF4
 tab-background: #4C566A
 tab-border-selected: #4C566A

--- a/core/palettes/Rocker.tid
+++ b/core/palettes/Rocker.tid
@@ -70,6 +70,8 @@ sidebar-tiddler-link-foreground-hover: #ffbb99
 sidebar-tiddler-link-foreground: #cc0000
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #d8d8d8
 tab-border-selected: #d8d8d8

--- a/core/palettes/Rocker.tid
+++ b/core/palettes/Rocker.tid
@@ -34,6 +34,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
 foreground: #333333
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: #ecf2ff
 message-border: #cfd6e6
 message-foreground: #547599
@@ -70,8 +72,6 @@ sidebar-tiddler-link-foreground-hover: #ffbb99
 sidebar-tiddler-link-foreground: #cc0000
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #d8d8d8
 tab-border-selected: #d8d8d8

--- a/core/palettes/SolarFlare.tid
+++ b/core/palettes/SolarFlare.tid
@@ -140,6 +140,8 @@ sidebar-muted-foreground-hover:
 sidebar-tab-background: #ded8c5
 sidebar-tiddler-link-foreground-hover:
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-border: #cccccc
     modal-footer-border: <<colour tab-border>>
     modal-header-border: <<colour tab-border>>

--- a/core/palettes/SolarFlare.tid
+++ b/core/palettes/SolarFlare.tid
@@ -131,6 +131,8 @@ external-link-background-hover: inherit
 external-link-background-visited: inherit
 external-link-background: inherit
 external-link-foreground-hover: inherit
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-border: #cfd6e6
 modal-border: #999999
 select-tag-background:
@@ -140,8 +142,6 @@ sidebar-muted-foreground-hover:
 sidebar-tab-background: #ded8c5
 sidebar-tiddler-link-foreground-hover:
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-border: #cccccc
     modal-footer-border: <<colour tab-border>>
     modal-header-border: <<colour tab-border>>

--- a/core/palettes/SolarizedDark.tid
+++ b/core/palettes/SolarizedDark.tid
@@ -71,6 +71,8 @@ sidebar-tiddler-link-foreground: #2aa198
 sidebar-tiddler-link-foreground-hover: #eee8d5
 site-title-foreground: #d33682
 static-alert-foreground: #93a1a1
+styled-inline-background: #ffff78
+styled-inline-foreground: #000000
 tab-background: #073642
 tab-background-selected: #002b36
 tab-border: #586e75

--- a/core/palettes/SolarizedDark.tid
+++ b/core/palettes/SolarizedDark.tid
@@ -35,6 +35,8 @@ external-link-foreground: #268bd2
 external-link-foreground-hover:
 external-link-foreground-visited: #268bd2
 foreground: #839496
+highlight-background: #ffff78
+highlight-foreground: #000000
 message-background: #002b36
 message-border: #586e75
 message-foreground: #839496
@@ -71,8 +73,6 @@ sidebar-tiddler-link-foreground: #2aa198
 sidebar-tiddler-link-foreground-hover: #eee8d5
 site-title-foreground: #d33682
 static-alert-foreground: #93a1a1
-styled-inline-background: #ffff78
-styled-inline-foreground: #000000
 tab-background: #073642
 tab-background-selected: #002b36
 tab-border: #586e75

--- a/core/palettes/SolarizedLight.tid
+++ b/core/palettes/SolarizedLight.tid
@@ -71,6 +71,8 @@ sidebar-tiddler-link-foreground: #2aa198
 sidebar-tiddler-link-foreground-hover: #002b36
 site-title-foreground: #d33682
 static-alert-foreground: #586e75
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background: #eee8d5
 tab-background-selected: #fdf6e3
 tab-border: #93a1a1

--- a/core/palettes/SolarizedLight.tid
+++ b/core/palettes/SolarizedLight.tid
@@ -35,6 +35,8 @@ external-link-foreground: #268bd2
 external-link-foreground-hover: inherit
 external-link-foreground-visited: #268bd2
 foreground: #657b83
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: #fdf6e3
 message-border: #93a1a1
 message-foreground: #657b83
@@ -71,8 +73,6 @@ sidebar-tiddler-link-foreground: #2aa198
 sidebar-tiddler-link-foreground-hover: #002b36
 site-title-foreground: #d33682
 static-alert-foreground: #586e75
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background: #eee8d5
 tab-background-selected: #fdf6e3
 tab-border: #93a1a1

--- a/core/palettes/SpartanDay.tid
+++ b/core/palettes/SpartanDay.tid
@@ -34,6 +34,8 @@ external-link-foreground-hover:
 external-link-foreground-visited: 
 external-link-foreground: 
 foreground: rgba(0, 0, 0, 0.87)
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: <<colour background>>
 message-border: <<colour very-muted-foreground>>
 message-foreground: rgba(0, 0, 0, 0.54)
@@ -70,8 +72,6 @@ sidebar-tiddler-link-foreground-hover: rgba(0, 0, 0, 0.87)
 sidebar-tiddler-link-foreground: rgba(0, 0, 0, 0.54)
 site-title-foreground: rgba(0, 0, 0, 0.87)
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: transparent
 tab-border-selected: <<colour table-border>>

--- a/core/palettes/SpartanDay.tid
+++ b/core/palettes/SpartanDay.tid
@@ -70,6 +70,8 @@ sidebar-tiddler-link-foreground-hover: rgba(0, 0, 0, 0.87)
 sidebar-tiddler-link-foreground: rgba(0, 0, 0, 0.54)
 site-title-foreground: rgba(0, 0, 0, 0.87)
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: transparent
 tab-border-selected: <<colour table-border>>

--- a/core/palettes/SpartanNight.tid
+++ b/core/palettes/SpartanNight.tid
@@ -34,6 +34,8 @@ external-link-foreground-hover:
 external-link-foreground-visited: #7c318c
 external-link-foreground: #9e3eb3
 foreground: rgba(255, 255, 255, 0.7)
+highlight-background: #ffff78
+highlight-foreground: #000000
 message-background: <<colour background>>
 message-border: <<colour very-muted-foreground>>
 message-foreground: rgba(255, 255, 255, 0.54)
@@ -70,8 +72,6 @@ sidebar-tiddler-link-foreground-hover: rgba(255, 255, 255, 0.7)
 sidebar-tiddler-link-foreground: rgba(255, 255, 255, 0.54)
 site-title-foreground: rgba(255, 255, 255, 0.7)
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff78
-styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: transparent
 tab-border-selected: <<colour table-border>>

--- a/core/palettes/SpartanNight.tid
+++ b/core/palettes/SpartanNight.tid
@@ -70,6 +70,8 @@ sidebar-tiddler-link-foreground-hover: rgba(255, 255, 255, 0.7)
 sidebar-tiddler-link-foreground: rgba(255, 255, 255, 0.54)
 site-title-foreground: rgba(255, 255, 255, 0.7)
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff78
+styled-inline-foreground: #000000
 tab-background-selected: <<colour background>>
 tab-background: transparent
 tab-border-selected: <<colour table-border>>

--- a/core/palettes/Twilight.tid
+++ b/core/palettes/Twilight.tid
@@ -43,6 +43,8 @@ external-link-foreground: rgb(179, 179, 255)
 external-link-foreground-hover: inherit
 external-link-foreground-visited: rgb(153, 153, 255)
 foreground: rgb(179, 179, 179)
+highlight-background: #ffff78
+highlight-foreground: #000000
 message-background: <<colour tag-foreground>>
 message-border: #96ccff
 message-foreground: <<colour tag-background>>
@@ -79,8 +81,6 @@ sidebar-tiddler-link-foreground: rgb(179, 179, 179)
 sidebar-tiddler-link-foreground-hover: rgb(115, 115, 115)
 site-title-foreground: rgb(255, 201, 102)
 static-alert-foreground: rgba(0,0,0,.3)
-styled-inline-background: #ffff78
-styled-inline-foreground: #000000
 tab-background: rgba(0,0,0,0.125)
 tab-background-selected: rgb(38, 38, 38)
 tab-border: rgb(255, 201, 102)

--- a/core/palettes/Twilight.tid
+++ b/core/palettes/Twilight.tid
@@ -79,6 +79,8 @@ sidebar-tiddler-link-foreground: rgb(179, 179, 179)
 sidebar-tiddler-link-foreground-hover: rgb(115, 115, 115)
 site-title-foreground: rgb(255, 201, 102)
 static-alert-foreground: rgba(0,0,0,.3)
+styled-inline-background: #ffff78
+styled-inline-foreground: #000000
 tab-background: rgba(0,0,0,0.125)
 tab-background-selected: rgb(38, 38, 38)
 tab-border: rgb(255, 201, 102)

--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -42,6 +42,8 @@ external-link-foreground-hover: inherit
 external-link-foreground-visited: #0000aa
 external-link-foreground: #0000ee
 foreground: #333333
+highlight-background: #ffff00
+highlight-foreground: #000000
 message-background: #ecf2ff
 message-border: #cfd6e6
 message-foreground: #547599
@@ -80,8 +82,6 @@ sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #999999
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
-styled-inline-background: #ffff00
-styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #d8d8d8
 tab-border-selected: #d8d8d8

--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -80,6 +80,8 @@ sidebar-tiddler-link-foreground-hover: #444444
 sidebar-tiddler-link-foreground: #999999
 site-title-foreground: <<colour tiddler-title-foreground>>
 static-alert-foreground: #aaaaaa
+styled-inline-background: #ffff00
+styled-inline-foreground: #000000
 tab-background-selected: #ffffff
 tab-background: #d8d8d8
 tab-border-selected: #d8d8d8

--- a/editions/fr-FR/tiddlers/$__editions_tw5.com_doc-macros.tid
+++ b/editions/fr-FR/tiddlers/$__editions_tw5.com_doc-macros.tid
@@ -117,7 +117,7 @@ C'est un exemple de tiddler. Voir [[Macros Table des matières (Exemples)|Table-
 <table class="doc-bad-example">
 <tbody>
 <tr class="evenRow">
-<td><span class="tc-inline-style" style="font-size:1.5em;">&#9888;</span> Attention&nbsp;:<br> Ne faites pas comme ça !</td>
+<td><span style="font-size:1.5em;">&#9888;</span> Attention&nbsp;:<br> Ne faites pas comme ça !</td>
 <td>
 
 $eg$

--- a/editions/test/tiddlers/tests/test-wikitext.js
+++ b/editions/test/tiddlers/tests/test-wikitext.js
@@ -67,6 +67,8 @@ describe("WikiText tests", function() {
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
 			"some @@highlighted@@ text")).toBe('<p>some <span class="tc-inline-style">highlighted</span> text</p>');
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
+			"some @@color:green;.tc-inline-style 1 style and 1 class@@ text")).toBe('<p>some <span class=" tc-inline-style " style="color:green;">1 style and 1 class</span> text</p>');
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
 			"some @@background-color:red;red@@ text")).toBe('<p>some <span style="background-color:red;">red</span> text</p>');
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
 			"some @@.myClass class@@ text")).toBe('<p>some <span class=" myClass ">class</span> text</p>');

--- a/editions/test/tiddlers/tests/test-wikitext.js
+++ b/editions/test/tiddlers/tests/test-wikitext.js
@@ -63,6 +63,20 @@ describe("WikiText tests", function() {
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@color:red;\n<div>\n\nContent</div>\n@@")).toBe("<div style=\"color:red;\"><p>Content</p></div>");
 		expect(wiki.renderText("text/html","text/vnd-tiddlywiki","@@color:red;\n---\n@@")).toBe("<hr style=\"color:red;\">");
 	});
+	it("handles inline style wikitext notation", function() {
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
+			"some @@highlighted@@ text")).toBe('<p>some <span class="tc-inline-style">highlighted</span> text</p>');
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
+			"some @@background-color:red;red@@ text")).toBe('<p>some <span style="background-color:red;">red</span> text</p>');
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
+			"some @@.myClass class@@ text")).toBe('<p>some <span class=" myClass ">class</span> text</p>');
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
+			"some @@.myClass.secondClass 2 classes@@ text")).toBe('<p>some <span class=" myClass secondClass ">2 classes</span> text</p>');
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
+			"some @@background:red;.myClass style and class@@ text")).toBe('<p>some <span class=" myClass " style="background:red;">style and class</span> text</p>');
+		expect(wiki.renderText("text/html","text/vnd-tiddlywiki",
+			"some @@background:red;color:white;.myClass 2 style and 1 class@@ text")).toBe('<p>some <span class=" myClass " style="background:red;color:white;">2 style and 1 class</span> text</p>');
+	});
 });
 
 })();

--- a/editions/tw5.com/tiddlers/system/doc-macros.tid
+++ b/editions/tw5.com/tiddlers/system/doc-macros.tid
@@ -117,7 +117,7 @@ This is an example tiddler. See [[Table-of-Contents Macros (Examples)]].
 <table class="doc-bad-example">
 <tbody>
 <tr class="evenRow">
-<td><span class="tc-inline-style" style="font-size:1.5em;">&#9888;</span> Warning:<br> Don't do it this way!</td>
+<td><span style="font-size:1.5em;">&#9888;</span> Warning:<br> Don't do it this way!</td>
 <td>
 
 $eg$

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -279,6 +279,11 @@ kbd {
 	color: <<colour selection-foreground>>;
 }
 
+.tc-inline-style {
+	background: <<colour styled-inline-background>>;
+	color: <<colour styled-inline-foreground>>;
+}
+
 form.tc-form-inline {
 	display: inline;
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -280,8 +280,8 @@ kbd {
 }
 
 .tc-inline-style {
-	background: <<colour styled-inline-background>>;
-	color: <<colour styled-inline-foreground>>;
+	background: <<colour highlight-background>>;
+	color: <<colour highlight-foreground>>;
 }
 
 form.tc-form-inline {


### PR DESCRIPTION
This PR fixes: **Add wikitext for default highlight: @@highlight@@** #2228 

- This PR adds `styled-inline-background` and `styled-inline-foreground` settings to all palettes. 
- It removes a redundant `.tc-inline-style` from a doc macro
- It adds `.tc-inline-style` CSS settings to "Vanilla base"

Docs 

I don't know if [Styles and Classes in WikiText](https://tiddlywiki.com/#Styles%20and%20Classes%20in%20WikiText) is enough documentation. ... 

If not we should create a new tiddler eg: "Styles and Classes for inline WikiText" which will be very similar to the first one. 
