### PR TITLE
Fix missing links in Getting Started.

### DIFF
--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
@@ -1,16 +1,16 @@
 created: 20131129090249275
-modified: 20200507203622933
+modified: 20220812144420645
 tags: [[Working with TiddlyWiki]]
 title: GettingStarted
 type: text/vnd.tiddlywiki
 
-The easiest way to use TiddlyWiki is to sign up for a free account with [[Tiddlyhost]], an independently run community service:
+The easiest way to use ~TiddlyWiki is to sign up for a free account with [[Tiddlyhost|https://tiddlyhost.com/]], an independently run community service:
 
 https://tiddlyhost.com/
 
 If you find Tiddlyhost useful, please consider [[donation or sponsorship|https://tiddlyhost.com/donate]].
 
-Click here to download an empty copy of TiddlyWiki: {{$:/editions/tw5.com/snippets/download-empty-button}}
+Click here to download an empty copy of ~TiddlyWiki: {{$:/editions/tw5.com/snippets/download-empty-button}}
 
 The next step is to choose a method for saving changes. There's a wide variety of methods available, with different features and limitations. Click on the badge for a method to see more information about it. You can also click on one of the platform filters to restrict the listing to methods that work with that platform.
 

--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted.tid
@@ -1,14 +1,10 @@
 created: 20131129090249275
-modified: 20220812144420645
+modified: 20220819041016415
 tags: [[Working with TiddlyWiki]]
 title: GettingStarted
 type: text/vnd.tiddlywiki
 
-The easiest way to use ~TiddlyWiki is to sign up for a free account with [[Tiddlyhost|https://tiddlyhost.com/]], an independently run community service:
-
-https://tiddlyhost.com/
-
-If you find Tiddlyhost useful, please consider [[donation or sponsorship|https://tiddlyhost.com/donate]].
+The easiest way to use ~TiddlyWiki is to sign up for a free account with [[Tiddlyhost|https://tiddlyhost.com/]], an independently run community service. If you find Tiddlyhost useful, please consider [[donation or sponsorship|https://tiddlyhost.com/donate]].
 
 Click here to download an empty copy of ~TiddlyWiki: {{$:/editions/tw5.com/snippets/download-empty-button}}
 

--- a/editions/tw5.com/tiddlers/saving/Saving.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving.tid
@@ -1,5 +1,5 @@
 created: 20140912140651119
-modified: 20220401151525812
+modified: 20220812144516626
 saving-browser: Firefox Chrome Edge [[Internet Explorer]] Safari Opera [[Standalone App]]
 saving-os: Windows Mac Linux Android iOS
 tags: [[Working with TiddlyWiki]]
@@ -34,7 +34,7 @@ type: text/vnd.tiddlywiki
 \end
 <$vars stateTiddler=<<qualify "$:/state/gettingstarted">> >
 
-Available methods for saving changes with TiddlyWiki:
+Available methods for saving changes with ~TiddlyWiki:
 
 <div class="tc-wrapper-flex">
 <div class="tc-saving-sidebar">


### PR DESCRIPTION
Unprettify TiddlyWiki camelcase links. Add actual link to "Tiddlyhost". Newcomers are confused about these missing links.