### PR TITLE
Handle ZoomIn issues when using tiddler template that starts with a text node

### DIFF
--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -40,6 +40,7 @@ Error/RetrievingSkinny: Error retrieving skinny tiddler list
 Error/SavingToTWEdit: Error saving to TWEdit
 Error/WhileSaving: Error while saving
 Error/XMLHttpRequest: XMLHttpRequest error code
+Error/ZoominTextNode: `<h2>''Story View Error''</h2>It appears you tried to interact with a tiddler that displays in a custom container. This is most likely caused by using `$:/tags/StoryTiddlerTemplateFilter` with a template that contains text or whitespace at the start. Please use the pragma <code>\whitespace trim</code> and ensure the whole contents of the tiddler is wrapped in a single HTML element.<br><br>''The text that caused this issue:''`
 InternalJavaScriptError/Title: Internal JavaScript Error
 InternalJavaScriptError/Hint: Well, this is embarrassing. It is recommended that you restart TiddlyWiki by refreshing your browser
 LayoutSwitcher/Description: Open the layout switcher

--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -40,7 +40,7 @@ Error/RetrievingSkinny: Error retrieving skinny tiddler list
 Error/SavingToTWEdit: Error saving to TWEdit
 Error/WhileSaving: Error while saving
 Error/XMLHttpRequest: XMLHttpRequest error code
-Error/ZoominTextNode: `<h2>''Story View Error''</h2>It appears you tried to interact with a tiddler that displays in a custom container. This is most likely caused by using `$:/tags/StoryTiddlerTemplateFilter` with a template that contains text or whitespace at the start. Please use the pragma <code>\whitespace trim</code> and ensure the whole contents of the tiddler is wrapped in a single HTML element.<br><br>''The text that caused this issue:''`
+Error/ZoominTextNode: Story View Error: It appears you tried to interact with a tiddler that displays in a custom container. This is most likely caused by using `$:/tags/StoryTiddlerTemplateFilter` with a template that contains text or whitespace at the start. Please use the pragma `\whitespace trim` and ensure the whole contents of the tiddler is wrapped in a single HTML element. The text that caused this issue:
 InternalJavaScriptError/Title: Internal JavaScript Error
 InternalJavaScriptError/Hint: Well, this is embarrassing. It is recommended that you restart TiddlyWiki by refreshing your browser
 LayoutSwitcher/Description: Open the layout switcher

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -17,6 +17,9 @@ var easing = "cubic-bezier(0.645, 0.045, 0.355, 1)"; // From http://easings.net/
 var ZoominListView = function(listWidget) {
 	var self = this;
 	this.listWidget = listWidget;
+	this.textNodeLogger = new $tw.utils.Logger("zoomin story river view", {
+		enable: true
+	});
 	// Get the index of the tiddler that is at the top of the history
 	var history = this.listWidget.wiki.getTiddlerDataCached(this.listWidget.historyTitle,[]),
 		targetTiddler;
@@ -48,7 +51,10 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 	var listItemWidget = this.listWidget.children[listElementIndex],
 		targetElement = listItemWidget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement) {
+		return;
+	} else if (targetElement.nodeType === Node.TEXT_NODE) {
+		this.alertTextNodeRoot(targetElement);
 		return;
 	}
 	// Make the new tiddler be position absolute and visible so that we can measure it
