### PR TITLE
add ignore .github, .vscode to loadPluginFolder() regexp definition

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1881,7 +1881,7 @@ A default set of files for TiddlyWiki to ignore during load.
 This matches what NPM ignores, and adds "*.meta" to ignore tiddler
 metadata files.
 */
-$tw.boot.excludeRegExp = /^\.DS_Store$|^.*\.meta$|^\..*\.swp$|^\._.*$|^\.git$|^\.hg$|^\.lock-wscript$|^\.svn$|^\.wafpickle-.*$|^CVS$|^npm-debug\.log$/;
+$tw.boot.excludeRegExp = /^\.DS_Store$|^.*\.meta$|^\..*\.swp$|^\._.*$|^\.git$|^\.github$|^\.vscode$|^\.hg$|^\.lock-wscript$|^\.svn$|^\.wafpickle-.*$|^CVS$|^npm-debug\.log$/;
 
 /*
 Load all the tiddlers recursively from a directory, including honouring `tiddlywiki.files` files for drawing in external files. Returns an array of {filepath:,type:,tiddlers: [{..fields...}],hasMetaFile:}. Note that no file information is returned for externally loaded tiddlers, just the `tiddlers` property.


### PR DESCRIPTION
One of my plugin directories is a github repo and contains an issue_template. When I do build the plguin library I do get: 

```
Warning: missing plugin.info file in E:\git\tiddly\wikilabs\plugins\.github\ISSUE_TEMPLATE
```

Because `$tw.loadPluginFolder = function(filepath,excludeRegExp) {` doesn't exclude it. .. I did also add .vscode because it may be there too. 