### PR TITLE
Add parser to display MS Office documents inside tiddler body using iframe

### DIFF
--- a/core/modules/parsers/binaryparser.js
+++ b/core/modules/parsers/binaryparser.js
@@ -14,37 +14,38 @@ The binary parser parses a binary tiddler into a warning message and download li
   var BINARY_WARNING_MESSAGE = "$:/core/ui/BinaryWarning";
   var EXPORT_BUTTON_IMAGE = "$:/core/images/export-button";
 
-  var BinaryParser = function (type, text, options) {
-    // Transclude the binary data tiddler warning message
-    var warn = {
-      type: "element",
-      tag: "p",
-      children: [
-        {
-          type: "transclude",
-          attributes: {
-            tiddler: { type: "string", value: BINARY_WARNING_MESSAGE },
-          },
+  // Transclude the binary data tiddler warning message
+  var warn = {
+    type: "element",
+    tag: "p",
+    children: [
+      {
+        type: "transclude",
+        attributes: {
+          tiddler: { type: "string", value: BINARY_WARNING_MESSAGE },
         },
-      ],
-    };
-    // Create download link based on binary tiddler title
-    var link = {
-      type: "element",
-      tag: "a",
-      attributes: {
-        title: { type: "indirect", textReference: "!!title" },
-        download: { type: "indirect", textReference: "!!title" },
       },
-      children: [
-        {
-          type: "transclude",
-          attributes: {
-            tiddler: { type: "string", value: EXPORT_BUTTON_IMAGE },
-          },
+    ],
+  };
+  // Create download link based on binary tiddler title
+  var link = {
+    type: "element",
+    tag: "a",
+    attributes: {
+      title: { type: "indirect", textReference: "!!title" },
+      download: { type: "indirect", textReference: "!!title" },
+    },
+    children: [
+      {
+        type: "transclude",
+        attributes: {
+          tiddler: { type: "string", value: EXPORT_BUTTON_IMAGE },
         },
-      ],
-    };
+      },
+    ],
+  };
+
+  var BinaryParser = function (type, text, options) {
     // Set the link href to external or internal data URI
     if (options._canonical_uri) {
       link.attributes.href = {
@@ -69,5 +70,7 @@ The binary parser parses a binary tiddler into a warning message and download li
     this.tree = [element];
   };
 
+  exports.BinaryParserWarn = warn;
+  exports.BinaryParserLink = link;
   exports["application/octet-stream"] = BinaryParser;
 })();

--- a/core/modules/parsers/binaryparser.js
+++ b/core/modules/parsers/binaryparser.js
@@ -6,67 +6,68 @@ module-type: parser
 The binary parser parses a binary tiddler into a warning message and download link
 
 \*/
-(function(){
+(function () {
+  /*jslint node: true, browser: true */
+  /*global $tw: false */
+  "use strict";
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
-"use strict";
+  var BINARY_WARNING_MESSAGE = "$:/core/ui/BinaryWarning";
+  var EXPORT_BUTTON_IMAGE = "$:/core/images/export-button";
 
-var BINARY_WARNING_MESSAGE = "$:/core/ui/BinaryWarning";
-var EXPORT_BUTTON_IMAGE = "$:/core/images/export-button";
+  var BinaryParser = function (type, text, options) {
+    // Transclude the binary data tiddler warning message
+    var warn = {
+      type: "element",
+      tag: "p",
+      children: [
+        {
+          type: "transclude",
+          attributes: {
+            tiddler: { type: "string", value: BINARY_WARNING_MESSAGE },
+          },
+        },
+      ],
+    };
+    // Create download link based on binary tiddler title
+    var link = {
+      type: "element",
+      tag: "a",
+      attributes: {
+        title: { type: "indirect", textReference: "!!title" },
+        download: { type: "indirect", textReference: "!!title" },
+      },
+      children: [
+        {
+          type: "transclude",
+          attributes: {
+            tiddler: { type: "string", value: EXPORT_BUTTON_IMAGE },
+          },
+        },
+      ],
+    };
+    // Set the link href to external or internal data URI
+    if (options._canonical_uri) {
+      link.attributes.href = {
+        type: "string",
+        value: options._canonical_uri,
+      };
+    } else if (text) {
+      link.attributes.href = {
+        type: "string",
+        value: "data:" + type + ";base64," + text,
+      };
+    }
+    // Combine warning message and download link in a div
+    var element = {
+      type: "element",
+      tag: "div",
+      attributes: {
+        class: { type: "string", value: "tc-binary-warning" },
+      },
+      children: [warn, link],
+    };
+    this.tree = [element];
+  };
 
-var BinaryParser = function(type,text,options) {
-	// Transclude the binary data tiddler warning message
-	var warn = {
-		type: "element",
-		tag: "p",
-		children: [{
-			type: "transclude",
-			attributes: {
-				tiddler: {type: "string", value: BINARY_WARNING_MESSAGE}
-			}
-		}]
-	};
-	// Create download link based on binary tiddler title
-	var link = {
-		type: "element",
-		tag: "a",
-		attributes: {
-			title: {type: "indirect", textReference: "!!title"},
-			download: {type: "indirect", textReference: "!!title"}
-		},
-		children: [{
-			type: "transclude",
-			attributes: {
-				tiddler: {type: "string", value: EXPORT_BUTTON_IMAGE}
-			}
-		}]
-	};
-	// Set the link href to external or internal data URI
-	if(options._canonical_uri) {
-		link.attributes.href = {
-			type: "string", 
-			value: options._canonical_uri
-		};
-	} else if(text) {
-		link.attributes.href = {
-			type: "string", 
-			value: "data:" + type + ";base64," + text
-		};
-	}
-	// Combine warning message and download link in a div
-	var element = {
-		type: "element",
-		tag: "div",
-		attributes: {
-			class: {type: "string", value: "tc-binary-warning"}
-		},
-		children: [warn, link]
-	}
-	this.tree = [element];
-};
-
-exports["application/octet-stream"] = BinaryParser;
-
+  exports["application/octet-stream"] = BinaryParser;
 })();
-

--- a/core/modules/parsers/docxparser.js
+++ b/core/modules/parsers/docxparser.js
@@ -1,0 +1,62 @@
+/*\
+title: $:/core/modules/parsers/docxparser.js
+type: application/javascript
+module-type: parser
+
+The Docx parser embeds a Docx viewer
+
+\*/
+
+(function () {
+  /*jslint node: true, browser: true */
+  /*global $tw: false */
+  "use strict";
+
+  const BinaryParser = require("./binaryparser");
+
+  var DocxParser = function (type, text, options) {
+    // Element to display MS Office files inside an iframe
+    var element_uri = {
+      type: "element",
+      tag: "iframe",
+      attributes: {
+        src: {
+          type: "string",
+          value: `https://view.officeapps.live.com/op/embed.aspx?src=${options._canonical_uri}`,
+        },
+        loading: { type: "string", value: "lazy" },
+        style: {
+          type: "string",
+          value: "border:0; width: 100%; object-fit: contain",
+        },
+      },
+    };
+
+    // Element to show "binary data" warning and link if _canonical_uri is not set
+    var element_binary = {
+      type: "element",
+      tag: "div",
+      attributes: {
+        class: { type: "string", value: "tc-binary-warning" },
+      },
+      children: [BinaryParser.BinaryParserWarn, BinaryParser.BinaryParserLink],
+    };
+
+    this.tree = options._canonical_uri ? [element_uri] : [element_binary];
+  };
+
+  // MS Word formats
+  exports[
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  ] = DocxParser;
+  exports["application/msword"] = DocxParser;
+  // MS Excel formats
+  exports["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"] =
+    DocxParser;
+  exports["application/vnd.ms-excel"] = DocxParser;
+  // MS Powerpoint
+  exports[
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+  ] = DocxParser;
+  exports["application/vnd.ms-powerpoint"] = DocxParser;
+})();


### PR DESCRIPTION
This PR adds a parser `DocxParser`

# What does it do?

1. If a user adds a tiddler with MS Office type like `application/msword`
2. AND sets its `_canonical_uri` to a word document

The the parser uses MS live.com embed feature to display those documents.

# Examples


<details>
<summary>
DOCX example
</summary>

![](https://i.imgur.com/IHJRcqx.png)

</details>

<details>
<summary>
DOC example
</summary>

![](https://i.imgur.com/B6moMrD.png)

</details>

<details>
<summary>
XLSX example
</summary>

![](https://i.imgur.com/fPOKBlI.png)

</details>

<details>
<summary>
XLS example
</summary>

![](https://i.imgur.com/8rLa6nV.png)

</details>

<details>
<summary>
PPTX example
</summary>

![](https://i.imgur.com/KlsFhN9.png)

</details>

<details>
<summary>
PPT example
</summary>

![](https://i.imgur.com/Mu7vdTs.png)

</details>

# Why does this PR change `BinaryParser`?

These changes are extremely minor. They export `warn` and `link` variables, so that other components can use them if needed.

In my case, `DocxParser` needed them to handle the following usecase,

1. User adds a word doc to the tiddlywiki
2. AND user has not set the `_canonical_uri`

In this case, the word doc is added as a binary data to the TiddlyWiki. MS Office live viewer cannot display word documents from the binary data. 

So the `DocxParser` shows binary data warning.

<details>
<summary>
Binary data warning example
</summary>

![](https://i.imgur.com/YbbRT7r.png)

</details>