### PR TITLE
update documentation to fix a mistake with format used by `created` and `modified`

### DIFF
--- a/editions/tw5.com/tiddlers/features/DateFormat.tid
+++ b/editions/tw5.com/tiddlers/features/DateFormat.tid
@@ -4,7 +4,7 @@ tags: Features
 title: DateFormat
 type: text/vnd.tiddlywiki
 
-The default representation of dates is a compact string such as `20211002153802059`. For example, the `created` and `modified` fields are stored like this. 
+The default representation of dates is a compact string such as `20211002153802059`. For example, the `created` and `modified` fields are stored like this.
 
 The display format for this string can be controlled with a template. For example, transcluding the `modified` field automatically applies a template to display the date as `Sat Oct 02 2021 17:40:50 GMT+0200 (Central European Summer Time)`. A few widgets and filter operators allow you to manually specify a template, for example the ViewWidget:
 
@@ -71,10 +71,10 @@ You can calculate the difference between two dates by doing the following:
 
 Here is an example of calculating the number of days that passed between creation and last modification of current tiddler:
 
-* Fields `modified` and `created` contain their respective datetimes in the format `YYYYMMDDHHMMSSmmm` so convert them to timestamps
+* Fields `modified` and `created` contain their respective datetimes in the format `[UTC]YYYY0MM0DD0hh0mm0ssXXX` so convert them to timestamps
 * `86400000` is the number of milliseconds in a day (1000 * 60 * 60 * 24)
 
-<$macrocall $name=".example" n="0" eg="""<$let 
+<$macrocall $name=".example" n="0" eg="""<$let
 	timestamp-modified={{{ [{!!modified}format:date[TIMESTAMP]] }}}
 	timestamp-created={{{ [{!!created}format:date[TIMESTAMP]] }}}
 	difference-days={{{ [<timestamp-modified>subtract<timestamp-created>divide[86400000]floor[]] }}}>


### PR DESCRIPTION
Fixes issue with documentation mentioned by @kookma in [here](https://github.com/Jermolene/TiddlyWiki5/pull/7043#issuecomment-1325958383).

I think it makes more sense to use TW's date format in the example on the Date Format than some arbitrary mental shortcut format that might be difficult to understand for non-developers.

The new format was taken from `utils.js::formatDateString()` so it hopefully should be correct!