### PR TITLE
Fixes share plugin stale url and prevents wikification of generated json

### DIFF
--- a/plugins/tiddlywiki/share/wizard.tid
+++ b/plugins/tiddlywiki/share/wizard.tid
@@ -1,7 +1,7 @@
 title: $:/plugins/tiddlywiki/share/wizard
 
 \define generate-json()
-<$macrocall $name="jsontiddlers" filter=<<share-filter>> spaces="" $output="text/vnd.tiddlywiki"/>
+<$macrocall $name="jsontiddlers" filter=<<share-filter>> spaces="" $output="text/raw"/>
 \end
 
 \define inner-share-actions()

--- a/plugins/tiddlywiki/share/wizard.tid
+++ b/plugins/tiddlywiki/share/wizard.tid
@@ -12,8 +12,10 @@ title: $:/plugins/tiddlywiki/share/wizard
 
 \define share-actions()
 <$set name="base-url" value={{$:/config/plugins/share/base-url}} emptyValue={{$:/info/url/full}}>
+<$set name="tv-action-refresh-policy" value="always">
 <$set name="share-filter" value={{$:/config/plugins/share/filter}}>
 <<inner-share-actions>>
+</$set>
 </$set>
 </$set>
 \end


### PR DESCRIPTION
Use the `tv-action-refresh-policy` variable to ensure the share url is up-to-date when the "Generate share url" button is clicked. Also use the macrocall widgets `$output="text/raw"` to ensure the generated json doesn't get modified by wikification.

Fixes #7205 