### PR TITLE
Add a th-modal-refreshed hook

### DIFF
--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -180,6 +180,7 @@ Modal.prototype.display = function(title,options) {
 		headerWidgetNode.refresh(changes,modalHeader,null);
 		bodyWidgetNode.refresh(changes,modalBody,null);
 		footerWidgetNode.refresh(changes,modalFooterButtons,null);
+		$tw.hooks.invokeHook("th-modal-refreshed");
 	};
 	this.wiki.addEventListener("change",refreshHandler);
 	// Add the close event handler

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -177,6 +177,7 @@ Modal.prototype.display = function(title,options) {
 	footerWidgetNode.render(modalFooterButtons,null);
 	// Set up the refresh handler
 	refreshHandler = function(changes) {
+		$tw.hooks.invokeHook("th-modal-refreshing");
 		headerWidgetNode.refresh(changes,modalHeader,null);
 		bodyWidgetNode.refresh(changes,modalBody,null);
 		footerWidgetNode.refresh(changes,modalFooterButtons,null);


### PR DESCRIPTION
Since the th-page-refreshed hook fires before modals are updated, it is not possible to react directly to changes in the modals' content.
This PR adds a th-modal-refreshed hook that triggers when modals are refreshed (but not when they're initially created).

Relates to [https://talk.tiddlywiki.org/t/does-th-page-refreshed-fire-before-modals-are-updated/6026](https://talk.tiddlywiki.org/t/does-th-page-refreshed-fire-before-modals-are-updated/6026)