### PR TITLE
[DOC] Improve ActionCreateTiddlerWidget documentation

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 1.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 1.tid
@@ -1,6 +1,6 @@
 created: 20200131142401129
-modified: 20211113230406823
-tags: ActionCreateTiddlerWidget Widgets
+modified: 20230111220902351
+tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 1
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 1.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 1.tid
@@ -1,5 +1,5 @@
 created: 20200131142401129
-modified: 20230111220902351
+modified: 20211113230406823
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 1
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 2.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 2.tid
@@ -1,6 +1,6 @@
 created: 20200131144828713
-modified: 20211113011036840
-tags: ActionCreateTiddlerWidget Widgets
+modified: 20230111220857013
+tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 2
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 2.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 2.tid
@@ -1,5 +1,5 @@
 created: 20200131144828713
-modified: 20230111220857013
+modified: 20211113011036840
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 2
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 3.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 3.tid
@@ -1,5 +1,5 @@
 created: 20200131145355658
-modified: 20230111220851909
+modified: 20211113011111052
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 3
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 3.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 3.tid
@@ -1,6 +1,6 @@
 created: 20200131145355658
-modified: 20211113011111052
-tags: ActionCreateTiddlerWidget Widgets
+modified: 20230111220851909
+tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 3
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 4.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 4.tid
@@ -1,6 +1,6 @@
 created: 20200131150229551
-modified: 20211113011129601
-tags: ActionCreateTiddlerWidget Widgets
+modified: 20230111220845950
+tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 4
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 4.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 4.tid
@@ -1,5 +1,5 @@
 created: 20200131150229551
-modified: 20230111220845950
+modified: 20211113011129601
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example 4
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 5.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget Example 5.tid
@@ -1,0 +1,32 @@
+created: 20200131144828713
+modified: 20230111220933412
+tags: ActionCreateTiddlerWidget
+title: ActionCreateTiddlerWidget Example 5
+type: text/vnd.tiddlywiki
+
+\define testCreate()
+<$action-createtiddler  $basetitle="base" $template="ActionCreateTiddlerWidget Template">
+	<$action-sendmessage $message="tm-edit-tiddler" $param=<<createTiddler-title>>/>
+</$action-createtiddler>
+\end
+
+This example will use the base title defined in [[ActionCreateTiddlerWidget Template]].
+
+It will create: "base", "base 1", "base 2" and so on, and navigate to this tiddler in draft mode.
+
+```
+\define testCreate()
+<$action-createtiddler $basetitle="base" $template="ActionCreateTiddlerWidget Template">
+	<$action-sendmessage $message="tm-edit-tiddler" $param=<<createTiddler-title>>/>
+</$action-createtiddler>
+\end
+
+<$button actions=<<testCreate>> >
+Create Tiddler
+</$button>
+```
+
+<$button actions=<<testCreate>> >
+<$action-setfield $tiddler="$:/state/tab/sidebar--595412856" text="$:/core/ui/SideBar/Recent"/>
+Create Tiddler
+</$button> - Clicking this button, will also open the Right sidebar: Recent tab

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget.tid
@@ -1,13 +1,15 @@
 caption: action-createtiddler
 created: 20161020152745942
-modified: 20210601092956998
+modified: 20230111224058974
 tags: Widgets ActionWidgets
 title: ActionCreateTiddlerWidget
 type: text/vnd.tiddlywiki
 
 ! Introduction
 
-The ''action-createtiddler'' widget is an [[action widget|ActionWidgets]] that creates new tiddlers. ActionWidgets are used within triggering widgets such as the ButtonWidget.
+
+
+The <<.widget "action-createtiddler">> widget is an [[action widget|ActionWidgets]] that creates new tiddlers. ActionWidgets are used within triggering widgets such as the ButtonWidget.
 
 There are several differences from the [[tm-new-tiddler message|WidgetMessage: tm-new-tiddler]]:
 
