### PR TITLE
Update readme tiddlers for TiddlyWebAdaptor and BrowserStorage plugins

### DIFF
--- a/plugins/tiddlywiki/browser-storage/readme.tid
+++ b/plugins/tiddlywiki/browser-storage/readme.tid
@@ -1,10 +1,24 @@
 title: $:/plugins/tiddlywiki/browser-storage/readme
 
-This plugin enables TiddlyWiki to save tiddlers in [[browser local storage|https://en.wikipedia.org/wiki/Web_storage#localStorage]]. This means that changes are stored within the browser, and automatically re-applied any time the base wiki is reloaded.
+This plugin enables ~TiddlyWiki to save tiddlers in [[browser local storage|https://en.wikipedia.org/wiki/Web_storage#localStorage]]. This means that changes are stored within the browser, and automatically re-applied any time the base wiki is reloaded.
 
 At startup, the plugin reads tiddlers from local storage. Any tiddlers that are identical to those built into the file are deleted from local storage. Once the wiki is up and running, any tiddler changes are written straight to local storage.
 
-Browser local storage is not a panacea for TiddlyWiki:
+!!Optional use with ~TiddlyWeb plugin
+
+For wikis served from a ~TiddlyWeb compatible server, including the ~TiddlyWiki Node JS server, this plugin may be added to provide temporary local storage of tiddler changes when the [[tiddlyweb sync adapter|https://github.com/Jermolene/TiddlyWiki5/tree/master/plugins/tiddlywiki/tiddlyweb]] is unable to successfully synchronize with the server, and to automatically synchronize tiddlers saved offline in browser storage once connection is re-established. The use of browser storage allows for tiddlers saved offline to be synced with the server even in the case where the browser is closed or the user (purposely, accidentally, or automatically in the case of a mobile browser periodically refreshing) navigates away from the wiki.
+
+Changes will be synchronized with the server the next time the wiki is loaded in the browser. Tiddlers are removed from browser-storage once synchronized to the server.
+
+By default only state tiddlers are saved by this plugin. On the settings tab, you can update the Save Filter to save all content and system tiddlers. The third example provided is a good choice. 
+
+!!!Limitations:
+
+* ''Deleted tiddlers:'' Tiddler deletions while offline are not synchronized with the server due to technical limitations. The intent of using this plugin with a ~TiddlyWeb server is to prevent the loss new or modified content while temporarily offline. 
+* ''Title changes:'' Tiddlers are saved by title, so a change to a tiddler title will be saved and synchronized to the server, but it will not overwrite the tiddler with the original title. 
+* ''Browser storage:'' While useful as a safety measure for //temporary// offline usage, as noted below, browser storage itself has limitations that could still result in losing data in some cases.   
+
+!!Browser local storage is not a panacea for TiddlyWiki:
 
 * Browsers limit the amount of local storage available to a page, typically to 5 or 10MB
 * Keeping personal data in browser local storage can lead to unexpected privacy violations

--- a/plugins/tiddlywiki/browser-storage/readme.tid
+++ b/plugins/tiddlywiki/browser-storage/readme.tid
@@ -6,7 +6,7 @@ At startup, the plugin reads tiddlers from local storage. Any tiddlers that are 
 
 !!Optional use with ~TiddlyWeb plugin
 
-For wikis served from a ~TiddlyWeb compatible server, including the ~TiddlyWiki Node JS server, this plugin may be added to provide temporary local storage of tiddler changes when the [[tiddlyweb sync adapter|https://github.com/Jermolene/TiddlyWiki5/tree/master/plugins/tiddlywiki/tiddlyweb]] is unable to successfully synchronize with the server, and to automatically synchronize tiddlers saved offline in browser storage once connection is re-established. The use of browser storage allows for tiddlers saved offline to be synced with the server even in the case where the browser is closed or the user (purposely, accidentally, or automatically in the case of a mobile browser periodically refreshing) navigates away from the wiki.
+For wikis served from a ~TiddlyWeb compatible server, including the ~TiddlyWiki Node JS server, this plugin may be added to provide temporary local storage of tiddler changes when the [[tiddlyweb sync adapter|https://github.com/Jermolene/TiddlyWiki5/tree/master/plugins/tiddlywiki/tiddlyweb]] is unable to successfully synchronize with the server, and to automatically synchronize tiddlers saved offline in browser storage once connection is re-established. The use of browser storage allows for tiddlers saved offline to be synchronized with the server even in the case where the browser is closed or the user (purposely, accidentally, or automatically in the case of a mobile browser periodically refreshing) navigates away from the wiki.
 
 Changes will be synchronized with the server the next time the wiki is loaded in the browser. Tiddlers are removed from browser-storage once synchronized to the server.
 
@@ -14,7 +14,7 @@ By default only state tiddlers are saved by this plugin. On the settings tab, yo
 
 !!!Limitations:
 
-* ''Deleted tiddlers:'' Tiddler deletions while offline are not synchronized with the server due to technical limitations. The intent of using this plugin with a ~TiddlyWeb server is to prevent the loss new or modified content while temporarily offline. 
+* ''Deleted tiddlers:'' Tiddler deletions while offline are not synchronized with the server due to technical limitations. The intent of using this plugin with a ~TiddlyWeb server is to prevent the loss of new or modified content while temporarily offline. 
 * ''Title changes:'' Tiddlers are saved by title, so a change to a tiddler title will be saved and synchronized to the server, but it will not overwrite the tiddler with the original title. 
 * ''Browser storage:'' While useful as a safety measure for //temporary// offline usage, as noted below, browser storage itself has limitations that could still result in losing data in some cases.   
 

--- a/plugins/tiddlywiki/tiddlyweb/readme.tid
+++ b/plugins/tiddlywiki/tiddlyweb/readme.tid
@@ -2,4 +2,6 @@ title: $:/plugins/tiddlywiki/tiddlyweb/readme
 
 This plugin runs in the browser to synchronise tiddler changes to and from a TiddlyWeb-compatible server (including TiddlyWiki 5 itself, running on Node.js). It is inert when run under Node.js. Disabling this plugin via the browser can not be undone via the browser since this plugin provides the mechanism to synchronize settings with the server.
 
+Changes made while offline are saved in memory and automatically synchonized with the server when the connection is re-established. However, if the browser tab is closed or another URL is loaded, the in-memory changes will be lost. The [[browser-storage plugin|https://github.com/Jermolene/TiddlyWiki5/tree/master/plugins/tiddlywiki/browser-storage]] may be added to provide temporary filesystem storage of tiddler changes made while offline and enable them to be synchronized with the server the next time the wiki is loaded in the browser.  
+
 [[Source code|https://github.com/Jermolene/TiddlyWiki5/blob/master/plugins/tiddlywiki/tiddlyweb]]


### PR DESCRIPTION
This pull request includes updates to the readme tiddlers for TiddlyWebAdaptor and BrowserStorage plugins related to earlier PR #7169 (Automatic sync of tiddler changes in browser storage when sync connection is re-established). 