### PR TITLE
Fix data-tiddler field duplications in server snapshots

### DIFF
--- a/plugins/tiddlywiki/tiddlyweb/css-tiddler.tid
+++ b/plugins/tiddlywiki/tiddlyweb/css-tiddler.tid
@@ -4,4 +4,4 @@ title: $:/core/templates/css-tiddler
 
 This template is used for saving CSS tiddlers as a style tag with data attributes representing the tiddler fields. This version includes the tiddler changecount as the field `revision`.
 
--->`<style`<$fields template=' data-tiddler-$name$="$encoded_value$"'></$fields>` data-tiddler-revision="`<<changecount>>`" data-tiddler-bag="default" type="text/css">`<$view field="text" format="text" />`</style>`
+-->`<style`<$fields exclude='text revision bag' template=' data-tiddler-$name$="$encoded_value$"'></$fields>` data-tiddler-revision="`<<changecount>>`" data-tiddler-bag="default" type="text/css">`<$view field="text" format="text" />`</style>`

--- a/plugins/tiddlywiki/tiddlyweb/javascript-tiddler.tid
+++ b/plugins/tiddlywiki/tiddlyweb/javascript-tiddler.tid
@@ -4,4 +4,4 @@ title: $:/core/templates/javascript-tiddler
 
 This template is used for saving JavaScript tiddlers as a script tag with data attributes representing the tiddler fields. This version includes the tiddler changecount as the field `revision`.
 
--->`<script`<$fields template=' data-tiddler-$name$="$encoded_value$"'></$fields>` data-tiddler-revision="`<<changecount>>`" data-tiddler-bag="default" type="text/javascript">`<$view field="text" format="text" />`</script>`
+-->`<script`<$fields exclude='text revision bag' template=' data-tiddler-$name$="$encoded_value$"'></$fields>` data-tiddler-revision="`<<changecount>>`" data-tiddler-bag="default" type="text/javascript">`<$view field="text" format="text" />`</script>`


### PR DESCRIPTION
This PR fixes duplications of some data-tiddler fields in the snapshots created by the server (tiddlyweb).

Before the fix, the snapshot result:

<pre><code>
&lt;div id="styleArea">
&lt;style <b>data-tiddler-bag</b>="default" <b>data-tiddler-revision</b>="0" data-tiddler-title="$:/boot/boot.css"
data-tiddler-type="text/css" <b>data-tiddler-revision</b>="0" <b>data-tiddler-bag</b>="default" type="text/css">
...

&lt;div id="libraryModules" style="display:none;">
&lt;script <b>data-tiddler-bag</b>="default" data-tiddler-library="yes" <b>data-tiddler-revision</b>="0" 
data-tiddler-title="$:/library/sjcl.js" data-tiddler-type="application/javascript" 
<b>data-tiddler-revision</b>="0" <b>data-tiddler-bag</b>="default" type="text/javascript">
...
</code></pre>

After:

<pre><code>
&lt;div id="styleArea">
&lt;style data-tiddler-title="$:/boot/boot.css" data-tiddler-type="text/css" 
<b>data-tiddler-revision</b>="0" <b>data-tiddler-bag</b>="default" type="text/css">
...

&lt;div id="libraryModules" style="display:none;">
&lt;script data-tiddler-library="yes" data-tiddler-title="$:/library/sjcl.js" 
data-tiddler-type="application/javascript" <b>data-tiddler-revision</b>="0" <b>data-tiddler-bag</b>="default" 
type="text/javascript">
...
</code></pre>
