### PR TITLE
Adds support for indenting pragmas with whitespace

### DIFF
--- a/core/modules/parsers/wikiparser/rules/import.js
+++ b/core/modules/parsers/wikiparser/rules/import.js
@@ -25,7 +25,7 @@ Instantiate parse rule
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^\\import[^\S\n]/mg;
+	this.matchRegExp = /\\import[^\S\n]/mg;
 };
 
 /*

--- a/core/modules/parsers/wikiparser/rules/macrodef.js
+++ b/core/modules/parsers/wikiparser/rules/macrodef.js
@@ -27,7 +27,7 @@ Instantiate parse rule
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^\\define\s+([^(\s]+)\(\s*([^)]*)\)(\s*\r?\n)?/mg;
+	this.matchRegExp = /\\define\s+([^(\s]+)\(\s*([^)]*)\)(\s*\r?\n)?/mg;
 };
 
 /*
@@ -58,7 +58,7 @@ exports.parse = function() {
 	var reEnd;
 	if(this.match[3]) {
 		// If so, the end of the body is marked with \end
-		reEnd = new RegExp("(\\r?\\n\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[1]) + ")?(?:$|\\r?\\n))","mg");
+		reEnd = new RegExp("(\\r?\\n\\s*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[1]) + ")?(?:$|\\r?\\n))","mg");
 	} else {
 		// Otherwise, the end of the definition is marked by the end of the line
 		reEnd = /($|\r?\n)/mg;

--- a/core/modules/parsers/wikiparser/rules/parsermode.js
+++ b/core/modules/parsers/wikiparser/rules/parsermode.js
@@ -26,7 +26,7 @@ Instantiate parse rule
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^\\parsermode[^\S\n]/mg;
+	this.matchRegExp = /\\parsermode[^\S\n]/mg;
 };
 
 /*

--- a/core/modules/parsers/wikiparser/rules/rules.js
+++ b/core/modules/parsers/wikiparser/rules/rules.js
@@ -26,7 +26,7 @@ Instantiate parse rule
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^\\rules[^\S\n]/mg;
+	this.matchRegExp = /\\rules[^\S\n]/mg;
 };
 
 /*

--- a/core/modules/parsers/wikiparser/rules/whitespace.js
+++ b/core/modules/parsers/wikiparser/rules/whitespace.js
@@ -26,7 +26,7 @@ Instantiate parse rule
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^\\whitespace[^\S\n]/mg;
+	this.matchRegExp = /\\whitespace[^\S\n]/mg;
 };
 
 /*

--- a/editions/test/tiddlers/tests/data/macros/NestedMacros-indented.tid
+++ b/editions/test/tiddlers/tests/data/macros/NestedMacros-indented.tid
@@ -1,0 +1,36 @@
+title: Macros/NestedMacros-indented
+description: Nested Macros-indented
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+
+\define outer()
+	\whitespace trim
+
+	\define middle()
+		\whitespace trim
+
+		\define inner()
+			\whitespace trim
+
+			Jaguar
+
+		\end inner
+
+		<<inner>>
+
+	\end middle
+
+	<<middle>>
+
+\end outer
+
+<<outer>>
+
++
+title: ExpectedResult
+
+<p>Jaguar</p>

--- a/editions/test/tiddlers/tests/data/macros/NestedMacros-indented2.tid
+++ b/editions/test/tiddlers/tests/data/macros/NestedMacros-indented2.tid
@@ -1,0 +1,36 @@
+title: Macros/NestedMacros-indented2
+description: Nested Macros-indented with spaces
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+
+\define outer()
+    \whitespace trim
+
+    \define middle()
+        \whitespace trim
+
+        \define inner()
+            \whitespace trim
+
+            Jaguar
+
+        \end inner
+
+        <<inner>>
+
+    \end middle
+
+    <<middle>>
+
+\end outer
+
+<<outer>>
+
++
+title: ExpectedResult
+
+<p>Jaguar</p>

--- a/editions/test/tiddlers/tests/data/pragmas/Parsermode-indented.tid
+++ b/editions/test/tiddlers/tests/data/pragmas/Parsermode-indented.tid
@@ -1,0 +1,36 @@
+title: Pragmas/Parsermode-indented
+description: parsermode pragma
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+{{AlwaysInline}}
+
+{{AlwaysBlock}}
+
+{{AlwaysInline}}{{AlwaysBlock}}
+
++
+title: AlwaysInline
+
+	\parsermode inline
+! Not Heading
+
+Text with ''bold''
++
+title: AlwaysBlock
+
+    \parsermode block
+! Heading
+
+Text with ''bold''
++
+title: ExpectedResult
+
+! Not Heading
+
+Text with <strong>bold</strong><h1 class="">Heading</h1><p>Text with <strong>bold</strong></p><p>! Not Heading
+
+Text with <strong>bold</strong><h1 class="">Heading</h1><p>Text with <strong>bold</strong></p>
+</p>

--- a/editions/tw5.com/tiddlers/concepts/Pragma.tid
+++ b/editions/tw5.com/tiddlers/concepts/Pragma.tid
@@ -1,5 +1,5 @@
 created: 20150219175930000
-modified: 20220122182842041
+modified: 20230107165037493
 tags: Concepts [[WikiText Parser Modes]]
 title: Pragma
 type: text/vnd.tiddlywiki
@@ -7,6 +7,8 @@ type: text/vnd.tiddlywiki
 A <<.def pragma>> is a special component of WikiText that provides control over the way the remaining text is parsed.
 
 Pragmas occupy lines that start with `\`. They can only appear at the start of the text, but blank lines are allowed between them. If a pragma line appears in the main body of the text, it is treated as if it was ordinary text.
+<<.from-version "5.2.6">> Pragmas can have preceding optional whitespace characters.
+
 
 The following pragmas are available:
 


### PR DESCRIPTION
This PR adds support for indenting pragmas with whitespace, which helps readability particularly in nested macros.

With the way that pragmas are parsed with a preceding call to skipWhitespace(), it turned out that the only change needed to the regular expressions was to drop the requirement to start with a new line. 

https://github.com/Jermolene/TiddlyWiki5/blob/f3ebb258f79fdd03478bd5a27060f9ac4ec8a59d/core/modules/parsers/wikiparser/wikiparser.js#L197-L203

@Jermolene Are there any caveats here that you can think of?