### PR TITLE
Typo in the readme of Dynannotate plugin

### DIFF
--- a/plugins/tiddlywiki/dynannotate/docs/readme.tid
+++ b/plugins/tiddlywiki/dynannotate/docs/readme.tid
@@ -108,11 +108,11 @@ The selection tracker triggers an action string whenever the browser text select
 
 The selection tracker works within DOM subtrees that have the following structure:
 
-* The outer wrapper element has the attribute `data-selection-action-title` containing the title of the tiddler containing the action string to be invoked when the selection changes
+* The outer wrapper element has the attribute `data-selection-actions-title` containing the title of the tiddler containing the action string to be invoked when the selection changes
 * Each child element of the outer element must have a unique `id` attribute to identify it
 
 ```
-<div data-selection-action-title="{tiddler title}">
+<div data-selection-actions-title="{tiddler title}">
 	<div id="{title}">
 		Content text
 	</div>


### PR DESCRIPTION
In addition, the Dynannotate plugin's Main Selection Tracker does not seem to work.

Is it because [json-ops](https://github.com/Jermolene/TiddlyWiki5/tree/json-ops) is not merged into the master branch?