### PR TITLE
add depth first destroy method 

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -617,7 +617,7 @@ Widget.prototype.waitDestroy = false;
 /*
 Remove any DOM nodes created by this widget or its children
 */
-Widget.prototype.removeChildDomNodes = function() {
+Widget.prototype.removeChildDomNodes = function(noDestroy) {
 	// If this widget has directly created DOM nodes, delete them and exit. This assumes that any child widgets are contained within the created DOM nodes, which would normally be the case
 	if(this.domNodes.length > 0) {
 		$tw.utils.each(this.domNodes,function(domNode) {
@@ -627,10 +627,10 @@ Widget.prototype.removeChildDomNodes = function() {
 	} else {
 		// Otherwise, ask the child widgets to delete their DOM nodes
 		$tw.utils.each(this.children,function(childWidget) {
-			childWidget.removeChildDomNodes();
+			childWidget.removeChildDomNodes(true); 
 		});
 	}
-	if (!this.waitDestroy) this.desendDestroy();
+	if (!noDestroy && !this.waitDestroy) this.desendDestroy();
 };
 
 /*

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -596,6 +596,24 @@ Widget.prototype.findFirstDomNode = function() {
 	return null;
 };
 
+
+
+/*
+Depth first destroy
+*/
+Widget.prototype.desendDestroy = function() {
+	this.waitDestroy = true; //for blocking repeat calls to this method from removeChildDomNodes
+	$tw.utils.each(this.children,function(childWidget) {
+		childWidget.desendDestroy();
+	});
+	
+	if (this.destroy) {
+		this.destroy();
+	}
+	this.waitDestroy = false;
+};
+
+Widget.prototype.waitDestroy = false;
 /*
 Remove any DOM nodes created by this widget or its children
 */
@@ -612,6 +630,7 @@ Widget.prototype.removeChildDomNodes = function() {
 			childWidget.removeChildDomNodes();
 		});
 	}
+	if (!this.waitDestroy) this.desendDestroy();
 };
 
 /*


### PR DESCRIPTION
This is another take on #6699.

A widget would add a method like this:

```
TextNodeWidget.prototype.destroy = function() {
	var text = this.getAttribute("text",this.parseTreeNode.text || "");
	text = text.replace(/\r/mg,"");
	console.log("destroy " + text );
};
```