### PR TITLE
add Polish translations introduced since I last updated them

### DIFF
--- a/languages/pl-PL/Buttons.multids
+++ b/languages/pl-PL/Buttons.multids
@@ -18,6 +18,8 @@ CopyToClipboard/Caption: skopiuj do schowka
 CopyToClipboard/Hint: Skopiuj ten tekst do schowka
 Delete/Caption: usuń
 Delete/Hint: Usuń tiddlera
+DeleteTiddlers/Caption: usuń tiddlery
+DeleteTiddlers/Hint: Usuwa tiddlery
 Edit/Caption: edytuj
 Edit/Hint: Edytuj tego tiddlera
 Encryption/Caption: szyfrowanie

--- a/languages/pl-PL/GettingStarted.tid
+++ b/languages/pl-PL/GettingStarted.tid
@@ -9,9 +9,10 @@ Zanim zaczniesz zapisywać ważne informacje w swojej ~TiddlyWiki ważne jest, �
 
 <div class="tc-control-panel">
 
-|<$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link> |<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
-|<$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link> |<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
-|<$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link> |<<lingo DefaultTiddlers/TopHint>><br> <$edit tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
+|tc-table-no-border tc-first-col-min-width tc-first-link-nowrap|k
+| <$link to="$:/SiteTitle"><<lingo Title/Prompt>></$link>|<$edit-text tiddler="$:/SiteTitle" default="" tag="input"/> |
+| <$link to="$:/SiteSubtitle"><<lingo Subtitle/Prompt>></$link>|<$edit-text tiddler="$:/SiteSubtitle" default="" tag="input"/> |
+|^ <$link to="$:/DefaultTiddlers"><<lingo DefaultTiddlers/Prompt>></$link><br><<lingo DefaultTiddlers/TopHint>>|<$edit tag="textarea" tiddler="$:/DefaultTiddlers"/><br>//<<lingo DefaultTiddlers/BottomHint>>// |
 </div>
 
 Przejdź do [[panelu sterowania|$:/ControlPanel]] by zmienić pozostałe opcje.

--- a/languages/pl-PL/Help/render.tid
+++ b/languages/pl-PL/Help/render.tid
@@ -31,5 +31,5 @@ Notatki:
 
 Przykłady:
 
-* `--render "[!is[system]]" "[encodeuricomponent[]addprefix[tiddlers/]addsuffix[.html]]"` -- renderuje wszystkie niesystemowe tiddlery jako pliki w podfolderze "tiddlers", kodując znaki URI w nazwie i dodając rozszerzenie .html
-
+* `--render '[!is[system]]' '[encodeuricomponent[]addprefix[tiddlers/]addsuffix[.html]]'` -- renderuje wszystkie niesystemowe tiddlery jako pliki w podfolderze "tiddlers", kodując znaki URI w nazwie i dodając rozszerzenie .html
+* `--render '.' 'tiddlers.json' 'text/plain' '$:/core/templates/exporters/JsonFile' 'exportFilter' '[tag[HelloThere]]'` -- renderuje wszystkie tiddlery z tagiem "HelloThere" do pliku JSON o nazwie "tiddlers.json"

--- a/languages/pl-PL/Misc.multids
+++ b/languages/pl-PL/Misc.multids
@@ -8,6 +8,7 @@ CloseAll/Button: zamknij wszystkie
 ColourPicker/Recent: Ostatnie:
 ConfirmCancelTiddler: Czy na pewno chcesz odrzucić zmiany w tiddlerze "<$text text=<<title>>/>"?
 ConfirmDeleteTiddler: Czy na pewno chcesz usunąc tiddlera "<$text text=<<title>>/>"?
+ConfirmDeleteTiddlers: Na pewno chcesz usunąć <<resultCount>> tiddler/y/ów?
 ConfirmOverwriteTiddler: Czy na pewno chcesz nadpisać tiddlera "<$text text=<<title>>/>"?
 ConfirmEditShadowTiddler: Próbujesz utworzyć tiddler-cień. Zmiany te nadpiszą oryginalne, systemowe tiddlery co może utrudniać aktualizację wiki. Czy na pewno chcesz zmodyfikować"<$text text=<<title>>/>"?
 ConfirmAction: Na pewno chcesz kontynuować?


### PR DESCRIPTION
This contains translations from the following commits:
 * ca762ab7a6d644cbe7ea07835f5f299fd404c13e
 * a453121e96ce122143cb65f50ffd47844f523109
 * d7b9e6fb02d38bc7a56b08cca96425faacf61999
 * 0b1fc8e574de16e280a6dd00ab5dc4477a7c8ee6
 * 4007610d522281204bdef90e11b68834cfee92b7 -- There was nothing to translate here because I already translated "wizard" to the equivalent of "modal window" the first time

----

Sorry for missing 5.2.3 release window, feel free to ping me before a few days before any new release and I'll make sure to get the translations in on time.