### PR TITLE
Fix issue with linked list remove

### DIFF
--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -136,13 +136,9 @@ function _removeOne(list,value) {
 	// we need to know if the FIRST value is the last in the list, not the last.
 	if(next !== undefined) {
 		if(typeof list.prev[next] === "object") {
-			if(prev === undefined) {
-				// Must have been first, and 'i' would be 0.
-				list.prev[next].shift();
-			} else {
-				var i = list.prev[next].indexOf(value);
-				list.prev[next][i] = prev;
-			}
+			// Nothing special needed for first since list.prev[next][0] will be 'undefined'
+			var i = list.prev[next].indexOf(value);
+			list.prev[next][i] = prev;
 		} else {
 			list.prev[next] = prev;
 		}

--- a/editions/test/tiddlers/tests/test-linked-list.js
+++ b/editions/test/tiddlers/tests/test-linked-list.js
@@ -137,6 +137,21 @@ describe("LinkedList class tests", function() {
 		compare(pushTop(newPair(["C", "X", "A", "A"]), "X")); // CAAX
 	});
 
+	it("can remove all instances of a multi-instance value #7059", function() {
+		// Remove duplicate items when one or more items between the duplicates
+		// are not removed and the first of those duplicates is not the first item.
+		// These tests used to fail prior to the fix to #7059
+		compare(remove(newPair(["A", "A", "C", "B", "A"]), ["A", "C", "A", "A"])); // B
+		compare(remove(newPair(["A", "A", "C", "B", "A"]), ["C", "A", "A", "A"])); // B
+		compare(remove(newPair(["A", "A", "C", "B", "A"]), ["A", "A", "A"])); // CB
+		compare(remove(newPair(["A", "A", "C", "B", "A"]), ["A", "A", "A", "C"])); // B
+		compare(remove(newPair(["A", "A", "B", "A"]), ["A", "A", "A"])); // B
+		compare(remove(newPair(["A", "A", "B", "A"]), ["A", "A", "A", "B"])); //
+		compare(remove(newPair(["C", "A", "B", "A"]), ["C", "A", "A"])); // B
+		compare(remove(newPair(["C", "A", "B", "A", "C"]), ["C", "A", "A", "C"])); // B
+		compare(remove(newPair(["B", "A", "B", "A"]), ["B", "A", "A"])); // B
+	});
+
 	it("can handle particularly nasty pushTop pitfall", function() {
 		var pair = newPair(["A", "B", "A", "C"]);
 		pushTop(pair, "A"); // BACA


### PR DESCRIPTION
Prior to this fix, the filter expression `A =A B =A :filter[match[B]]` resulted in `B A` instead of just `B`.

The prev pointer of the underlying double linked-list implementation was getting corrupted for this case. The code for `prev` was "symmetric" with the `next` code, even though for `prev` there can be an extra `undefined`  at the front of the list, but the same extra `undefined` entry is not present at the end of `next`.

Fixes #7059