### PR TITLE
Added using the TextWidget to suppress soft and hard links

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/TextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/TextWidget.tid
@@ -9,6 +9,9 @@ text-test: e=mc^^2^^
 
 The text widget displays plain text without parsing it as [[WikiText]], opposite of [[WikifyWidget]].
 
+* The ~TextWidget can be used to suppress a soft link from being recognised see [[Hard and Soft Links]]
+* The ~TextWidget is commonly used to suppress a soft link when using [[Filtered Transclusions|Transclusion in WikiText]]
+
 ! Content and Attributes
 
 The content of the `<$text>` widget is not used.


### PR DESCRIPTION
Supporting a recent change to `[[Hard and Soft Links]]` tiddler.

The initial issue was discussed here https://talk.tiddlywiki.org/t/lost-in-brackets/5354?u=tw_tones

The TextWidget is often used to suppress hard and soft links so a reference to `[[Hard and Soft Links]]` in the documentation given.

A common use of the text widget is to suppress soft links as the result of "Filtered Transclusions" so a reference to `[[Filtered Transclusions|Transclusion in WikiText]]`

The above text also results in additional search results for "soft links" and "filtered transclusions" which show how the TextWidget is commonly used for this purpose.