### PR TITLE
Fix the share plugin so it can decode tiddlers from the URI

### DIFF
--- a/plugins/tiddlywiki/share/rawmarkup.js
+++ b/plugins/tiddlywiki/share/rawmarkup.js
@@ -17,7 +17,7 @@ var rawHash = document.location.hash.substring(1);
 if(rawHash.charAt(0) === "#") {
 	var hash;
 	try{
-		hash = $tw.utils.decodeURIComponentSafe(rawHash.substring(1));
+		hash = decodeURIComponent(rawHash.substring(1));
 	} catch(ex) {
 		console.log("Share plugin: Error decoding location hash",ex);
 	}


### PR DESCRIPTION
Reverts the part of #5999 which changed the URI decoding in the share plugin. The URI decoding for the share plugin happens in rawmarkup before `$tw.utils` exists. In addition, the "safe" version of the function is not required since a try/catch is already present in the rawmarkup.

Without this change, the share plugin is only able to generate url payloads. It cannot receive and render any url payload. When the page is loaded the following message is in the console: `Share plugin: Error decoding location hash ReferenceError: $tw is not defined`