### PR TITLE
fix long words in CODE element makes tables overflow [base css]

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -166,6 +166,7 @@ code {
 	padding: 0 3px 2px;
 	border-radius: 3px;
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/codefontfamily}};
+	word-break: break-word;
 }
 
 blockquote {


### PR DESCRIPTION
Hi Jeremy, I'm sorry, but there is still one element that can make tables overflow if it contains long words. 

With the last PR I did fix PRE code-blocks, but I did miss the CODE element, because I wasn't exactly sure, what caused the problem. Now I know. It's the following 2 things. 

[code-and-pre-causing-table-overflow.zip](https://github.com/Jermolene/TiddlyWiki5/files/10176064/code-and-pre-causing-table-overflow.zip)

The coincidence is, that the URLs reach to the same position, which should trigger the word-break. So I didn't see the CODE element also causes a problem. While testing -- the PRE element was more obvious to cause problems.

![image](https://user-images.githubusercontent.com/374655/206181580-e23d27a9-7cb5-4158-80d3-0e3bdbd5156d.png)
