### PR TITLE
make tag-picker and keyboard-driven-input macros human readable

### DIFF
--- a/core/wiki/macros/keyboard-driven-input.tid
+++ b/core/wiki/macros/keyboard-driven-input.tid
@@ -4,12 +4,14 @@ tags: $:/tags/Macro
 \define change-input-tab(stateTitle,tag,beforeafter,defaultState,actions)
 \whitespace trim
 <$set name="tabsList" filter="[all[shadows+tiddlers]tag<__tag__>!has[draft.of]]">
-	<$let currentState={{{ [<__stateTitle__>!is[missing]get[text]] ~[<__defaultState__>] }}}
+	<$let
+		currentState={{{ [<__stateTitle__>!is[missing]get[text]] ~[<__defaultState__>] }}}
 		firstTab={{{ [enlist<tabsList>nth[1]] }}}
 		lastTab={{{ [enlist<tabsList>last[]] }}}
-		nextTab={{{ [all[shadows+tiddlers]tag<__tag__>!has[draft.of]$beforeafter$<currentState>] ~[[$beforeafter$]removeprefix[after]suffix[]addprefix<firstTab>] ~[[$beforeafter$]removeprefix[before]suffix[]addprefix<lastTab>] }}}>
-			<$action-setfield $tiddler=<<__stateTitle__>> text=<<nextTab>>/>
-			$actions$
+		nextTab={{{ [all[shadows+tiddlers]tag<__tag__>!has[draft.of]$beforeafter$<currentState>] ~[[$beforeafter$]removeprefix[after]suffix[]addprefix<firstTab>] ~[[$beforeafter$]removeprefix[before]suffix[]addprefix<lastTab>] }}}
+	>
+		<$action-setfield $tiddler=<<__stateTitle__>> text=<<nextTab>>/>
+		$actions$
 	</$let>
 </$set>
 \end
@@ -40,36 +42,46 @@ tags: $:/tags/Macro
 
 \define input-next-actions(afterOrBefore:"after",reverse:"")
 \whitespace trim
-<$list filter="[<__storeTitle__>get[text]minlength<__filterMinLength__>] [<__filterMinLength__>match[0]] +[limit[1]]" variable="ignore">
-	<$let userInput={{{ [<__storeTitle__>get[text]] }}}
+<$list
+	filter="[<__storeTitle__>get[text]minlength<__filterMinLength__>] [<__filterMinLength__>match[0]] +[limit[1]]"
+	variable="ignore"
+>
+	<$let
+		userInput={{{ [<__storeTitle__>get[text]] }}}
 		selectedItem={{{ [<__selectionStateTitle__>get[text]] }}}
 		configTiddler={{{ [subfilter<__configTiddlerFilter__>] }}}
 		primaryListFilter={{{ [<configTiddler>get<__firstSearchFilterField__>] }}}
-		secondaryListFilter={{{ [<configTiddler>get<__secondSearchFilterField__>] }}}>
-			<$set name="filteredList" filter="[subfilter<primaryListFilter>addsuffix[-primaryList]] =[subfilter<secondaryListFilter>addsuffix[-secondaryList]]">
-				<$let nextItem={{{ [enlist<filteredList>$afterOrBefore$<selectedItem>] ~[enlist<filteredList>$reverse$nth[1]] }}}
-					firstItem={{{ [enlist<filteredList>nth[1]] }}}
-					lastItem={{{ [enlist<filteredList>last[]] }}}>
-						<$list filter="[<selectedItem>match<firstItem>!match<lastItem>]" variable="ignore">
-							<$set name="nextItem" value={{{ [[$afterOrBefore$]match[before]then<userInput>addsuffix[-userInput]] ~[<nextItem>] }}}>
-								<<input-next-actions-inner>>
-							</$set>
-						</$list>
-						<$list filter="[<selectedItem>match<lastItem>!match<firstItem>]" variable="ignore">
-							<$set name="nextItem" value={{{ [[$afterOrBefore$]match[after]then<userInput>addsuffix[-userInput]] ~[<nextItem>] }}}>
-								<<input-next-actions-inner>>
-							</$set>
-						</$list>
-						<$list filter="[<selectedItem>match<firstItem>match<lastItem>]" variable="ignore">
-							<$set name="nextItem" value={{{ [<userInput>addsuffix[-userInput]] }}}>
-								<<input-next-actions-inner>>
-							</$set>
-						</$list>
-						<$list filter="[<selectedItem>!match<firstItem>!match<lastItem>]" variable="ignore">
-							<<input-next-actions-inner>>
-						</$list>
-				</$let>
-			</$set>
+		secondaryListFilter={{{ [<configTiddler>get<__secondSearchFilterField__>] }}}
+	>
+		<$set
+			name="filteredList"
+			filter="[subfilter<primaryListFilter>addsuffix[-primaryList]] =[subfilter<secondaryListFilter>addsuffix[-secondaryList]]"
+		>
+			<$let
+				nextItem={{{ [enlist<filteredList>$afterOrBefore$<selectedItem>] ~[enlist<filteredList>$reverse$nth[1]] }}}
+				firstItem={{{ [enlist<filteredList>nth[1]] }}}
+				lastItem={{{ [enlist<filteredList>last[]] }}}
+			>
+				<$list filter="[<selectedItem>match<firstItem>!match<lastItem>]" variable="ignore">
+					<$set name="nextItem" value={{{ [[$afterOrBefore$]match[before]then<userInput>addsuffix[-userInput]] ~[<nextItem>] }}}>
+						<<input-next-actions-inner>>
+					</$set>
+				</$list>
+				<$list filter="[<selectedItem>match<lastItem>!match<firstItem>]" variable="ignore">
+					<$set name="nextItem" value={{{ [[$afterOrBefore$]match[after]then<userInput>addsuffix[-userInput]] ~[<nextItem>] }}}>
+						<<input-next-actions-inner>>
+					</$set>
+				</$list>
+				<$list filter="[<selectedItem>match<firstItem>match<lastItem>]" variable="ignore">
+					<$set name="nextItem" value={{{ [<userInput>addsuffix[-userInput]] }}}>
+						<<input-next-actions-inner>>
+					</$set>
+				</$list>
+				<$list filter="[<selectedItem>!match<firstItem>!match<lastItem>]" variable="ignore">
+					<<input-next-actions-inner>>
+				</$list>
+			</$let>
+		</$set>
 	</$let>
 </$list>
 \end
