### PR TITLE
wip parseutils add callback, html.js avoid extensive backtracking

### DIFF
--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -86,13 +86,15 @@ exports.parseTokenString = function(source,pos,token) {
 /*
 Look for a token matching a regex. Returns null if not found, otherwise returns {type: "regexp", match:, start:, end:,}
 */
-exports.parseTokenRegExp = function(source,pos,reToken) {
+exports.parseTokenRegExp = function(source,pos,reToken,options) {
+	options = options || {};
 	var node = {
 		type: "regexp",
 		start: pos
 	};
 	reToken.lastIndex = pos;
 	node.match = reToken.exec(source);
+	(options.cb) ? options.cb(node) : null;
 	if(node.match && node.match.index === pos) {
 		node.end = pos + node.match[0].length;
 		return node;

--- a/core/modules/parsers/wikiparser/rules/html.js
+++ b/core/modules/parsers/wikiparser/rules/html.js
@@ -46,7 +46,7 @@ exports.parse = function() {
 	// Retrieve the most recent match so that recursive calls don't overwrite it
 	var self = this;
 	var options = {};
-	var hasLineBreak;
+	var hasLineBreak=false;
 	var tag = this.nextTag;
 	this.nextTag = null;
 	// Advance the parser position to past the tag


### PR DESCRIPTION
## Test - Work in progress

@linonetwo ... Can you test this branch with your wiki mentioned at: https://github.com/Jermolene/TiddlyWiki5/issues/7277
And send me chrome profile. I want to see the differences

This PR tries to improve html and widget parsing for big blocks of html-like wikitext, **which has no line-breaks**

The TW "isBlock" detection uses this regexp `([^\S\n\r]*\r?\n(?:[^\S\n\r]*\r?\n|$))` which can need a lot of time if there are no linebreaks till the end of the tiddler. So the regexp "fails late". 

The example in the screenshot shows an UL block with 3 LI blocks. Where the detection finds the `\n\n` after 64 regexp iterations. Every iteration (for 1 char in the test text) needs 4 steps. ... The regexp is OK it can not be improved. 

![image](https://user-images.githubusercontent.com/374655/221398404-365d7cd8-afb8-473d-840e-f698f3cba5a3.png)

- This regexp is evaluated for every TW block-detection. see [wikiparser/rules/html.js](https://github.com/Jermolene/TiddlyWiki5/blob/2271f6885af8b6301696d3aa33f82472f691ba72/core/modules/parsers/wikiparser/rules/html.js#L51)
- It finds the end of the UL block and throws away this info
- It searches again for the first LI and throws away this info
- 2nd LI and throws away this info
- 3rd LI and throws away this info

So it needs 1 UL iteration to find the `\n\n` and there are 3 LI iterations, where we know the end of the block already, but we throw this info away. ... 

The new code returns the info from the utility function `$tw.utils.parseTokenRegExp(this.parser.source,this.parser.pos,/([^\S\n\r]*\r?\n(?:[^\S\n\r]*\r?\n|$))/g)` into the calling function **with a callback(),** so the result can be reused. ... 

For long HTML blocks with no linebreaks this optimisation can save a lot of time. In the testcase from issue **[IDEA] Delay the backlink indexer #7277** it's a 30% improvement at TW startup-time. ... 

**OLD performance profile** can be inspected with Chrome or Edge

[tw-loading-profiling.json.zip](https://github.com/Jermolene/TiddlyWiki5/files/10833239/tw-loading-profiling.json.zip)

![image](https://user-images.githubusercontent.com/374655/221398945-b089dbba-1826-47e8-ac2a-0dc4fc7d91c0.png)


**NEW performance profile** can be inspected with Chrome or Edge

[wiki-backlink-withmodification.json.zip](https://github.com/Jermolene/TiddlyWiki5/files/10833238/wiki-backlink-withmodification.json.zip)

![image](https://user-images.githubusercontent.com/374655/221399079-16a59b8c-99e1-44ce-a4c7-1277ba797f3e.png)
