### PR TITLE
Backlinks that respect dynamically rendered links

### DIFF
--- a/core/modules/indexers/backlinks-index.js
+++ b/core/modules/indexers/backlinks-index.js
@@ -26,11 +26,23 @@ BacklinksIndexer.prototype.rebuild = function() {
 }
 
 BacklinksIndexer.prototype._getLinks = function(tiddler) {
-	var parser =  this.wiki.parseText(tiddler.fields.type, tiddler.fields.text, {});
-	if(parser) {
-		return this.wiki.extractLinks(parser.tree);
-	}
-	return [];
+	var parser =  this.wiki.parseText(tiddler.fields.type,tiddler.fields.text,{});
+	parser.tree = [{
+		type: "importvariables",
+		attributes: {
+			filter: {
+				name: "filter",
+				type: "string",
+				value: "[[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]"
+			}
+		},
+		isBlock: false,
+		children: parser.tree
+	}];
+	var widget = this.wiki.makeWidget(parser,{document: $tw.fakeDocument, parseAsInline: false, variables: {currentTiddler: tiddler.fields.title}});
+	var container = $tw.fakeDocument.createElement("div");
+	widget.render(container,null);
+	return this.wiki.extractLinksFromWidgetTree(widget);
 }
 
 BacklinksIndexer.prototype.update = function(updateDescriptor) {


### PR DESCRIPTION
There has been [some discussion](https://talk.tiddlywiki.org/t/backlinks-that-respect-lists/4844) about backlinks not respecting dynamically rendered links (for example, the output of the `<<list-links>>` macro).

This has come up many times before, and I've always given the standard answer that performance would be a concern. However, I've never gone as far as experimenting to quantify the performance hit. As it turns out, it's quite usable.

This PR is a first attempt at an implementation of backlinks that fully renders tiddlers before extracting the links.

It works surprisingly well in my limited experiments. Using the tiddlywiki.com wiki, the first time I clicks on the "backlinks" tab I am experiencing a 2-4 second delay on my Mac. But thereafter things seem to be reasonable zippy thanks to the various levels of caching involved. I suspect that it consumes a good deal of memory too, but I haven't attempted to instrument it yet.

The implementation is very much a proof of concept, with some serious shortcomings in its current form:

* The new-style backlinks completely override the existing backlinks implementation. Presumably we'd want to make them available side-by-side with a switch to choose
* The global import of `[[tag[$:/tags/Macro]]` that we have to do to make globals available is repeated for each tiddler. It would be more efficient to cache the widget tree resulting from rendering the globals, and reuse it
