### PR TITLE
make search dropdown visible on small screens

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1999,6 +1999,15 @@ html body.tc-body.tc-single-tiddler-window {
 	margin: auto;
 }
 
+/* Make search dropdown visible on small screens. issue #7003 */
+@media (max-width: <<sidebarbreakpoint>>) {
+
+	.tc-sidebar-search .tc-block-dropdown-wrapper {
+		position: initial;
+	}
+
+}
+
 /*
 ** Modals
 */


### PR DESCRIPTION
fix for  [BUG] search dropdown is hidden on smaller screens #7003 
fix for  search dropdown is hidden on narrow screens #4038 

This PR adds a media-query, which checks if the search input is on top of the screen and modifies the CSS accordingly. 

Did test it with 

- FF latest on Windows, 
- Edge latest on Widows and 
- Android FF mobile
- Android Chrome on mobile

### To Reproduce

- Go to tiddlywiki.com
- make the browser window small -> so sidebar is on top
- search for "test"
- see the problem