### PR TITLE
Add VScode user settings directory to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .c9/
+.vscode/
 tmp/
 output/
 node_modules/


### PR DESCRIPTION
Like the title says, this PR just adds the VSCode user settings directory to `.gitignore`. It's not a directory that would ever want to be committed and it's slightly annoying to always see the files from it in my unstaged changes, hence I'd love it to be added to git ignore.