### PR TITLE
Fix miscellaneous typos

### DIFF
--- a/editions/dev/tiddlers/from tw5.com/Developing plugins using Node.js and GitHub.tid
+++ b/editions/dev/tiddlers/from tw5.com/Developing plugins using Node.js and GitHub.tid
@@ -10,7 +10,7 @@ The most practical way to develop plugins is to use Node.js with the tiddlywiki5
 
 !! 1. Installation
 
-First read  https://tiddlywiki.com/static/PluginMechanism.html.
+First read https://tiddlywiki.com/static/PluginMechanism.html.
 
 Install Git from http://git-scm.com/downloads
 
@@ -85,7 +85,7 @@ For example files see the plugins in the ~TiddlyWiki5 repository i.e. those loca
 
 !!5. Build your files into a ~TiddlyWiki
 
-Modify `editions/tw5.com/tiddlywiki.info` to include a reference to your plugin directory,  i.e. find `"plugins": [ ` and add `"yourname/pluginname"`.
+Modify `editions/tw5.com/tiddlywiki.info` to include a reference to your plugin directory, i.e. find `"plugins": [ ` and add `"yourname/pluginname"`.
 
 From the TW5 directory issue the command
 

--- a/editions/markdowndemo/tiddlers/MarkdownExample.tid
+++ b/editions/markdowndemo/tiddlers/MarkdownExample.tid
@@ -117,7 +117,7 @@ Output:
 
 Unordered (bulleted) lists use asterisks, pluses, and hyphens (`*`,
 `+`, and `-`) as list markers. These three markers are
-interchangable; this:
+interchangeable; this:
 
     *   Candy.
     *   Gum.
@@ -264,7 +264,7 @@ it easy to use Markdown to write about HTML example code:
     I strongly recommend against using any `<blink>` tags.
 
     I wish SmartyPants used named entities like `&mdash;`
-    instead of decimal-encoded entites like `&#8212;`.
+    instead of decimal-encoded entities like `&#8212;`.
 
 Output:
 
@@ -273,7 +273,7 @@ Output:
 
     <p>I wish SmartyPants used named entities like
     <code>&amp;mdash;</code> instead of decimal-encoded
-    entites like <code>&amp;#8212;</code>.</p>
+    entities like <code>&amp;#8212;</code>.</p>
 
 
 To specify an entire block of pre-formatted code, indent every line of

--- a/editions/tw5.com/tiddlers/community/resources/BrainTest.tid
+++ b/editions/tw5.com/tiddlers/community/resources/BrainTest.tid
@@ -12,5 +12,5 @@ A collection of customisations and macros from Danielo Rodriguez.
 <<<
 This is my personal tiddlywiki file for testing.
 
-Here I will post the tools and Macros that I develop for this awesome tool. That way, all the help the comunity gave me can came back to the comunity again.
+Here I will post the tools and Macros that I develop for this awesome tool. That way, all the help the community gave me can came back to the community again.
 <<<

--- a/editions/tw5.com/tiddlers/concepts/CoordinateSystems.tid
+++ b/editions/tw5.com/tiddlers/concepts/CoordinateSystems.tid
@@ -21,7 +21,7 @@ Relative coordinates are expressed in the form ''(x,y,w,h)''. Where ''x'' and ''
 
 !! Absolute coordinate system
 
-The relative coordinate system works flawless most of the time. Problems occure if the target element (for example, a popup) and the source element (the triggering button) do not share the same positioned ancherstor element. This is often the case if the popup is declared outside a table and the triggering button is declared within a table cell. In this case the coordiante systems have different origins and the popup will be displayed in the wrong location.
+The relative coordinate system works flawless most of the time. Problems occure if the target element (for example, a popup) and the source element (the triggering button) do not share the same positioned ancestor element. This is often the case if the popup is declared outside a table and the triggering button is declared within a table cell. In this case the coordinate systems have different origins and the popup will be displayed in the wrong location.
 
 Absolute coordinates can fix this problem by using the root element of the page (the upper-left corner of the page) as the origin of the coordinate system. Absolute coordinates are expressed in the form ''@(x,y,w,h)''. Where ''x'' and ''y'' represent the position and ''w'' and ''h'' the width and height of the element. The leading ''@''-symbol marks these coordinates as absolute.
 
