### PR TITLE
Allow boot code to remain as tiddlers in tiddlywikicore.js

### DIFF
--- a/core/templates/external-js/save-all-external-js.tid
+++ b/core/templates/external-js/save-all-external-js.tid
@@ -1,5 +1,6 @@
 title: $:/core/save/all-external-js
 
+\whitespace trim
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 \define saveTiddlerFilter()
 [is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$

--- a/core/templates/external-js/save-offline-external-js.tid
+++ b/core/templates/external-js/save-offline-external-js.tid
@@ -1,5 +1,6 @@
 title: $:/core/save/offline-external-js
 
+\whitespace trim
 \import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
 \define saveTiddlerFilter()
 [is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/plugins/tiddlywiki/filesystem]] -[[$:/plugins/tiddlywiki/tiddlyweb]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$

--- a/core/templates/external-js/tiddlywiki.js.load.tid
+++ b/core/templates/external-js/tiddlywiki.js.load.tid
@@ -1,0 +1,3 @@
+title: $:/core/templates/tiddlywiki.js/load-tiddler
+
+_load(window,<$macrocall $name="jsontiddler" $output="text/raw"/>);

--- a/core/templates/external-js/tiddlywiki.js.tid
+++ b/core/templates/external-js/tiddlywiki.js.tid
@@ -1,15 +1,48 @@
+
 title: $:/core/templates/tiddlywiki5.js
 
 \rules only filteredtranscludeinline transcludeinline codeinline
 
-/*
-{{ $:/core/copyright.txt ||$:/core/templates/plain-text-tiddler}}
-`*/
-`<!--~~ Library modules ~~-->
-{{{ [is[system]type[application/javascript]library[yes]] ||$:/core/templates/plain-text-tiddler}}}
-<!--~~ Boot prefix ~~-->
-{{ $:/boot/bootprefix.js ||$:/core/templates/plain-text-tiddler}}
-<!--~~ Core plugin ~~-->
-{{$:/core/templates/tiddlywiki5.js/tiddlers}}
-<!--~~ Boot kernel ~~-->
-{{ $:/boot/boot.js ||$:/core/templates/plain-text-tiddler}}
+`/*
+`{{ $:/core/copyright.txt ||$:/core/templates/plain-text-tiddler}}`
+*/
+
+$tw = (typeof $tw === 'undefined') ? Object.create(null) : $tw;
+
+$tw.preloadTiddlers = $tw.preloadTiddlers || [];
+
+_load = function(window,tiddler) {
+	"use strict";
+	var f;
+	$tw.preloadTiddlers.push(tiddler);
+	if(tiddler.library === "yes") {
+		var module = { exports:{} };
+		var moduleName = function moduleName(path) {
+			var word = path.split("/").pop();
+			word = word.substring(0,word.indexOf(".")) || word;
+			return word;
+		}
+		f = new Function("module",tiddler.text);
+		f(module);
+		window[moduleName(tiddler.title)] = module.exports;
+	} else {
+		f = new Function("window",tiddler.text);
+		f(window);
+	}
+}
+
+/* ~~ Library modules ~~ */
+
+`{{{ [is[system]type[application/javascript]library[yes]] ||$:/core/templates/tiddlywiki.js/load-tiddler}}}`
+
+/* ~~ Boot kernel prologue ~~ */
+
+`{{ $:/boot/bootprefix.js ||$:/core/templates/tiddlywiki.js/load-tiddler}}`
+
+/* ~~ Core tiddlers ~~ */
+
+`{{$:/core/templates/tiddlywiki5.js/tiddlers}}`
+
+/* ~~ Boot kernel ~~ */
+
+`{{ $:/boot/boot.js ||$:/core/templates/tiddlywiki.js/load-tiddler}}`

--- a/core/templates/external-js/tiddlywiki5-external-js.html.tid
+++ b/core/templates/external-js/tiddlywiki5-external-js.html.tid
@@ -1,48 +1,50 @@
 title: $:/core/templates/tiddlywiki5-external-js.html
 
-\rules only filteredtranscludeinline transcludeinline
-<!doctype html>
-{{$:/core/templates/MOTW.html}}<html lang="{{{ [{$:/language}get[name]] }}}">
+<$set name="saveTiddlerAndShadowsFilter" filter="[subfilter<saveTiddlerFilter>] [subfilter<saveTiddlerFilter>plugintiddlers[]]">
+`<!doctype html>
+`{{$:/core/templates/MOTW.html}}`<html lang="`<$text text={{{ [{$:/language}get[name]] }}}/>`">
 <head>
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <!--~~ Raw markup for the top of the head section ~~-->
-{{{ [all[shadows+tiddlers]tag[$:/tags/RawMarkupWikified/TopHead]] ||$:/core/templates/raw-static-tiddler}}}
+`{{{ [enlist<saveTiddlerAndShadowsFilter>tag[$:/tags/RawMarkupWikified/TopHead]] ||$:/core/templates/raw-static-tiddler}}}`
 <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
 <meta name="application-name" content="TiddlyWiki" />
 <meta name="generator" content="TiddlyWiki" />
-<meta name="tiddlywiki-version" content="{{$:/core/templates/version}}" />
+<meta name="tiddlywiki-version" content="`{{$:/core/templates/version}}`" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 <meta name="mobile-web-app-capable" content="yes"/>
 <meta name="format-detection" content="telephone=no" />
-<meta name="copyright" content="{{$:/core/copyright.txt}}" />
+<meta name="copyright" content="`{{$:/core/copyright.txt}}`" />
 <link id="faviconLink" rel="shortcut icon" href="favicon.ico">
-<title>{{$:/core/wiki/title}}</title>
+<title>`{{$:/core/wiki/title}}`</title>
 <!--~~ This is a Tiddlywiki file. The points of interest in the file are marked with this pattern ~~-->
 
 <!--~~ Raw markup ~~-->
-{{{ [all[shadows+tiddlers]tag[$:/core/wiki/rawmarkup]] [all[shadows+tiddlers]tag[$:/tags/RawMarkup]] ||$:/core/templates/plain-text-tiddler}}}
-{{{ [all[shadows+tiddlers]tag[$:/tags/RawMarkupWikified]] ||$:/core/templates/raw-static-tiddler}}}
+`{{{ [enlist<saveTiddlerAndShadowsFilter>tag[$:/core/wiki/rawmarkup]] ||$:/core/templates/plain-text-tiddler}}}`
+`{{{ [enlist<saveTiddlerAndShadowsFilter>tag[$:/tags/RawMarkup]] ||$:/core/templates/plain-text-tiddler}}}`
+`{{{ [enlist<saveTiddlerAndShadowsFilter>tag[$:/tags/RawMarkupWikified]] ||$:/core/templates/raw-static-tiddler}}}`
 </head>
 <body class="tc-body">
 <!--~~ Raw markup for the top of the body section ~~-->
-{{{ [all[shadows+tiddlers]tag[$:/tags/RawMarkupWikified/TopBody]] ||$:/core/templates/raw-static-tiddler}}}
+`{{{ [enlist<saveTiddlerAndShadowsFilter>tag[$:/tags/RawMarkupWikified/TopBody]] ||$:/core/templates/raw-static-tiddler}}}`
 <!--~~ Static styles ~~-->
 <div id="styleArea">
-{{$:/boot/boot.css||$:/core/templates/css-tiddler}}
+`{{$:/boot/boot.css||$:/core/templates/css-tiddler}}`
 </div>
 <!--~~ Static content for Google and browsers without JavaScript ~~-->
 <noscript>
 <div id="splashArea">
-{{$:/core/templates/static.area}}
+`{{$:/core/templates/static.area}}`
 </div>
 </noscript>
 <!--~~ Ordinary tiddlers ~~-->
-{{$:/core/templates/store.area.template.html}}
+`{{$:/core/templates/store.area.template.html}}`
 <!--~~ Raw markup for the bottom of the body section ~~-->
-{{{ [all[shadows+tiddlers]tag[$:/tags/RawMarkupWikified/BottomBody]] ||$:/core/templates/raw-static-tiddler}}}
+`{{{ [enlist<saveTiddlerAndShadowsFilter>tag[$:/tags/RawMarkupWikified/BottomBody]] ||$:/core/templates/raw-static-tiddler}}}`
+<!--~~ Load external JavaScripts ~~-->
+<script src="`{{{ [<coreURL>] }}}`" onerror="alert('Error: Cannot load `{{{ [<coreURL>] }}}`');"></script>
 </body>
-<!--~~ Load external JS ~~-->
-<script src="{{{ [<coreURL>] }}}" onerror="alert('Error: Cannot load {{{ [<coreURL>] }}}');"></script>
-</html>
+</html>`
+</$set>

--- a/core/ui/DownloadFullWiki.tid
+++ b/core/ui/DownloadFullWiki.tid
@@ -1,0 +1,17 @@
+title: $:/core/ui/DownloadFullWiki
+
+\whitespace trim
+\rules except wikilink
+
+To download the standard single-file version of your wiki:
+
+<$wikify name="site-title" text={{$:/config/SaveWikiButton/Filename}}>
+<$let publishFilter="""-[[$:/config/SaveWikiButton/Template]] -[[$:/plugins/tiddlywiki/filesystem]] -[[$:/plugins/tiddlywiki/tiddlyweb]]""">
+<$button tooltip="Download fully standalone wiki" aria-label="download full wiki" class="tc-btn-big-green">
+<$action-sendmessage $message="tm-download-file" $param="$:/core/save/all" publishFilter=<<publishFilter>> filename=<<site-title>>/>
+{{$:/core/images/download-button}}
+&#32;
+Download full wiki
+</$button>
+</$let>
+</$wikify>

--- a/core/ui/ExportTiddlyWikiCore.tid
+++ b/core/ui/ExportTiddlyWikiCore.tid
@@ -1,11 +1,6 @@
 title: $:/core/ui/ExportTiddlyWikiCore
 
 \define jsFileName() tiddlywikicore-$(version)$.js
-\define noExportMsg()
-It appears that you have a wiki with an external ~TiddlyWiki core. The export action cannot be performed.
-<p>You will need to view the page source in your browser. Then go to the very bottom the the source, find the last `<script>`
-element, and right-click its `src` URI. Save the link as ''$(jsFileName)$''</p>
-\end
 \rules except wikilink
 \whitespace trim
 
@@ -17,13 +12,7 @@ Export the TiddlyWiki core JavaScript code for running with external JavaScript:
 	tooltip="Export the TiddlyWiki core code for running with external JavaScript"
 	aria-label="export TiddlyWiki core"
 	class="tc-btn-big-green">
-<$list
-	filter="[[$:/boot/boot.js]is[missing]]"
-	variable="ignore"
-	emptyMessage="<$action-sendmessage $message='tm-download-file' $param='$:/core/templates/tiddlywiki5.js' filename=<<jsFileName>>/>" >
-<$action-setfield $tiddler=<<qualify "$:/temp/alert">> text=<<noExportMsg>> subtitle="Export ~TiddllyWiki Core"/>
-<$action-sendmessage $message="tm-modal" $param=<<qualify "$:/temp/alert">>/>
-</$list>
+<$action-sendmessage $message='tm-download-file' $param='$:/core/templates/tiddlywiki5.js' filename=<<jsFileName>>/>
 {{$:/core/images/download-button}}
 &#32;
 Download TiddlyWiki core


### PR DESCRIPTION
This PR retains boot tiddlers in `tiddlywikicore.js`; therefore, making it possible to easily save an external-js wiki as a standard single-file wiki. Exporting tiddlywikicore from an external-js wiki is no longer a problem.

**Important:**

The last part of a "library" tiddler's title determines how the module can be accessed from the global scope. For example, `$:/library/sjcl.js` module is loaded into `window.sjcl`.