@@ -81,12 +93,14 @@ tags: $:/tags/Macro
 <$keyboard key="((input-up))" actions=<<input-next-actions "before" "reverse[]">>>
 <$keyboard key="((input-down))" actions=<<input-next-actions>>>
 <$keyboard key="((input-cancel))" actions=<<__inputCancelActions__>>>
-<$edit-text tiddler=<<__tiddler__>> field=<<__field__>> index=<<__index__>> 
-		inputActions=<<keyboard-input-actions>> tag=<<__tag__>> class=<<__class__>> 
-		placeholder=<<__placeholder__>> default=<<__default__>> focusPopup=<<__focusPopup__>> 
-		focus=<<__focus__>> type=<<__type__>> rows=<<__rows__>> minHeight=<<__minHeight__>> 
-		tabindex=<<__tabindex__>> size=<<__size__>> autoHeight=<<__autoHeight__>> 
-		refreshTitle=<<__refreshTitle__>> cancelPopups=<<__cancelPopups__>>/>
+	<$edit-text
+		tiddler=<<__tiddler__>> field=<<__field__>> index=<<__index__>>
+		inputActions=<<keyboard-input-actions>> tag=<<__tag__>> class=<<__class__>>
+		placeholder=<<__placeholder__>> default=<<__default__>> focusPopup=<<__focusPopup__>>
+		focus=<<__focus__>> type=<<__type__>> rows=<<__rows__>> minHeight=<<__minHeight__>>
+		tabindex=<<__tabindex__>> size=<<__size__>> autoHeight=<<__autoHeight__>>
+		refreshTitle=<<__refreshTitle__>> cancelPopups=<<__cancelPopups__>>
+	/>
 </$keyboard>
 </$keyboard>
 </$keyboard>

--- a/core/wiki/macros/keyboard-driven-input.tid
+++ b/core/wiki/macros/keyboard-driven-input.tid
@@ -4,76 +4,73 @@ tags: $:/tags/Macro
 \define change-input-tab(stateTitle,tag,beforeafter,defaultState,actions)
 \whitespace trim
 <$set name="tabsList" filter="[all[shadows+tiddlers]tag<__tag__>!has[draft.of]]">
-<$let
-	currentState={{{ [<__stateTitle__>!is[missing]get[text]] ~[<__defaultState__>] }}}
-	firstTab={{{ [enlist<tabsList>nth[1]] }}}
-	lastTab={{{ [enlist<tabsList>last[]] }}}
-	nextTab={{{ [all[shadows+tiddlers]tag<__tag__>!has[draft.of]$beforeafter$<currentState>] ~[[$beforeafter$]removeprefix[after]suffix[]addprefix<firstTab>] ~[[$beforeafter$]removeprefix[before]suffix[]addprefix<lastTab>] }}}>
-<$action-setfield $tiddler=<<__stateTitle__>> text=<<nextTab>>/>
-$actions$
-</$let>
+	<$let currentState={{{ [<__stateTitle__>!is[missing]get[text]] ~[<__defaultState__>] }}}
+		firstTab={{{ [enlist<tabsList>nth[1]] }}}
+		lastTab={{{ [enlist<tabsList>last[]] }}}
+		nextTab={{{ [all[shadows+tiddlers]tag<__tag__>!has[draft.of]$beforeafter$<currentState>] ~[[$beforeafter$]removeprefix[after]suffix[]addprefix<firstTab>] ~[[$beforeafter$]removeprefix[before]suffix[]addprefix<lastTab>] }}}>
+			<$action-setfield $tiddler=<<__stateTitle__>> text=<<nextTab>>/>
+			$actions$
+	</$let>
 </$set>
 \end
 
 \define keyboard-input-actions()
 \whitespace trim
 <$list filter="[<__index__>match[]]">
