### PR TITLE
Change first letter in two plugin-related buttons to be uppercase for consistency

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -90,8 +90,8 @@ Plugins/Languages/Caption: Languages
 Plugins/Languages/Hint: Language pack plugins
 Plugins/NoInfoFound/Hint: No ''"<$text text=<<currentTab>>/>"'' found
 Plugins/NotInstalled/Hint: This plugin is not currently installed
-Plugins/OpenPluginLibrary: open plugin library
-Plugins/ClosePluginLibrary: close plugin library
+Plugins/OpenPluginLibrary: Open plugin library
+Plugins/ClosePluginLibrary: Close plugin library
 Plugins/PluginWillRequireReload: (requires reload)
 Plugins/Plugins/Caption: Plugins
 Plugins/Plugins/Hint: Plugins


### PR DESCRIPTION
# What?

Change the case of the first letter in two plugin-related buttons to be uppercase.

# Why?

* To be consistent with the earlier big button "Get more plugins"
* I think buttons starting with uppercase letter look better (100% subjective)

# Counterpoint

* We could consider change "Get more plugins" to "get more plugins" since most of the time it seems the text on buttons in TW is all lowercase.

# Screenshots

<img width="729" alt="image" src="https://user-images.githubusercontent.com/4552000/206438164-9366efeb-71f9-4e63-b127-ca248ab45109.png">