### PR TITLE
add console-error to the Logger class

### DIFF
--- a/core/modules/utils/logger.js
+++ b/core/modules/utils/logger.js
@@ -52,7 +52,19 @@ Logger.prototype.log = function(/* args */) {
 			logMessage[logMessage.length-1] += $tw.utils.terminalColour();
 			return Function.apply.call(console.log, console, logMessage);
 		}
-	} 
+	}
+};
+
+/*
+Log an error message to console.error so it also gets a red colour in browsers
+*/
+Logger.prototype.error = function(/* args */) {
+	var self = this;
+	if(console !== undefined && console.error !== undefined) {
+		var logMessage = [$tw.utils.terminalColour(this.colour) + this.componentName + ":"].concat(Array.prototype.slice.call(arguments,0));
+		logMessage[logMessage.length-1] += $tw.utils.terminalColour();
+		return Function.apply.call(console.error, console, logMessage);
+	}
 };
 
 /*


### PR DESCRIPTION
This PR allows the Logger class to use `console.error()` ... since `console.log()` doesn't add any color to messages in the browser dev-console. 

This is needed, if a core function throws an error and there is a `try/catch` function. If possible the `catch()` function should avoid data corruption. 

-----------

There is a `$tw.utils.error()` function which would write a message to the browser console. BUT it also creates the RSOD info. .. So it's not usable. 

`$tw.utils.log()` is not usable for my usecase, since it's not visible enough. 

----------

An alternative would be to create global `$tw.utils.errorToConsole()` utility function. .. BUT I think the implementation in the PR is more versatile. 


-------

If the PR is merged I'll add some docs to the tiddlywiki.com/dev edition. ... Because messing around with the naming inconsistencies did cost me 3 hours. 

So investing 2 more to create some docs aobut what I learned IMO would be OK
