### PR TITLE
Allow table-padding TD and TH to be user configurable

### DIFF
--- a/core/language/en-GB/ThemeTweaks.multids
+++ b/core/language/en-GB/ThemeTweaks.multids
@@ -40,3 +40,8 @@ Metrics/SidebarBreakpoint: Sidebar breakpoint
 Metrics/SidebarBreakpoint/Hint: the minimum page width at which the story<br>river and sidebar will appear side by side
 Metrics/SidebarWidth: Sidebar width
 Metrics/SidebarWidth/Hint: the width of the sidebar in fluid-fixed layout
+Table: Table
+Table/Padding/Data: Table padding data cells
+Table/Padding/Data/Hint: default distance between the table border and content (top right bottom left)
+Table/Padding/Heading: Table padding heading cells
+Table/Padding/Heading/Hint: default distance between the table border and content (top right bottom left)

--- a/themes/tiddlywiki/vanilla/ThemeTweaks.tid
+++ b/themes/tiddlywiki/vanilla/ThemeTweaks.tid
@@ -75,3 +75,8 @@ caption: {{$:/language/ThemeTweaks/ThemeTweaks}}
 |<$link to="$:/themes/tiddlywiki/vanilla/metrics/tiddlerwidth"><<lingo Metrics/TiddlerWidth>></$link><br>//<<lingo Metrics/TiddlerWidth/Hint>>//<br> |^<$edit-text tiddler="$:/themes/tiddlywiki/vanilla/metrics/tiddlerwidth" default="" tag="input"/> |
 |<$link to="$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint"><<lingo Metrics/SidebarBreakpoint>></$link><br>//<<lingo Metrics/SidebarBreakpoint/Hint>>// |^<$edit-text tiddler="$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint" default="" tag="input"/> |
 |<$link to="$:/themes/tiddlywiki/vanilla/metrics/sidebarwidth"><<lingo Metrics/SidebarWidth>></$link><br>//<<lingo Metrics/SidebarWidth/Hint>>// |^<$edit-text tiddler="$:/themes/tiddlywiki/vanilla/metrics/sidebarwidth" default="" tag="input"/> |
+
+! <<lingo Table>>
+
+|<$link to="$:/themes/tiddlywiki/vanilla/metrics/tdpadding"><<lingo Table/Padding/Data>></$link><br>//<<lingo Table/Padding/Data/Hint>>// |^<$edit-text tiddler="$:/themes/tiddlywiki/vanilla/metrics/tdpadding" default="" tag="input"/> |
+|<$link to="$:/themes/tiddlywiki/vanilla/metrics/thpadding"><<lingo Table/Padding/Heading>></$link><br>//<<lingo Table/Padding/Heading/Hint>>// |^<$edit-text tiddler="$:/themes/tiddlywiki/vanilla/metrics/thpadding" default="" tag="input"/> |

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -330,9 +330,16 @@ table {
 }
 
 table th, table td {
-	padding: 4px 6px 4px 6px;
 	border-top: 1px solid <<colour table-border>>;
 	border-left: 1px solid <<colour table-border>>;
+}
+
+table th {
+	padding: {{$:/themes/tiddlywiki/vanilla/metrics/thpadding}};
+}
+
+table td {
+	padding: {{$:/themes/tiddlywiki/vanilla/metrics/tdpadding}};
 }
 
 table thead tr td, table th {

--- a/themes/tiddlywiki/vanilla/metrics.multids
+++ b/themes/tiddlywiki/vanilla/metrics.multids
@@ -11,3 +11,5 @@ storywidth: 770px
 tiddlerwidth: 686px
 sidebarbreakpoint: 960px
 sidebarwidth: 350px
+thpadding: 0px 7px 0px 7px
+tdpadding: 0px 7px 0px 7px


### PR DESCRIPTION
This PR allows users to define padding in table cells to be configurable. For some usecases the existing top and bottom 0px setting is inconvenient. This PR should fix this.

It adds new settings to ControlPanel -> Appearence -> ThemeTweaks

As seen in the screenshot it allows the user to set the metrics of table headings differently to data cells

![image](https://user-images.githubusercontent.com/374655/208314478-44fe20b9-f798-4bbf-a55d-59fa3aac329d.png)

