### PR TITLE
"Saving with the HTML5 saver" improvements

### DIFF
--- a/editions/es-ES/tiddlers/GettingStarted_-_Chrome.tid
+++ b/editions/es-ES/tiddlers/GettingStarted_-_Chrome.tid
@@ -7,4 +7,4 @@ type: text/vnd.tiddlywiki
 
 En Google Chrome, TiddlyWiki sólo puede guardar cambios usando el módulo alternativo de guardado compatible con HTML5
 
-{{Saving with the HTML5 fallback saver}}
+{{Saving with the HTML5 saver}}

--- a/editions/es-ES/tiddlers/Saving_with_the_HTML5_fallback_saver.tid
+++ b/editions/es-ES/tiddlers/Saving_with_the_HTML5_fallback_saver.tid
@@ -6,30 +6,4 @@ tags: Saving
 title: Saving with the HTML5 fallback saver
 type: text/vnd.tiddlywiki
 
-Este método para guardar cambios es un poco rudimentario porque requiere intervención manual para cada acción de guardado. Tiene, sin embargo, la ventaja de que funciona en casi todos los navegadores de escritorio y en muchos navegadores móviles.
-
-# Descarga un TiddlyWiki en blanco pulsando este botón
-
-#> {{$:/editions/es-ES/snippets/download-empty-button}}
-
-#>Si el botón no funciona, guarda este enlace: https://tiddlywiki.com/languages/es-ES/empty.html
-
-#> Seguramente el navegador te pida que confirmes la descarga
-
-#Localiza el archivo que acabas de descargar
-
-#*Puedes cambiarle el nombre, siempre que mantengas la extensión `.html` o `.htm`
-
-#Abre el archivo en el navegador
-
-# Crea un nuevo tiddler usando el botón ''Nuevo tiddler'' {{$:/core/images/new-button}} de la barra lateral. Escribe algo en él y haz clic en el botón ''OK'' {{$:/core/images/done-button}}
-
-# Guarda los cambios con el botón ''Guardar cambios'' {{$:/core/images/save-button}} de la barra lateral
-
-# El navegador descargará una copia del wiki que incluye tus cambios.
-
-# Localiza el archivo nuevo y ábrelo en el navegador
-
-# Comprueba que los cambios se han guardado correctamente
-
-''Consejo'': la mayoría de navegadores permiten la opción de especificar la localización de cada descarga, en lugar de descargar a la carpeta por defecto. Esta opción te permite "planchar" tu archivo con la nueva versión.
+[[Saving with the HTML5 saver]]

--- a/editions/es-ES/tiddlers/Saving_with_the_HTML5_saver.tid
+++ b/editions/es-ES/tiddlers/Saving_with_the_HTML5_saver.tid
@@ -1,0 +1,35 @@
+caption: Guardar con módulo HTML5
+created: 20131129092604900
+es-title: Guardar con el módulo alternativo de guardado
+modified: 20160603131518256
+tags: Saving
+title: Saving with the HTML5 saver
+type: text/vnd.tiddlywiki
+
+Este método para guardar cambios es un poco rudimentario porque requiere intervención manual para cada acción de guardado. Tiene, sin embargo, la ventaja de que funciona en casi todos los navegadores de escritorio y en muchos navegadores móviles.
+
+# Descarga un TiddlyWiki en blanco pulsando este botón
+
+#> {{$:/editions/es-ES/snippets/download-empty-button}}
+
+#>Si el botón no funciona, guarda este enlace: https://tiddlywiki.com/languages/es-ES/empty.html
+
+#> Seguramente el navegador te pida que confirmes la descarga
+
+#Localiza el archivo que acabas de descargar
+
+#*Puedes cambiarle el nombre, siempre que mantengas la extensión `.html` o `.htm`
+
+#Abre el archivo en el navegador
+
+# Crea un nuevo tiddler usando el botón ''Nuevo tiddler'' {{$:/core/images/new-button}} de la barra lateral. Escribe algo en él y haz clic en el botón ''OK'' {{$:/core/images/done-button}}
+
+# Guarda los cambios con el botón ''Guardar cambios'' {{$:/core/images/save-button}} de la barra lateral
+
+# El navegador descargará una copia del wiki que incluye tus cambios.
+
+# Localiza el archivo nuevo y ábrelo en el navegador
+
+# Comprueba que los cambios se han guardado correctamente
+
+''Consejo'': la mayoría de navegadores permiten la opción de especificar la localización de cada descarga, en lugar de descargar a la carpeta por defecto. Esta opción te permite "planchar" tu archivo con la nueva versión.

