### PR TITLE
Fix bug when using built-in `list` field as listField parameter to checkbox widget

### DIFF
--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -212,6 +212,10 @@ CheckboxWidget.prototype.handleChangeEvent = function(event) {
 		} else {
 			listContents = $tw.utils.parseStringArray(this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxListIndex) || "") || [];
 		}
+		if(Object.isFrozen(listContents)) {
+			// Can happen if using, say, the built-in "list" field which is frozen against modifications
+			listContents = listContents.slice(0);
+		}
 		oldPos = notValue ? listContents.indexOf(notValue) : -1;
 		newPos = value ? listContents.indexOf(value) : -1;
 		if(oldPos === -1 && newPos !== -1) {

--- a/editions/test/tiddlers/tests/test-checkbox-widget.js
+++ b/editions/test/tiddlers/tests/test-checkbox-widget.js
@@ -234,6 +234,38 @@ Tests the checkbox widget thoroughly.
             },
         ];
 
+        // https://github.com/Jermolene/TiddlyWiki5/issues/6871
+        const listModeTestsWithListField = (
+            listModeTests
+            .filter(data => data.widgetText.includes("listField='colors'"))
+            .map(data => {
+                const newData = {
+                    ...data,
+                    tiddlers: data.tiddlers.map(tiddler => ({...tiddler, list: tiddler.colors, colors: undefined})),
+                    widgetText: data.widgetText.replace("listField='colors'", "listField='list'"),
+                    expectedChange: {
+                        "Colors": { list: data.expectedChange.Colors.colors.split(' ') }
+                    },
+                }
+                return newData;
+            })
+        );
+        const listModeTestsWithTagsField = (
+            listModeTests
+            .filter(data => data.widgetText.includes("listField='colors'"))
+            .map(data => {
+                const newData = {
+                    ...data,
+                    tiddlers: data.tiddlers.map(tiddler => ({...tiddler, tags: tiddler.colors, colors: undefined})),
+                    widgetText: data.widgetText.replace("listField='colors'", "listField='tags'"),
+                    expectedChange: {
+                        "Colors": { tags: data.expectedChange.Colors.colors.split(' ') }
+                    },
+                }
+                return newData;
+            })
+        );
+
         const indexListModeTests = listModeTests.map(data => {
             const newData = {...data};
             const newName = data.testName.replace('list mode', 'index list mode');
@@ -453,6 +485,8 @@ Tests the checkbox widget thoroughly.
         const checkboxTestData = fieldModeTests.concat(
             indexModeTests,
             listModeTests,
+            listModeTestsWithListField,
+            listModeTestsWithTagsField,
             indexListModeTests,
             filterModeTests,
         );
@@ -495,7 +529,7 @@ Tests the checkbox widget thoroughly.
                     for (const fieldName of Object.keys(change)) {
                         const expectedValue = change[fieldName];
                         const fieldValue = tiddler.fields[fieldName];
-                        expect(fieldValue).toBe(expectedValue);
+                        expect(fieldValue).toEqual(expectedValue);
                     }
                 }
             })


### PR DESCRIPTION
This fixes the `TypeError: can't define array index property past the end of an array with non-writable length` error from #6871. The cause of this problem is that when I implemented the `listField` feature, I tried to be efficient by saying "if the field is already stored as a list internally, just modify it in place". But TiddlyWiki's internal tiddler objects are "frozen" against being modified in-place. And my tests didn't catch that because most fields are stored as text internally, but the `list` field is, for obvious reasons, stored as a list internally.

This PR also adds regression tests so that the bug won't happen again. The bug would have manifested with the `tags` field as well, but since the checkbox widget already has a `tag` input property, most people aren't going to use `listField="tags"` so they won't run into that version of the bug. Still, I added regression tests to test both the `list` and `tags` fields, just to make sure that possibility was covered as well.
