### PR TITLE
Allow overriding the coreURL used by external-js

### DIFF
--- a/core/templates/external-js/core-url.tid
+++ b/core/templates/external-js/core-url.tid
@@ -1,0 +1,3 @@
+title: $:/core/save/offline-external-js/core-url
+
+tiddlywikicore-<$macrocall $name="version"/>.js

--- a/core/templates/external-js/save-offline-external-js.tid
+++ b/core/templates/external-js/save-offline-external-js.tid
@@ -4,5 +4,6 @@ title: $:/core/save/offline-external-js
 \define saveTiddlerFilter()
 [is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/plugins/tiddlywiki/filesystem]] -[[$:/plugins/tiddlywiki/tiddlyweb]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
-\define coreURL() tiddlywikicore-$(version)$.js
+<$wikify name="coreURL" text="{{$:/core/save/offline-external-js/core-url}}">
 {{$:/core/templates/tiddlywiki5-external-js.html}}
+</$wikify>


### PR DESCRIPTION
Based on https://tiddlywiki-5-2-4-prerelease-external-js.tiddlyhost.com/

The motivation is to more easily allow the tiddlywikicore js file to be served from a CDN or some other shared location.

Related to the goals of #7091 . Also will be useful for Tiddlyhost, see https://github.com/simonbaird/tiddlyhost/issues/171 , since I want the coreURL for a particular TiddlyWiki version to be the same for everyone.