--- a/editions/fr-FR/tiddlers/GettingStarted - Chrome.tid
+++ b/editions/fr-FR/tiddlers/GettingStarted - Chrome.tid
@@ -7,4 +7,4 @@ type: text/vnd.tiddlywiki
 
 Sous Google Chrome, <<tw>> ne parvient à sauvegarder les modifications qu'à l'aide de la solution de repli standard : le module de sauvegarde compatible HTML5.
 
-{{Saving with the HTML5 fallback saver}}
+{{Saving with the HTML5 saver}}

--- a/editions/fr-FR/tiddlers/Saving with the HTML5 fallback saver.tid
+++ b/editions/fr-FR/tiddlers/Saving with the HTML5 fallback saver.tid
@@ -5,19 +5,4 @@ tags: Saving
 title: Saving with the HTML5 fallback saver
 type: text/vnd.tiddlywiki
 
-Cette manière d'enregistrer les modifications est assez pénible, car elle requiert une intervention manuelle à chaque enregistrement. Elle a l'avantage de fonctionner avec pratiquement tous les navigateurs tournant sur les ordinateurs de bureaux, et de nombreux navigateurs tournant sur appareils mobiles.
-
-# [[Téléchargez|Download]] un TiddlyWiki en cliquant sur ce bouton<<dp>>
-#> {{$:/editions/fr-FR/snippets/download-empty-button}}
-#> Si le bouton ne fonctionne pas, enregistrez ce lien<<dp>> https://tiddlywiki.com/languages/fr-FR/empty.html
-#> Votre navigateur vous demandera peut-être d'accepter explicitement l'enregistrement avant qu'il démarre
-# Localisez le fichier que vous venez de télécharger
-#* Vous pouvez le renommer, mais assurez-vous de conserver l'extension `.html` ou `.htm`
-# Ouvrez le fichier dans votre navigateur
-# Essayez de créer un nouveau tiddler à l'aide du bouton ''nouveau tiddler'' {{$:/core/images/new-button}} de la barre latérale. Ajouter du contenu dans le tiddler, et cliquez sur le bouton ''terminé'' {{$:/core/images/done-button}}
-# Enregistrez vos modifications en cliquant sur le bouton ''enregistrer les modifications'' {{$:/core/images/save-button}} de la barre latérale
-# Votre navigateur téléchargera alors un nouvel exemplaire du wiki, avec vos modifications à l'intérieur
-# Localisez ce nouveau fichier et ouvrez-le dans votre navigateur
-# Vérifiez que vos modifications ont correctement été enregistrées
-
-''Truc'': la plupart des navigateurs peuvent être configurés pour proposer un chemin d'enregistrement à chaque téléchargement. Cela vous permet de sélectionner la version précédente du fichier et ainsi de la remplacer.
+[[Saving with the HTML5 saver]]

