### PR TITLE
Automatic sync of tiddler changes in browser storage when sync connection is re-established

### DIFF
--- a/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
+++ b/plugins/tiddlywiki/tiddlyweb/tiddlywebadaptor.js
@@ -76,6 +76,14 @@ TiddlyWebAdaptor.prototype.getStatus = function(callback) {
 			if(err) {
 				return callback(err);
 			}
+
+			//If Browser-Storage plugin is present, add pre-loaded tiddlers to the event queue to sync to the server 
+			if($tw.wiki.getTiddlerText("$:/config/BrowserStorage/Enabled") === "yes" && $tw.boot.preloadDirty != null) {
+				$tw.boot.preloadDirty.forEach(function(item){
+					$tw.wiki.enqueueTiddlerEvent(item, false);
+				});
+			}
+
 			// Decode the status JSON
 			var json = null;
 			try {
@@ -211,6 +219,12 @@ TiddlyWebAdaptor.prototype.saveTiddler = function(tiddler,callback,options) {
 			if(err) {
 				return callback(err);
 			}
+
+			//If Browser-Storage plugin is present, remove tiddler from local storage after successful sync to the server
+			if($tw.wiki.getTiddlerText("$:/config/BrowserStorage/Enabled") === "yes") {
+				window.localStorage.removeItem("tw5#" + window.location.pathname + "#" + tiddler.fields.title);
+			}
+
 			// Save the details of the new revision of the tiddler
 			var etag = request.getResponseHeader("Etag");
 			if(!etag) {


### PR DESCRIPTION
The intent of this change is to leverage the browser-storage plugin as a temporary offline storage mechanism when the sync adapter is unable to successfully sync to the server, and to automatically sync tiddlers saved offline in browser storage once connection is re-established. The use of browser storage allows for tiddlers saved offline to be synced with the server even in the case where the browser is closed or the user (purposely, accidentally, or automatically in the case of a mobile browser periodically refreshing) navigates away from the wiki. 

The two changes are:

1. To check browser storage when GetStatus is called and sync the tiddlers in browser storage with the server
2. To remove a tiddler from browser storage when successfully synced to the server

If the browser storage plugin is not present, or is disabled, the changes are inert. 

NOTE - Deletions that occur when offline are not synced. This could be added, but would be more complex and doesn't seem critical for the purpose, which is to prevent loss of information in cases where the user is temporarily disconnected from the server. If the user has deleted some tiddlers while temporarily offline, it is not nearly so frustrating to have to do the delete again as it would be to lose new or modified content. 