### PR TITLE
Fixes reduce, filter, and sortsub operators undefined variable exception

### DIFF
--- a/core/modules/filters/filter.js
+++ b/core/modules/filters/filter.js
@@ -21,14 +21,15 @@ exports.filter = function(source,operator,options) {
 		target = operator.prefix !== "!";
 	source(function(tiddler,title) {
 		var list = filterFn.call(options.wiki,options.wiki.makeTiddlerIterator([title]),{
-				getVariable: function(name) {
+				getVariable: function(name,opts) {
+					opts = opts || {};
 					switch(name) {
 						case "currentTiddler":
 							return "" + title;
 						case "..currentTiddler":
 							return options.widget.getVariable("currentTiddler");
 						default:
-							return options.widget.getVariable(name);
+							return options.widget.getVariable(name,opts);
 					}
 				}
 			});

--- a/core/modules/filters/reduce.js
+++ b/core/modules/filters/reduce.js
@@ -27,7 +27,8 @@ exports.reduce = function(source,operator,options) {
 	for(var index=0; index<results.length; index++) {
 		var title = results[index],
 			list = filterFn.call(options.wiki,options.wiki.makeTiddlerIterator([title]),{
-				getVariable: function(name) {
+				getVariable: function(name,opts) {
+					opts = opts || {};
 					switch(name) {
 						case "currentTiddler":
 							return "" + title;
@@ -42,7 +43,7 @@ exports.reduce = function(source,operator,options) {
 						case "length":
 							return "" + results.length;
 						default:
-							return options.widget.getVariable(name);
+							return options.widget.getVariable(name,opts);
 					}
 				}
 			});

--- a/core/modules/filters/sortsub.js
+++ b/core/modules/filters/sortsub.js
@@ -26,14 +26,15 @@ exports.sortsub = function(source,operator,options) {
 		var r = filterFn.call(options.wiki,function(iterator) {
 			iterator(options.wiki.getTiddler(title),title);
 		},{
-			getVariable: function(name) {
+			getVariable: function(name,opts) {
+				opts = opts || {};
 				switch(name) {
 					case "currentTiddler":
 						return "" + title;
 					case "..currentTiddler":
 						return options.widget.getVariable("currentTiddler");
 					default:
-						return options.widget.getVariable(name);
+						return options.widget.getVariable(name, opts);
 				}
 			}
 		});

--- a/core/modules/filters/sortsub.js
+++ b/core/modules/filters/sortsub.js
@@ -34,7 +34,7 @@ exports.sortsub = function(source,operator,options) {
 					case "..currentTiddler":
 						return options.widget.getVariable("currentTiddler");
 					default:
-						return options.widget.getVariable(name, opts);
+						return options.widget.getVariable(name,opts);
 				}
 			}
 		});

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -983,6 +983,7 @@ Tests the filtering mechanism.
 			rootWidget.setVariable("sort2","[get[text]else[]length[]]");
 			rootWidget.setVariable("sort3","[{!!value}divide{!!cost}]");
 			rootWidget.setVariable("sort4","[{!!title}]");
+			rootWidget.setVariable("undefined-variable","[<doesnotexist>]");
 			expect(wiki.filterTiddlers("[sortsub:number<sort1>]",anchorWidget).join(",")).toBe("one,hasList,has filter,TiddlerOne,$:/TiddlerTwo,Tiddler Three,$:/ShadowPlugin,a fourth tiddler,filter regexp test");
 			expect(wiki.filterTiddlers("[!sortsub:number<sort1>]",anchorWidget).join(",")).toBe("filter regexp test,a fourth tiddler,$:/ShadowPlugin,$:/TiddlerTwo,Tiddler Three,has filter,TiddlerOne,hasList,one");
 			expect(wiki.filterTiddlers("[sortsub:string<sort1>]",anchorWidget).join(",")).toBe("has filter,TiddlerOne,$:/TiddlerTwo,Tiddler Three,$:/ShadowPlugin,a fourth tiddler,filter regexp test,one,hasList");
@@ -993,6 +994,8 @@ Tests the filtering mechanism.
 			expect(wiki.filterTiddlers("[!sortsub:string<sort2>]",anchorWidget).join(",")).toBe("filter regexp test,$:/TiddlerTwo,Tiddler Three,a fourth tiddler,$:/ShadowPlugin,has filter,hasList,TiddlerOne,one");
 			expect(wiki.filterTiddlers("[[TiddlerOne]] [[$:/TiddlerTwo]] [[Tiddler Three]] [[a fourth tiddler]] +[!sortsub:number<sort3>]",anchorWidget).join(",")).toBe("$:/TiddlerTwo,Tiddler Three,TiddlerOne,a fourth tiddler");
 			expect(wiki.filterTiddlers("a1 a10 a2 a3 b10 b3 b1 c9 c11 c1 +[sortsub:alphanumeric<sort4>]",anchorWidget).join(",")).toBe("a1,a2,a3,a10,b1,b3,b10,c1,c9,c11");
+			// #7155. The order of the output is the same as the input when an undefined variable is used in the subfitler
+			expect(wiki.filterTiddlers("a2 a10 a1 +[sortsub:alphanumeric<undefined-variable>]",anchorWidget).join(",")).toBe("a2,a10,a1");
 		});
 		
 		it("should handle the toggle operator", function() {

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -984,6 +984,8 @@ Tests the filtering mechanism.
 			rootWidget.setVariable("sort3","[{!!value}divide{!!cost}]");
 			rootWidget.setVariable("sort4","[{!!title}]");
 			rootWidget.setVariable("undefined-variable","[<doesnotexist>]");
+			rootWidget.setVariable("echo","$text$",[{name:"text"}],true);
+			rootWidget.setVariable("sort4-macro-param","[subfilter<echo '[{!!title}]'>]");
 			expect(wiki.filterTiddlers("[sortsub:number<sort1>]",anchorWidget).join(",")).toBe("one,hasList,has filter,TiddlerOne,$:/TiddlerTwo,Tiddler Three,$:/ShadowPlugin,a fourth tiddler,filter regexp test");
 			expect(wiki.filterTiddlers("[!sortsub:number<sort1>]",anchorWidget).join(",")).toBe("filter regexp test,a fourth tiddler,$:/ShadowPlugin,$:/TiddlerTwo,Tiddler Three,has filter,TiddlerOne,hasList,one");
 			expect(wiki.filterTiddlers("[sortsub:string<sort1>]",anchorWidget).join(",")).toBe("has filter,TiddlerOne,$:/TiddlerTwo,Tiddler Three,$:/ShadowPlugin,a fourth tiddler,filter regexp test,one,hasList");
@@ -996,6 +998,7 @@ Tests the filtering mechanism.
 			expect(wiki.filterTiddlers("a1 a10 a2 a3 b10 b3 b1 c9 c11 c1 +[sortsub:alphanumeric<sort4>]",anchorWidget).join(",")).toBe("a1,a2,a3,a10,b1,b3,b10,c1,c9,c11");
 			// #7155. The order of the output is the same as the input when an undefined variable is used in the subfitler
 			expect(wiki.filterTiddlers("a2 a10 a1 +[sortsub:alphanumeric<undefined-variable>]",anchorWidget).join(",")).toBe("a2,a10,a1");
+			expect(wiki.filterTiddlers("a1 a10 a2 a3 b10 b3 b1 c9 c11 c1 +[sortsub:alphanumeric<sort4-macro-param>]",anchorWidget).join(",")).toBe("a1,a2,a3,a10,b1,b3,b10,c1,c9,c11");
 		});
 		
 		it("should handle the toggle operator", function() {

--- a/editions/test/tiddlers/tests/test-prefixes-filter.js
+++ b/editions/test/tiddlers/tests/test-prefixes-filter.js
@@ -344,6 +344,8 @@ describe("'reduce' and 'intersection' filter prefix tests", function() {
 		rootWidget.setVariable("num-items","[get[quantity]add<accumulator>]");
 		rootWidget.setVariable("join-with-commas","[<index>compare:number:gt[0]then<accumulator>addsuffix[, ]addsuffix<currentTiddler>else<currentTiddler>]");
 		rootWidget.setVariable("undefined-variable","[<doesnotexist>]");
+		rootWidget.setVariable("echo","$text$",[{name:"text"}],true);
+		rootWidget.setVariable("num-items-macro-param","[subfilter<echo '[get[quantity]]'>add<accumulator>]");
 
 		expect(wiki.filterTiddlers("[tag[shopping]reduce<num-items>]",anchorWidget).join(",")).toBe("22");
 		expect(wiki.filterTiddlers("[tag[shopping]reduce<add-price>]",anchorWidget).join(",")).toBe("27.75");
@@ -354,6 +356,7 @@ describe("'reduce' and 'intersection' filter prefix tests", function() {
 		expect(wiki.filterTiddlers("[tag[non-existent]reduce<add-price>else[0]]",anchorWidget).join(",")).toBe("0");
 		// #7155
 		expect(wiki.filterTiddlers("a +[reduce<undefined-variable>]",anchorWidget).join(",")).toBe("");
+		expect(wiki.filterTiddlers("[tag[shopping]reduce<num-items-macro-param>]",anchorWidget).join(",")).toBe("22");
 	});
 
 	it("should handle the average operator", function() {
@@ -396,12 +399,15 @@ describe("'reduce' and 'intersection' filter prefix tests", function() {
 		rootWidget.setVariable("nr","18");
 		rootWidget.setVariable("larger-than-18-with-var","[get[text]length[]compare:integer:gteq<nr>]");
 		rootWidget.setVariable("undefined-variable","[<doesnotexist>]");
+		rootWidget.setVariable("echo","$text$",[{name:"text"}],true);
+		rootWidget.setVariable("larger-than-18-macro-param","[subfilter<echo '[get[text]length[]compare:integer:gteq[18]]'>]");
 		expect(wiki.filterTiddlers("[tag[textexample]] :filter[get[text]length[]compare:integer:gteq[18]]",anchorWidget).join(",")).toBe("Cheesecake,Chocolate Cake,Red wine");
 		expect(wiki.filterTiddlers("[tag[textexample]]",anchorWidget).join(",")).toBe("Cheesecake,Chocolate Cake,Red wine,Sparkling water");
 		expect(wiki.filterTiddlers("[tag[textexample]filter<larger-than-18>]",anchorWidget).join(",")).toBe("Cheesecake,Chocolate Cake,Red wine");
 		expect(wiki.filterTiddlers("[tag[textexample]filter<larger-than-18-with-var>]",anchorWidget).join(",")).toBe("Cheesecake,Chocolate Cake,Red wine");
 		// #7155
 		expect(wiki.filterTiddlers("a +[filter<undefined-variable>]",anchorWidget).join(",")).toBe("a");
+		expect(wiki.filterTiddlers("[tag[textexample]filter<larger-than-18-macro-param>]",anchorWidget).join(",")).toBe("Cheesecake,Chocolate Cake,Red wine");
 	});
 
 	it("should handle the :sort prefix", function() {

--- a/editions/test/tiddlers/tests/test-prefixes-filter.js
+++ b/editions/test/tiddlers/tests/test-prefixes-filter.js
@@ -343,6 +343,7 @@ describe("'reduce' and 'intersection' filter prefix tests", function() {
 		rootWidget.setVariable("add-price","[get[price]multiply{!!quantity}add<accumulator>]");
 		rootWidget.setVariable("num-items","[get[quantity]add<accumulator>]");
 		rootWidget.setVariable("join-with-commas","[<index>compare:number:gt[0]then<accumulator>addsuffix[, ]addsuffix<currentTiddler>else<currentTiddler>]");
+		rootWidget.setVariable("undefined-variable","[<doesnotexist>]");
 
 		expect(wiki.filterTiddlers("[tag[shopping]reduce<num-items>]",anchorWidget).join(",")).toBe("22");
 		expect(wiki.filterTiddlers("[tag[shopping]reduce<add-price>]",anchorWidget).join(",")).toBe("27.75");
@@ -351,6 +352,8 @@ describe("'reduce' and 'intersection' filter prefix tests", function() {
 		expect(wiki.filterTiddlers("[tag[non-existent]reduce<add-price>,[0]]",anchorWidget).join(",")).not.toBe("0");
 		expect(wiki.filterTiddlers("[tag[non-existent]reduce<add-price>,[0]]",anchorWidget).length).toBe(0);
 		expect(wiki.filterTiddlers("[tag[non-existent]reduce<add-price>else[0]]",anchorWidget).join(",")).toBe("0");
+		// #7155
+		expect(wiki.filterTiddlers("a +[reduce<undefined-variable>]",anchorWidget).join(",")).toBe("");
 	});
 
 	it("should handle the average operator", function() {
@@ -392,10 +395,13 @@ describe("'reduce' and 'intersection' filter prefix tests", function() {
 		rootWidget.setVariable("larger-than-18","[get[text]length[]compare:integer:gteq[18]]");
 		rootWidget.setVariable("nr","18");
 		rootWidget.setVariable("larger-than-18-with-var","[get[text]length[]compare:integer:gteq<nr>]");
+		rootWidget.setVariable("undefined-variable","[<doesnotexist>]");
 		expect(wiki.filterTiddlers("[tag[textexample]] :filter[get[text]length[]compare:integer:gteq[18]]",anchorWidget).join(",")).toBe("Cheesecake,Chocolate Cake,Red wine");
 		expect(wiki.filterTiddlers("[tag[textexample]]",anchorWidget).join(",")).toBe("Cheesecake,Chocolate Cake,Red wine,Sparkling water");
 		expect(wiki.filterTiddlers("[tag[textexample]filter<larger-than-18>]",anchorWidget).join(",")).toBe("Cheesecake,Chocolate Cake,Red wine");
 		expect(wiki.filterTiddlers("[tag[textexample]filter<larger-than-18-with-var>]",anchorWidget).join(",")).toBe("Cheesecake,Chocolate Cake,Red wine");
+		// #7155
+		expect(wiki.filterTiddlers("a +[filter<undefined-variable>]",anchorWidget).join(",")).toBe("a");
 	});
 
 	it("should handle the :sort prefix", function() {


### PR DESCRIPTION
In some case when the subfilter for the `reduce`, `filter`, and `sortsub` operators contains reference to an undefined variable, a `Linked List only accepts string values, not undefined` exception is thrown.

The `getVariable` override defined in those filter operators was not passing the `{params:varTree.params,defaultValue: ""}` options through to the `widget.getVariable` call and due to that a value of `undefined` was being pushed onto the results array.

Fixes 7155.

Also before this fix, literal macro parameters inside of these three operators did not work correctly.