### PR TITLE
Fix html macro exception missing parameter value

### DIFF
--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -71,7 +71,15 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	// Make the child widgets
 	this.makeChildWidgets();
 	// Create the DOM node and render children
-	var domNode = this.document.createElementNS(this.namespace,this.tag);
+	try {
+		var domNode = this.document.createElementNS(this.namespace,this.tag);
+	} catch (error) {
+		this.makeChildWidgets([{type: "error", attributes: {
+			"$message": {type: "string", value: 'Parameter value is missing: "' + this.tag + '"' }
+		}}]);
+		this.renderChildren(this.parentDomNode,null);
+		return;
+	}
 	this.assignAttributes(domNode,{excludeEventAttributes: true});
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);

--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -74,8 +74,10 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	try {
 		var domNode = this.document.createElementNS(this.namespace,this.tag);
 	} catch (error) {
+		$tw.utils.log("HTML element rendering error: " + error)
 		this.makeChildWidgets([{type: "error", attributes: {
 			"$message": {type: "string", value: 'Parameter value is missing: "' + this.tag + '"' }
+			// $tw.language.getString("Error/RecursiveTransclusion") <- new translation string needed TODO
 		}}]);
 		this.renderChildren(this.parentDomNode,null);
 		return;


### PR DESCRIPTION
This PR fixes the problem where a macrocall with an empty parameter causes the RSOD 
Also see the discussion at [Talk](https://talk.tiddlywiki.org/t/bug-with-selecting-which-field-to-render-macro-results-in/5472)

To preproduce

- open tiddlywiki.com
- create a tiddler with this content: `<<list-links '[tag[HelloThere]]' field:>>`
- Activate the preview 
- The RSOD comes up. 

![image](https://user-images.githubusercontent.com/374655/207766669-5355cb97-41b1-4c23-938a-6c0cd884d2c9.png)

The problem is this line

```
var domNode = this.document.createElementNS(this.namespace,this.tag);
```

[.createElementNS()](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElementNS) allows the second parameter `createElementNS(namespaceURI, qualifiedName)` to be a HTML tag name. 

**In this case `this.tag` -> `qualifiedName` contains the value `field:` ... where the `:` colon throws an exception. ...** 

This PR 

- creates an error message and 
- writes the JS-error string to the console. 

![image](https://user-images.githubusercontent.com/374655/207908374-67aa4ad0-587f-47e4-b0e8-97ea73d93fc5.png)

