### PR TITLE
Updated and improved tag picker macro

### DIFF
--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -9,12 +9,12 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 
 \define add-tag-actions(actions,tagField:"tags")
 \whitespace trim
-<$set name="tag" value={{{ [<__tiddler__>get[text]] }}}>
+<$let tag={{{ [<__tiddler__>get[text]] }}}>
 <$list filter="[<saveTiddler>!contains:$tagField$<tag>!match[]]" variable="ignore" emptyMessage="<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter='-[<tag>]'/>">
 <$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
 $actions$
 </$list>
-</$set>
+</$let>
 <<delete-tag-state-tiddlers>>
 <$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
 \end
@@ -28,73 +28,125 @@ $actions$
 
 \define clear-tags-actions()
 \whitespace trim
-<$set name="userInput" value={{{ [<storeTitle>get[text]] }}}>
+<$let userInput={{{ [<storeTitle>get[text]] }}}>
 <$list filter="[<newTagNameTiddler>get[text]!match<userInput>]" emptyMessage="<<clear-tags-actions-inner>>">
 <$action-setfield $tiddler=<<newTagNameTiddler>> text=<<userInput>>/><$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
 </$list>
-</$set>
+</$let>
+\end
+
+\define tag-button(classes) <$let button-classes='tc-btn-invisible $classes$' currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$let>
+
+\define tagsAutoComplete()
+<$list filter=<<tagsAutoCompleteFilter>> emptyMessage=<<tagsAutoCompleteEmptyMessage>> variable="listItem">
+<$list filter=<<tagsFilter>> variable="tag">
+<$list filter="[<tag>addsuffix<suffix>] -[<tagSelectionState>get[text]]" emptyMessage=<<tag-button 'tc-tag-button-selected'>> variable="ignore">
+<<tag-button>>
+</$list>
+</$list>
+</$list>
 \end
 
 \define tag-picker-inner(actions,tagField:"tags")
 \whitespace trim
