### PR TITLE
Improve docs for genesis-widget

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
@@ -1,6 +1,7 @@
+bad-example: <$genesis $type="my-element" $names="one two" $values="1 2">Test Genesis Widget</$genesis>
 caption: genesis
 created: 20221101100729587
-modified: 20221101100729587
+modified: 20230103152008291
 tags: Widgets
 title: GenesisWidget
 type: text/vnd.tiddlywiki
@@ -25,10 +26,10 @@ Note that attributes explicitly specified take precedence over attributes with t
 
 ! Examples
 
-<$macrocall $name='wikitext-example-without-html' 
+<$macrocall $name='wikitext-example' 
 src='<$genesis $type="div" class="tc-thing" label="Squeak">Mouse</$genesis>'/>
 
-<$macrocall $name='wikitext-example-without-html' 
+<$macrocall $name='wikitext-example' 
 src="""\define my-banner(mode:"inline",caption)
 <$genesis $type={{{ [<__mode__>match[inline]then[span]else[div]] }}} class="tc-mybanner">
 <<__caption__>>
@@ -39,3 +40,12 @@ src="""\define my-banner(mode:"inline",caption)
 
 <<my-banner mode:"block" caption:"I'm in a DIV">>
 """/>
+
+! Important
+<<.warning """In the following example the parameter `one` is absent from the HTML output, since HTML parameters with the prefix `on` are ''removed for security reasons''. It's needed to remove eg: `onClick=` from "copy / pasted" HTML content. At the moment, every parameter prefixed `on` is removed. 
+
+<pre><code><$view field="bad-example" format="text" /></code></pre>
+
+... and the underlying HTML is:
+<pre><code><$view field="bad-example" format="htmlwikified" /></code></pre>
+""">>

--- a/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
@@ -1,28 +1,27 @@
-bad-example: <$genesis $type="my-element" $names="one two" $values="1 2">Test Genesis Widget</$genesis>
 caption: genesis
 created: 20221101100729587
-modified: 20230103152008291
+modified: 20230115095816093
 tags: Widgets
 title: GenesisWidget
 type: text/vnd.tiddlywiki
 
 ! Introduction
 
-<<.from-version "5.2.4">> The <<.wlink GenesisWidget>> widget allows the dynamic construction of another widget, where the name and attributes of the new widget can be dynamically determined, without needing to be known in advance.
+<<.from-version "5.2.4">> The <<.wid genesis>> widget allows the dynamic construction of another widget, where the name and attributes of the new widget can be dynamically determined, without needing to be known in advance.
 
 ! Content and Attributes
 
-The content of the <<.wlink GenesisWidget>> widget is used as the content of the dynamically created widget.
+The content of the <<.wid genesis>> widget is used as the content of the dynamically created widget.
 
 |!Attribute |!Description |
 |$type |The type of widget or element to create (an initial `$` indicates a widget, otherwise an HTML element will be created) |
 |$names |An optional filter evaluating to the names of a list of attributes to be applied to the widget |
-|$values |An optional filter evaluating to the values corresponding to the list of names specified in `$names` |
+|$values |An optional filter evaluating to the values corresponding to the list of names specified in <<.param $names>> |
 |//{other attributes starting with $}// |Other attributes starting with a single dollar sign are reserved for future use |
 |//{attributes starting with $$}// |Attributes starting with two dollar signs are applied as attributes to the output widget, but with the attribute name changed to use a single dollar sign |
 |//{attributes not starting with $}// |Any other attributes that do not start with a dollar are applied as attributes to the output widget |
 
-Note that attributes explicitly specified take precedence over attributes with the same name specified in the `$names` filter.
+Note that attributes explicitly specified take precedence over attributes with the same name specified in the <<.param $names>> filter.
 
 ! Examples
 
@@ -42,10 +41,9 @@ src="""\define my-banner(mode:"inline",caption)
 """/>
 
 ! Important
-<<.warning """In the following example the parameter `one` is absent from the HTML output, since HTML parameters with the prefix `on` are ''removed for security reasons''. It's needed to remove eg: `onClick=` from "copy / pasted" HTML content. At the moment, every parameter prefixed `on` is removed. 
 