-<$action-setfield $tiddler=<<__storeTitle__>> text={{{ [<__tiddler__>get<__field__>] }}}/>
+	<$action-setfield $tiddler=<<__storeTitle__>> text={{{ [<__tiddler__>get<__field__>] }}}/>
 </$list>
 <$list filter="[<__index__>!match[]]">
-<$action-setfield $tiddler=<<__storeTitle__>> text={{{ [<__tiddler__>getindex<__index__>] }}}/>
+	<$action-setfield $tiddler=<<__storeTitle__>> text={{{ [<__tiddler__>getindex<__index__>] }}}/>
 </$list>
 \end
 
 \define input-next-actions-inner()
 \whitespace trim
 <$list filter="[<nextItem>minlength[1]]" variable="ignore">
-<$action-setfield $tiddler=<<__selectionStateTitle__>> text=<<nextItem>>/>
-<$list filter="[<__index__>match[]]">
-<$action-setfield $tiddler=<<__tiddler__>> $field=<<__field__>> $value={{{ [<nextItem>] +[splitregexp[(?:.(?!-))+$]] }}}/>
-</$list>
-<$list filter="[<__index__>!match[]]">
-<$action-setfield $tiddler=<<__tiddler__>> $index=<<__index__>> $value={{{ [<nextItem>] +[splitregexp[(?:.(?!-))+$]] }}}/>
-</$list>
-<$action-setfield $tiddler=<<__refreshTitle__>> text="yes"/>
+	<$action-setfield $tiddler=<<__selectionStateTitle__>> text=<<nextItem>>/>
+	<$list filter="[<__index__>match[]]">
+		<$action-setfield $tiddler=<<__tiddler__>> $field=<<__field__>> $value={{{ [<nextItem>] +[splitregexp[(?:.(?!-))+$]] }}}/>
+	</$list>
+	<$list filter="[<__index__>!match[]]">
+		<$action-setfield $tiddler=<<__tiddler__>> $index=<<__index__>> $value={{{ [<nextItem>] +[splitregexp[(?:.(?!-))+$]] }}}/>
+	</$list>
+	<$action-setfield $tiddler=<<__refreshTitle__>> text="yes"/>
 </$list>
 \end
 
 \define input-next-actions(afterOrBefore:"after",reverse:"")
 \whitespace trim
 <$list filter="[<__storeTitle__>get[text]minlength<__filterMinLength__>] [<__filterMinLength__>match[0]] +[limit[1]]" variable="ignore">
