### PR TITLE
Allow innerwiki $data widget to override tiddler fields

### DIFF
--- a/plugins/tiddlywiki/innerwiki/innerwiki.js
+++ b/plugins/tiddlywiki/innerwiki/innerwiki.js
@@ -295,7 +295,7 @@ InnerWikiWidget.prototype.readTiddlerDataWidget = function(dataWidget) {
 			if(tiddler) {
 				fields = tiddler.getFieldStrings();
 			}
-			results.push($tw.utils.extend({},item,fields));
+			results.push($tw.utils.extend({},fields,item));
 		})
 		return results;
 	} else {


### PR DESCRIPTION
Change the innerwiki plugin's $data widget so it allows the fields of an existing tiddler to be overridden using attributes, as documented.

Fixes #7171