### PR TITLE
Getting started new table layout

### DIFF
--- a/core/language/en-GB/GettingStarted.tid
+++ b/core/language/en-GB/GettingStarted.tid
@@ -9,9 +9,10 @@ Before you start storing important information in ~TiddlyWiki it is vital to mak
 
 <div class="tc-control-panel">
 
-|<$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link> |<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
-|<$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link> |<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
-|<$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link> |<<lingo DefaultTiddlers/TopHint>><br> <$edit tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
+|tc-table-no-grid tc-first-col-min-width tc-first-link-nowrap|k
+| <$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link>|<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
+| <$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link>|<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
+|^ <$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link><br><<lingo DefaultTiddlers/TopHint>>|<$edit tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
 </div>
 
 See the [[control panel|$:/ControlPanel]] for more options.

--- a/core/language/en-GB/GettingStarted.tid
+++ b/core/language/en-GB/GettingStarted.tid
@@ -9,7 +9,7 @@ Before you start storing important information in ~TiddlyWiki it is vital to mak
 
 <div class="tc-control-panel">
 
-|tc-table-no-grid tc-first-col-min-width tc-first-link-nowrap|k
+|tc-table-no-border tc-first-col-min-width tc-first-link-nowrap|k
 | <$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link>|<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
 | <$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link>|<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
 |^ <$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link><br><<lingo DefaultTiddlers/TopHint>>|<$edit tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -329,9 +329,9 @@ Table utility classes
 */
 
 /* Remove borders from table as used in eg: GettingStarted*/
-.tc-table-no-grid,
-.tc-table-no-grid th,
-.tc-table-no-grid td {
+.tc-table-no-border,
+.tc-table-no-border th,
+.tc-table-no-border td {
 	border: initial;
 }
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -293,6 +293,10 @@ pre > code {
 	color: inherit;
 }
 
+/*
+Table defaults
+*/
+
 table {
 	border: 1px solid <<colour table-border>>;
 	width: auto;
@@ -320,9 +324,39 @@ table tfoot tr td {
 	background-color: <<colour table-footer-background>>;
 }
 
+/*
+Table utility classes
+*/
+
+/* Remove borders from table as used in eg: GettingStarted*/
+.tc-table-no-grid,
+.tc-table-no-grid th,
+.tc-table-no-grid td {
+	border: initial;
+}
+
+/* First column in table width will fit to text.*/
+/* This rule makes most sense with tc-first-link-nowrap*/
+.tc-first-col-min-width td:nth-child(1) {
+	width: 1%;
+}
+
+/* First link A element will not wrap */
+.tc-first-link-nowrap:first-of-type a {
+	white-space: nowrap;
+}
+
+/*
+CSV parser plugin
+*/
+
 .tc-csv-table {
 	white-space: nowrap;
 }
+
+/*
+Tiddler frame in story river
+*/
 
 .tc-tiddler-frame img,
 .tc-tiddler-frame svg,


### PR DESCRIPTION
This PR is related to: https://github.com/Jermolene/TiddlyWiki5/issues/1344#issuecomment-1207500258

This PR 

- changes the GettingStarted table layout as shown in images below
- It adds the needed table utility classes, so the settings can be reused by all users
   - Removing borders is done using the new `tc-` utility classes
- Text positioning "align right" and "vertical align top" is done using wikitext syntax


## Screenshot FF

<details><summary>New Layout FF</summary>

![image](https://user-images.githubusercontent.com/374655/183669317-1fa9f63a-8603-4d5f-a656-008833728d85.png)
</details>

## Screenshot Windows Edge
<details><summary>New Layout FF</summary>

![image](https://user-images.githubusercontent.com/374655/183669938-422d82b9-af4c-4bb0-bf09-9d665f349e47.png)
</details>

## Screenshot Existing 

<details><summary>OLD Layout FF</summary>

![image](https://user-images.githubusercontent.com/374655/183670441-91cc58d5-0088-4af2-923a-1290d7722d10.png)
</details>
