### PR TITLE
Zoomin: Avoid using broken tc-storyview-zoomin-tiddler class

### DIFF
--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -35,7 +35,6 @@ var ZoominListView = function(listWidget) {
 		} else {
 			self.currentTiddlerDomNode = domNode;
 		}
-		$tw.utils.addClass(domNode,"tc-storyview-zoomin-tiddler");
 	});
 };
 
@@ -52,7 +51,6 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 		return;
 	}
 	// Make the new tiddler be position absolute and visible so that we can measure it
-	$tw.utils.addClass(targetElement,"tc-storyview-zoomin-tiddler");
 	$tw.utils.setStyle(targetElement,[
 		{display: "block"},
 		{transformOrigin: "0 0"},
@@ -134,7 +132,6 @@ ZoominListView.prototype.insert = function(widget) {
 		return;
 	}
 	// Make the newly inserted node position absolute and hidden
-	$tw.utils.addClass(targetElement,"tc-storyview-zoomin-tiddler");
 	$tw.utils.setStyle(targetElement,[
 		{display: "none"}
 	]);
@@ -157,7 +154,6 @@ ZoominListView.prototype.remove = function(widget) {
 		return;
 	}
 	// Set up the tiddler that is being closed
-	$tw.utils.addClass(targetElement,"tc-storyview-zoomin-tiddler");
 	$tw.utils.setStyle(targetElement,[
 		{display: "block"},
 		{transformOrigin: "50% 50%"},
@@ -173,7 +169,6 @@ ZoominListView.prototype.remove = function(widget) {
 	var toWidgetDomNode = toWidget && toWidget.findFirstDomNode();
 	// Set up the tiddler we're moving back in
 	if(toWidgetDomNode) {
-		$tw.utils.addClass(toWidgetDomNode,"tc-storyview-zoomin-tiddler");
 		$tw.utils.setStyle(toWidgetDomNode,[
 			{display: "block"},
 			{transformOrigin: "50% 50%"},

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -35,6 +35,7 @@ var ZoominListView = function(listWidget) {
 		} else {
 			self.currentTiddlerDomNode = domNode;
 		}
+		$tw.utils.addClass(domNode,"tc-storyview-zoomin-tiddler");
 	});
 };
 
@@ -51,6 +52,7 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 		return;
 	}
 	// Make the new tiddler be position absolute and visible so that we can measure it
+	$tw.utils.addClass(targetElement,"tc-storyview-zoomin-tiddler");
 	$tw.utils.setStyle(targetElement,[
 		{display: "block"},
 		{transformOrigin: "0 0"},
@@ -132,6 +134,7 @@ ZoominListView.prototype.insert = function(widget) {
 		return;
 	}
 	// Make the newly inserted node position absolute and hidden
+	$tw.utils.addClass(targetElement,"tc-storyview-zoomin-tiddler");
 	$tw.utils.setStyle(targetElement,[
 		{display: "none"}
 	]);
@@ -154,6 +157,7 @@ ZoominListView.prototype.remove = function(widget) {
 		return;
 	}
 	// Set up the tiddler that is being closed
+	$tw.utils.addClass(targetElement,"tc-storyview-zoomin-tiddler");
 	$tw.utils.setStyle(targetElement,[
 		{display: "block"},
 		{transformOrigin: "50% 50%"},
@@ -169,6 +173,7 @@ ZoominListView.prototype.remove = function(widget) {
 	var toWidgetDomNode = toWidget && toWidget.findFirstDomNode();
 	// Set up the tiddler we're moving back in
 	if(toWidgetDomNode) {
+		$tw.utils.addClass(toWidgetDomNode,"tc-storyview-zoomin-tiddler");
 		$tw.utils.setStyle(toWidgetDomNode,[
 			{display: "block"},
 			{transformOrigin: "50% 50%"},

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1445,7 +1445,7 @@ html body.tc-body.tc-single-tiddler-window {
 		width: {{$:/themes/tiddlywiki/vanilla/metrics/sidebarwidth}};
 	}
 
-	body.tc-body .tc-storyview-zoomin-tiddler {
+	body.tc-body .tc-page-container.tc-page-view-zoomin .tc-tiddler-frame {
 		width: 100%;
 		width: calc(100% - 42px);
 	}
@@ -1457,7 +1457,7 @@ html body.tc-body.tc-single-tiddler-window {
 		margin-right: 0;
 	}
 
-	body.tc-body .tc-storyview-zoomin-tiddler {
+	body.tc-body .tc-page-container.tc-page-view-zoomin .tc-tiddler-frame {
 		width: 100%;
 		width: calc(100% - 84px);
 	}
@@ -1716,7 +1716,7 @@ html body.tc-body.tc-single-tiddler-window {
 	margin-right: .3em;
 }
 
-.tc-storyview-zoomin-tiddler {
+.tc-page-container.tc-page-view-zoomin .tc-tiddler-frame {
 	position: absolute;
 	display: block;
 	width: 100%;
@@ -1724,7 +1724,7 @@ html body.tc-body.tc-single-tiddler-window {
 
 @media (min-width: <<sidebarbreakpoint>>) {
 
-	.tc-storyview-zoomin-tiddler {
+	.tc-page-container.tc-page-view-zoomin .tc-tiddler-frame {
 		width: calc(100% - 84px);
 	}
 


### PR DESCRIPTION
The Zoomin storyview uses a brittle technique for setting the tc-storyview-zoomin-tiddler class on the tiddler frames in the story view. This is required for the tiddler widths to be set correctly. This PR uses the newer storyview classes on the page container instead.

Fixes #7247