### PR TITLE
small gap fix for the updated toc macro (alternative to tc-tiny-gap-left)

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -7,7 +7,7 @@ tags: $:/tags/Macro
 
 \define toc-caption()
 \whitespace trim
-<span class="tc-toc-caption tc-tiny-gap-left">
+<span class="tc-toc-caption">
 <$set name="tv-wikilinks" value="no">
   <$transclude field="caption">
     <$view field="title"/>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2774,6 +2774,11 @@ input.tc-palette-manager-colour-input {
 	color: <<colour sidebar-foreground>>;
 }
 
+button + .tc-toc-caption,
+button > .tc-toc-caption{
+	margin-left: .25em;
+}
+
 .tc-table-of-contents svg {
 	width: 0.7em;
 	height: 0.7em;


### PR DESCRIPTION
As discussed here : https://github.com/Jermolene/TiddlyWiki5/pull/7121


This PR fix the css for the TOC macro