### PR TITLE
add a hidden config to disable Syncer logging to the console

### DIFF
--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -121,7 +121,11 @@ exports.startup = function() {
 	});
 	// Set up the syncer object if we've got a syncadaptor
 	if($tw.syncadaptor) {
-		$tw.syncer = new $tw.Syncer({wiki: $tw.wiki, syncadaptor: $tw.syncadaptor});
+		$tw.syncer = new $tw.Syncer({
+			wiki: $tw.wiki,
+			syncadaptor: $tw.syncadaptor,
+			logging: $tw.wiki.getTiddlerText('$:/config/SyncLogging', "yes") === "yes"
+		});
 	}
 	// Setup the saver handler
 	$tw.saverHandler = new $tw.SaverHandler({

--- a/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting SyncLogging.tid
+++ b/editions/tw5.com/tiddlers/hiddensettings/Hidden Setting SyncLogging.tid
@@ -1,0 +1,13 @@
+created: 20190903192324700
+modified: 20190903192324700
+tags: [[Hidden Settings]]
+title: Hidden Setting: Sync Logging
+type: text/vnd.tiddlywiki
+
+Specifies whether [[Syncadaptor|https://tiddlywiki.com/dev/#Syncadaptor]] should log information to the browser's developer console or not.
+
+Defaults to `yes`. Set to `no` to disable logging.
+
+Changing needs restart to take effect.
+
+$:/config/SyncLogging


### PR DESCRIPTION
# What:

* Adds a hidden/undocumented config option `$:/config/SyncLogging` that allows disabling Syncer's logging

# Why:

* Currently using Node server with plugins `plugins/tiddlywiki/filesystem` and `plugins/tiddlywiki/tiddlyweb` will happily log up to 3 console logs each time any tiddler is changed.
* This makes using console for plugin development a chore, as any relevant info you log will be interspersed with Syncer logs.
* I opted for a hidden setting because developer console is already something that non-developers are unlikely to use.

----

**Logs created after changing a typing a single character in a tiddler's title:**
![image](https://user-images.githubusercontent.com/4552000/202905872-f7fcb3f5-c202-47ff-a246-23aedc36b742.png)
