### PR TITLE
Fix importTitle and autoOpenOnImport in the tm-import-tiddler message

### DIFF
--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -540,7 +540,7 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	// Save the $:/Import tiddler
 	newFields.text = JSON.stringify(importData,null,$tw.config.preferences.jsonSpaces);
 	this.wiki.addTiddler(new $tw.Tiddler(importTiddler,newFields));
-	// Update the story and history details.
+	// Update the story and history details
 	var autoOpenOnImport = event.autoOpenOnImport || paramObject.autoOpenOnImport || this.getVariable("tv-auto-open-on-import");
 	if(autoOpenOnImport !== "no") {
 		var storyList = this.getStoryList(),

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -499,7 +499,8 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	// Get the tiddlers
 	var tiddlers = $tw.utils.parseJSONSafe(event.param,[]);
 	// Get the current $:/Import tiddler
-	var importTitle = event.importTitle ? event.importTitle : IMPORT_TITLE,
+	var paramObject = event.paramObject || event,
+		importTitle = paramObject.importTitle ? paramObject.importTitle : IMPORT_TITLE,
 		importTiddler = this.wiki.getTiddler(importTitle),
 		importData = this.wiki.getTiddlerData(importTitle,{}),
 		newFields = new Object({
@@ -540,7 +541,7 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	newFields.text = JSON.stringify(importData,null,$tw.config.preferences.jsonSpaces);
 	this.wiki.addTiddler(new $tw.Tiddler(importTiddler,newFields));
 	// Update the story and history details
-	var autoOpenOnImport = event.autoOpenOnImport ? event.autoOpenOnImport : this.getVariable("tv-auto-open-on-import");  
+	var autoOpenOnImport = paramObject.autoOpenOnImport ? paramObject.autoOpenOnImport : this.getVariable("tv-auto-open-on-import");  
 	if(autoOpenOnImport !== "no") {
 		var storyList = this.getStoryList(),
 			history = [];

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -540,7 +540,7 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	// Save the $:/Import tiddler
 	newFields.text = JSON.stringify(importData,null,$tw.config.preferences.jsonSpaces);
 	this.wiki.addTiddler(new $tw.Tiddler(importTiddler,newFields));
-	// Update the story and history details
+	// Update the story and history details. Note: paramObject is either event or event.paramObject
 	var autoOpenOnImport = paramObject.autoOpenOnImport ? paramObject.autoOpenOnImport : this.getVariable("tv-auto-open-on-import");  
 	if(autoOpenOnImport !== "no") {
 		var storyList = this.getStoryList(),

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -499,8 +499,8 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	// Get the tiddlers
 	var tiddlers = $tw.utils.parseJSONSafe(event.param,[]);
 	// Get the current $:/Import tiddler
-	var paramObject = event.paramObject || event,
-		importTitle = paramObject.importTitle ? paramObject.importTitle : IMPORT_TITLE,
+	var paramObject = event.paramObject || {},
+		importTitle = event.importTitle || paramObject.importTitle || IMPORT_TITLE,
 		importTiddler = this.wiki.getTiddler(importTitle),
 		importData = this.wiki.getTiddlerData(importTitle,{}),
 		newFields = new Object({
@@ -540,8 +540,8 @@ NavigatorWidget.prototype.handleImportTiddlersEvent = function(event) {
 	// Save the $:/Import tiddler
 	newFields.text = JSON.stringify(importData,null,$tw.config.preferences.jsonSpaces);
 	this.wiki.addTiddler(new $tw.Tiddler(importTiddler,newFields));
-	// Update the story and history details. Note: paramObject is either event or event.paramObject
-	var autoOpenOnImport = paramObject.autoOpenOnImport ? paramObject.autoOpenOnImport : this.getVariable("tv-auto-open-on-import");  
+	// Update the story and history details.
+	var autoOpenOnImport = event.autoOpenOnImport || paramObject.autoOpenOnImport || this.getVariable("tv-auto-open-on-import");
 	if(autoOpenOnImport !== "no") {
 		var storyList = this.getStoryList(),
 			history = [];

--- a/editions/test/tiddlers/tests/data/messages/tm-import-tiddler/CustomTitle.tid
+++ b/editions/test/tiddlers/tests/data/messages/tm-import-tiddler/CustomTitle.tid
@@ -1,0 +1,35 @@
+title: Message/tm-import-tiddlers/CustomTitle
+description: tm-import-tiddlers message can import to a tiddler with a custom title 
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+text: <$text text={{MyCustomTitle}}/>
+plugin-type: <$text text={{MyCustomTitle!!plugin-type}}/>
+~$:/StoryList: <$text text={{$:/StoryList!!list}}/>
++
+title: Actions
+
+<$navigator story="$:/StoryList">
+<$action-sendmessage
+  $message="tm-import-tiddlers"
+  $param='[{"title": "Elephants"}, {"title": "Eagles"}]'
+  importTitle=MyCustomTitle/>
+</$navigator>
+
++
+title: ExpectedResult
+
+<p>text: {
+    "tiddlers": {
+        "Elephants": {
+            "title": "Elephants"
+        },
+        "Eagles": {
+            "title": "Eagles"
+        }
+    }
+}
+plugin-type: import
+$:/StoryList: MyCustomTitle</p>

--- a/editions/test/tiddlers/tests/data/messages/tm-import-tiddler/NoAutoOpen.tid
+++ b/editions/test/tiddlers/tests/data/messages/tm-import-tiddler/NoAutoOpen.tid
@@ -1,0 +1,35 @@
+title: Message/tm-import-tiddlers/NoAutoOpen
+description: tm-import-tiddlers can import without automatically opening the import tiddler
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+text: <$text text={{$:/Import}}/>
+plugin-type: <$text text={{$:/Import!!plugin-type}}/>
+~$:/StoryList: <$text text={{$:/StoryList!!list}}/>
++
+title: Actions
+
+<$navigator story="$:/StoryList">
+<$action-sendmessage
+  $message="tm-import-tiddlers"
+  $param='[{"title": "Elephants"}, {"title": "Eagles"}]'
+  autoOpenOnImport=no/>
+</$navigator>
+
++
+title: ExpectedResult
+
+<p>text: {
+    "tiddlers": {
+        "Elephants": {
+            "title": "Elephants"
+        },
+        "Eagles": {
+            "title": "Eagles"
+        }
+    }
+}
+plugin-type: import
+$:/StoryList: </p>

--- a/editions/test/tiddlers/tests/data/messages/tm-import-tiddler/NoAutoOpenViaVar.tid
+++ b/editions/test/tiddlers/tests/data/messages/tm-import-tiddler/NoAutoOpenViaVar.tid
@@ -1,0 +1,36 @@
+title: Message/tm-import-tiddlers/NoAutoOpenViaVar
+description: tm-import-tiddlers can import and open based on tv-auto-open-on-import
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+text: <$text text={{$:/Import}}/>
+plugin-type: <$text text={{$:/Import!!plugin-type}}/>
+~$:/StoryList: <$text text={{$:/StoryList!!list}}/>
++
+title: Actions
+
+<$let tv-auto-open-on-import="no">
+<$navigator story="$:/StoryList">
+<$action-sendmessage
+  $message="tm-import-tiddlers"
+  $param='[{"title": "Elephants"}, {"title": "Eagles"}]'/>
+</$navigator>
+</$let>
+
++
+title: ExpectedResult
+
+<p>text: {
+    "tiddlers": {
+        "Elephants": {
+            "title": "Elephants"
+        },
+        "Eagles": {
+            "title": "Eagles"
+        }
+    }
+}
+plugin-type: import
+$:/StoryList: </p>

--- a/editions/test/tiddlers/tests/data/messages/tm-import-tiddler/default.tid
+++ b/editions/test/tiddlers/tests/data/messages/tm-import-tiddler/default.tid
@@ -1,0 +1,34 @@
+title: Message/tm-import-tiddlers/default
+description: tm-import-tiddlers message by default should import to $:/Import and open the tiddler
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+text: <$text text={{$:/Import}}/>
+plugin-type: <$text text={{$:/Import!!plugin-type}}/>
+~$:/StoryList: <$text text={{$:/StoryList!!list}}/>
++
+title: Actions
+
+<$navigator story="$:/StoryList">
+<$action-sendmessage
+  $message="tm-import-tiddlers"
+  $param='[{"title": "Elephants"}, {"title": "Eagles"}]'/>
+</$navigator>
+
++
+title: ExpectedResult
+
+<p>text: {
+    "tiddlers": {
+        "Elephants": {
+            "title": "Elephants"
+        },
+        "Eagles": {
+            "title": "Eagles"
+        }
+    }
+}
+plugin-type: import
+$:/StoryList: $:/Import</p>


### PR DESCRIPTION
Since the action-sendmessage widget can only pass parameters using `event.paramObject`, change the tm-import-tiddlers message handler to look in both `event.paramObject` and `event` for the options. Fixes #7234.

Added tests which fail before the fix and pass after the fix. Also added a test which passes both before and after the fix.