### PR TITLE
Extend page template with filter assigned classes

### DIFF
--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -23,7 +23,7 @@ title: $:/core/ui/EditTemplate
 <div
 	data-tiddler-title=<<currentTiddler>>
 	data-tags={{!!tags}}
-	class={{{ tc-tiddler-frame tc-tiddler-edit-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}
+	class={{{ [all[shadows+tiddlers]tag[$:/tags/ClassFilters/TiddlerTemplate]!is[draft]] :map:flat[subfilter{!!text}] tc-tiddler-frame tc-tiddler-edit-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}
 	role="region"
 	aria-label={{$:/language/EditTemplate/Caption}}>
 <$fieldmangler>

--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -3,9 +3,6 @@ name: {{$:/language/PageTemplate/Name}}
 description: {{$:/language/PageTemplate/Description}}
 
 \whitespace trim
-\define containerClasses()
-tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
-\end
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 
 <$vars
@@ -17,7 +14,7 @@ tc-page-container tc-page-view-$(storyviewTitle)$ tc-language-$(languageTitle)$
 	storyviewTitle={{$:/view}}
 	languageTitle={{{ [{$:/language}get[name]] }}}>
 
-<div class=<<containerClasses>>>
+<div class={{{ [all[shadows+tiddlers]tag[$:/tags/BodyClassFilters]] :map:flat[subfilter{!!text}] tc-page-container [[tc-page-view-]addsuffix<storyviewTitle>] [[tc-language-]addsuffix<languageTitle>] :and[join[ ]] }}} >
 
 <$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
 

--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -14,7 +14,7 @@ description: {{$:/language/PageTemplate/Description}}
 	storyviewTitle={{$:/view}}
 	languageTitle={{{ [{$:/language}get[name]] }}}>
 
-<div class={{{ [all[shadows+tiddlers]tag[$:/tags/BodyClassFilters]] :map:flat[subfilter{!!text}] tc-page-container [[tc-page-view-]addsuffix<storyviewTitle>] [[tc-language-]addsuffix<languageTitle>] :and[join[ ]] }}} >
+<div class={{{ [all[shadows+tiddlers]tag[$:/tags/ClassFilters/PageTemplate]!is[draft]] :map:flat[subfilter{!!text}] tc-page-container [[tc-page-view-]addsuffix<storyviewTitle>] [[tc-language-]addsuffix<languageTitle>] :and[unique[]join[ ]] }}} >
 
 <$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
 

--- a/core/ui/ViewTemplate.tid
+++ b/core/ui/ViewTemplate.tid
@@ -7,7 +7,7 @@ $:/state/folded/$(currentTiddler)$
 \define cancel-delete-tiddler-actions(message) <$action-sendmessage $message="tm-$message$-tiddler"/>
 \import [all[shadows+tiddlers]tag[$:/tags/Macro/View]!has[draft.of]]
 <$vars storyTiddler=<<currentTiddler>> tiddlerInfoState=<<qualify "$:/state/popup/tiddler-info">>>
-<div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ tc-tiddler-frame tc-tiddler-view-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[shadow]is[tiddler]then[tc-tiddler-overridden-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}} role="article">
+<div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ [all[shadows+tiddlers]tag[$:/tags/ClassFilters/TiddlerTemplate]!is[draft]] :map:flat[subfilter{!!text}] tc-tiddler-frame tc-tiddler-view-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[shadow]is[tiddler]then[tc-tiddler-overridden-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}} role="article">
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate]!has[draft.of]]" variable="listItem">
 <$transclude tiddler=<<listItem>>/>
 </$list>

--- a/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_ClassFilters_PageTemplate.tid
+++ b/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_ClassFilters_PageTemplate.tid
@@ -1,0 +1,9 @@
+caption: $:/tags/ClassFilters/PageTemplate
+created: 20221020035315795
+description: marks filters evaluated to dynamically add classes to the page template.
+modified: 20221020035945262
+tags: SystemTags
+title: SystemTag: $:/tags/ClassFilters/PageTemplate
+type: text/vnd.tiddlywiki
+
+The [[system tag|SystemTags]] `$:/tags/ClassFilters/PageTemplate` marks filters marks filters evaluated to dynamically add their output as CSS classes to the page template.

--- a/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_ClassFilters_TiddlerTemplate.tid
+++ b/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_ClassFilters_TiddlerTemplate.tid
@@ -1,0 +1,9 @@
+caption: $:/tags/ClassFilters/TiddlerTemplate
+created: 20221020035738692
+description: marks filters evaluated to dynamically add classes to the page template.
+modified: 20221020035933363
+tags: SystemTags
+title: SystemTag: $:/tags/ClassFilters/TiddlerTemplate
+type: text/vnd.tiddlywiki
+
+The [[system tag|SystemTags]] `$:/tags/ClassFilters/TiddlerTemplate` marks filters marks filters evaluated to dynamically add their output as CSS classes to the tiddler template.


### PR DESCRIPTION
This PR introduces the new system tags `$:/tags/ClassFilters/PageTemplate` and `$:/tags/ClassFilters/TiddlerTemplate`  to allow dynamically assigning CSS classes to the page template container DIV and the tiddler template container DIV respectively.

The assignment of classes is changed to:
* avoid the use of text substitution via a macro
* introduces the new system tags `$:/tags/ClassFilters/PageTemplate` and `$:/tags/ClassFilters/TiddlerTemplate`
  * the text field of all tiddlers with these tags are evaluated as filters and their output concatenated into the classes assigned.

Example use cases for adding/removing classes:
* when a drag is active, set a state tiddler which in turn sets a class on the page container div
* when an error is being displayed to the user and the class assigned can thus be removed when the error message is dismissed
* when a modal or lightbox is shown
