### PR TITLE
fix: correctly identify paste events to be handled by editor widgets

### DIFF
--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -259,7 +259,7 @@ DropZoneWidget.prototype.handlePasteEvent  = function(event) {
 			}
 		};
 	// Let the browser handle it if we're in a textarea or input box
-	if(["TEXTAREA","INPUT"].indexOf(event.target.tagName) == -1 && !event.target.isContentEditable) {
+	if(["TEXTAREA","INPUT"].indexOf(event.target.tagName) == -1 && !event.target.isContentEditable && !event.twEditor) {
 		var self = this,
 			items = event.clipboardData.items;
 		// Enumerate the clipboard items

--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -220,9 +220,15 @@ function CodeMirrorEngine(options) {
 			}
 		});
 		this.cm.on("paste",function(cm,event) {
+			event["twEditor"] = true;
 			self.widget.handlePasteEvent.call(self.widget,event);
 		});
+	} else {
+		this.cm.on("paste",function(cm,event){
+			event["twEditor"] = true;
+		});
 	}
+;
 }
 
 /*


### PR DESCRIPTION
This PR allows paste events that should be handled by an editor widget to be correctly identified by the dropzone widget and fixes #7244 

The attribute `twEditor` is added to the paste event by the codemirror plugin, which is used as part of the check in $dropzone to determine whether the event originated from an editor. Other editor widgets would be able to use the same attribute if/when necessary and this is more robust than checking for a specific event target or DOM structure.

@pmario @ittayd can you please check at https://tiddlywiki5-8gsvrvjx2-jermolene.vercel.app/ if this resolves the problem for you and report back as to your browser and OS? I have tested on the latest Chrome on Windows and Ubuntu. In particular this needs testing on Firefox.