### PR TITLE
Remove the tag to itself on the "Open collective" tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/about/Open Collective.tid
+++ b/editions/tw5.com/tiddlers/about/Open Collective.tid
@@ -1,7 +1,7 @@
 title: Open Collective
 modified: 20221204165636777
 created: 20221204165636777
-tags: About HelloThere [[Open Collective]]
+tags: About HelloThere
 
 Open Collective is a platform for transparent fundraising and expenses for projects like TiddlyWiki. It is the official TiddlyWiki community fundraising space.
 


### PR DESCRIPTION
Remove [[Open Collective]] from the tags of itself.

This breaks the heirachy of the TOC and produces an entry that will not open its own list see HelloThere > Open Collective

Mentioned here https://talk.tiddlywiki.org/t/filter-question-return-all-toc-tiddler-titles-as-a-plain-list/5752/9?u=tw_tones