--- a/editions/fr-FR/tiddlers/Saving with the HTML5 saver.tid
+++ b/editions/fr-FR/tiddlers/Saving with the HTML5 saver.tid
@@ -1,0 +1,23 @@
+created: 20131129092604900
+fr-title: Sauvegarder avec l'enregistreur HTML 5 par défaut
+modified: 20160526130128327
+tags: Saving
+title: Saving with the HTML5 saver
+type: text/vnd.tiddlywiki
+
+Cette manière d'enregistrer les modifications est assez pénible, car elle requiert une intervention manuelle à chaque enregistrement. Elle a l'avantage de fonctionner avec pratiquement tous les navigateurs tournant sur les ordinateurs de bureaux, et de nombreux navigateurs tournant sur appareils mobiles.
+
+# [[Téléchargez|Download]] un TiddlyWiki en cliquant sur ce bouton<<dp>>
+#> {{$:/editions/fr-FR/snippets/download-empty-button}}
+#> Si le bouton ne fonctionne pas, enregistrez ce lien<<dp>> https://tiddlywiki.com/languages/fr-FR/empty.html
+#> Votre navigateur vous demandera peut-être d'accepter explicitement l'enregistrement avant qu'il démarre
+# Localisez le fichier que vous venez de télécharger
+#* Vous pouvez le renommer, mais assurez-vous de conserver l'extension `.html` ou `.htm`
+# Ouvrez le fichier dans votre navigateur
+# Essayez de créer un nouveau tiddler à l'aide du bouton ''nouveau tiddler'' {{$:/core/images/new-button}} de la barre latérale. Ajouter du contenu dans le tiddler, et cliquez sur le bouton ''terminé'' {{$:/core/images/done-button}}
+# Enregistrez vos modifications en cliquant sur le bouton ''enregistrer les modifications'' {{$:/core/images/save-button}} de la barre latérale
+# Votre navigateur téléchargera alors un nouvel exemplaire du wiki, avec vos modifications à l'intérieur
+# Localisez ce nouveau fichier et ouvrez-le dans votre navigateur
+# Vérifiez que vos modifications ont correctement été enregistrées
+
+''Truc'': la plupart des navigateurs peuvent être configurés pour proposer un chemin d'enregistrement à chaque téléchargement. Cela vous permet de sélectionner la version précédente du fichier et ainsi de la remplacer.

--- a/editions/tw5.com/tiddlers/community/resources/_file-backups_ Extension Firefox by pmario.tid
+++ b/editions/tw5.com/tiddlers/community/resources/_file-backups_ Extension Firefox by pmario.tid
@@ -5,13 +5,13 @@ created: 20171116165500000
 delivery: Browser Extension
 description: Browser extension for Firefox
 method: save
-modified: 20210106151027036
+modified: 20221210215416509
 tags: Firefox Saving [[Other Resources]] plugins Windows Linux Mac
 title: "file-backups" Extension for Firefox by pmario
 type: text/vnd.tiddlywiki
 url: https://github.com/pmario/file-backups
 
-An extension for Mozilla Firefox that smoothes out some of the friction from ~TiddlyWiki's built-in [[HTML5 fallback saver|Saving with the HTML5 fallback saver]], making it almost as easy to use as ~TiddlyFox. The workflow is intended to work out of the box, without configuration.
+An extension for Mozilla Firefox that smoothes out some of the friction from ~TiddlyWiki's built-in [[HTML5 saver|Saving with the HTML5 saver]], making it almost as easy to use as ~TiddlyFox. The workflow is intended to work out of the box, without configuration.
 
 https://github.com/pmario/file-backups which contains links to the documentation and introduction video(s).
 

--- a/editions/tw5.com/tiddlers/community/resources/_savetiddlers_ Extension for Chrome and Firefox by buggyj.tid
+++ b/editions/tw5.com/tiddlers/community/resources/_savetiddlers_ Extension for Chrome and Firefox by buggyj.tid
@@ -5,12 +5,12 @@ created: 20171109171935039
 delivery: Browser Extension
 description: Browser extension for Chrome and Firefox
 method: save
-modified: 20210106151027189
+modified: 20221210215430083
 tags: Chrome Firefox Saving [[Other Resources]] plugins
 title: "savetiddlers" Extension for Chrome and Firefox by buggyj
 type: text/vnd.tiddlywiki
 url: https://github.com/buggyj/savetiddlers
 
-An extension for Google Chrome and Mozilla Firefox that smoothes out some of the friction from TiddlyWiki's built-in [[HTML5 fallback saver|Saving with the HTML5 fallback saver]], making it almost as easy to use as TiddlyFox once it is set up correctly.
+An extension for Google Chrome and Mozilla Firefox that smoothes out some of the friction from TiddlyWiki's built-in [[HTML5 saver|Saving with the HTML5 saver]], making it almost as easy to use as TiddlyFox once it is set up correctly.
 
 https://github.com/buggyj/savetiddlers

--- a/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Chrome.tid
+++ b/editions/tw5.com/tiddlers/gettingstarted/GettingStarted - Chrome.tid
@@ -1,9 +1,9 @@
 caption: Chrome
 created: 20140811165935523
-modified: 20140811170107969
+modified: 20221210215507579
 title: GettingStarted - Chrome
 type: text/vnd.tiddlywiki
 
