### PR TITLE
Update community resources TiddlyResearch and Drift

### DIFF
--- a/editions/tw5.com/tiddlers/_TiddlyStudy_ by Kebi.tid
+++ b/editions/tw5.com/tiddlers/_TiddlyStudy_ by Kebi.tid
@@ -1,8 +1,9 @@
 created: 20210101162308245
-modified: 20210101201435693 
+modified: 20230110220417543
 tags: [[Community Editions]]
-title: "TiddlyResearch" by Kebi
-url: https://kebifurai.github.io/TiddlyResearch/
+title: "TiddlyStudy" by Kebi
+type: text/vnd.tiddlywiki
+url: https://postkevone.github.io/tiddlystudy/
 
 A adaptation of TiddlyWiki perfect for using as a Notebook sysetem.
 

--- a/editions/tw5.com/tiddlers/community/editions/Drift by Tony K.tid
+++ b/editions/tw5.com/tiddlers/community/editions/Drift by Tony K.tid
@@ -1,8 +1,9 @@
 created: 20210101161529206
-modified: 20210101201435693 
+modified: 20230110220010665
 tags: [[Community Editions]]
 title: "Drift - Collect, Organise, Grow." by Tony K
-url: https://akhater.github.io/drift/
+type: text/vnd.tiddlywiki
+url: https://github.com/bmann/drift-tiddlywiki-template/tree/master/drift
 
 A adaptation of TiddlyWiki perfect for using as a Notebook sysetem.
 


### PR DESCRIPTION
Changes to community resources. The real question is whether they should be deleted rather than maintained so there aren't two sources of "truth".