### PR TITLE
Convert Rendertiddler(s) Command in Sever TiddlyWIki.info

### DIFF
--- a/editions/empty/tiddlywiki.info
+++ b/editions/empty/tiddlywiki.info
@@ -8,19 +8,19 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--render","$:/core/save/all","index.html","text/plain"],
 		"empty": [
-			"--rendertiddler","$:/core/save/all","empty.html","text/plain",
-			"--rendertiddler","$:/core/save/all","empty.hta","text/plain"],
+			"--render","$:/core/save/all","empty.html","text/plain",
+			"--render","$:/core/save/all","empty.hta","text/plain"],
 		"externalimages": [
 			"--savetiddlers","[is[image]]","images",
 			"--setfield","[is[image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[is[image]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","externalimages.html","text/plain"],
+			"--render","$:/core/save/all","externalimages.html","text/plain"],
 		"static": [
-			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
-			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--render","$:/core/templates/static.template.html","static.html","text/plain",
+			"--render","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain",			
+			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"]
 	}
 }

--- a/editions/highlightdemo/tiddlywiki.info
+++ b/editions/highlightdemo/tiddlywiki.info
@@ -11,11 +11,11 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","highlightdemo.html","text/plain"],
+			"--render","$:/core/save/all","highlightdemo.html","text/plain"],
 		"static": [
-			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
-			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--render","$:/core/templates/static.template.html","static.html","text/plain",
+			"--render","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain",
+			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"]
 	}
 }

--- a/editions/katexdemo/tiddlywiki.info
+++ b/editions/katexdemo/tiddlywiki.info
@@ -11,11 +11,11 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","katexdemo.html","text/plain"],
+			"--render","$:/core/save/all","katexdemo.html","text/plain"],
 		"static": [
-			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
-			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--render","$:/core/templates/static.template.html","static.html","text/plain",
+			"--render","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain",			
+			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"]
 	}
 }

--- a/editions/katexdemo/tiddlywiki.info
+++ b/editions/katexdemo/tiddlywiki.info
@@ -15,7 +15,7 @@
 		"static": [
 			"--render","$:/core/templates/static.template.html","static.html","text/plain",
 			"--render","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain",			
+			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain",
 			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"]
 	}
 }

--- a/editions/server-external-js/tiddlywiki.info
+++ b/editions/server-external-js/tiddlywiki.info
@@ -13,13 +13,13 @@
 		"listen": [
 			"--listen","root-tiddler=$:/core/save/all-external-js","use-browser-cache=yes"],
 		"index": [
-			"--rendertiddler","$:/core/save/offline-external-js","index.html","text/plain",
+			"--render","$:/core/save/offline-external-js","index.html","text/plain",
 			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"],
 		"static": [
-			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
-			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"],
+			"--render","$:/core/templates/static.template.html","static.html","text/plain",
+			"--render","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain",			
+			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"],
 		"tiddlywikicore": [
 			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"]
 	}

--- a/editions/server/tiddlywiki.info
+++ b/editions/server/tiddlywiki.info
@@ -11,11 +11,11 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/plugins/tiddlywiki/tiddlyweb/save/offline","index.html","text/plain"],
+			"--render","$:/plugins/tiddlywiki/tiddlyweb/save/offline","index.html","text/plain"],
 		"static": [
-			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
-			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--render","$:/core/templates/static.template.html","static.html","text/plain",
+			"--render","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain",
+			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"]
 	}
 }

--- a/editions/tw.org/tiddlywiki.info
+++ b/editions/tw.org/tiddlywiki.info
@@ -15,14 +15,14 @@
 			"--savetiddlers","[tag[external-image]]","images",
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-image]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--render","$:/core/save/all","index.html","text/plain"],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico"],
 		"static": [
-			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
-			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"]
+			"--render","$:/core/templates/static.template.html","static.html","text/plain",
+			"--render","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain","$:/core/templates/static.tiddler.html",				
+			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"]
 	},
 	"config": {
 		"retain-original-tiddler-path": true

--- a/editions/tw5.com-docs/tiddlywiki.info
+++ b/editions/tw5.com-docs/tiddlywiki.info
@@ -10,6 +10,6 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"]
+			"--render","$:/core/save/all","index.html","text/plain"]
 	}
 }