-<$let
-	userInput={{{ [<__storeTitle__>get[text]] }}}
-	selectedItem={{{ [<__selectionStateTitle__>get[text]] }}}
-	configTiddler={{{ [subfilter<__configTiddlerFilter__>] }}}
-	primaryListFilter={{{ [<configTiddler>get<__firstSearchFilterField__>] }}}
-	secondaryListFilter={{{ [<configTiddler>get<__secondSearchFilterField__>] }}}>
-<$set name="filteredList" filter="[subfilter<primaryListFilter>addsuffix[-primaryList]] =[subfilter<secondaryListFilter>addsuffix[-secondaryList]]">
-<$let
-	nextItem={{{ [enlist<filteredList>$afterOrBefore$<selectedItem>] ~[enlist<filteredList>$reverse$nth[1]] }}}
-	firstItem={{{ [enlist<filteredList>nth[1]] }}}
-	lastItem={{{ [enlist<filteredList>last[]] }}}>
-<$list filter="[<selectedItem>match<firstItem>!match<lastItem>]" variable="ignore">
-<$set name="nextItem" value={{{ [[$afterOrBefore$]match[before]then<userInput>addsuffix[-userInput]] ~[<nextItem>] }}}>
-<<input-next-actions-inner>>
-</$set>
-</$list>
-<$list filter="[<selectedItem>match<lastItem>!match<firstItem>]" variable="ignore">
-<$set name="nextItem" value={{{ [[$afterOrBefore$]match[after]then<userInput>addsuffix[-userInput]] ~[<nextItem>] }}}>
-<<input-next-actions-inner>>
-</$set>
-</$list>
-<$list filter="[<selectedItem>match<firstItem>match<lastItem>]" variable="ignore">
-<$set name="nextItem" value={{{ [<userInput>addsuffix[-userInput]] }}}>
-<<input-next-actions-inner>>
-</$set>
-</$list>
-<$list filter="[<selectedItem>!match<firstItem>!match<lastItem>]" variable="ignore">
-<<input-next-actions-inner>>
-</$list>
-</$let>
-</$set>
-</$let>
+	<$let userInput={{{ [<__storeTitle__>get[text]] }}}
+		selectedItem={{{ [<__selectionStateTitle__>get[text]] }}}
+		configTiddler={{{ [subfilter<__configTiddlerFilter__>] }}}
+		primaryListFilter={{{ [<configTiddler>get<__firstSearchFilterField__>] }}}
+		secondaryListFilter={{{ [<configTiddler>get<__secondSearchFilterField__>] }}}>
+			<$set name="filteredList" filter="[subfilter<primaryListFilter>addsuffix[-primaryList]] =[subfilter<secondaryListFilter>addsuffix[-secondaryList]]">
+				<$let nextItem={{{ [enlist<filteredList>$afterOrBefore$<selectedItem>] ~[enlist<filteredList>$reverse$nth[1]] }}}
+					firstItem={{{ [enlist<filteredList>nth[1]] }}}
+					lastItem={{{ [enlist<filteredList>last[]] }}}>
+						<$list filter="[<selectedItem>match<firstItem>!match<lastItem>]" variable="ignore">
+							<$set name="nextItem" value={{{ [[$afterOrBefore$]match[before]then<userInput>addsuffix[-userInput]] ~[<nextItem>] }}}>
+								<<input-next-actions-inner>>
+							</$set>
+						</$list>
+						<$list filter="[<selectedItem>match<lastItem>!match<firstItem>]" variable="ignore">
+							<$set name="nextItem" value={{{ [[$afterOrBefore$]match[after]then<userInput>addsuffix[-userInput]] ~[<nextItem>] }}}>
+								<<input-next-actions-inner>>
+							</$set>
+						</$list>
+						<$list filter="[<selectedItem>match<firstItem>match<lastItem>]" variable="ignore">
+							<$set name="nextItem" value={{{ [<userInput>addsuffix[-userInput]] }}}>
+								<<input-next-actions-inner>>
+							</$set>
+						</$list>
+						<$list filter="[<selectedItem>!match<firstItem>!match<lastItem>]" variable="ignore">
+							<<input-next-actions-inner>>
+						</$list>
+				</$let>
+			</$set>
+	</$let>
 </$list>
 \end
 

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -10,10 +10,10 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 \define add-tag-actions(actions,tagField:"tags")
 \whitespace trim
 <$set name="tag" value={{{ [<__tiddler__>get[text]] }}}>
-<$list filter="[<saveTiddler>!contains:$tagField$<tag>!match[]]" variable="ignore" emptyMessage="<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter='-[<tag>]'/>">
-<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
-$actions$
-</$list>
+	<$list filter="[<saveTiddler>!contains:$tagField$<tag>!match[]]" variable="ignore" emptyMessage="<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter='-[<tag>]'/>">
+		<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
+		$actions$
+	</$list>
 </$set>
 <<delete-tag-state-tiddlers>>
 <$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
@@ -22,79 +22,114 @@ $actions$
 \define clear-tags-actions-inner()
 \whitespace trim
 <$list filter="[<storeTitle>has[text]] [<newTagNameTiddler>has[text]]" variable="ignore" emptyMessage="<<cancel-delete-tiddler-actions 'cancel'>>">
-<<delete-tag-state-tiddlers>>
+	<<delete-tag-state-tiddlers>>
 </$list>
 \end
 
 \define clear-tags-actions()
 \whitespace trim
 <$set name="userInput" value={{{ [<storeTitle>get[text]] }}}>
-<$list filter="[<newTagNameTiddler>get[text]!match<userInput>]" emptyMessage="<<clear-tags-actions-inner>>">
-<$action-setfield $tiddler=<<newTagNameTiddler>> text=<<userInput>>/><$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
-</$list>
+	<$list filter="[<newTagNameTiddler>get[text]!match<userInput>]" emptyMessage="<<clear-tags-actions-inner>>">
+		<$action-setfield $tiddler=<<newTagNameTiddler>> text=<<userInput>>/><$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
+	</$list>
 </$set>
 \end
 
 \define tag-picker-inner(actions,tagField:"tags")
 \whitespace trim