-<pre><code><$view field="bad-example" format="text" /></code></pre>
+<$macrocall $name=".warning" _="""
+In the following example the widget parameter named `one` is absent from the HTML output, since HTML attributes with the prefix `on` are removed for security reasons. See [[HTML in WikiText]] "Security" for more details.
 
-... and the underlying HTML is:
-<pre><code><$view field="bad-example" format="htmlwikified" /></code></pre>
-""">>
+<<wikitext-example '<$genesis $type="my-element" $names="one two" $values="1 2">Test Genesis Widget</$genesis>'>>
+"""/>

--- a/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
@@ -1,6 +1,6 @@
 caption: genesis
 created: 20221101100729587
-modified: 20230115095816093
+modified: 20230115101800345
 tags: Widgets
 title: GenesisWidget
 type: text/vnd.tiddlywiki
@@ -16,19 +16,19 @@ The content of the <<.wid genesis>> widget is used as the content of the dynamic
 |!Attribute |!Description |
 |$type |The type of widget or element to create (an initial `$` indicates a widget, otherwise an HTML element will be created) |
 |$names |An optional filter evaluating to the names of a list of attributes to be applied to the widget |
-|$values |An optional filter evaluating to the values corresponding to the list of names specified in <<.param $names>> |
+|$values |An optional filter evaluating to the values corresponding to the list of names specified in <<.attr $names>> |
 |//{other attributes starting with $}// |Other attributes starting with a single dollar sign are reserved for future use |
 |//{attributes starting with $$}// |Attributes starting with two dollar signs are applied as attributes to the output widget, but with the attribute name changed to use a single dollar sign |
 |//{attributes not starting with $}// |Any other attributes that do not start with a dollar are applied as attributes to the output widget |
 
-Note that attributes explicitly specified take precedence over attributes with the same name specified in the <<.param $names>> filter.
+<<.tip """Note that attributes explicitly specified take precedence over attributes with the same name specified in the <<.attr $names>> filter.""">>
 
 ! Examples
 
-<$macrocall $name='wikitext-example' 
-src='<$genesis $type="div" class="tc-thing" label="Squeak">Mouse</$genesis>'/>
+<$macrocall $name="wikitext-example"
+src="""<$genesis $type="div" class="tc-thing" label="Squeak">Mouse</$genesis>"""/>
 
-<$macrocall $name='wikitext-example' 
+<$macrocall $name="wikitext-example"
 src="""\define my-banner(mode:"inline",caption)
 <$genesis $type={{{ [<__mode__>match[inline]then[span]else[div]] }}} class="tc-mybanner">
 <<__caption__>>
@@ -43,7 +43,7 @@ src="""\define my-banner(mode:"inline",caption)
 ! Important
 
 <$macrocall $name=".warning" _="""
-In the following example the widget parameter named `one` is absent from the HTML output, since HTML attributes with the prefix `on` are removed for security reasons. See [[HTML in WikiText]] "Security" for more details.
+In the following example the widget attribute named `one` is absent from the HTML output, since HTML attributes with the prefix `on` are removed for security reasons. See [[HTML in WikiText]] "Security" for more details.
 
 <<wikitext-example '<$genesis $type="my-element" $names="one two" $values="1 2">Test Genesis Widget</$genesis>'>>
 """/>

--- a/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/HTML in WikiText.tid
@@ -1,6 +1,6 @@
 caption: HTML
 created: 20131205160816081
-modified: 20220123174919252
+modified: 20230115100934146
 tags: WikiText
 title: HTML in WikiText
 type: text/vnd.tiddlywiki
@@ -31,7 +31,14 @@ some text <!-- inline comment -->
 
 ! Important
 
-<<.tip """[[Widgets share the same syntax as HTML tags|Widgets in WikiText]], and so the following information applies to them, too.""">>
+!! Security 
+
+<<.warning """Every HTML attribute prefixed with `on` is removed from rendered HTML content for security reasons. eg: `onclick="some evil code"` would be executed, if no sanitation is active. In ~TiddlyWiki It's important to remove every attribute prefixed with `on` so future extensions to the HTML spec will be secure by default. This can lead to some inconvenience since custom attributes like eg: `one` are removed too. """>> 
+
+!! Widgets
+
+<<.tip """[[Widgets share the same syntax as HTML tags|Widgets in WikiText]]<br>and so the following information applies to them, too.""">>
+
 
 ! Block mode versus Inline mode
 


### PR DESCRIPTION
- There is an ! Important section at the end of the description now
- The examples now also show the rendered HTML code

This PR should fix: [BUG] Genesis widget: names begining with "on" are not rendered #7154 