### PR TITLE
allow the big download button to be defined using the colour palette values

### DIFF
--- a/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
+++ b/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
@@ -183,17 +183,17 @@ div.content {
 .tc-btn-download {
 	padding: 10px 30px;
 	border-radius: 5px;
-	background: #1462ff;
-        border: none;
-	box-shadow: 0 2px 2px 0 #4a74c9;
+	background: <<colour "download-background">>;
+	border: none;
+	box-shadow: 1px 2px 2px 0 <<colour muted-foreground>>;
 	overflow: hidden;
 	cursor: pointer;
-        font-size: 1.2em;
-        line-height: 1.4em;
-        color: #fff;
-        fill: #fff;
+	font-size: 1.2em;
+	line-height: 1.4em;
+	color: #fff;
+	fill: #fff;
 }
 
 .tc-btn-download:active {
-	background: #1475ff;
+	box-shadow: none;
 }


### PR DESCRIPTION
This PR fixes #7041 

It allows the download button to be defined by the colour palette value

![image](https://user-images.githubusercontent.com/374655/204022740-ce58e2e8-b494-4123-986d-e082d3768254.png)
