### PR TITLE
Move the version number to the top of the upgrader

### DIFF
--- a/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
+++ b/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
@@ -6,9 +6,9 @@ tags: $:/tags/AboveStory
 
 <div class="tc-upgrade-wizard">
 
-! ~TiddlyWiki Upgrade Wizard
+! ~TiddlyWiki version <<version>>
 
-!! version <<version>>
+!! Upgrade Wizard
 
 <$list filter="[[$:/Import]is[missing]]">
 

--- a/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
+++ b/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
@@ -6,9 +6,9 @@ tags: $:/tags/AboveStory
 
 <div class="tc-upgrade-wizard">
 
-! ~TiddlyWiki version <<version>>
+! Upgrade Wizard
 
-!! Upgrade Wizard
+!! ~TiddlyWiki version <<version>>
 
 <$list filter="[[$:/Import]is[missing]]">
 

--- a/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
+++ b/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
@@ -8,6 +8,8 @@ tags: $:/tags/AboveStory
 
 ! ~TiddlyWiki Upgrade Wizard
 
+!! version <<version>>
+
 <$list filter="[[$:/Import]is[missing]]">
 
 {{$:/core/images/download-button}}
@@ -47,8 +49,6 @@ For help and support, visit [[the TiddlyWiki discussion forum|http://groups.goog
 </$reveal>
 
 </div>
-
-version <<version>>
 
 //Your data will not leave your browser. <a href="#" download="upgrade.html">Download</a> this upgrader to use it offline//
 


### PR DESCRIPTION
This PR only moves the version number to the top area of the upgrader UI

**Start View**

![image](https://user-images.githubusercontent.com/374655/183284407-4a43fd4d-607b-4206-b4c7-a2115dfddfe0.png)


**Import View**

![image](https://user-images.githubusercontent.com/374655/183284438-0e6b7277-79f0-4ad6-a08d-ea9d7c8c6aca.png)