@@ -18,7 +20,7 @@ There are several differences from the [[tm-new-tiddler message|WidgetMessage: t
 
 The ''action-createtiddler'' widget is invisible.
 
-<<.from-version "5.2.0">> The action widgets contained within the ''action-createtiddler'' widget are executed after the new tiddler has been created with the title of the tiddler in the variable `createTiddler-title` and `createTiddler-draftTitle`.
+<<.from-version "5.2.0">> The action widgets contained in the widget-body of the ''action-createtiddler'' widget are executed after the new tiddler has been created with the title of the tiddler in the variable `createTiddler-title` and `createTiddler-draftTitle`. See the last example.
 
 |!Attribute |!Description |
 |$basetitle |The initial title that will be attempted. If a tiddler with that title already exists, then a numerical counter is added to the title and incremented until it is unique|
@@ -61,4 +63,9 @@ The ''action-createtiddler'' widget is invisible.
 {{ActionCreateTiddlerWidget Example 4}}
 <<<
 
+---
+
+<<<
+{{ActionCreateTiddlerWidget Example 5}}
+<<<
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget.tid
@@ -1,37 +1,39 @@
 caption: action-createtiddler
 created: 20161020152745942
-modified: 20230111224058974
+modified: 20230115084716196
 tags: Widgets ActionWidgets
 title: ActionCreateTiddlerWidget
 type: text/vnd.tiddlywiki
 
 ! Introduction
 
+The <<.wid "action-createtiddler">> widget is an [[action widget|ActionWidgets]] that creates new tiddlers. Action widgets are used within triggering widgets such as the ButtonWidget.
 
+There are several //differences// from the [[tm-new-tiddler message|WidgetMessage: tm-new-tiddler]]:
 
-The <<.widget "action-createtiddler">> widget is an [[action widget|ActionWidgets]] that creates new tiddlers. ActionWidgets are used within triggering widgets such as the ButtonWidget.
-
-There are several differences from the [[tm-new-tiddler message|WidgetMessage: tm-new-tiddler]]:
-
-* The new tiddler is not automatically displayed in the [[story river|StoryRiver]]
+* The new tiddler is not automatically displayed in the [[story river|Story River]]
 * The title of the new tiddler is made available for subsequent operations
 
 ! Content and Attributes
 
 The ''action-createtiddler'' widget is invisible.
 
-<<.from-version "5.2.0">> The action widgets contained in the widget-body of the ''action-createtiddler'' widget are executed after the new tiddler has been created with the title of the tiddler in the variable `createTiddler-title` and `createTiddler-draftTitle`. See the last example.
-
 |!Attribute |!Description |
 |$basetitle |The initial title that will be attempted. If a tiddler with that title already exists, then a numerical counter is added to the title and incremented until it is unique|
-|$savetitle |//(deprecated – see below)// A text reference identifying a field or index into which the title of the newly created tiddler will be stored after it is created |
-|$savedrafttitle |//(deprecated – see below)// <<.from-version "5.1.20">> A text reference identifying a field or index into which the draft title associated with the newly created tiddler will be stored after it is created. This is useful when using a sequence of action widgets to create a new tiddler, put it into edit mode, and position it within the list of its parent tag |
+|$savetitle |<<.deprecated-since "5.1.20" "ActionCreateTiddlerWidget Example 5">> A text reference identifying a field or index into which the title of the newly created tiddler will be stored after it is created |
+|$savedrafttitle |<<.deprecated-since "5.1.20" "ActionCreateTiddlerWidget Example 5">> A text reference identifying a field or index into which the draft title associated with the newly created tiddler will be stored after it is created. This is useful when using a sequence of action widgets to create a new tiddler, put it into edit mode, and position it within the list of its parent tag |
 |$timestamp |Specifies whether the timestamp(s) of the target tiddler will be updated (''modified'' and ''modifier'', plus ''created'' and ''creator'' for newly created tiddlers). Can be "yes" (the default) or "no" |
 |$template |<<.from-version "5.1.22">> The title of a template tiddler, that will be used to create a new tiddler |
 |$overwrite |<<.from-version "5.1.22">> If set to "yes", it will overwrite existing tiddlers. ''Be careful!'' |
 |//{any attributes not starting with $}// |Each attribute name specifies a field to be created in the new tiddler  |
 
-<<.from-version "5.2.0">> Note that the attributes `$savetitle` and `$savedrafttitle` are no longer needed. Instead, any action widgets that need to use the title of the newly created tiddler should be contained within the ''action-createtiddler'' widget, and reference the variables `createTiddler-title` and `createTiddler-draftTitle` to obtain the title.
+! Variables
+
+<<.from-version "5.2.0">> The content of the <<.wid "action-createtiddler">> widget is executed after the new tiddler has been created. The title of the newly created tiddler is stored in the variable <<.var "createTiddler-title">>.
+
+|!Variables |!Description |
+|`createTiddler-title` |The tittle of the tiddler that has been created. See [[ActionCreateTiddlerWidget Example 5]] |
+|`createTiddler-draftTitle` |This variable only exists to have feature parity with the deprecated parameters. It contains the title of a "draft tiddler" |
 
 ! Examples
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget_Example.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget_Example.tid
@@ -1,6 +1,6 @@
 created: 20161020153426686
-modified: 20211113011019510
-tags: ActionCreateTiddlerWidget Widgets
+modified: 20230111220908525
+tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget_Example.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionCreateTiddlerWidget_Example.tid
@@ -1,5 +1,5 @@
 created: 20161020153426686
-modified: 20230111220908525
+modified: 20211113011019510
 tags: ActionCreateTiddlerWidget
 title: ActionCreateTiddlerWidget Example
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
This PR fixes:  **[PR] Add example #5 to ActionCreateTiddlerWidget.tid #7200**

- It contains the Example No 5 from the issue above
- It removes the tag: "Widget" from all example tiddlers. They should have not been there in the first place.
    - This makes the Reference TOC a bit cleaner