### PR TITLE
make input and button elements consistent for all browsers

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -76,16 +76,17 @@ $else$
 	-webkit-box-sizing: border-box;
 }
 
-input[type="search"] {
-	outline-offset: initial;
-}
-
+/*
+** Button default styles. Makes them look consistent for all browsers
+*/
 html button {
 	line-height: 1.2;
 	color: <<colour button-foreground>>;
 	fill: <<colour button-foreground>>;
 	background: <<colour button-background>>;
-	border-color: <<colour button-border>>;
+	border: 1px solid <<colour button-border>>;
+	border-radius: 3px;
+	padding: 2px 5px;
 }
 
 button:disabled svg {
@@ -221,8 +222,19 @@ dl dt {
 	margin-top: 6px;
 }
 
-button, textarea, input, select {
-	outline-color: <<colour primary>>;
+/*
+** Definition for text input elements so they look consistent for all browsers
+*/
+
+textarea, input, select {
+	border: 2px solid <<colour tiddler-editor-border>>;
+	background-color: <<colour tiddler-editor-background>>;
+}
+
+/* Input elements accessibility -- overwrite the reset */
+:focus-visible {
+	outline: 2px solid <<colour primary>>;
+	outline-offset: -2px;    /* same as in reset.css [type='search'] but for more elements */
 }
 
 textarea,
@@ -231,7 +243,6 @@ input[type=search],
 input[type=""],
 input:not([type]) {
 	color: <<colour foreground>>;
-	background: <<colour background>>;
 }
 
 input[type="checkbox"] {
@@ -1174,6 +1185,7 @@ button.tc-btn-invisible.tc-remove-tag-button {
 
 .tc-tiddler-frame .tc-tiddler-controls {
 	float: right;
+	padding: 3px; /* make space for outline */
 }
 
 .tc-tiddler-controls .tc-drop-down {


### PR DESCRIPTION
This PR fixes: **[BUG] Input fields in Edge and FireFox behave slightly different in terms of outline colour setting. #6874**

This PR does 2 things

- It defines the [:focus-visible] pseudo class in a way that fits your theme
  - the new [reset]( https://github.com/sindresorhus/modern-normalize) we introduced with v5.1.23 defined `:-moz-focusring`, which wasn't part of the older reset we did use. --> that caused the problem. 
  - see [MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-focusring) 
- input fields use the same border and background settings now. So they should look consistent for all platforms now. 

# I did test the PR with the following browsers and OSes

- FireFox latest version .. Windows 
- FireFox latest version .. Linux 22.04
- FireFox latest for Android 
- Chrome for Android 
- Chromium ... Ubuntu 22.04 .. Version 104.0.5112.79 (Official Build) snap (64-bit)
- Edge latest version ... Windows
- Brave browser latest version ... Windows
- I did test _all_ the palette's that are part of tiddlywiki.com 
- I did test all the dropdowns I know

**--> I can't test with Safari.** 

-------

# FireFox before

**The selected element outlines are almost invisible**

<details><summary>FireFox before  (click me)</summary>

![grafik](https://user-images.githubusercontent.com/374655/185120120-2cc9963d-f829-4975-9487-db40af970bf0.png)

![grafik](https://user-images.githubusercontent.com/374655/185118041-be1e343f-e7ac-4da1-8b91-a1b4aa26de0f.png)

![grafik](https://user-images.githubusercontent.com/374655/185118884-34673e92-26cc-4b28-a5f7-678ef952cadc.png)

![grafik](https://user-images.githubusercontent.com/374655/185119228-79693a2d-4de0-48c8-967e-24ce48c71e66.png)

</details>

# FireFox after 

**The selections are visible again as up to TW v5.1.22**

<details><summary>FireFox after</summary>

![grafik](https://user-images.githubusercontent.com/374655/185127718-b032c821-497a-4f6c-bd2a-a477354a4818.png)

![grafik](https://user-images.githubusercontent.com/374655/185121301-361dffe9-c9c3-4462-9306-5a0b9bd129d4.png)

![grafik](https://user-images.githubusercontent.com/374655/185121657-97fc6421-d759-4673-9bea-e1d56515f0cf.png)

![grafik](https://user-images.githubusercontent.com/374655/185124786-4f2a1834-2e7a-43e8-93cd-f78a45358904.png)

</details>

# Edge before

**WebKit browsers weren't effected by the new reset we started to use with v5.1.23**

<details ><summary>Edge before</summary>

![grafik](https://user-images.githubusercontent.com/374655/185130323-995081fb-de4a-4e13-a15d-6bf5280b3c0e.png)

![grafik](https://user-images.githubusercontent.com/374655/185124193-50f88d42-b66b-47fb-9fb8-f5bed486369e.png)

![grafik](https://user-images.githubusercontent.com/374655/185125594-9b330acd-b802-453e-a7bd-d82ae4e2827f.png)

![grafik](https://user-images.githubusercontent.com/374655/185126147-2071364f-f1dc-4cfb-80b9-341eeb754392.png)

</details>

# Edge after

**Border settings look consistent between browsers and palette settings are respected**

<details ><summary>Edge after</summary>

![grafik](https://user-images.githubusercontent.com/374655/185126665-303c7e9e-97ab-4155-994d-ff4bbd34d636.png)

</details>
