### PR TITLE
allow us to remove a field with empty key

### DIFF
--- a/core/modules/widgets/action-deletefield.js
+++ b/core/modules/widgets/action-deletefield.js
@@ -59,7 +59,7 @@ DeleteFieldWidget.prototype.invokeAction = function(triggeringWidget,event) {
 		tiddler = this.wiki.getTiddler(self.actionTiddler),
 		removeFields = {},
 		hasChanged = false;
-	if((this.actionField != null) && tiddler) {
+	if((this.actionField !== null) && tiddler) {
 		removeFields[this.actionField] = undefined;
 		if(this.actionField in tiddler.fields) {
 			hasChanged = true;

--- a/core/modules/widgets/action-deletefield.js
+++ b/core/modules/widgets/action-deletefield.js
@@ -36,7 +36,7 @@ Compute the internal state of the widget
 */
 DeleteFieldWidget.prototype.execute = function() {
 	this.actionTiddler = this.getAttribute("$tiddler",this.getVariable("currentTiddler"));
-	this.actionField = this.getAttribute("$field");
+	this.actionField = this.getAttribute("$field",null);
 };
 
 /*
@@ -59,7 +59,7 @@ DeleteFieldWidget.prototype.invokeAction = function(triggeringWidget,event) {
 		tiddler = this.wiki.getTiddler(self.actionTiddler),
 		removeFields = {},
 		hasChanged = false;
-	if(this.actionField && tiddler) {
+	if((this.actionField != null) && tiddler) {
 		removeFields[this.actionField] = undefined;
 		if(this.actionField in tiddler.fields) {
 			hasChanged = true;


### PR DESCRIPTION
This PR is related to **[BUG] Nameless field can't be deleted #6886**

It will fix the UI related problem. A nameless field can be removed after this PR is merged. 
