### PR TITLE
Sort completed tasks by 'modified' instead of 'created' field

### DIFF
--- a/editions/tw5.com/tiddlers/demonstrations/Tasks/TaskManagementExampleDraggable.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/Tasks/TaskManagementExampleDraggable.tid
@@ -16,7 +16,7 @@ This is a version of the TaskManagementExample enhanced with the ability to drag
 
 //(Listed in reverse order of completion)//
 
-<$list filter="[!has[draft.of]tag[task]tag[done]sort[created]]">
+<$list filter="[!has[draft.of]tag[task]tag[done]sort[modified]]">
 <div>
 <$checkbox tag="done"> ~~<$link/>~~</$checkbox>
 </div>


### PR DESCRIPTION
see details here 

https://talk.tiddlywiki.org/t/a-probable-mistake-in-the-official-documentations-task-management-example/5198

The test claims, completed tasks are listed in the order of completion. This can only be done if tasks are sorted by `modified`.