-<$vars newTagNameInputTiddlerQualified=<<qualify "$:/temp/NewTagName/input">> newTagNameSelectionTiddlerQualified=<<qualify "$:/temp/NewTagName/selected-item">> fallbackTarget={{$(palette)$##tag-background}} colourA={{$(palette)$##foreground}} colourB={{$(palette)$##background}}>
-<$vars storeTitle={{{ [<newTagNameInputTiddler>!match[]] ~[<newTagNameInputTiddlerQualified>] }}} tagSelectionState={{{ [<newTagNameSelectionTiddler>!match[]] ~[<newTagNameSelectionTiddlerQualified>] }}}>
-<$vars refreshTitle=<<qualify "$:/temp/NewTagName/refresh">> nonSystemTagsFilter="[tags[]!is[system]search:title<userInput>sort[]]" systemTagsFilter="[tags[]is[system]search:title<userInput>sort[]]">
-<div class="tc-edit-add-tag">
-<div>
-<span class="tc-add-tag-name tc-small-gap-right">
-<$macrocall $name="keyboard-driven-input" tiddler=<<newTagNameTiddler>> storeTitle=<<storeTitle>> refreshTitle=<<refreshTitle>>
-		selectionStateTitle=<<tagSelectionState>> inputAcceptActions="<$macrocall $name='add-tag-actions' actions=<<__actions__>> tagField=<<__tagField__>>/>"
-		inputCancelActions=<<clear-tags-actions>> tag="input" placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}}
-		focusPopup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-edit-texteditor tc-popup-handle" tabindex=<<tabIndex>> 
-		focus={{{ [{$:/config/AutoFocus}match[tags]then[true]] ~[[false]] }}} filterMinLength={{$:/config/Tags/MinLength}} 
-		cancelPopups=<<cancelPopups>> configTiddlerFilter="[[$:/core/macros/tag-picker]]"/>
-</span><$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>{{$:/core/images/down-arrow}}</$button><$reveal state=<<storeTitle>> type="nomatch" text=""><$button class="tc-btn-invisible tc-small-gap tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/ClearInput/Hint}} aria-label={{$:/language/EditTemplate/Tags/ClearInput/Caption}}>{{$:/core/images/close-button}}<<delete-tag-state-tiddlers>></$button></$reveal><span class="tc-add-tag-button tc-small-gap-left">
-<$set name="tag" value={{{ [<newTagNameTiddler>get[text]] }}}>
-<$button set=<<newTagNameTiddler>> setTo="" class="">
-<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
-$actions$
-<$set name="currentTiddlerCSSEscaped" value={{{ [<saveTiddler>escapecss[]] }}}>
-<<delete-tag-state-tiddlers>><$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>>/>
-</$set>
-{{$:/language/EditTemplate/Tags/Add/Button}}
-</$button>
-</$set>
-</span>
-</div>
-<div class="tc-block-dropdown-wrapper">
-<$reveal state=<<qualify "$:/state/popup/tags-auto-complete">> type="nomatch" text="" default="">
-<div class="tc-block-dropdown tc-block-tags-dropdown">
-<$set name="userInput" value={{{ [<storeTitle>get[text]] }}}>
-<$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
-<$list filter=<<nonSystemTagsFilter>> variable="tag">
-<$list filter="[<tag>addsuffix[-primaryList]] -[<tagSelectionState>get[text]]" emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>">
-<$vars button-classes="tc-btn-invisible" actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>
-</$list>
-</$list></$list>
-<hr>
-<$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
-<$list filter=<<systemTagsFilter>> variable="tag">
-<$list filter="[<tag>addsuffix[-secondaryList]] -[<tagSelectionState>get[text]]" emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>">
-<$vars button-classes="tc-btn-invisible" actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>
-</$list>
-</$list></$list>
-</$set>
-</div>
-</$reveal>
-</div>
-</div>
-</$vars>
-</$vars>
+<$vars newTagNameInputTiddlerQualified=<<qualify "$:/temp/NewTagName/input">>
+		newTagNameSelectionTiddlerQualified=<<qualify "$:/temp/NewTagName/selected-item">>
+		fallbackTarget={{$(palette)$##tag-background}}
+		colourA={{$(palette)$##foreground}}
+		colourB={{$(palette)$##background}}>
+	<$vars storeTitle={{{ [<newTagNameInputTiddler>!match[]] ~[<newTagNameInputTiddlerQualified>] }}}
+			tagSelectionState={{{ [<newTagNameSelectionTiddler>!match[]] ~[<newTagNameSelectionTiddlerQualified>] }}}>
+		<$vars refreshTitle=<<qualify "$:/temp/NewTagName/refresh">> 
+				nonSystemTagsFilter="[tags[]!is[system]search:title<userInput>sort[]]"
+				systemTagsFilter="[tags[]is[system]search:title<userInput>sort[]]">
+			<div class="tc-edit-add-tag">
+				<div>
+					<span class="tc-add-tag-name tc-small-gap-right">
+						<$macrocall $name="keyboard-driven-input"
+							tiddler=<<newTagNameTiddler>>
+							storeTitle=<<storeTitle>>
+							refreshTitle=<<refreshTitle>>
+							selectionStateTitle=<<tagSelectionState>>
+							inputAcceptActions="<$macrocall $name='add-tag-actions' actions=<<__actions__>> tagField=<<__tagField__>>/>"
+							inputCancelActions=<<clear-tags-actions>>
+							tag="input"
+							placeholder={{$:/language/EditTemplate/Tags/Add/Placeholder}}
+							focusPopup=<<qualify "$:/state/popup/tags-auto-complete">>
+							class="tc-edit-texteditor tc-popup-handle"
+							tabindex=<<tabIndex>>
+							focus={{{ [{$:/config/AutoFocus}match[tags]then[true]] ~[[false]] }}}
+							filterMinLength={{$:/config/Tags/MinLength}}
+							cancelPopups=<<cancelPopups>>
+							configTiddlerFilter="[[$:/core/macros/tag-picker]]"/>
+					</span>
+					<$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>
+						{{$:/core/images/down-arrow}}
+					</$button>
+					<$reveal state=<<storeTitle>> type="nomatch" text="">
+						<$button class="tc-btn-invisible tc-small-gap tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/ClearInput/Hint}} aria-label={{$:/language/EditTemplate/Tags/ClearInput/Caption}}>
+							{{$:/core/images/close-button}}<<delete-tag-state-tiddlers>>
+						</$button>
+					</$reveal>
+					<span class="tc-add-tag-button tc-small-gap-left">
+						<$set name="tag" value={{{ [<newTagNameTiddler>get[text]] }}}>
+							<$button set=<<newTagNameTiddler>> setTo="" class="">
+								<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
+								$actions$
+								<$set name="currentTiddlerCSSEscaped" value={{{ [<saveTiddler>escapecss[]] }}}>
+									<<delete-tag-state-tiddlers>><$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>>/>
+								</$set>
+								{{$:/language/EditTemplate/Tags/Add/Button}}
+							</$button>
+						</$set>
+					</span>
+				</div>
+				<div class="tc-block-dropdown-wrapper">
+					<$reveal state=<<qualify "$:/state/popup/tags-auto-complete">> type="nomatch" text="" default="">
+						<div class="tc-block-dropdown tc-block-tags-dropdown">
+							<$set name="userInput" value={{{ [<storeTitle>get[text]] }}}>
+								<$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>
+									{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
+									<$list filter=<<nonSystemTagsFilter>> variable="tag">
+										<$list filter="[<tag>addsuffix[-primaryList]] -[<tagSelectionState>get[text]]" emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>">
+											<$vars button-classes="tc-btn-invisible" actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>
+												{{||$:/core/ui/TagPickerTagTemplate}}
+											</$vars>
+										</$list>
+									</$list>
+								</$list>
+								<hr>
+								<$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>
+									{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
+									<$list filter=<<systemTagsFilter>> variable="tag">
+										<$list filter="[<tag>addsuffix[-secondaryList]] -[<tagSelectionState>get[text]]" emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>">
+											<$vars button-classes="tc-btn-invisible" actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>
+												{{||$:/core/ui/TagPickerTagTemplate}}
+											</$vars>
+										</$list>
+									</$list>
+								</$list>
+							</$set>
+						</div>
+					</$reveal>
+				</div>
+			</div>
+		</$vars>
+	</$vars>
 </$vars>
 \end
+
 \define tag-picker(actions,tagField:"tags")
 \whitespace trim
 <$vars saveTiddler=<<currentTiddler>> palette={{$:/palette}}>
-<$list filter="[<newTagNameTiddler>match[]]" emptyMessage="<$macrocall $name='tag-picker-inner' actions=<<__actions__>> tagField=<<__tagField__>>/>">
-<$set name="newTagNameTiddler" value=<<qualify "$:/temp/NewTagName">>>
-<$macrocall $name="tag-picker-inner" actions=<<__actions__>> tagField=<<__tagField__>>/>
-</$set>
-</$list>
+	<$list filter="[<newTagNameTiddler>match[]]" emptyMessage="<$macrocall $name='tag-picker-inner' actions=<<__actions__>> tagField=<<__tagField__>>/>">
+		<$set name="newTagNameTiddler" value=<<qualify "$:/temp/NewTagName">>>
+			<$macrocall $name="tag-picker-inner" actions=<<__actions__>> tagField=<<__tagField__>>/>
+		</$set>
+	</$list>
 </$vars>
 \end

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -10,7 +10,11 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 \define add-tag-actions(actions,tagField:"tags")
 \whitespace trim
 <$set name="tag" value={{{ [<__tiddler__>get[text]] }}}>
-	<$list filter="[<saveTiddler>!contains:$tagField$<tag>!match[]]" variable="ignore" emptyMessage="<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter='-[<tag>]'/>">
+	<$list
+		filter="[<saveTiddler>!contains:$tagField$<tag>!match[]]"
+		variable="ignore"
+		emptyMessage="<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter='-[<tag>]'/>"
+	>
 		<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
 		$actions$
 	</$list>
@@ -21,7 +25,11 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 
 \define clear-tags-actions-inner()
 \whitespace trim
-<$list filter="[<storeTitle>has[text]] [<newTagNameTiddler>has[text]]" variable="ignore" emptyMessage="<<cancel-delete-tiddler-actions 'cancel'>>">
+<$list
+	filter="[<storeTitle>has[text]] [<newTagNameTiddler>has[text]]"
+	variable="ignore"
+	emptyMessage="<<cancel-delete-tiddler-actions 'cancel'>>"
+>
 	<<delete-tag-state-tiddlers>>
 </$list>
 \end
@@ -37,20 +45,27 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 
 \define tag-picker-inner(actions,tagField:"tags")
 \whitespace trim
-<$vars newTagNameInputTiddlerQualified=<<qualify "$:/temp/NewTagName/input">>
-		newTagNameSelectionTiddlerQualified=<<qualify "$:/temp/NewTagName/selected-item">>
-		fallbackTarget={{$(palette)$##tag-background}}
-		colourA={{$(palette)$##foreground}}
-		colourB={{$(palette)$##background}}>
-	<$vars storeTitle={{{ [<newTagNameInputTiddler>!match[]] ~[<newTagNameInputTiddlerQualified>] }}}
-			tagSelectionState={{{ [<newTagNameSelectionTiddler>!match[]] ~[<newTagNameSelectionTiddlerQualified>] }}}>
-		<$vars refreshTitle=<<qualify "$:/temp/NewTagName/refresh">> 
-				nonSystemTagsFilter="[tags[]!is[system]search:title<userInput>sort[]]"
-				systemTagsFilter="[tags[]is[system]search:title<userInput>sort[]]">
+<$vars
+	newTagNameInputTiddlerQualified=<<qualify "$:/temp/NewTagName/input">>
+	newTagNameSelectionTiddlerQualified=<<qualify "$:/temp/NewTagName/selected-item">>
+	fallbackTarget={{$(palette)$##tag-background}}
+	colourA={{$(palette)$##foreground}}
+	colourB={{$(palette)$##background}}
+>
+	<$vars
+		storeTitle={{{ [<newTagNameInputTiddler>!match[]] ~[<newTagNameInputTiddlerQualified>] }}}
+		tagSelectionState={{{ [<newTagNameSelectionTiddler>!match[]] ~[<newTagNameSelectionTiddlerQualified>] }}}
+	>
+		<$vars
+			refreshTitle=<<qualify "$:/temp/NewTagName/refresh">> 
+			nonSystemTagsFilter="[tags[]!is[system]search:title<userInput>sort[]]"
+			systemTagsFilter="[tags[]is[system]search:title<userInput>sort[]]"
+		>
 			<div class="tc-edit-add-tag">
 				<div>
 					<span class="tc-add-tag-name tc-small-gap-right">
-						<$macrocall $name="keyboard-driven-input"
+						<$macrocall
+							$name="keyboard-driven-input"
 							tiddler=<<newTagNameTiddler>>
 							storeTitle=<<storeTitle>>
 							refreshTitle=<<refreshTitle>>
@@ -65,13 +80,21 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 							focus={{{ [{$:/config/AutoFocus}match[tags]then[true]] ~[[false]] }}}
 							filterMinLength={{$:/config/Tags/MinLength}}
 							cancelPopups=<<cancelPopups>>
-							configTiddlerFilter="[[$:/core/macros/tag-picker]]"/>
+							configTiddlerFilter="[[$:/core/macros/tag-picker]]"
+						/>
 					</span>
-					<$button popup=<<qualify "$:/state/popup/tags-auto-complete">> class="tc-btn-invisible tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}} aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}>
+					<$button popup=<<qualify "$:/state/popup/tags-auto-complete">> 
+						class="tc-btn-invisible tc-btn-dropdown"
+						tooltip={{$:/language/EditTemplate/Tags/Dropdown/Hint}}
+						aria-label={{$:/language/EditTemplate/Tags/Dropdown/Caption}}
+					>
 						{{$:/core/images/down-arrow}}
 					</$button>
 					<$reveal state=<<storeTitle>> type="nomatch" text="">
-						<$button class="tc-btn-invisible tc-small-gap tc-btn-dropdown" tooltip={{$:/language/EditTemplate/Tags/ClearInput/Hint}} aria-label={{$:/language/EditTemplate/Tags/ClearInput/Caption}}>
+						<$button class="tc-btn-invisible tc-small-gap tc-btn-dropdown"
+							tooltip={{$:/language/EditTemplate/Tags/ClearInput/Hint}}
+							aria-label={{$:/language/EditTemplate/Tags/ClearInput/Caption}}
+						>
 							{{$:/core/images/close-button}}<<delete-tag-state-tiddlers>>
 						</$button>
 					</$reveal>
@@ -79,7 +102,7 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 						<$set name="tag" value={{{ [<newTagNameTiddler>get[text]] }}}>
 							<$button set=<<newTagNameTiddler>> setTo="" class="">
 								<$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="[<tag>trim[]]"/>
-								$actions$
+									$actions$
 								<$set name="currentTiddlerCSSEscaped" value={{{ [<saveTiddler>escapecss[]] }}}>
 									<<delete-tag-state-tiddlers>><$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>>/>
 								</$set>
@@ -92,11 +115,21 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 					<$reveal state=<<qualify "$:/state/popup/tags-auto-complete">> type="nomatch" text="" default="">
 						<div class="tc-block-dropdown tc-block-tags-dropdown">
 							<$set name="userInput" value={{{ [<storeTitle>get[text]] }}}>
-								<$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>
+								<$list
+									filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]"
+									emptyMessage="<div class='tc-search-results'
+								>
 									{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
 									<$list filter=<<nonSystemTagsFilter>> variable="tag">
-										<$list filter="[<tag>addsuffix[-primaryList]] -[<tagSelectionState>get[text]]" emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>">
-											<$vars button-classes="tc-btn-invisible" actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>
+										<$list
+											filter="[<tag>addsuffix[-primaryList]] -[<tagSelectionState>get[text]]" 
+											emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>"
+										>
+											<$vars button-classes="tc-btn-invisible"
+												actions=<<__actions__>> 
+												tagField=<<__tagField__>>
+												currentTiddler=<<tag>>
+											>
 												{{||$:/core/ui/TagPickerTagTemplate}}
 											</$vars>
 										</$list>
@@ -106,8 +139,14 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 								<$list filter="[<userInput>minlength{$:/config/Tags/MinLength}limit[1]]" emptyMessage="<div class='tc-search-results'>
 									{{$:/language/Search/Search/TooShort}}</div>" variable="listItem">
 									<$list filter=<<systemTagsFilter>> variable="tag">
-										<$list filter="[<tag>addsuffix[-secondaryList]] -[<tagSelectionState>get[text]]" emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>">
-											<$vars button-classes="tc-btn-invisible" actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>
+										<$list filter="[<tag>addsuffix[-secondaryList]] -[<tagSelectionState>get[text]]"
+											emptyMessage="<$vars button-classes='tc-btn-invisible tc-tag-button-selected' actions=<<__actions__>> tagField=<<__tagField__>> currentTiddler=<<tag>>>{{||$:/core/ui/TagPickerTagTemplate}}</$vars>"
+										>
+											<$vars button-classes="tc-btn-invisible"
+												actions=<<__actions__>>
+												tagField=<<__tagField__>>
+												currentTiddler=<<tag>>
+											>
 												{{||$:/core/ui/TagPickerTagTemplate}}
 											</$vars>
 										</$list>
@@ -126,7 +165,10 @@ second-search-filter: [tags[]is[system]search:title<userInput>sort[]]
 \define tag-picker(actions,tagField:"tags")
 \whitespace trim
 <$vars saveTiddler=<<currentTiddler>> palette={{$:/palette}}>
-	<$list filter="[<newTagNameTiddler>match[]]" emptyMessage="<$macrocall $name='tag-picker-inner' actions=<<__actions__>> tagField=<<__tagField__>>/>">
+	<$list
+		filter="[<newTagNameTiddler>match[]]"
+		emptyMessage="<$macrocall $name='tag-picker-inner' actions=<<__actions__>> tagField=<<__tagField__>>/>"
+	>
 		<$set name="newTagNameTiddler" value=<<qualify "$:/temp/NewTagName">>>
 			<$macrocall $name="tag-picker-inner" actions=<<__actions__>> tagField=<<__tagField__>>/>
 		</$set>


### PR DESCRIPTION
This PR only improves the readability of the "tag-picker" and "keyboard-driven-input" macro. 

Both macors already used the `\whitespace trim` pragma. So there should be no visual differences between the old and new code. 

While trying to understand the tag-picker macro I found out that there is a lot of documentation missing for the keyboard-driven-input ... (New issue will be needed)

