### PR TITLE
allow select widget class to update if it uses a filter and is output changes

### DIFF
--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -170,11 +170,16 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 SelectWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	// If we're using a different tiddler/field/index then completely refresh ourselves
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tooltip || changedAttributes.class) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tooltip) {
 		this.refreshSelf();
 		return true;
 	// If the target tiddler value has changed, just update setting and refresh the children
 	} else {
+		if(changedAttributes.class) {
+			this.selectClass = this.getAttribute("class");
+			this.getSelectDomNode().setAttribute("class",this.selectClass); 
+		}
+		
 		var childrenRefreshed = this.refreshChildren(changedTiddlers);
 		if(changedTiddlers[this.selectTitle] || childrenRefreshed) {
 			this.setSelectValue();

--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -170,7 +170,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 SelectWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	// If we're using a different tiddler/field/index then completely refresh ourselves
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tooltip) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tooltip || changedAttributes.class) {
 		this.refreshSelf();
 		return true;
 	// If the target tiddler value has changed, just update setting and refresh the children


### PR DESCRIPTION
This fixes #6986 

The issue was caused by `class` not being in the list of compared attributes.

That being said, I am wondering if it wouldn't be better to do something like this:

```
SelectWidget.prototype.refresh = function(changedTiddlers) {
	var changedAttributes = this.computeAttributes();
	// If we're using a different tiddler/field/index then completely refresh ourselves
	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tooltip) {
		this.refreshSelf();
		return true;
	// If the target tiddler value has changed, just update setting and refresh the children
	} else {
                // ---> THIS HERE <----
		if (changedAttributes.class) {
			this.getSelectDomNode().className = this.getAttribute("class");            // EITHER THIS
                        this.getSelectDomNode().setAttribute("class",this.getAttribute("class"));  // OR THAT
		}
                // ---> TO HERE <----
		
		var childrenRefreshed = this.refreshChildren(changedTiddlers);
		if(changedTiddlers[this.selectTitle] || childrenRefreshed) {
			this.setSelectValue();
		} 
		return childrenRefreshed;
	}
};
```

This way the whole widget doesn't need to be refreshed. Probably the latter option would be more idiomatic given other code in TW?