@@ -30,7 +30,7 @@ The ButtonWidget has an option (''popupAbsCoords'') to put absolute coordinates 
 
 !! Example
 
-The following example shows a popup that is triggerd from within a table cell. The table cell is the nearest positioned ancestor element. The popup was defined outside the table cell. The button using relative coordinates will open the popup in the wrong location because the button and the popup do not agree on the same coordinate system. Using absolute coordinates fixes this problem.
+The following example shows a popup that is triggered from within a table cell. The table cell is the nearest positioned ancestor element. The popup was defined outside the table cell. The button using relative coordinates will open the popup in the wrong location because the button and the popup do not agree on the same coordinate system. Using absolute coordinates fixes this problem.
 
 <<wikitext-example-without-html '<$reveal type="popup" state="$:/state/CoordinateSampleReveal">
 <div class="tc-drop-down">

--- a/editions/tw5.com/tiddlers/definitions/GitHub.tid
+++ b/editions/tw5.com/tiddlers/definitions/GitHub.tid
@@ -4,7 +4,7 @@ tags: Definitions
 title: GitHub
 type: text/vnd.tiddlywiki
 
-GitHub is a hosting service for distributed projects that use git as their version-control system. It allows free hosting and management of open-source projects and facilitates collaborative developement on the source code. Using GitHub for non-open-source endeavors requires additional fees.
+GitHub is a hosting service for distributed projects that use git as their version-control system. It allows free hosting and management of open-source projects and facilitates collaborative development on the source code. Using GitHub for non-open-source endeavours requires additional fees.
 
 The code and documentation of TiddlyWiki is hosted on GitHub at:
 

--- a/editions/tw5.com/tiddlers/filters/filter.tid
+++ b/editions/tw5.com/tiddlers/filters/filter.tid
@@ -32,7 +32,7 @@ Note that within the subfilter, the "currentTiddler" variable is set to the titl
 
 <<.tip "Compare with the similar [[subfilter|subfilter Operator]] operator which runs a subfilter and directly returns the results">>
 
-<<.tip "Compare with the analagous named filter run prefix `:filter`">>
+<<.tip "Compare with the analogous named filter run prefix `:filter`">>
 
 ```
 \define larger-than-1k() [get[text]length[]compare:integer:gteq[1000]]

--- a/editions/tw5.com/tiddlers/filters/getvariable.tid
+++ b/editions/tw5.com/tiddlers/filters/getvariable.tid
@@ -4,7 +4,7 @@ tags: [[Filter Operators]] [[Special Operators]]
 title: getvariable Operator
 caption: getvariable
 op-purpose: select all values of variables named in the input titles
-op-input: a selection of varible names
+op-input: a selection of variable names
 op-parameter: ignored
 op-output: the values of each of the variables named in the input titles (or blank if the variable is not defined)
 

--- a/editions/tw5.com/tiddlers/filters/reduce.tid
+++ b/editions/tw5.com/tiddlers/filters/reduce.tid
@@ -33,7 +33,7 @@ If the <<.op reduce>> operator receives no input, its output will be empty. The 
 </$set>
 ```
 
