### PR TITLE
make core/ui/MoreSideBar/Tags look nice in the story river

### DIFF
--- a/core/ui/MoreSideBar/Tags.tid
+++ b/core/ui/MoreSideBar/Tags.tid
@@ -2,26 +2,17 @@ title: $:/core/ui/MoreSideBar/Tags
 tags: $:/tags/MoreSideBar
 caption: {{$:/language/SideBar/Tags/Caption}}
 
-<$set name="tv-config-toolbar-icons" value="yes">
+\whitespace trim
 
-<$set name="tv-config-toolbar-text" value="yes">
-
-<$set name="tv-config-toolbar-class" value="">
-
-{{$:/core/ui/Buttons/tag-manager}}
-
-</$set>
-
-</$set>
-
-</$set>
-
+<$let tv-config-toolbar-icons="yes" tv-config-toolbar-text="yes" tv-config-toolbar-class="">
+	<div class="tc-tiny-v-gap-bottom">
+    	{{$:/core/ui/Buttons/tag-manager}}
+	</div>
+</$let>
 <$list filter={{$:/core/Filters/AllTags!!filter}}>
-
-<$transclude tiddler="$:/core/ui/TagTemplate"/>
-
+	<div class="tc-tiny-v-gap-bottom">
+    	<$transclude tiddler="$:/core/ui/TagTemplate"/>
+	</div>
 </$list>
-
 <hr class="tc-untagged-separator">
-
 {{$:/core/ui/UntaggedTemplate}}

--- a/core/ui/UntaggedTemplate.tid
+++ b/core/ui/UntaggedTemplate.tid
@@ -3,10 +3,8 @@ title: $:/core/ui/UntaggedTemplate
 \define lingo-base() $:/language/SideBar/
 \whitespace trim
 <$button popup=<<qualify "$:/state/popup/tag">> class="tc-btn-invisible tc-untagged-label tc-tag-label">
-<<lingo Tags/Untagged/Caption>>
+	<<lingo Tags/Untagged/Caption>>
 </$button>
-<$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below">
-<div class="tc-drop-down">
-<$list filter="[untagged[]!is[system]] -[tags[]] +[sort[title]]" template="$:/core/ui/ListItemTemplate"/>
-</div>
+<$reveal class="tc-drop-down" tag="div" state=<<qualify "$:/state/popup/tag">> type="popup" position="below">
+	<$list filter="[untagged[]!is[system]] -[tags[]] +[sort[title]]" template="$:/core/ui/ListItemTemplate"/>
 </$reveal>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -818,9 +818,6 @@ button.tc-tag-label, span.tc-tag-label {
 }
 
 .tc-untagged-separator {
-	width: 10em;
-	left: 0;
-	margin-left: 0;
 	border: 0;
 	height: 1px;
 	background: <<colour tab-divider>>;
@@ -3163,6 +3160,8 @@ select {
 ** Other utility classes
 */
 
+/* Horizontal gaps */
+
 .tc-tiny-gap {
 	margin-left: .25em;
 	margin-right: .25em;
@@ -3204,4 +3203,10 @@ select {
 
 .tc-word-break {
 	word-break: break-all;
+}
+
+/* Vertical gaps */
+
+.tc-tiny-v-gap-bottom {
+	margin-bottom: 3px;
 }


### PR DESCRIPTION
This PR will fix #6924 **[BUG] core/ui/MoreSideBar/Tags looks different in the story river**

- P tags in sidebar have been replaced by a DIV with `class="tc-tiny-v-gap-bottom"` which is `3px;`
- 3 set-widgets have been combined to 1 let-widget call
- indentation has been added for readability
- `\whitespace trim` has been added to remove the indents
- `core/ui/UntaggedTemplate.tid` .. the reveal-widget creates a DIV now to produce a valid HTML structure
- base CSS rule: `.tc-sidebar-header .tc-sidebar-lists p {` has been deprecated since there are no P tags in this sidebar anymore
    - The rule is still there, to be compatible with 3rd party plugins that may need it
- HR `.tc-untagged-separator` has been made wider to work with story river

## Manual Tests

- I did test with FF latest on windows
- FF latest on Android phone
- Chrome on Android
- Edge latest on windows

## Screenshot with PR active

![image](https://user-images.githubusercontent.com/374655/185792720-17b2a9b7-577f-44a5-943f-b8d6285ff37f.png)
