### PR TITLE
Translators edtion: Add global option to show default text below the edit textarea

### DIFF
--- a/plugins/tiddlywiki/translators/macros/translatableStringEditor.tid
+++ b/plugins/tiddlywiki/translators/macros/translatableStringEditor.tid
@@ -10,6 +10,10 @@ tags: $:/tags/Macro
 <$list filter="""$(editFieldsFilter)$""" variable="editorField">
 <$edit-text tag="$(editorTagName)$" field=<<editorField>> type="text" class="tc-edit-texteditor" minHeight="10px"/>
 </$list>
+<$reveal state="$:/state/showEnglishText" type=match text="show" tag="p">
+Default text:
+<pre><code><$view tiddler="$:/core" subtiddler=<<currentTiddler>> field=<<editorField>>/></code></pre>
+</$reveal>
 </td>
 <td width="20px">
 <div class="tc-drop-down-wrapper">
@@ -59,6 +63,8 @@ Delete translation
 <div class="tc-translators-string-table">
 
 //<$count filter=<<translatableTiddlerTitles>>/> translatable tiddlers in this group//
+
+<$checkbox tiddler="$:/state/showEnglishText" field="text" checked="show" unchecked="hide" default="hide"> Show the default text below editor field</$checkbox>
 
 <$radio tiddler="$:/plugins/tiddlywiki/translators/editorTag" value="textarea"> Multi-line editors</$radio><br>
 <$radio tiddler="$:/plugins/tiddlywiki/translators/editorTag" value="input"> Single-line editors</$radio>

--- a/plugins/tiddlywiki/translators/system/styles.tid
+++ b/plugins/tiddlywiki/translators/system/styles.tid
@@ -13,3 +13,8 @@ tags: $:/tags/Stylesheet
 .tc-translators-string-table .tc-drop-down {
 	min-width: 500px;
 }
+
+.tc-tiddler-frame textarea.tc-edit-texteditor,
+.tc-tiddler-frame input.tc-edit-texteditor {
+  background-color: #feffef;
+}


### PR DESCRIPTION
This PR fixes:  [IDEA] $:/Translators should directly expose the English prompts #6879 

![image](https://user-images.githubusercontent.com/374655/183059120-fe23d08a-5da9-451a-aa70-d7d12c606bc6.png)