### PR TITLE
Server timing for server-side performance measurement

### DIFF
--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -331,7 +331,7 @@ exports.compileFilter = function(filterString) {
 		})());
 	});
 	// Return a function that applies the operations to a source iterator of tiddler titles
-	var fnMeasured = $tw.perf.measure("filter: " + filterString,function filterFunction(source,widget) {
+	var fnMeasured = $tw.perf.measureFn("filter: " + filterString,function filterFunction(source,widget) {
 		if(!source) {
 			source = self.each;
 		} else if(typeof source === "object") { // Array or hashmap

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -331,7 +331,7 @@ exports.compileFilter = function(filterString) {
 		})());
 	});
 	// Return a function that applies the operations to a source iterator of tiddler titles
-	var fnMeasured = $tw.perf.measureFn("filter",filterString,function filterFunction(source,widget) {
+	var fnMeasured = $tw.perf.measureFn("filter"+filterString,filterString,function filterFunction(source,widget) {
 		if(!source) {
 			source = self.each;
 		} else if(typeof source === "object") { // Array or hashmap

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -331,7 +331,7 @@ exports.compileFilter = function(filterString) {
 		})());
 	});
 	// Return a function that applies the operations to a source iterator of tiddler titles
-	var fnMeasured = $tw.perf.measureFn("filter: " + filterString,function filterFunction(source,widget) {
+	var fnMeasured = $tw.perf.measureFn("filter",filterString,function filterFunction(source,widget) {
 		if(!source) {
 			source = self.each;
 		} else if(typeof source === "object") { // Array or hashmap

--- a/core/modules/server/routes/get-index.js
+++ b/core/modules/server/routes/get-index.js
@@ -17,9 +17,10 @@ exports.method = "GET";
 exports.path = /^\/$/;
 
 exports.handler = function(request,response,state) {
-	var text = state.wiki.renderTiddler(state.server.get("root-render-type"),state.server.get("root-tiddler")),
-		responseHeaders = {
-		"Content-Type": state.server.get("root-serve-type")
+	var text = state.wiki.renderTiddler(state.server.get("root-render-type"),state.server.get("root-tiddler"));
+	var responseHeaders = {
+		"Content-Type": state.server.get("root-serve-type"),
+		"Server-Timing": $tw.perf.generateHeader()
 	};
 	state.sendResponse(200,responseHeaders,text);
 };

--- a/core/modules/server/routes/get-index.js
+++ b/core/modules/server/routes/get-index.js
@@ -20,7 +20,7 @@ exports.handler = function(request,response,state) {
 	var text = state.wiki.renderTiddler(state.server.get("root-render-type"),state.server.get("root-tiddler"));
 	var responseHeaders = {
 		"Content-Type": state.server.get("root-serve-type"),
-		"Server-Timing": $tw.perf.generateHeader()
+		"Server-Timing": $tw.perf.generateHeader() || ""
 	};
 	state.sendResponse(200,responseHeaders,text);
 };

--- a/core/modules/server/routes/get-status.js
+++ b/core/modules/server/routes/get-status.js
@@ -17,6 +17,8 @@ exports.method = "GET";
 exports.path = /^\/status$/;
 
 exports.handler = function(request,response,state) {
+	$tw.perf.reset();
+	$tw.perf.timer("stringify", "JSON.stringify");
 	var text = JSON.stringify({
 		username: state.authenticatedUsername || state.server.get("anon-username") || "",
 		anonymous: !state.authenticatedUsername,
@@ -27,7 +29,8 @@ exports.handler = function(request,response,state) {
 		},
 		tiddlywiki_version: $tw.version
 	});
-	state.sendResponse(200,{"Content-Type": "application/json"},text,"utf8");
+	$tw.perf.timer("stringify");
+	state.sendResponse(200,{"Content-Type": "application/json", "Server-Timing": $tw.perf.generateHeader()},text,"utf8");
 };
 
 }());

--- a/core/modules/server/routes/get-status.js
+++ b/core/modules/server/routes/get-status.js
@@ -30,7 +30,7 @@ exports.handler = function(request,response,state) {
 		tiddlywiki_version: $tw.version
 	});
 	$tw.perf.timer("stringify");
-	state.sendResponse(200,{"Content-Type": "application/json", "Server-Timing": $tw.perf.generateHeader()},text,"utf8");
+	state.sendResponse(200,{"Content-Type": "application/json", "Server-Timing": $tw.perf.generateHeader() || ""},text,"utf8");
 };
 
 }());

--- a/core/modules/server/routes/get-tiddler.js
+++ b/core/modules/server/routes/get-tiddler.js
@@ -43,7 +43,7 @@ exports.handler = function(request,response,state) {
 		$tw.perf.timer("prepare-tiddler", "Prepare fields of tiddler");
 		state.sendResponse(200, {
 				"Content-Type": "application/json",
-				"Server-Timing": $tw.perf.generateHeader()
+				"Server-Timing": $tw.perf.generateHeader() || ""
 			},
 			JSON.stringify(tiddlerFields),
 			"utf8"

--- a/core/modules/server/routes/get-tiddlers-json.js
+++ b/core/modules/server/routes/get-tiddlers-json.js
@@ -52,7 +52,7 @@ exports.handler = function(request,response,state) {
 	$tw.perf.timer("stringify-tiddlers", "JSON.stringify");
 	var text = JSON.stringify(tiddlers);
 	$tw.perf.timer("stringify-tiddlers");
-	state.sendResponse(200,{"Content-Type": "application/json", "Server-Timing": $tw.perf.generateHeader()},text,"utf8");
+	state.sendResponse(200,{"Content-Type": "application/json", "Server-Timing": $tw.perf.generateHeader() || ""},text,"utf8");
 };
 
 }());

--- a/core/modules/server/routes/get-tiddlers-json.js
+++ b/core/modules/server/routes/get-tiddlers-json.js
@@ -19,7 +19,9 @@ exports.method = "GET";
 exports.path = /^\/recipes\/default\/tiddlers.json$/;
 
 exports.handler = function(request,response,state) {
+	$tw.perf.reset();
 	var filter = state.queryParameters.filter || DEFAULT_FILTER;
+	$tw.perf.timer("check-config", "Config about filters and system tiddlers");
 	if(state.wiki.getTiddlerText("$:/config/Server/AllowAllExternalFilters") !== "yes") {
 		if(state.wiki.getTiddlerText("$:/config/Server/ExternalFilters/" + filter) !== "yes") {
 			console.log("Blocked attempt to GET /recipes/default/tiddlers.json with filter: " + filter);
@@ -31,9 +33,12 @@ exports.handler = function(request,response,state) {
 	if(state.wiki.getTiddlerText("$:/config/SyncSystemTiddlersFromServer") === "no") {
 		filter += "+[!is[system]]";
 	}
+	$tw.perf.timer("check-config");
+	// filtering will call perf there
 	var excludeFields = (state.queryParameters.exclude || "text").split(","),
 		titles = state.wiki.filterTiddlers(filter);
 	var tiddlers = [];
+	$tw.perf.timer("get-tiddlers", "Get each tiddler as list");
 	$tw.utils.each(titles,function(title) {
 		var tiddler = state.wiki.getTiddler(title);
 		if(tiddler) {
@@ -43,8 +48,11 @@ exports.handler = function(request,response,state) {
 			tiddlers.push(tiddlerFields);
 		}
 	});
+	$tw.perf.timer("get-tiddlers");
+	$tw.perf.timer("stringify-tiddlers", "JSON.stringify");
 	var text = JSON.stringify(tiddlers);
-	state.sendResponse(200,{"Content-Type": "application/json"},text,"utf8");
+	$tw.perf.timer("stringify-tiddlers");
+	state.sendResponse(200,{"Content-Type": "application/json", "Server-Timing": $tw.perf.generateHeader()},text,"utf8");
 };
 
 }());

--- a/core/modules/server/routes/put-tiddler.js
+++ b/core/modules/server/routes/put-tiddler.js
@@ -17,6 +17,8 @@ exports.method = "PUT";
 exports.path = /^\/recipes\/default\/tiddlers\/(.+)$/;
 
 exports.handler = function(request,response,state) {
+	$tw.perf.reset();
+	$tw.perf.timer("parse-tiddler-content", "Decode and parseJSONSafe");
 	var title = $tw.utils.decodeURIComponentSafe(state.params[0]),
 	fields = $tw.utils.parseJSONSafe(state.data);
 	// Pull up any subfields in the `fields` object
@@ -30,21 +32,29 @@ exports.handler = function(request,response,state) {
 	if(fields.revision) {
 		delete fields.revision;
 	}
+	$tw.perf.timer("parse-tiddler-content");
 	// If this is a skinny tiddler, it means the client never got the full
 	// version of the tiddler to edit. So we must preserve whatever text
 	// already exists on the server, or else we'll inadvertently delete it.
 	if(fields._is_skinny !== undefined) {
+		$tw.perf.timer("get-skinny", "Restore text on server");
 		var tiddler = state.wiki.getTiddler(title);
 		if(tiddler) {
 			fields.text = tiddler.fields.text;
 		}
 		delete fields._is_skinny;
+		$tw.perf.timer("get-skinny");
 	}
+	$tw.perf.timer("add-tiddler", "new Tiddler instance and add to wiki");
 	state.wiki.addTiddler(new $tw.Tiddler(fields,{title: title}));
+	$tw.perf.timer("add-tiddler");
+	$tw.perf.timer("count-change", "Construct etag using changed count of tiddler");
 	var changeCount = state.wiki.getChangeCount(title).toString();
+	$tw.perf.timer("count-change");
 	response.writeHead(204, "OK",{
 		Etag: "\"default/" + encodeURIComponent(title) + "/" + changeCount + ":\"",
-		"Content-Type": "text/plain"
+		"Content-Type": "text/plain",
+		"Server-Timing": $tw.perf.generateHeader()
 	});
 	response.end();
 };

--- a/core/modules/server/routes/put-tiddler.js
+++ b/core/modules/server/routes/put-tiddler.js
@@ -54,7 +54,7 @@ exports.handler = function(request,response,state) {
 	response.writeHead(204, "OK",{
 		Etag: "\"default/" + encodeURIComponent(title) + "/" + changeCount + ":\"",
 		"Content-Type": "text/plain",
-		"Server-Timing": $tw.perf.generateHeader()
+		"Server-Timing": $tw.perf.generateHeader() || ""
 	});
 	response.end();
 };

--- a/core/modules/utils/performance.js
+++ b/core/modules/utils/performance.js
@@ -147,7 +147,9 @@ Performance.prototype.generateHeader = function() {
 	});
 
 	// remove trailing comma and return header string
-	return header.replace(/,\s*$/, "");
+	header = header.replace(/,\s*$/, "");
+	this.reset();
+	return header;
 };
 
 exports.Performance = Performance;

--- a/core/modules/utils/performance.js
+++ b/core/modules/utils/performance.js
@@ -137,13 +137,19 @@ Performance.prototype.timer = function(name, description) {
 
 /** Generate header that can be used as server-timing */
 Performance.prototype.generateHeader = function() {
+	if(!this.enabled) return;
 	var header = "";
 	// loop the metrics
 	Object.keys(this.measures).forEach(name => {
 		// if that timer is not ended, omit it.
 		if (this.measures[name].measureStart) return;
+		/**
+		 * Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
+		 * https://httpwg.org/specs/rfc7230.html#rfc.section.3.2.6
+		*/
+		var validName = name.replace(/[\s(),\/:;<=>?@\\[\]\{\}]/g, '_');
 		var desc = this.measures[name].desc + "(" + this.measures[name].invocations + "times)";
-		header += name + "; dur=" + this.measures[name].time + '; desc="' + desc + '",';
+		header += validName + "; dur=" + this.measures[name].time + '; desc="' + desc + '",';
 	});
 
 	// remove trailing comma and return header string

--- a/core/modules/utils/performance.js
+++ b/core/modules/utils/performance.js
@@ -147,8 +147,8 @@ Performance.prototype.generateHeader = function() {
 		 * Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
 		 * https://httpwg.org/specs/rfc7230.html#rfc.section.3.2.6
 		*/
-		var validName = name.replace(/[\s(),\/:;<=>?@\\[\]\{\}]/g, '_');
-		var desc = this.measures[name].desc + "(" + this.measures[name].invocations + "times)";
+		var validName = name.replace(/[^a-zA-Z-]/g, '-');
+		var desc = this.measures[name].desc.replace(/[^a-zA-Z-\[\]!.()<>$\/ ~0-9:]/g, '-') + "(" + this.measures[name].invocations + "times)";
 		header += validName + "; dur=" + this.measures[name].time + '; desc="' + desc + '",';
 	});
 

--- a/core/modules/utils/performance.js
+++ b/core/modules/utils/performance.js
@@ -14,10 +14,18 @@ Performance measurement.
 
 function Performance(enabled) {
 	this.enabled = !!enabled;
-	this.measures = {}; // Hashmap by measurement name of {time:, invocations:}
+	/**
+	 * Hashmap by measurement name of {time:, invocations:}
+	 * with optional "lastStart" for the last time calling "measureStart"
+	 */
+	this.reset();
 	this.logger = new $tw.utils.Logger("performance");
 	this.showGreeting();
 }
+
+Performance.prototype.reset = function() {
+	this.measures = {};
+};
 
 Performance.prototype.showGreeting = function() {
 	if($tw.browser) {
@@ -68,10 +76,10 @@ Performance.prototype.log = function() {
 /*
 Wrap performance measurements around a subfunction
 */
-Performance.prototype.measure = function(name,fn) {
+Performance.prototype.measureFn = function(name,fn) {
 	var self = this;
 	if(this.enabled) {
-		return function() {
+		return function measureCallback() {
 			var startTime = $tw.utils.timer(),
 				result = fn.apply(this,arguments);
 			if(!(name in self.measures)) {
@@ -84,6 +92,58 @@ Performance.prototype.measure = function(name,fn) {
 	} else {
 		return fn;
 	}
+};
+
+/**
+ * Start a timer, add a record to `this.measures`.
+ * Name has to be slag-separated, like "image-processing"; description is optional.
+ */
+Performance.prototype.timerStart = function(name, description) {
+	if(this.enabled) {
+			var measureStart = $tw.utils.timer();
+			if(!(name in this.measures)) {
+				this.measures[name] = {time: 0, invocations: 0, desc: description};
+			}
+			this.measures[name].measureStart = measureStart;
+	}
+};
+
+/**
+ * If an operation you are timing fails before the timer can be stopped, you can clear that timer.
+ */
+Performance.prototype.clearTimer = function(name) {
+	if (this.measures[name]) this.measures[name].measureStart = undefined;
+};
+
+Performance.prototype.timerEnd = function(name) {
+	if(this.enabled) {
+		if (!this.measures[name]) return;
+		var measureStart = this.measures[name].measureStart;
+		if (!measureStart) return;
+		this.measures[name].time += $tw.utils.timer(measureStart);
+		this.measures[name].invocations++;
+		this.clearTimer(name);
+	}
+};
+
+/** Generate header that can be used as server-timing */
+Performance.prototype.generateHeader = function() {
+	var header = "";
+	// loop the metrics
+	Object.keys(this.measures).forEach(name => {
+		// if that timer is not ended, omit it.
+		if (this.measures[name].measureStart) return;
+		header +=
+			name +
+			"; dur=" +
+			this.measures[name].time +
+			'; desc="' +
+			this.measures[name].desc +
+			'",';
+	});
+
+	// remove trailing comma and return header string
+	return header.replace(/,\s*$/, "");
 };
 
 exports.Performance = Performance;


### PR DESCRIPTION
Extend $tw.perf to have easy-to-use timer, that can do fine-grained measure.

Result will show in the webDevTool's network panel's timing tab.

![](https://user-images.githubusercontent.com/3746270/209464455-01e890ec-ca73-4c2c-9fc9-e2bc775d3e40.png)

![](https://user-images.githubusercontent.com/3746270/209464456-c719aa40-9a66-4316-9886-05bace5e15c4.png)