### PR TITLE
fix problem with hidden preview DOM structure

### DIFF
--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -117,15 +117,15 @@ title: $:/core/ui/ImportListing
 		</div>
 	</td>
 </$reveal>
-<tr>
+<$reveal type="match" text="yes" state=<<previewPopupState>> tag="tr">
 <td colspan="3">
-<$reveal type="match" text="yes" state=<<previewPopupState>> tag="div">
 <$list filter="[{$:/state/importpreviewtype}has[text]]" variable="listItem" emptyMessage={{$:/core/ui/ImportPreviews/Text}}>
-<$transclude tiddler={{$:/state/importpreviewtype}}/>
+	<div>
+		<$transclude tiddler={{$:/state/importpreviewtype}}/>
+	</div>
 </$list>
-</$reveal>
 </td>
-</tr>
+</$reveal>
 </$list>
 </tbody>
 </table>


### PR DESCRIPTION
@kookma @saqimtiaz please test the wiki in the ZIP .. It contains fixes to issue #7056 AND it also contains the changes PR #7039, which IMO have been reverted without any need. 

 [fix-7056-import-visual-glitch.zip](https://github.com/Jermolene/TiddlyWiki5/files/10075092/fix-7056-import-visual-glitch.zip)  <------------------ Test me

This is the fix to the real problem that my PR #7039 made visible. ... 

The problem was the "preview element" it added visibe TR and TD elements to the DOM with a hidden content DIV. Since the TD had some padding from #7039 it was visible. 

This PR fixes:  [BUG] Visual regression in import table in 5.2.4 pre-release #7056 .

---------
@Jermolene please reapply PR #7039 and then this PR. 

There should be no visual glitches anymore. My PR didn't cause the problem it made it visible
