### PR TITLE
feat: add "key" to propogateKeydownEvent's cloneEvent

### DIFF
--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -298,7 +298,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	Propogate keydown events to our container for the keyboard widgets benefit
 	*/
 	EditTextWidget.prototype.propogateKeydownEvent = function(event) {
-		var newEvent = this.cloneEvent(event,["keyCode","which","metaKey","ctrlKey","altKey","shiftKey"]);
+		var newEvent = this.cloneEvent(event,["keyCode","which","key","metaKey","ctrlKey","altKey","shiftKey"]);
 		return !this.parentDomNode.dispatchEvent(newEvent);
 	};
 

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -298,7 +298,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 	Propogate keydown events to our container for the keyboard widgets benefit
 	*/
 	EditTextWidget.prototype.propogateKeydownEvent = function(event) {
-		var newEvent = this.cloneEvent(event,["keyCode","which","key","metaKey","ctrlKey","altKey","shiftKey"]);
+		var newEvent = this.cloneEvent(event,["keyCode","code","which","key","metaKey","ctrlKey","altKey","shiftKey"]);
 		return !this.parentDomNode.dispatchEvent(newEvent);
 	};
 


### PR DESCRIPTION
Sometimes we need this "key" to handle hot key.

Actually I'm trying to fix this issue... https://github.com/JohannesKlauss/react-hotkeys-hook/issues/834#issuecomment-1331033460