-TiddlyWiki on Google Chrome can only save changes using the HTML5-compatible fallback saver module.
+TiddlyWiki on Google Chrome can only save changes using the HTML5-compatible saver module.
 
-{{Saving with the HTML5 fallback saver}}
+{{Saving with the HTML5 saver}}

--- a/editions/tw5.com/tiddlers/saving/Saving with the HTML5 fallback saver.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving with the HTML5 fallback saver.tid
@@ -1,27 +1,7 @@
-caption: Download Saver
-color: #7986CB
 created: 20131129092604900
-delivery: Saver
-description: Slightly awkward but universal technique that works on almost every browser
-method: save
-modified: 20200507202835577
-tags: Chrome Firefox [[Internet Explorer]] Opera Safari Saving Edge
-title: Saving with the HTML5 fallback saver
+modified: 201321210215335384
+tags: 
+title: Saving with the HTML5 saver
 type: text/vnd.tiddlywiki
 
-This method of saving changes is clunky because it requires manual intervention for each save. It has the advantage of working on almost all desktop browsers, and many mobile browsers.
-
-# [[Download]] an empty TiddlyWiki by clicking this button:
-#> {{$:/editions/tw5.com/snippets/download-empty-button}}
-#> If the button doesn't work save this link: https://tiddlywiki.com/empty.html
-#> Your browser may ask you to accept the download before it begins
-# Locate the file you just downloaded
-#* You may rename it, but be sure to keep the `.html` or `.htm` extension
-# Open the file in your browser
-# Try creating a new tiddler using the ''new tiddler'' <<.icon $:/core/images/new-button>> button in the sidebar. Type some content for the tiddler, and click the <<.icon $:/core/images/done-button>> ''ok'' button
-# Save your changes by clicking the <<.icon $:/core/images/save-button>> ''save changes'' button in the sidebar
-# Your browser will download a new copy of the wiki incorporating your changes
-# Locate the newly downloaded file and open it in your browser
-# Verify that your changes have been saved correctly
-
-''Tip'': most browsers have an option to prompt each time for the download location. This allows you to select the existing version of the file and replace it.
+See: [[Saving with the HTML5 saver]]

--- a/editions/tw5.com/tiddlers/saving/Saving with the HTML5 saver.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving with the HTML5 saver.tid
@@ -1,0 +1,27 @@
+caption: Download Saver
+color: #7986CB
+created: 20221210215207986
+delivery: Saver
+description: Universal technique that works on almost every browse
+method: save
+modified: 20221210215716269
+tags: Chrome Firefox [[Internet Explorer]] Opera Safari Saving Edge
+title: Saving with the HTML5 saver
+type: text/vnd.tiddlywiki
+
+This is the default method of saving if no other method is installed. It uses your browser's built-in "download a file" handler, and has the advantage of working on almost all desktop browsers, and many mobile browsers.
+
+# [[Download]] an empty TiddlyWiki by clicking this button:
+#> {{$:/editions/tw5.com/snippets/download-empty-button}}
+#> If the button doesn't work save this link: https://tiddlywiki.com/empty.html
+#> Your browser may ask you to accept the download before it begins
+# Locate the file you just downloaded
+#* You may rename it, but be sure to keep the `.html` or `.htm` extension
+# Open the file in your browser
+# Try creating a new tiddler using the ''new tiddler'' <<.icon $:/core/images/new-button>> button in the sidebar. Type some content for the tiddler, and click the <<.icon $:/core/images/done-button>> ''ok'' button
+# Save your changes by clicking the <<.icon $:/core/images/save-button>> ''save changes'' button in the sidebar
+# Your browser will download a new copy of the wiki incorporating your changes
+# Locate the newly downloaded file and open it in your browser
+# Verify that your changes have been saved correctly
+
+''Tip'': most browsers have an option to prompt each time for the download location. This allows you to select the existing version of the file and replace it.


### PR DESCRIPTION
This PR fixes:  **[IDEA] "Saving with the HTML5 fallback saver" improvements #7107** 
and also changes related tiddlers that also use the "old" link. There are 2 tiddlers now. 

"Saving with the HTML5 fallback saver" intentionally has the _old_ timestamp. IMO it should be hidden as good as possible. 