### PR TITLE
fix 7220 whitespace issue with editor save button

### DIFF
--- a/core/ui/EditToolbar/save.tid
+++ b/core/ui/EditToolbar/save.tid
@@ -3,6 +3,7 @@ tags: $:/tags/EditToolbar
 caption: {{$:/core/images/done-button}} {{$:/language/Buttons/Save/Caption}}
 description: {{$:/language/Buttons/Save/Hint}}
 
+\whitespace trim
 \define save-tiddler-button()
 \whitespace trim
 <$fieldmangler><$button tooltip={{$:/language/Buttons/Save/Hint}} aria-label={{$:/language/Buttons/Save/Caption}} class=<<tv-config-toolbar-class>>>


### PR DESCRIPTION
This PR fixes issue **#7220 whitespace issue with editor save button** by adding the `\whitespace trim` at the beginning of the tiddler. 

So it does not matter anymore if there is an empty line at the end of the file