### PR TITLE
Use deprecated macro for deprecated commands

### DIFF
--- a/editions/tw5.com/tiddlers/commands/RenderTiddlerCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/RenderTiddlerCommand.tid
@@ -2,4 +2,6 @@ title: RenderTiddlerCommand
 tags: Commands
 caption: rendertiddler
 
+<<.deprecated-since "5.1.15" "RenderCommand">>.
+
 {{$:/language/Help/rendertiddler}}

--- a/editions/tw5.com/tiddlers/commands/RenderTiddlersCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/RenderTiddlersCommand.tid
@@ -2,4 +2,6 @@ title: RenderTiddlersCommand
 tags: Commands
 caption: rendertiddlers
 
+<<.deprecated-since "5.1.15" "RenderCommand">>.
+
 {{$:/language/Help/rendertiddlers}}

--- a/editions/tw5.com/tiddlers/commands/SaveTiddlerCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/SaveTiddlerCommand.tid
@@ -4,4 +4,6 @@ created: 20131218121606089
 modified: 20131218121606089
 caption: savetiddler
 
+<<.deprecated-since "5.1.15" "SaveCommand">>.
+
 {{$:/language/Help/savetiddler}}

--- a/editions/tw5.com/tiddlers/commands/SaveTiddlersCommand.tid
+++ b/editions/tw5.com/tiddlers/commands/SaveTiddlersCommand.tid
@@ -4,4 +4,6 @@ created: 20140609121606089
 modified: 20140609121606089
 caption: savetiddlers
 
+<<.deprecated-since "5.1.15" "SaveCommand">>.
+
 {{$:/language/Help/savetiddlers}}


### PR DESCRIPTION
This just brings the documentation for these commands more inline with other deprecations, plus offers a link to the recommended alternative as well as the explanation for deprecation