@@ -130,7 +136,10 @@ function findTitleDomNode(widget,targetClass) {
 ZoominListView.prototype.insert = function(widget) {
 	var targetElement = widget.findFirstDomNode();
 	// Abandon if the list entry isn't a DOM element (it might be a text node)
-	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
+	if(!targetElement) {
+		return;
+	} else if (targetElement.nodeType === Node.TEXT_NODE) {
+		this.alertTextNodeRoot(targetElement);
 		return;
 	}
 	// Make the newly inserted node position absolute and hidden
@@ -173,16 +182,21 @@ ZoominListView.prototype.remove = function(widget) {
 	var toWidgetDomNode = toWidget && toWidget.findFirstDomNode();
 	// Set up the tiddler we're moving back in
 	if(toWidgetDomNode) {
-		$tw.utils.addClass(toWidgetDomNode,"tc-storyview-zoomin-tiddler");
-		$tw.utils.setStyle(toWidgetDomNode,[
-			{display: "block"},
-			{transformOrigin: "50% 50%"},
-			{transform: "translateX(0px) translateY(0px) scale(10)"},
-			{transition: $tw.utils.roundTripPropertyName("transform") + " " + duration + "ms " + easing + ", opacity " + duration + "ms " + easing},
-			{opacity: "0"},
-			{zIndex: "500"}
-		]);
-		this.currentTiddlerDomNode = toWidgetDomNode;
+		if (toWidgetDomNode.nodeType === Node.TEXT_NODE) {
+			this.alertTextNodeRoot(toWidgetDomNode);
+			toWidgetDomNode = null;
+		} else {
+			$tw.utils.addClass(toWidgetDomNode,"tc-storyview-zoomin-tiddler");
+			$tw.utils.setStyle(toWidgetDomNode,[
+				{display: "block"},
+				{transformOrigin: "50% 50%"},
+				{transform: "translateX(0px) translateY(0px) scale(10)"},
+				{transition: $tw.utils.roundTripPropertyName("transform") + " " + duration + "ms " + easing + ", opacity " + duration + "ms " + easing},
+				{opacity: "0"},
+				{zIndex: "500"}
+			]);
+			this.currentTiddlerDomNode = toWidgetDomNode;
+		}
 	}
 	// Animate them both
 	// Force layout
@@ -204,6 +218,10 @@ ZoominListView.prototype.remove = function(widget) {
 		]);
 	}
 	return true; // Indicate that we'll delete the DOM node
+};
+
+ZoominListView.prototype.alertTextNodeRoot = function(node) {
+	this.textNodeLogger.alert($tw.language.getString("Error/ZoominTextNode") + " " + node.textContent);
 };
 
 exports.zoomin = ZoominListView;

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -18,7 +18,8 @@ var ZoominListView = function(listWidget) {
 	var self = this;
 	this.listWidget = listWidget;
 	this.textNodeLogger = new $tw.utils.Logger("zoomin story river view", {
-		enable: true
+		enable: true,
+		colour: 'red'
 	});
 	// Get the index of the tiddler that is at the top of the history
 	var history = this.listWidget.wiki.getTiddlerDataCached(this.listWidget.historyTitle,[]),
@@ -54,7 +55,7 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 	if(!targetElement) {
 		return;
 	} else if (targetElement.nodeType === Node.TEXT_NODE) {
-		this.alertTextNodeRoot(targetElement);
+		this.logTextNodeRoot(targetElement);
 		return;
 	}
 	// Make the new tiddler be position absolute and visible so that we can measure it
@@ -139,7 +140,7 @@ ZoominListView.prototype.insert = function(widget) {
 	if(!targetElement) {
 		return;
 	} else if (targetElement.nodeType === Node.TEXT_NODE) {
-		this.alertTextNodeRoot(targetElement);
+		this.logTextNodeRoot(targetElement);
 		return;
 	}
 	// Make the newly inserted node position absolute and hidden
@@ -183,7 +184,7 @@ ZoominListView.prototype.remove = function(widget) {
 	// Set up the tiddler we're moving back in
 	if(toWidgetDomNode) {
 		if (toWidgetDomNode.nodeType === Node.TEXT_NODE) {
-			this.alertTextNodeRoot(toWidgetDomNode);
+			this.logTextNodeRoot(toWidgetDomNode);
 			toWidgetDomNode = null;
 		} else {
 			$tw.utils.addClass(toWidgetDomNode,"tc-storyview-zoomin-tiddler");
@@ -220,8 +221,8 @@ ZoominListView.prototype.remove = function(widget) {
 	return true; // Indicate that we'll delete the DOM node
 };
 
-ZoominListView.prototype.alertTextNodeRoot = function(node) {
-	this.textNodeLogger.alert($tw.language.getString("Error/ZoominTextNode") + " " + node.textContent);
+ZoominListView.prototype.logTextNodeRoot = function(node) {
+	this.textNodeLogger.log($tw.language.getString("Error/ZoominTextNode") + " " + node.textContent);
 };
 
 exports.zoomin = ZoominListView;


### PR DESCRIPTION
This fixes #6992.

Two changes were made here:

1. Anytime ZoomIn tries to interact with a tiddler that is rendered through `$:/tags/StoryTiddlerTemplateFilter` and starts with a text node, a warning alert appears.
2. Prevent TW getting stuck when such a tiddler is rendered, making it impossible to fix the issue.

The alert in question looks like this:
<img width="972" alt="image" src="https://user-images.githubusercontent.com/4552000/197378290-2da5a1ad-c829-46ad-8a2b-71eddcee0d3e.png">

