### PR TITLE
Check Content-Type of Pasted Tiddlers

### DIFF
--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -195,8 +195,7 @@ exports.importPaste = function(item,fallbackTitle,callback) {
 exports.itemHasValidDataType = function(item) {
 	for(var t=0; t<importDataTypes.length; t++) {
 		if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
-			if(item.type === importDataTypes[t].type)
-			{
+			if(item.type === importDataTypes[t].type) {
 				return true;
 			}
 		}

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -195,7 +195,10 @@ exports.importPaste = function(item,fallbackTitle,callback) {
 exports.itemHasValidDataType = function(item) {
 	for(var t=0; t<importDataTypes.length; t++) {
 		if(!$tw.browser.isIE || importDataTypes[t].IECompatible) {
-			return true;
+			if(item.type === importDataTypes[t].type)
+			{
+				return true;
+			}
 		}
 	}
 	return false;

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -271,6 +271,20 @@ DropZoneWidget.prototype.handlePasteEvent  = function(event) {
 					callback: readFileCallback,
 					deserializer: this.dropzoneDeserializer
 				});
+			} else if(item.kind === "string" && !["text/html", "text/plain", "Text"].includes(item.type) && $tw.utils.itemHasValidDataType(item)) {
+				// Try to import the various data types we understand
+				var fallbackTitle = self.wiki.generateNewTitle("Untitled");
+				//Use the deserializer specified if any
+				if(this.dropzoneDeserializer) {
+					item.getAsString(function(str){
+						var tiddlerFields = self.wiki.deserializeTiddlers(null,str,{title: fallbackTitle},{deserializer:self.dropzoneDeserializer});
+						if(tiddlerFields && tiddlerFields.length) {
+							readFileCallback(tiddlerFields);
+						}
+					});
+				} else {
+					$tw.utils.importPaste(item,fallbackTitle,readFileCallback);
+				}
 			} else if(item.kind === "string") {
 				// Create tiddlers from string items
 				var tiddlerFields;

--- a/editions/dev/tiddlers/new/dragndropinterop.html
+++ b/editions/dev/tiddlers/new/dragndropinterop.html
@@ -15,6 +15,10 @@
     <div id="draggable" draggable="true">
         Drag me to a TiddlyWiki window
     </div>
+    <button id="copy">
+        Click to copy two tiddlers to the clipboard
+    </button>
+
 </body>
 <script>
 
@@ -30,6 +34,18 @@
         event.stopPropagation();
         return false;
     });
-    
+
+    document.getElementById("copy").addEventListener("click",function(event) {
+
+    function listener(event) {
+        event.clipboardData.setData("URL","data:text/vnd.tiddler," + encodeURIComponent(JSON.stringify(tiddlerData)));
+        event.preventDefault();
+    }
+
+    document.addEventListener("copy",listener);
+    document.execCommand("copy");
+    document.removeEventListener("copy",listener);
+
+    });
 </script>
 </html>


### PR DESCRIPTION
Currently, if you paste-import a tiddler it assumes you are pasting in text (or a file). The issue is, this isn't always true. You could be pasting in, for example, a URI.

This PR fixes that by checking the content type and handling that data accordingly.

For testing reasons, [here is a code pen](https://codepen.io/gamedungeon/pen/ZEjXrwd) that will put a tiddler onto your clipboard.

I tested it in Chrome, Edge, and Firefox.