### PR TITLE
Remove "Saving" tag from "Saving on TiddlySpot"

### DIFF
--- a/editions/tw5.com/tiddlers/saving/Saving on TiddlyHost.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TiddlyHost.tid
@@ -3,7 +3,7 @@ color: #29B6F6
 community-author: Simon Baird
 created: 20210422191232572
 delivery: Service
-description: Online service for creating and hosting TiddlyWikis
+description: Online service for creating and hosting ~TiddlyWikis
 method: save
 modified: 20210423003921468
 tags: Android Chrome Firefox [[Internet Explorer]] Linux Mac Opera PHP Safari Saving Windows iOS Edge

--- a/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving on TiddlySpot.tid
@@ -6,7 +6,6 @@ delivery: Service
 description: Online TiddlyWiki hosting. (Deprecated in favour of TiddlyHost)
 method: save
 modified: 20210423004027196
-tags: Android Chrome Firefox [[Internet Explorer]] Linux Mac Opera PHP Safari Saving Windows iOS Edge
 title: Saving on TiddlySpot
 type: text/vnd.tiddlywiki
 


### PR DESCRIPTION
The content is still there since there are links to it from various places, but let's not have its card appear in the list of savers shown in the "Saving" tiddler any more.

Removing just the "Saving" tag would have been sufficient, but I think it makes sense to remove the other tags as well.