### PR TITLE
Make dialogs over deleting AdvancedSearch filter results translatable

### DIFF
--- a/core/language/en-GB/Buttons.multids
+++ b/core/language/en-GB/Buttons.multids
@@ -18,6 +18,8 @@ CopyToClipboard/Caption: copy to clipboard
 CopyToClipboard/Hint: Copy this text to the clipboard
 Delete/Caption: delete
 Delete/Hint: Delete this tiddler
+DeleteTiddlers/Caption: delete tiddlers
+DeleteTiddlers/Hint: Delete tiddlers
 Edit/Caption: edit
 Edit/Hint: Edit this tiddler
 Encryption/Caption: encryption

--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -8,6 +8,7 @@ CloseAll/Button: close all
 ColourPicker/Recent: Recent:
 ConfirmCancelTiddler: Do you wish to discard changes to the tiddler "<$text text=<<title>>/>"?
 ConfirmDeleteTiddler: Do you wish to delete the tiddler "<$text text=<<title>>/>"?
+ConfirmDeleteTiddlers: Are you sure you wish to delete <<resultCount>> tiddler(s)?
 ConfirmOverwriteTiddler: Do you wish to overwrite the tiddler "<$text text=<<title>>/>"?
 ConfirmEditShadowTiddler: You are about to edit a ShadowTiddler. Any changes will override the default system making future upgrades non-trivial. Are you sure you want to edit "<$text text=<<title>>/>"?
 ConfirmAction: Do you wish to proceed?

--- a/core/ui/AdvancedSearch/FilterButtons/delete.tid
+++ b/core/ui/AdvancedSearch/FilterButtons/delete.tid
@@ -3,7 +3,7 @@ tags: $:/tags/AdvancedSearch/FilterButton
 
 \whitespace trim
 <$reveal state="$:/temp/advancedsearch" type="nomatch" text="">
-<$button popup=<<qualify "$:/state/filterDeleteDropdown">> class="tc-btn-invisible">
+<$button tooltip={{$:/language/Buttons/DeleteTiddlers/Hint}} popup=<<qualify "$:/state/filterDeleteDropdown">> class="tc-btn-invisible">
 {{$:/core/images/delete-button}}
 </$button>
 </$reveal>
@@ -13,13 +13,13 @@ tags: $:/tags/AdvancedSearch/FilterButton
 <div class="tc-block-dropdown tc-edit-type-dropdown">
 <div class="tc-dropdown-item-plain">
 <$set name="resultCount" value="""<$count filter={{$:/temp/advancedsearch}}/>""">
-Are you sure you wish to delete <<resultCount>> tiddler(s)?
+{{$:/language/ConfirmDeleteTiddlers}}
 </$set>
 </div>
 <div class="tc-dropdown-item-plain">
 <$button class="tc-btn">
 <$action-deletetiddler $filter={{$:/temp/advancedsearch}}/>
-Delete these tiddlers
+{{$:/language/Buttons/DeleteTiddlers/Hint}}
 </$button>
 </div>
 </div>

--- a/languages/fr-FR/Buttons.multids
+++ b/languages/fr-FR/Buttons.multids
@@ -18,6 +18,8 @@ CopyToClipboard/Caption: copier dans le presse-papier
 CopyToClipboard/Hint: Copie ce texte dans le presse-papier
 Delete/Caption: supprimer
 Delete/Hint: Supprime ce tiddler
+DeleteTiddlers/Caption: supprimer les tiddlers
+DeleteTiddlers/Hint: Supprime ces tiddlers
 Edit/Caption: éditer
 Edit/Hint: Édite ce tiddler
 Encryption/Caption: chiffrement

--- a/languages/fr-FR/Misc.multids
+++ b/languages/fr-FR/Misc.multids
@@ -7,8 +7,9 @@ ClassicWarning/Upgrade/Caption: mettre à jour
 CloseAll/Button: tout fermer
 ColourPicker/Recent: Récent :
 ConfirmCancelTiddler: Souhaitez-vous annuler les modifications apportées au tiddler « <$text text=<<title>>/> » ?
-ConfirmDeleteTiddler: Souhaitez-vous supprimer le tiddler « <$text text=<<title>>/> » ?
-ConfirmOverwriteTiddler: Souhaitez-vous supplanter le tiddler « <$text text=<<title>>/> » ?
+ConfirmDeleteTiddler: Souhaitez-vous supprimer le tiddler « <$text text=<<title>>/> » ?
+ConfirmDeleteTiddlers: Êtes-vous sûr•e de vouloir supprimer <<resultCount>> tiddler(s) ?
+ConfirmOverwriteTiddler: Souhaitez-vous supplanter le tiddler « <$text text=<<title>>/> » ?
 ConfirmEditShadowTiddler: Vous êtes sur le point d'éditer un ShadowTiddler. Toute modification supplantera la version par défaut du système, rendant les prochaines mises à jour non-triviales. Êtes-vous sûr(e) de vouloir éditer "<$text text=<<title>>/>"?
 ConfirmAction: Souhaitez-vous poursuivre ?
 Count: total 


### PR DESCRIPTION
The _delete_ operation featured next to the [AdvancedSearch ](https://tiddlywiki.com/#%24%3A%2FAdvancedSearch) filter results missed translatable strings. This PR aims at:

1. Replacing the hard coded strings with transclusions on relevant snippet names
2. Adding _Hint_ and _Caption_ entries for the button as well as a user confirmation entry  in the default _core/language/en-GB/_ directory
3. Adding the _fr-FR_ translation for the above entries