-<$vars newTagNameInputTiddlerQualified=<<qualify "$:/temp/NewTagName/input">> newTagNameSelectionTiddlerQualified=<<qualify "$:/temp/NewTagName/selected-item">> fallbackTarget={{$(palette)$##tag-background}} colourA={{$(palette)$##foreground}} colourB={{$(palette)$##background}}>
-<$vars storeTitle={{{ [<newTagNameInputTiddler>!match[]] ~[<newTagNameInputTiddlerQualified>] }}} tagSelectionState={{{ [<newTagNameSelectionTiddler>!match[]] ~[<newTagNameSelectionTiddlerQualified>] }}}>
-<$vars refreshTitle=<<qualify "$:/temp/NewTagName/refresh">> nonSystemTagsFilter="[tags[]!is[system]search:title<userInput>sort[]]" systemTagsFilter="[tags[]is[system]search:title<userInput>sort[]]">
+<$let 
+newTagNameInputTiddlerQualified=<<qualify "$:/temp/NewTagName/input">> 
+newTagNameSelectionTiddlerQualified=<<qualify "$:/temp/NewTagName/selected-item">> 
+fallbackTarget={{$(palette)$##tag-background}}
+colourA={{$(palette)$##foreground}}
+colourB={{$(palette)$##background}}
+storeTitle={{{ [<newTagNameInputTiddler>!match[]] ~[<newTagNameInputTiddlerQualified>] }}} 
+tagSelectionState={{{ [<newTagNameSelectionTiddler>!match[]] ~[<newTagNameSelectionTiddlerQualified>] }}}
+refreshTitle=<<qualify "$:/temp/NewTagName/refresh">>
+nonSystemTagsFilter="[tags[]] $(first-search-filter)$ +[!is[system]] -[<storyTiddler>tags[]] :filter[search:title<userInput>]+[sort[]]"
+systemTagsFilter="[tags[]] $(second-search-filter)$ +[is[system]] -[<storyTiddler>tags[]] :filter[search:title<userInput>]+[sort[]]"
+displayTagsPopup="[all[tiddlers]subfilter<systemTagsFilter>][all[tiddlers]subfilter<nonSystemTagsFilter>] +[limit[1]]"
+>
 <div class="tc-edit-add-tag">
 <div>
 <span class="tc-add-tag-name tc-small-gap-right">
-<$macrocall $name="keyboard-driven-input" tiddler=<<newTagNameTiddler>> storeTitle=<<storeTitle>> refreshTitle=<<refreshTitle>>
-		selectionStateTitle=<<tagSelectionState>> inputAcceptActions="<$macrocall $name='add-tag-actions' actions=<<__actions__>> tagField=<<__tagField__>>/>"
-		inputCancelActions=<<clear-tags-actions>> tag="input" placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}}
-		focusPopup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-edit-texteditor tc-popup-handle" tabindex=<<tabIndex>> 
-		focus={{{ [{$:/config/AutoFocus}match[tags]then[true]] ~[[false]] }}} filterMinLength={{$:/config/Tags/MinLength}} 
-		cancelPopups=<<cancelPopups>> configTiddlerFilter="[[$:/core/macros/tag-picker]]"/>
-</span><$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button><$reveal state=<<storeTitle>> type="nomatch" text=""><$button class="tc-btn-invisible tc-small-gap tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/ClearInput/Hint}} aria-label={{$:/language/EditTemplate/Tags/ClearInput/Caption}}>{{$:/core/images/close-button}}<<delete-tag-state-tiddlers>></$button></$reveal><span class="tc-add-tag-button tc-small-gap-left">
-<$set name="tag" value={{{ [<newTagNameTiddler>get[text]] }}}>
-<$button set=<<newTagNameTiddler>> setTo="" class="">
+<$macrocall $name="keyboard-driven-input"
+tiddler=<<newTagNameTiddler>>
+storeTitle=<<storeTitle>>
+refreshTitle=<<refreshTitle>>
+selectionStateTitle=<<tagSelectionState>>
+inputAcceptActions="<$macrocall $name='add-tag-actions'
+actions=<<__actions__>>
+tagField=<<__tagField__>>/>"
+inputCancelActions=<<clear-tags-actions>>
+tag="input"
+placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}}
+focusPopup=<<qualify "$:/state/popup/tags-auto-complete">>
+class="tc-edit-texteditor tc-popup-handle"
+tabindex=<<tabIndex>> 
+focus={{{ [{$:/config/AutoFocus}match[tags]then[true]] ~[[false]] }}}
+filterMinLength={{$:/config/Tags/MinLength}} 
+cancelPopups=<<cancelPopups>>
+configTiddlerFilter="[[$:/core/macros/tag-picker]]"
+/>
+</span>
+<$button
+popup=<<qualify "$:/state/popup/tags-auto-complete">>
+class="tc-btn-invisible tc-btn-dropdown"
+tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}}
+aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}
+>
+{{$:/core/images/down-arrow}}
+</$button>
+<$reveal state=<<storeTitle>> type="nomatch" text="">
+<$button
+class="tc-btn-invisible tc-small-gap tc-btn-dropdown"
+tooltip={{$:/language/EditTemplate/Tags/ClearInput/Hint}}
+aria-label={{$:/language/EditTemplate/Tags/ClearInput/Caption}}
+actions=<<delete-tag-state-tiddlers>>
+>
+{{$:/core/images/close-button}}
+</$button>
+</$reveal>
+<span class="tc-add-tag-button tc-small-gap-left">
+<$let tag={{{ [<newTagNameTiddler>get[text]] }}} currentTiddlerCSSEscaped={{{ [<saveTiddler>escapecss[]] }}}>
+<$button set=<<newTagNameTiddler>> setTo="">
 <$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
 $actions$
-<$set name="currentTiddlerCSSEscaped" value={{{ [<saveTiddler>escapecss[]] }}}>
-<<delete-tag-state-tiddlers>><$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>>/>
-</$set>
+<<delete-tag-state-tiddlers>>
+<$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>>/>
 {{$:/language/EditTemplate/Tags/Add/Button}}
 </$button>
-</$set>
+</$let>
 </span>
 </div>
-<div class="tc-block-dropdown-wrapper">
-<$reveal state=<<qualify "$:/state/popup/tags-auto-complete">> type="nomatch" text="" default="">
-<div class="tc-block-dropdown tc-block-tags-dropdown">
-<$set name="userInput" value={{{ [<storeTitle>get[text]] }}}>
-<$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
-<$list filter=<<nonSystemTagsFilter>> variable="tag">
-<$list filter="[<tag>addsuffix[-primaryList]] -[<tagSelectionState>get[text]]" emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>">
-<$vars button-classes="tc-btn-invisible" actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>
-</$list>
-</$list></$list>
+<$reveal
+class="tc-block-dropdown tc-block-tags-dropdown tc-block-dropdown-wrapper"
+default={{{ [subfilter<displayTagsPopup>then[]else[hide]] }}}
+state=<<qualify "$:/state/popup/tags-auto-complete">>
+tag={{{ [subfilter<displayTagsPopup>then[div]else[template]] }}}
+text=""
+type="nomatch"
+>
+<$let
+actions=<<__actions__>> 
+currentTiddler=<<tag>>
+tagField=<<__tagField__>>
+userInput={{{ [<storeTitle>get[text]] }}}
+tagsAutoCompleteFilter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]"
+tagsAutoCompleteEmptyMessage="<div class='tc-search-results'>{{$:/language/Search/Search/TooShort}}</div>"
+>
+<$let tagsFilter=<<nonSystemTagsFilter>> suffix="-primaryList"><<tagsAutoComplete>></$let>
 <hr>
