### PR TITLE
Fixed issue where $genesis didn't pass isBlock

### DIFF
--- a/core/modules/widgets/genesis.js
+++ b/core/modules/widgets/genesis.js
@@ -46,6 +46,7 @@ GenesisWidget.prototype.execute = function() {
 	this.genesisRemappable = this.getAttribute("$remappable","yes") === "yes";
 	this.genesisNames = this.getAttribute("$names","");
 	this.genesisValues = this.getAttribute("$values","");
+	this.genesisIsBlock = this.getAttribute("$mode",this.parseTreeNode.isBlock && "block") === "block";
 	// Do not create a child widget if the $type attribute is missing or blank
 	if(!this.genesisType) {
 		this.makeChildWidgets(this.parseTreeNode.children);
@@ -60,7 +61,7 @@ GenesisWidget.prototype.execute = function() {
 		tag: nodeTag,
 		attributes: {},
 		orderedAttributes: [],
-		isBlock: this.parseTreeNode.isBlock,
+		isBlock: this.genesisIsBlock,
 		children: this.parseTreeNode.children || [],
 		isNotRemappable: !this.genesisRemappable
 	}];

--- a/core/modules/widgets/genesis.js
+++ b/core/modules/widgets/genesis.js
@@ -60,6 +60,7 @@ GenesisWidget.prototype.execute = function() {
 		tag: nodeTag,
 		attributes: {},
 		orderedAttributes: [],
+		isBlock: this.parseTreeNode.isBlock,
 		children: this.parseTreeNode.children || [],
 		isNotRemappable: !this.genesisRemappable
 	}];

--- a/editions/test/tiddlers/tests/data/genesis-widget/Block.tid
+++ b/editions/test/tiddlers/tests/data/genesis-widget/Block.tid
@@ -1,0 +1,18 @@
+title: Genesis/Block
+description: genesis widget distinguishes between block and inline
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$genesis $type="$reveal" type=nomatch>
+
+Block
+</$genesis>
+
+<$genesis $type=$reveal type=nomatch>Inline</$genesis>
++
+title: ExpectedResult
+
+<div class=" tc-reveal"><p>Block</p></div><p><span class=" tc-reveal">Inline</span></p>

--- a/editions/test/tiddlers/tests/data/genesis-widget/Block.tid
+++ b/editions/test/tiddlers/tests/data/genesis-widget/Block.tid
@@ -11,8 +11,20 @@ title: Output
 Block
 </$genesis>
 
+<$genesis $type="$reveal" type=nomatch $mode=block>
+
+Block forced block
+</$genesis>
+
+<$genesis $type="$reveal" type=nomatch $mode=inline>
+
+Block forced inline
+</$genesis>
+
 <$genesis $type=$reveal type=nomatch>Inline</$genesis>
+<$genesis $type=$reveal type=nomatch $mode=block>Inline forced block</$genesis>
+<$genesis $type=$reveal type=nomatch $mode=inline>Inline forced inline</$genesis>
 +
 title: ExpectedResult
 
-<div class=" tc-reveal"><p>Block</p></div><p><span class=" tc-reveal">Inline</span></p>
+<div class=" tc-reveal"><p>Block</p></div><div class=" tc-reveal"><p>Block forced block</p></div><span class=" tc-reveal"><p>Block forced inline</p></span><p><span class=" tc-reveal">Inline</span><div class=" tc-reveal">Inline forced block</div><span class=" tc-reveal">Inline forced inline</span></p>

--- a/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/GenesisWidget.tid
@@ -17,6 +17,7 @@ The content of the <<.wid genesis>> widget is used as the content of the dynamic
 |$type |The type of widget or element to create (an initial `$` indicates a widget, otherwise an HTML element will be created) |
 |$names |An optional filter evaluating to the names of a list of attributes to be applied to the widget |
 |$values |An optional filter evaluating to the values corresponding to the list of names specified in <<.attr $names>> |
+|$mode |An optional override of the parsing mode. May be "inline" or "block" |
 |//{other attributes starting with $}// |Other attributes starting with a single dollar sign are reserved for future use |
 |//{attributes starting with $$}// |Attributes starting with two dollar signs are applied as attributes to the output widget, but with the attribute name changed to use a single dollar sign |
 |//{attributes not starting with $}// |Any other attributes that do not start with a dollar are applied as attributes to the output widget |


### PR DESCRIPTION
The $genesis widget wasn't passing the parseTreeNode.isBlock attribute along to the generated widget. Not all widgets make use of it, but some do. I think $transclude is one of them.

I used $reveal to do the test because it's one of the only widgets that makes a visible difference whether it's block or inline without needing extra sorcery. Hope that's all right. (I used it a bunch in tests for TW-Uglify.)