--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -24,35 +24,35 @@
 	"build": {
 		"index": [
 			"--savetiddlers","[tag[external-image]]","images",
-			"--rendertiddlers","[tag[external-text]]","$:/core/templates/tid-tiddler","text","text/plain",".tid",
+			"--render","[tag[external-text]]","[encodeuricomponent[]addprefix[text/]addsuffix[.tid]]","text/plain","$:/core/templates/tid-tiddler",
 			"--setfield","[tag[external-image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",
 			"--setfield","[tag[external-text]]","_canonical_uri","$:/core/templates/canonical-uri-external-text","text/plain",
 			"--setfield","[tag[external-image]] [tag[external-text]]","text","","text/plain",
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"],
+			"--render","$:/core/save/all","index.html","text/plain"],
 		"empty": [
-			"--rendertiddler","$:/editions/tw5.com/download-empty","empty.html","text/plain",
-			"--rendertiddler","$:/editions/tw5.com/download-empty","empty.hta","text/plain"],
+			"--render","$:/editions/tw5.com/download-empty","empty.html","text/plain",
+			"--render","$:/editions/tw5.com/download-empty","empty.hta","text/plain"],
 		"encrypted": [
 			"--password", "password",
-			"--rendertiddler", "$:/core/save/all", "encrypted.html", "text/plain",
+			"--render", "$:/core/save/all", "encrypted.html", "text/plain",
 			"--clearpassword"],
 		"favicon": [
 			"--savetiddler","$:/favicon.ico","favicon.ico",
 			"--savetiddler","$:/green_favicon.ico","static/favicon.ico"],
 		"readmes": [
-			"--rendertiddler","ReadMe","readme.md","text/html",
-			"--rendertiddler","ReadMeBinFolder","bin/readme.md","text/html",
-			"--rendertiddler","ContributingTemplate","contributing.md","text/html",
-			"--rendertiddler","$:/core/copyright.txt","license","text/plain"],
+			"--render","ReadMe","readme.md","text/html",
+			"--render","ReadMeBinFolder","bin/readme.md","text/html",
+			"--render","ContributingTemplate","contributing.md","text/html",
+			"--render","$:/core/copyright.txt","license","text/plain"],
 		"tw2": [
-			"--rendertiddler","TiddlyWiki2ReadMe","tw2/readme.md","text/html"],
+			"--render","TiddlyWiki2ReadMe","tw2/readme.md","text/html"],
 		"static": [
-			"--rendertiddler","$:/core/templates/static.template.html","static.html","text/plain",
-			"--rendertiddler","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
-			"--rendertiddlers","[!is[system]]","$:/core/templates/static.tiddler.html","static","text/plain",
-			"--rendertiddler","$:/core/templates/static.template.css","static/static.css","text/plain"],
+			"--render","$:/core/templates/static.template.html","static.html","text/plain",
+			"--render","$:/core/templates/alltiddlers.template.html","alltiddlers.html","text/plain",
+			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain","$:/core/templates/static.tiddler.html",			
+			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"],
 		"external-js": [
-			"--rendertiddler","$:/core/save/offline-external-js","index.html","text/plain",
+			"--render","$:/core/save/offline-external-js","index.html","text/plain",
 			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"]
 	},
 	"config": {

--- a/editions/twitter-archivist/tiddlywiki.info
+++ b/editions/twitter-archivist/tiddlywiki.info
@@ -11,6 +11,6 @@
 	],
 	"build": {
 		"index": [
-			"--rendertiddler","$:/core/save/all","index.html","text/plain"]
+			"--render","$:/core/save/all","index.html","text/plain"]
 	}
 }


### PR DESCRIPTION
This is the first PR to convert deprecated `rendertiddler` and `rendertiddlers` to `render` command.

I will do the change in several steps to be able to revert in case of unseen issues.