### PR TITLE
Fully committing core to the $genesis widget

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -26,7 +26,7 @@ tags: $:/tags/Macro
 \whitespace trim
 <span class="tc-links-draggable-list">
 <$vars targetTiddler="""$tiddler$""" targetField="""$field$""">
-<$type$ class="$class$">
+<$genesis $type=<<__type__>> class="$class$">
 <$list filter="[list[$tiddler$!!$field$]]" emptyMessage=<<__emptyMessage__>>>
 <$droppable actions=<<list-links-draggable-drop-actions>> tag="""$subtype$""" enable=<<tv-enable-drag-and-drop>>>
 <div class="tc-droppable-placeholder"/>
@@ -51,7 +51,7 @@ tags: $:/tags/Macro
 <div style="height:0.5em;"/>
 </$droppable>
 </$tiddler>
-</$type$>
+</$genesis>
 </$vars>
 </span>
 \end
@@ -84,24 +84,24 @@ tags: $:/tags/Macro
 <span class="tc-tagged-draggable-list">
 <$set name="tag" value=<<__tag__>>>
 <$list filter="[<__tag__>tagging[]$subFilter$]" emptyMessage=<<__emptyMessage__>> storyview=<<__storyview__>>>
-<$elementTag$ class="tc-menu-list-item">
+<$genesis $type=<<__elementTag__>> class="tc-menu-list-item">
 <$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""" enable=<<tv-enable-drag-and-drop>>>
-<$elementTag$ class="tc-droppable-placeholder"/>
-<$elementTag$>
+<$genesis $type=<<__elementTag__>> class="tc-droppable-placeholder"/>
+<$genesis $type=<<__elementTag__>>>
 <$transclude tiddler="""$itemTemplate$""">
 <$link to={{!!title}}>
 <$view field="title"/>
 </$link>
 </$transclude>
-</$elementTag$>
+</$genesis>
 </$droppable>
-</$elementTag$>
+</$genesis>
 </$list>
 <$tiddler tiddler="">
 <$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""" enable=<<tv-enable-drag-and-drop>>>
-<$elementTag$ class="tc-droppable-placeholder"/>
-<$elementTag$ style="height:0.5em;">
-</$elementTag$>
+<$genesis $type=<<__elementTag__>> class="tc-droppable-placeholder"/>
+<$genesis $type=<<__elementTag__>> style="height:0.5em;">
+</$genesis>
 </$droppable>
 </$tiddler>
 </$set>


### PR DESCRIPTION
I *love* the new genesis widget.

It's great. It provides a far better mechanism for dynamic widgets than the old way, which was to do placeholder widget like this: `\define macro(tag:div) <$tag$>...`

Placeholder widgets were **bad** for plugin developers like me. Take Uglify. It can't parse <$tag$>, so it actually saw it as plaintext containing a placeholder. And all it could do was stay away from it, because touching it was dangerous. As a result, Uglify becomes much less effective around them. But it *can* handle `<$genesis>` just fine. It's safer. It compresses better.

Even Relink prefers $genesis. If it encountered `<$tag$ attribute=...>`, it couldn't relink any of its attributes at all, because it couldn't parse it as a widget. With $genesis, it can. (It may still fail to identify some string-value attributes that require relinking in some cases, but it's still **far** better off with a $genesis widget).

In fact, my only complaint about the genesis widget is this:

### *Why aren't we fully embracing it?*

This PR addresses that by migrating the few remaining places in core where dangerous placeholder widgets were still used.