### PR TITLE
add data-tags and data-tiddler-title attributes to preview area

### DIFF
--- a/core/ui/EditTemplate/body/default.tid
+++ b/core/ui/EditTemplate/body/default.tid
@@ -19,7 +19,7 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 
 <$transclude tiddler="$:/core/ui/EditTemplate/body/editor" mode="inline"/>
 
-<div class="tc-tiddler-preview-preview">
+<div class="tc-tiddler-preview-preview" data-tiddler-title={{!!draft.title}} data-tags={{!!tags}}>
 
 <$transclude tiddler={{$:/state/editpreviewtype}} mode="inline">
 


### PR DESCRIPTION
This PR will fix issue #3661 ... 

To test the new function: 

- open a new tiddler and tag it: `example-test`
   - the preview and the draft tiddler will get a pink border as explained at: https://tiddlywiki.com/#Custom%20styles%20by%20data-tags
- create a new tiddler eg: `test-style` and tagged: `$:/tags/Stylesheet`

```
title: test-styles
tags: $:/tags/Stylesheet

[data-tiddler-title="asdf"] {
border: 2px solid lightgreen;
}
```

- Now open a new tiddler 
- set the new name to "asdf"
- the preview area should have a light green border now
- as explained at: https://tiddlywiki.com/#Custom%20styles%20by%20data-tiddler-title

