### PR TITLE
Add meta viewport to StaticRiver

### DIFF
--- a/core/templates/exporters/StaticRiver.tid
+++ b/core/templates/exporters/StaticRiver.tid
@@ -14,6 +14,7 @@ extension: .html
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="generator" content="TiddlyWiki" />
 <meta name="tiddlywiki-version" content="{{$:/core/templates/version}}" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="format-detection" content="telephone=no">
 <link id="faviconLink" rel="shortcut icon" href="favicon.ico">
 <title>{{$:/core/wiki/title}}</title>


### PR DESCRIPTION
StaticRiver HTML didn't feature a <meta name="viewport" line, which made single-page full wiki static exports look bad on mobile.