-<$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
-<$list filter=<<systemTagsFilter>> variable="tag">
-<$list filter="[<tag>addsuffix[-secondaryList]] -[<tagSelectionState>get[text]]" emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>">
-<$vars button-classes="tc-btn-invisible" actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>
-</$list>
-</$list></$list>
-</$set>
-</div>
+<$let tagsFilter=<<systemTagsFilter>> suffix="-secondaryList"><<tagsAutoComplete>></$let>
+</$let>
 </$reveal>
 </div>
-</div>
-</$vars>
-</$vars>
-</$vars>
+</$let>
 \end
+
 \define tag-picker(actions,tagField:"tags")
 \whitespace trim
-<$vars saveTiddler=<<currentTiddler>> palette={{$:/palette}}>
+<$let saveTiddler=<<currentTiddler>> palette={{$:/palette}}>
 <$list filter="[<newTagNameTiddler>match[]]" emptyMessage="<$macrocall $name='tag-picker-inner' actions=<<__actions__>> tagField=<<__tagField__>>/>">
-<$set name="newTagNameTiddler" value=<<qualify "$:/temp/NewTagName">>>
+<$let newTagNameTiddler=<<qualify "$:/temp/NewTagName">>>
 <$macrocall $name="tag-picker-inner" actions=<<__actions__>> tagField=<<__tagField__>>/>
-</$set>
+</$let>
 </$list>
-</$vars>
+</$let>
 \end


### PR DESCRIPTION
**Code update**

- All the set and vars widgets are replaced with the let widget
- tag-picker-inner is rewritten to be more readable, parts of the macro that was repeated was separated into two smaller macro, tag-button and tagsAutoComplete

**Improvements**

- When a tag is added to a tiddler, it is not longer suggested in the drop down list, this help reduce clutter.
- The popup no longer appears when there is no results in the suggestion dropdown.
- Variables added into the `nonSystemTagsFilter` and `SystemTagsFilter` : `first-search-filter` and `second-search-filter`. These variables allow to edit the tag list suggestions with ease.