### PR TITLE
better content type handle

### DIFF
--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -858,8 +858,8 @@ Convert text and content type to a data URI
 */
 exports.makeDataUri = function(text,type,_canonical_uri) {
 	type = type || "text/vnd.tiddlywiki";
-	var typeInfo = $tw.config.contentTypeInfo[type] || $tw.config.contentTypeInfo["text/plain"],
-		isBase64 = typeInfo.encoding === "base64",
+	var typeInfo = $tw.config.contentTypeInfo[type],
+		isBase64 = (!!typeInfo && typeInfo.encoding === "base64") || !typeInfo,
 		parts = [];
 	if(_canonical_uri) {
 		parts.push(_canonical_uri);

--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -75,7 +75,7 @@ EditWidget.prototype.getEditorType = function() {
 	var editorType = this.wiki.getTiddlerText(EDITOR_MAPPING_PREFIX + type);
 	if(!editorType) {
 		var typeInfo = $tw.config.contentTypeInfo[type];
-		if(typeInfo && typeInfo.encoding === "base64") {
+		if(!typeInfo || (typeInfo && typeInfo.encoding === "base64")) {
 			editorType = "binary";
 		} else {
 			editorType = "text";


### PR DESCRIPTION
This should fix #7157.
Assume files via import will always have `type` field with a value,
if the type is unknown in `$tw.config.contentTypeInfo`,  then treat it as binary.
If tiddler which did not have `type` field, treat it as `text/vnd.tiddlywiki` just like before.