### PR TITLE
Record state saving timestamp

### DIFF
--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -114,6 +114,7 @@ function SaverHandler(options) {
 SaverHandler.prototype.titleSyncFilter = "$:/config/SaverFilter";
 SaverHandler.prototype.titleAutoSave = "$:/config/AutoSave";
 SaverHandler.prototype.titleSavedNotification = "$:/language/Notifications/Save/Done";
+SaverHandler.prototype.saveState = "$:/state/saving/timestamp";
 
 /*
 Select the appropriate saver modules and set them up
@@ -158,9 +159,14 @@ SaverHandler.prototype.saveWiki = function(options) {
 	}
 	var	variables = options.variables || {},
 		template = (options.template || 
-		           this.wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
-		downloadType = options.downloadType || "text/plain",
-		text = this.wiki.renderTiddler(downloadType,template,options),
+					this.wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
+		downloadType = options.downloadType || "text/plain";
+
+	if (options.recordSaveTime || true) {
+		this.wiki.addTiddler(new $tw.Tiddler({title: this.saveState, text: "" + Date.now()}, this.wiki.getModificationFields()));
+	}
+
+	var text = this.wiki.renderTiddler(downloadType,template,options),
 		callback = function(err) {
 			if(err) {
 				alert($tw.language.getString("Error/WhileSaving") + ":\n\n" + err);

--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -147,7 +147,6 @@ Save the wiki contents. Options are:
 	method: "save", "autosave" or "download"
 	template: the tiddler containing the template to save
 	downloadType: the content type for the saved file
-	invokePreSaveActions: invoke actions tagged: "$:/tags/PreSaveAction". defaults to yes
 */
 SaverHandler.prototype.saveWiki = function(options) {
 	options = options || {};
@@ -157,7 +156,8 @@ SaverHandler.prototype.saveWiki = function(options) {
 	if(method === "autosave" && ($tw.config.disableAutoSave || this.wiki.getTiddlerText(this.titleAutoSave,"yes") !== "yes")) {
 		return false;
 	}
-	var	invokePreSaveActions = options.invokePreSaveActions || "yes",
+
+	var	invokePreSaveActions = this.wiki.getTiddlerText("$:/config/InvokePreSaveActions","yes").trim(),
 		variables = options.variables || {},
 		template = (options.template || this.wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
 		downloadType = options.downloadType || "text/plain";

--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -148,7 +148,7 @@ Save the wiki contents. Options are:
 	method: "save", "autosave" or "download"
 	template: the tiddler containing the template to save
 	downloadType: the content type for the saved file
-	recordSaveTime: A state tiddler with a save timestamp is created. defaults to true
+	invokePreSaveActions: A state tiddler with a save timestamp is created. defaults to true
 */
 SaverHandler.prototype.saveWiki = function(options) {
 	options = options || {};
@@ -163,18 +163,9 @@ SaverHandler.prototype.saveWiki = function(options) {
 					this.wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
 		downloadType = options.downloadType || "text/plain";
 
-	// It saves a save timestamp to a state tiddler
-	// It also concatenates the last modified tiddler title with its "modified" TW string
-	if (options.recordSaveTime || true) {
-		var lastChanged = this.wiki.getTiddler( this.wiki.filterTiddlers("[!is[system]!sort[modified]limit[1]]"));
-		if (lastChanged) {
-			this.wiki.addTiddler(
-				new $tw.Tiddler({title:this.saveState,
-					text:"timestamp: " + Date.now() +
-						"\nlastModifiedSha: " + $tw.utils.sha256(lastChanged.fields.title + lastChanged.getFieldString("modified")),
-					type:"application/x-tiddler-dictionary"},
-					this.wiki.getModificationFields()));
-		}
+	// Execute any pre save actions defaults to yes
+	if (options.invokePreSaveActions || true) {
+		$tw.rootWidget.invokeActionsByTag("$:/tags/PreSaveAction");
 	}
 
 	var text = this.wiki.renderTiddler(downloadType,template,options),

--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -114,7 +114,6 @@ function SaverHandler(options) {
 SaverHandler.prototype.titleSyncFilter = "$:/config/SaverFilter";
 SaverHandler.prototype.titleAutoSave = "$:/config/AutoSave";
 SaverHandler.prototype.titleSavedNotification = "$:/language/Notifications/Save/Done";
-SaverHandler.prototype.saveState = "$:/state/saving/timestamp";
 
 /*
 Select the appropriate saver modules and set them up
@@ -148,26 +147,26 @@ Save the wiki contents. Options are:
 	method: "save", "autosave" or "download"
 	template: the tiddler containing the template to save
 	downloadType: the content type for the saved file
-	invokePreSaveActions: A state tiddler with a save timestamp is created. defaults to true
+	invokePreSaveActions: invoke actions tagged: "$:/tags/PreSaveAction". defaults to yes
 */
 SaverHandler.prototype.saveWiki = function(options) {
 	options = options || {};
 	var self = this,
-		method = options.method || "save";
-	// Ignore autosave if disabled
-	if(method === "autosave" && ($tw.config.disableAutoSave || this.wiki.getTiddlerText(this.titleAutoSave,"yes") !== "yes")) {
+	method = options.method || "save";
+	// Ignore autosave if disabled ... return early
+	if(method === "autosave" && ($tw.config.disableAutoSave || this.wiki.getTiddlerText(this.titleAutoSave,"yes") !== "yes") {
 		return false;
 	}
-	var	variables = options.variables || {},
+	var	invokePreSaveActions = options.invokePreSaveActions || "yes",
+		variables = options.variables || {},
 		template = (options.template || 
 					this.wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
 		downloadType = options.downloadType || "text/plain";
 
 	// Execute any pre save actions defaults to yes
-	if (options.invokePreSaveActions || true) {
+	if(invokePreSaveActions === "yes") {
 		$tw.rootWidget.invokeActionsByTag("$:/tags/PreSaveAction");
 	}
-
 	var text = this.wiki.renderTiddler(downloadType,template,options),
 		callback = function(err) {
 			if(err) {

--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -148,6 +148,7 @@ Save the wiki contents. Options are:
 	method: "save", "autosave" or "download"
 	template: the tiddler containing the template to save
 	downloadType: the content type for the saved file
+	recordSaveTime: A state tiddler with a save timestamp is created. defaults to true
 */
 SaverHandler.prototype.saveWiki = function(options) {
 	options = options || {};
@@ -162,8 +163,18 @@ SaverHandler.prototype.saveWiki = function(options) {
 					this.wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
 		downloadType = options.downloadType || "text/plain";
 
+	// It saves a save timestamp to a state tiddler
+	// It also concatenates the last modified tiddler title with its "modified" TW string
 	if (options.recordSaveTime || true) {
-		this.wiki.addTiddler(new $tw.Tiddler({title: this.saveState, text: "" + Date.now()}, this.wiki.getModificationFields()));
+		var lastChanged = this.wiki.getTiddler( this.wiki.filterTiddlers("[!is[system]!sort[modified]limit[1]]"));
+		if (lastChanged) {
+			this.wiki.addTiddler(
+				new $tw.Tiddler({title:this.saveState,
+					text:"timestamp: " + Date.now() +
+						"\nlastModifiedSha: " + $tw.utils.sha256(lastChanged.fields.title + lastChanged.getFieldString("modified")),
+					type:"application/x-tiddler-dictionary"},
+					this.wiki.getModificationFields()));
+		}
 	}
 
 	var text = this.wiki.renderTiddler(downloadType,template,options),

--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -152,15 +152,14 @@ Save the wiki contents. Options are:
 SaverHandler.prototype.saveWiki = function(options) {
 	options = options || {};
 	var self = this,
-	method = options.method || "save";
+		method = options.method || "save";
 	// Ignore autosave if disabled ... return early
 	if(method === "autosave" && ($tw.config.disableAutoSave || this.wiki.getTiddlerText(this.titleAutoSave,"yes") !== "yes")) {
 		return false;
 	}
 	var	invokePreSaveActions = options.invokePreSaveActions || "yes",
 		variables = options.variables || {},
-		template = (options.template || 
-					this.wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
+		template = (options.template || this.wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
 		downloadType = options.downloadType || "text/plain";
 
 	// Execute any pre save actions defaults to yes

--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -154,7 +154,7 @@ SaverHandler.prototype.saveWiki = function(options) {
 	var self = this,
 	method = options.method || "save";
 	// Ignore autosave if disabled ... return early
-	if(method === "autosave" && ($tw.config.disableAutoSave || this.wiki.getTiddlerText(this.titleAutoSave,"yes") !== "yes") {
+	if(method === "autosave" && ($tw.config.disableAutoSave || this.wiki.getTiddlerText(this.titleAutoSave,"yes") !== "yes")) {
 		return false;
 	}
 	var	invokePreSaveActions = options.invokePreSaveActions || "yes",
@@ -165,7 +165,8 @@ SaverHandler.prototype.saveWiki = function(options) {
 
 	// Execute any pre save actions defaults to yes
 	if(invokePreSaveActions === "yes") {
-		$tw.rootWidget.invokeActionsByTag("$:/tags/PreSaveAction");
+		// $tw.rootWidget.invokeActionsByTag(tag, event, variables);
+		$tw.rootWidget.invokeActionsByTag("$:/tags/PreSaveAction", undefined, options);
 	}
 	var text = this.wiki.renderTiddler(downloadType,template,options),
 		callback = function(err) {

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -811,7 +811,7 @@ exports.hashString = function(str) {
 
 /*
 Same cryptographic hash function as used by sha256 filter operator
-options.lenghth .. number of characters returned defaults to 64
+options.length .. number of characters returned defaults to 64
 */
 exports.sha256 = function(str, options) {
 	options = options || {}

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -810,6 +810,15 @@ exports.hashString = function(str) {
 };
 
 /*
+Same cryptographic hash function as used by sha256 filter operator
+options.lenghth .. number of characters returned defaults to 64
+*/
+exports.sha256 = function(str, options) {
+	options = options || {}
+	return sjcl.codec.hex.fromBits(sjcl.hash.sha256.hash(str)).substr(0,options.length || 64);
+}
+
+/*
 Decode a base64 string
 */
 exports.base64Decode = function(string64) {

--- a/core/wiki/config/PreSaveActionLastModifiedSha.txt
+++ b/core/wiki/config/PreSaveActionLastModifiedSha.txt
@@ -1,0 +1,1 @@
+<$action-setfield $tiddler="$:/state/saving/lastModifiedSha" text={{{ [!is[system]!sort[modified]limit[1]] :map[get[modified]addsuffix<currentTiddler>sha256[64]] }}} />

--- a/core/wiki/config/PreSaveActionLastModifiedSha.txt.meta
+++ b/core/wiki/config/PreSaveActionLastModifiedSha.txt.meta
@@ -1,0 +1,5 @@
+created: 20221216120021692
+modified: 20221216203035885
+tags: $:/tags/PreSaveAction
+title: $:/config/presave/action/lastModifiedSha
+type: text/plain

--- a/core/wiki/config/PreSaveActionTimestamp.txt
+++ b/core/wiki/config/PreSaveActionTimestamp.txt
@@ -1,0 +1,1 @@
+<$action-setfield $tiddler="$:/state/saving/timestamp" text={{{ [<now "TIMESTAMP">] }}} />

--- a/core/wiki/config/PreSaveActionTimestamp.txt.meta
+++ b/core/wiki/config/PreSaveActionTimestamp.txt.meta
@@ -1,0 +1,5 @@
+created: 20221216113950372
+modified: 20221216202924542
+tags: $:/tags/PreSaveAction
+title: $:/config/presave/action/timestamp
+type: text/plain

--- a/editions/tw5.com/tiddlers/Hidden Setting_ Invoke PreSaveActions.tid
+++ b/editions/tw5.com/tiddlers/Hidden Setting_ Invoke PreSaveActions.tid
@@ -1,0 +1,7 @@
+created: 20221218171854577
+modified: 20221218172318279
+tags: [[Hidden Settings]]
+title: Hidden Setting: Invoke PreSaveActions
+type: text/vnd.tiddlywiki
+
+The PreSaveActions are active by default. If the actions should be disabled the tiddler $:/config/InvokePreSaveActions has to be set to ''no''. 

--- a/editions/tw5.com/tiddlers/features/PreSaveActions.tid
+++ b/editions/tw5.com/tiddlers/features/PreSaveActions.tid
@@ -1,0 +1,54 @@
+created: 20221216145421576
+modified: 20221216204955053
+tags: Features
+title: PreSaveActions
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.2.5">> TiddlyWiki executes any ActionWidgets found in tiddlers with the following system tag right prior to a file save action. This allows you to create some status tiddlers right before a file-saver is activated. 
+
+* <<tag "$:/tags/PreSaveAction">> is executed on all platforms
+
+!! Core Default Actions
+
+The core default actions are:
+
+<<list-links "[all[shadows+tiddlers]!has[draft.of]tag[$:/tags/PreSaveAction]]">>
+
+
+''~$:/config/presave/action/timestamp''
+
+See: <$transclude tiddler="$:/config/presave/action/timestamp" mode="block" />
+
+Creates a tiddler named: <<.tid $:/state/saving/timestamp>>
+
+* It contains the date [[TIMESTAMP|http://local.lan:8080/#DateFormat]] when the wiki has been saved. 
+* This value can be easily compared to find out which wiki has been saved first, if opened in more than 1 browser tabs.
+
+''~$:/config/presave/action/lastModifiedSha''
+
+See: <$transclude tiddler="$:/config/presave/action/lastModifiedSha" mode="block" />
+
+This action creates a tiddler named: <<.tid $:/state/saving/lastModifiedSha>>
+
+* The filter searches for the latest non-system tiddler, that has been saved.
+* It takes the <<.field modified>> timestamp.
+* It concatenates the name of that tiddler with the timestamp.
+* It creates a sha256, that can be compared with a sha from a second wiki. 
+** Using a sha256 prevents information leaks if a tiddlywiki is encrypted. 
+** The tiddler title is part of the sha but isn't leaked if information is broadcasted from 1 browser tab to any other browser tabs.
+
+!! Important
+
+* Pre-save actions are only active for TW ''file-savers''.
+* They are not active for server backends, since every action is saved by default.
+** Pre-save actions should only use tiddlers ''prefixed `$:/state/`'', since those tiddlers are not saved back to the server.
+* ''Pre-save actions must be well tested!''
+
+!! Testing ~PreSave Actions
+
+The following code allows you to test if your actions are executed in the right way, without a save or download is triggered. It's important that your actions work. ''If your causes a fatal error, it may be possible that the wiki is _not_ saved!''
+
+<<.example 1 """<$wikify name="test-actions" text="{{{ [all[shadows+tiddlers]!has[draft.of]tag[$:/tags/PreSaveAction]get[text]] }}}" mode=block>
+  <$button actions=<<test-actions>> >Invoke Pre Save Actions</$button>
+</$wikify>
+""">>

--- a/editions/tw5.com/tiddlers/features/PreSaveActions.tid
+++ b/editions/tw5.com/tiddlers/features/PreSaveActions.tid
@@ -1,5 +1,5 @@
 created: 20221216145421576
-modified: 20221216204955053
+modified: 20221218172215043
 tags: Features
 title: PreSaveActions
 type: text/vnd.tiddlywiki
@@ -52,3 +52,18 @@ The following code allows you to test if your actions are executed in the right 
   <$button actions=<<test-actions>> >Invoke Pre Save Actions</$button>
 </$wikify>
 """>>
+
+!! Logging Variables
+
+If you want to see the variables, that are available for the actions you need to add the following line to the ~PreSave action tiddler. 
+
+Important: The variables are only active if you invoke a real save action. So the "test" button from the example above will ''not'' work. See [[ActionLogWidget]]
+
+```
+<$action-log $$message="pre-save timestamp" $$all=yes />
+```
+
+!! How to Deactivate the ~PreSaveActions
+
+{{Hidden Setting: Invoke PreSaveActions}}
+


### PR DESCRIPTION
This PR will fix: **[IDEA] Last saved timestamp and what it may enable #6684**

Every save action that saves a file-wiki will create 2 new `$:/state/` tiddlers. 

- $:/state/saving/timestamp
- $:/state/saving/lastModifiedSha

Link to more [detailed documentation](https://tiddlywiki5-git-fork-pmario-record-state-savin-654a0f-jermolene.vercel.app/#PreSaveActions)

In short. 

All tiddlers tagged: **$:/tags/PreSaveAction** are invoked, similar to the [StartupActions](https://tiddlywiki.com/#StartupActions)

**$:/config/presave/action/timestamp** creates `$:/state/saving/timestamp` that contains a unix Date [TIMESTAMP](https://tiddlywiki.com/#DateFormat)

```
<$action-setfield $tiddler="$:/state/saving/timestamp" text={{{ [<now "TIMESTAMP">] }}} />
```

**$:/config/presave/action/lastModifiedSha** creates `$:/state/saving/lastModifiedSha` which contains an information about the last modified tiddler as a SHA256. This makes sure that _no_ information about tiddlers with an encrypted wiki are leaked.

```
<$action-setfield $tiddler="$:/state/saving/lastModifiedSha" text={{{ [!is[system]!sort[modified]limit[1]] :map[get[modified]addsuffix<currentTiddler>sha256[64]] }}} />
```

- Those 2 tiddlers make it possible to identify if a file wiki is opened in 2 or more browser tabs. and
- Which one was  modified last
- The startup actions to detect this info are _not_ part of this PR.

**New Hidden Setting**

The PreSaveActions are active by default. If the actions should be disabled the tiddler $:/config/InvokePreSaveActions has to be set to no.
