### PR TITLE
fix 7227 parser mode checkbox text spacing

### DIFF
--- a/core/ui/ControlPanel/Parsing.tid
+++ b/core/ui/ControlPanel/Parsing.tid
@@ -12,7 +12,7 @@ field="text"
 checked="enable"
 unchecked="disable"
 default="enable">
-<<rule>>
+<span class="tc-small-gap-left"><<rule>></span>
 </$checkbox>
 \end
 


### PR DESCRIPTION
This PR fixex #7227 parser mode checkbox text spacing

![image](https://user-images.githubusercontent.com/374655/214132873-71a2b756-5358-492a-91c0-9733a451ed90.png)