### PR TITLE
Fix for #4767: lazy-loading deletes tiddler bodies

### DIFF
--- a/core/modules/server/routes/put-tiddler.js
+++ b/core/modules/server/routes/put-tiddler.js
@@ -30,6 +30,16 @@ exports.handler = function(request,response,state) {
 	if(fields.revision) {
 		delete fields.revision;
 	}
+	// If this is a skinny tiddler, it means the client never got the full
+	// version of the tiddler to edit. So we must preserve whatever text
+	// already exists on the server, or else we'll inadvertently delete it.
+	if(fields._is_skinny !== undefined) {
+		var tiddler = state.wiki.getTiddler(title);
+		if(tiddler) {
+			fields.text = tiddler.fields.text;
+		}
+		delete fields._is_skinny;
+	}
 	state.wiki.addTiddler(new $tw.Tiddler(fields,{title: title}));
 	var changeCount = state.wiki.getChangeCount(title).toString();
 	response.writeHead(204, "OK",{


### PR DESCRIPTION
This is a fix to mitigate the horribleness that is lazy-loading. Without this, lazy-loading, especially combined with some plugins, can delete entire swaths of the user's tiddlers. It's *bad*.

This fix makes it better. It should no longer delete people's tiddlers, but lazy-loading still has problems. Relink doesn't work with it since relinking occurs on the client (and there is no mechanism for relinking on the server), but at least Relink won't blast people's tiddlers away anymore.

Installing TiddlyMap also will no longer delete literally everything.

By the way, guys. Lazy-loading should really be deprecated. Even with this bug fix, it's still disastrously dangerous.