-<<.tip "Compare with the analagous named [[filter run prefix|Filter Expression]] `:reduce`">>
+<<.tip "Compare with the analogous named [[filter run prefix|Filter Expression]] `:reduce`">>
 
 ```
 \define num-items() [get[quantity]add<accumulator>]

--- a/editions/tw5.com/tiddlers/macros/ListMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/ListMacro.tid
@@ -16,7 +16,7 @@ Note: Each first [[step|Filter Step]] of a [[filter run|Filter Run]] not given a
 ;filter
 : A [[filter|Filters]] selecting which tiddlers to include
 ;caption
-: The name of the field to transclude for each list item, defaultingt to `caption`
+: The name of the field to transclude for each list item, defaulting to `caption`
 ;type
 : An HTML element to use for the overall list element, defaulting to `ul`
 ;subtype

--- a/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/UnusedTitleMacro.tid
@@ -29,10 +29,10 @@ It uses the same method as the create new tiddler button, a number is appended t
 : This variable will be replaced by the ''separator'' parameter
 
 ;`$count$`
-: This variable will be createad automatically and is a counter starting with 0
+: This variable will be created automatically and is a counter starting with 0
 
 ;`$count:4$`
-: This variable will be createad automatically and starts at 0000
+: This variable will be created automatically and starts at 0000
 : `:4` represents the number of digits
 
 !! Examples

--- a/editions/tw5.com/tiddlers/mechanisms/StateMechanism.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/StateMechanism.tid
@@ -36,6 +36,6 @@ Now consider the implementation of the info panel within the tiddler template. W
 
 However, we can't track the state in a tiddler called, say, [[$:/InfoPanelState]] because every tiddler would share the same state; changing the value of the tiddler would affect all tiddlers displayed in the story.
 
-The solution is to dynamically generate a unique title for each state tiddler that we need. We need to ensure that the same state tiddler title is generated each time a user interface element is rendered. To do that, we append together tokens representating each of the stack of transclusions that led to the current rendering location. Then that string of symbols is hashed to a simple numeric value.
+The solution is to dynamically generate a unique title for each state tiddler that we need. We need to ensure that the same state tiddler title is generated each time a user interface element is rendered. To do that, we append together tokens representing each of the stack of transclusions that led to the current rendering location. Then that string of symbols is hashed to a simple numeric value.
 
 The process of generating a state tiddler title is encapsulated in the <<.mlink qualify>> macro.

--- a/editions/tw5.com/tiddlers/mechanisms/TranslationMechanism.tid
+++ b/editions/tw5.com/tiddlers/mechanisms/TranslationMechanism.tid
@@ -6,9 +6,9 @@ type: text/vnd.tiddlywiki
 
 The translation mechanism of TiddlyWiki manages and switches between language plugins that provide translations of the TiddlyWiki user interface. The developer site at https://tiddlywiki.com/dev/ explains how translators can create and submit translations for TiddlyWiki.
 
-The title of the current language plugin is read from the tiddler [[$:/language]]. If the selected plugin changes then any displayed translateable text automatically changes.
+The title of the current language plugin is read from the tiddler [[$:/language]]. If the selected plugin changes then any displayed translatable text automatically changes.
 
-Translation plugins are bundles of tiddlers that each contain an indepedent translatable string. The strings are transcluded as needed.
+Translation plugins are bundles of tiddlers that each contain an independent translatable string. The strings are transcluded as needed.
 
 Translatable strings are generally in the namespace `$:/language/`, for example:
 

--- a/editions/tw5.com/tiddlers/nodejs/tiddlywiki.files_Files.tid
+++ b/editions/tw5.com/tiddlers/nodejs/tiddlywiki.files_Files.tid
@@ -65,7 +65,7 @@ There are also several examples of `tiddlywiki.files` files in the main [[Tiddly
 
 !! Importing a folder of PDFs
 
-This example retrieves all the files with the extension `.pdf` from a folder specified by a relative path. This path starts with "../../../" indicating 3 directory levels above the folder holdng this confog fole. Each tiddler is set up for LazyLoading with the following fields:
+This example retrieves all the files with the extension `.pdf` from a folder specified by a relative path. This path starts with "../../../" indicating 3 directory levels above the folder holding this config file. Each tiddler is set up for LazyLoading with the following fields:
 
 * ''title'' - set to the URI decoded base filename of the PDF file. [[URI decoding|https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent]] allows characters like "/" to be included in titles by URI encoding them as "%2F"
 * ''created'' - set to the creation date/time of the PDF file

--- a/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
@@ -7,7 +7,7 @@ type: text/vnd.tiddlywiki
 
 ! Introduction
 
-The edit text widget provides a user interface in the browser for editing text tiddler fields. The editing element is dynamically bound to the underlying tiddler value: changes to the tiddler are instantly reflected, and any edits are instantly propogated.
+The edit text widget provides a user interface in the browser for editing text tiddler fields. The editing element is dynamically bound to the underlying tiddler value: changes to the tiddler are instantly reflected, and any edits are instantly propagated.
 
 By default, applying the EditTextWidget to the `text` field of a tiddler will generates an HTML `<textarea>` element, i.e. a multi-line editor. Applying the EditTextWidget to any other field generates an HTML `<input type="text">` element, a single-line editor. This behaviour can be overridden with the `tag` and `type` attributes.
 

--- a/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EventCatcherWidget.tid
@@ -16,7 +16,7 @@ In order for the events to be trapped:
 
 * The event must be of one of the events specified in the event catcher widget's `events` attribute
 * The event must target a DOM node with an ancestor that matches the widget's `selector` attribute
-* <<.from-version "5.2.2">> Optionally, the DOM node targetted by the event must also match the widgets `matchSelector` attribute
+* <<.from-version "5.2.2">> Optionally, the DOM node targeted by the event must also match the widgets `matchSelector` attribute
 * The event must support event bubbling
 
 Use of the event catcher widget is beneficial when using large numbers of other trigger widgets such as the ButtonWidget is causing performance problems. The workflow it enables is akin to what is referred to as "event delegation" in JavaScript parlance.
@@ -27,7 +27,7 @@ The content of the `<$eventcatcher>` widget is displayed normally.
 
 |!Attribute |!Description |
 |selector |A CSS selector. Only events originating inside a DOM node with this selector will be trapped |
-|matchSelector |<<.from-version "5.2.2">> An optional CSS selector. Only events targetting DOM nodes matching this selector will be trapped |
+|matchSelector |<<.from-version "5.2.2">> An optional CSS selector. Only events targeting DOM nodes matching this selector will be trapped |
 |//{any attributes starting with $}// |<<.from-version "5.2.0">> Each attribute name (excluding the $) specifies the name of an event, and the value specifies the action string to be invoked. For example: `$click=<<clickActions>>`  |
 |tag |Optional. The HTML element the widget creates to capture the events, defaults to:<br>» `span` when parsed in inline-mode<br>» `div` when parsed in block-mode |
 |class |Optional. A CSS class name (or names) to be assigned to the widget HTML element |

--- a/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
@@ -18,7 +18,7 @@ The content of the <<.wlink GenesisWidget>> widget is used as the content of the
 |$names |An optional filter evaluating to the names of a list of attributes to be applied to the widget |
 |$values |An optional filter evaluating to the values corresponding to the list of names specified in `$names` |
 |//{other attributes starting with $}// |Other attributes starting with a single dollar sign are reserved for future use |
-|//{attributes starting with $$}// |Attributes starting with two dollar signs are appplied as attributes to the output widget, but with the attribute name changed to use a single dollar sign |
+|//{attributes starting with $$}// |Attributes starting with two dollar signs are applied as attributes to the output widget, but with the attribute name changed to use a single dollar sign |
 |//{attributes not starting with $}// |Any other attributes that do not start with a dollar are applied as attributes to the output widget |
 
 Note that attributes explicitly specified take precedence over attributes with the same name specified in the `$names` filter.

--- a/editions/tw5.com/tiddlers/widgets/NavigatorWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/NavigatorWidget.tid
@@ -17,7 +17,7 @@ The navigator widget displays any contained content, and responds to Messages di
 |story |Name of the tiddler containing the story list to be manipulated |
 |history |Name of the tiddler containing the history list to be manipulated |
 |openLinkFromInsideRiver |Determines the location for opening new tiddlers from links within the story river: at the ''top'' or ''bottom'' of the story river, or ''above'' or ''below'' the current tiddler |
-|openLinkFromOutsideRiver|Determines the location for opening new tiddlers from linkes outside the story river: at the ''top'' or ''bottom'' of the story river|
+|openLinkFromOutsideRiver|Determines the location for opening new tiddlers from links outside the story river: at the ''top'' or ''bottom'' of the story river|
 |relinkOnRename|<<.from-version "5.1.14">> Determines if tags in other tiddlers are renamed if the tiddler title changes. ''yes'' or ''no''. default: ''no''|
 
 ! Widget Messages

--- a/editions/tw5.com/tiddlers/widgets/VarsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/VarsWidget.tid
@@ -48,5 +48,5 @@ In contrast, here is the same example using the <<.wid set>> widget:
 It should be noted that this widget differs from the <<.wid set>> widget in the following ways:
 
 * A fallback (also known as "emptyValue") cannot be specified
-* Filters cannot be used to produce a conditional variable assignement
+* Filters cannot be used to produce a conditional variable assignment
 * Variable names must be literal strings


### PR DESCRIPTION
I ran `aspell --master en_GB --lang en_GB check file` over several `*.tid` files and found more typos.

Also, I found several tiddlers using US spelling (even in their names) and fixed them, but these are not a part of this pull request.