### PR TITLE
Add 'commands' command to run commands from a tiddler

### DIFF
--- a/core/language/en-GB/Help/commands.tid
+++ b/core/language/en-GB/Help/commands.tid
@@ -1,0 +1,14 @@
+title: $:/language/Help/commands
+description: Run commands returned from a filter
+
+It runs sequentially the commands returned from the filter.
+
+```
+--commands <filter>
+```
+
+Examples
+
+`--commands "[enlist{$:/build-commands-as-text}]"`
+
+`--commands "[{$:/build-commands-as-json}jsonindexes[]] :map[{$:/build-commands-as-json}jsonget<currentTiddler>]"`

--- a/core/modules/commands/commands.js
+++ b/core/modules/commands/commands.js
@@ -1,0 +1,43 @@
+/*\
+title: $:/core/modules/commands/commands.js
+type: application/javascript
+module-type: command
+
+Runs sequentially the commands returned from the filter.
+
+\*/
+
+(function() {
+
+  /*jslint node: true, browser: true */
+  /*global $tw: false */
+  "use strict";
+
+  exports.info = {
+    name: "commands",
+    synchronous: true
+  };
+
+  var Command = function(params, commander) {
+    this.params = params;
+    this.commander = commander;
+  };
+
+  Command.prototype.execute = function() {
+    // Parse the filter
+    var filter = this.params[0];
+    if(!filter) {
+      return "No filter specified";
+    }
+    var commands = this.commander.wiki.filterTiddlers(filter)
+    if(commands.length === 0) {
+      return "No tiddlers found for filter '" + filter + "'";
+    }
+
+    this.commander.addCommandTokens(commands);
+    return null;
+  };
+
+  exports.Command = Command;
+
+})();


### PR DESCRIPTION
---
name: Pull Request
about: Propose a change to TiddlyWiki 5
title: ""
labels: ''
assignees: ''

---

**Is your PR related to a problem? Please describe.**

I am iterating on my website built from Tiddlywiki, using the static site generation, I found annoying having to update the configuration that generates the html that in my case is a cronjob in a kubernetes instance.

**Describe the solution you are proposing**
Configuring the commands to run in a tiddler

**Describe alternatives you've considered**
I initially created a plugin for my instance but I thought that loading the commands from a tiddler is tiddlywiki idiomatic. I also considered extending the `build` command but I cannot think a way to do it that is also backward compatible.

**Additional context**

### how to run the command 

`tiddlywiki /tiddlywiki-folder --commands "[enlist{$:/build-commands-as-text}]"`

`tiddlywiki /tiddlywiki-folder --commands "[{$:/build-commands-as-json}jsonindexes[]] :map[{$:/build-commands-as-json}jsonget<currentTiddler>]"`


### tiddler target examples

```
created: 20221203155351975
modified: 20221204092852845
revision: 1
tags: 
title: $:/build-commands-as-text
type: text/vnd.tiddlywiki

--verbose
--rendertiddler
$:/litapp/core/templates/static.blog.css
static/static.css
text/plain
--render
[title[Welcome]]
static/index.html
text/plain
$:/litapp/templates/static.tiddler.html
```

```
created: 20221203155351975
modified: 20221203155426931
tags: 
title: $:/build-commands-as-json
type: application/json

[
  "--verbose",
  "--rendertiddler",
  "$:/litapp/core/templates/static.blog.css",
  "static/static.css",
  "text/plain",
  "--render",
  "[title[Welcome]]",
  "static/index.html",
  "text/plain",
  "$:/litapp/templates/static.tiddler.html"
]
```

### Simplification for my static blog generation (using a tiddlywiki node plugin)

https://github.com/carlo-colombo/deployment/commit/847bcd4917783b2fb1e35c11a6dd9c43bcaa4077

_Please ignore the noise from defining it in kubernetes_

## Checklist before requesting a review

- [ ] Illustrate any visual changes (however minor) with before/after screenshots
- [ ] Self-review of code
- [x] Documentation updates (for user-visible changes)
- [ ] Tests (for core code changes)
- [x] Complies with coding style guidelines (for JavaScript code)
