### PR TITLE
Update ActionListopsWidget documentation including notes on de-duplication

### DIFF
--- a/editions/tw5.com/tiddlers/learning/Introduction to Lists.tid
+++ b/editions/tw5.com/tiddlers/learning/Introduction to Lists.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 
 Making lists of items plays a central role in working with TiddlyWiki. The following is a brief run-through of some of the more common techniques.
 
-~TiddlyWiki [[uses|The Extended Listops Filters]] lists [[internally|ListField]] for many purposes so the word can have several meanings. Here we are concerned with displaying sequences of items, but not necessarily presented as a conventional bullet list.
+~TiddlyWiki [[uses|Extended Listops Filters]] lists [[internally|ListField]] for many purposes so the word can have several meanings. Here we are concerned with displaying sequences of items, but not necessarily presented as a conventional bullet list.
 
 ! Manually Typed Lists
 

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.1.16.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.1.16.tid
@@ -112,7 +112,7 @@ Prompted by the [[General Data Protection Regulation (GDPR)|https://en.wikipedia
 * [[Fixed|https://github.com/Jermolene/TiddlyWiki5/pull/3093]] problem with crash when dragging over TiddlyWiki on some browsers
 * [[Fixed|https://github.com/Jermolene/TiddlyWiki5/pull/3079]] issue with new journal button
 * [[Fixed|https://github.com/Jermolene/TiddlyWiki5/pull/3164]] problem with ''filter'' and ''value'' attributes of SetWidget
-* [[Fixed|https://github.com/Jermolene/TiddlyWiki5/pull/3190]] problem with numeric operands in the [[The Extended Listops Filters]]
+* [[Fixed|https://github.com/Jermolene/TiddlyWiki5/pull/3190]] problem with numeric operands in the [[Extended Listops Filters]]
 * [[Fixed|https://github.com/Jermolene/TiddlyWiki5/commit/df1f7e9798b5f6c3d2c3fd82e438cbc9713ade04]] problem with "put" saver and 412 return codes
 * [[Fixed|https://github.com/Jermolene/TiddlyWiki5/pull/3048]] problem with variable references in field values in the edit template
 * [[Extended|https://github.com/Jermolene/TiddlyWiki5/pull/3219]] behaviour of list-after field so that the tiddler is placed at the end of the list if the list-after field is present but empty 

--- a/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
@@ -58,11 +58,11 @@ is mostly equivalent to using `$subfilter` along with "tags" for the value of `$
 
 !! Comparison to [[ActionSetFieldWidget]]
 
-In general, [[ActionSetFieldWidget]] is better for setting multiple fields at once and for replacing the value of a field, which can also be a list. The ActionListopsWidget is better for modifying a list field based on the existing list and for using a [[Filter Expression]] to derive the value of the field.
+In general, ActionSetFieldWidget is better for setting multiple fields at once and for replacing the value of a field, which can also be a list. The ActionListopsWidget is better for modifying a list field based on the existing list and for using a [[Filter Expression]] to derive the value of the field.
 
-The ActionSetFieldWidget sets the value of a field using `$field` and `$value` attribute pairs or attributes that do not start with a `$`. A single ActionSetFieldWidget can be used to set any number of fields of a single tiddler.
+The ~ActionSetFieldWidget sets the value of a field using `$field` and `$value` attribute pairs or attributes that do not start with a `$`. A single ~ActionSetFieldWidget can be used to set any number of fields of a single tiddler.
 
-The ActionListopsWidget replaces or modifies a single field's value using filter expressions.
+The ~ActionListopsWidget replaces or modifies a single field's value using filter expressions.
 
 The following widgets are functionally equivalent:
 

--- a/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
@@ -1,7 +1,7 @@
 caption: action-listops
 created: 20141025120850184
 list: efg hlm pqr
-modified: 20211115091121133
+modified: 20230227170803513
 myfield: 
 revision: 0
 tags: ActionWidgets Widgets
@@ -36,7 +36,7 @@ The ''action-listops'' widget is invisible. Any content within it is ignored.
 |$subfilter |An optional subfilter expression, which takes the list being manipulated as input, and saves the modified list back to the field/index being manipulated |
 |$tags |An optional subfilter expression, which takes the 'tags' field of the target tiddler as input, and saves the modified list of tags back to the 'tags' field |
 
-! $filter vs. $subfilter
+!! Using $filter or $subfilter
 
 Standalone use of the `$subfilter` attribute can be replaced by using a (more complicated) `$filter` attribute value.
 
@@ -54,7 +54,7 @@ The same can be achieved using the `$filter` attribute and prepending the [[Filt
 
 The short form is more convenient, but the long form is useful for live-debugging complicated `$subfilter` values using the filter tab of [[$:/AdvancedSearch]]. By using [[$:/AdvancedSearch]], the [[Filter Expression]] can be tested before using ''action-listops'' to modify actual tiddler fields. For this use case, the `all[current]` portion of the expression needs to be changed to select the proper test tiddler.
 
-! $tags vs. $field + $subfilter
+!! Using $tags or $subfilter
 
 [[Tagging]] is implemented using a tiddler's 'tags' field, so appending the tags "abc" and "123" using the `$tags` attribute like this:
 
@@ -68,9 +68,9 @@ is mostly equivalent to using `$subfilter` along with "tags" for the value of `$
 <$action-listops $field="tags" $subfilter="abc 123"/>
 ```
 
-! $action-listops widget vs. $action-setfield widget
+!! Comparison to [[ActionSetFieldWidget]]
 
-The ActionSetFieldWidget replaces a field's value using `$field`/`$value` attributes. A single ActionSetFieldWidget can be used to set any number of fields by using attributes not starting with $.
+The [[ActionSetFieldWidget]] replaces a field's value using `$field`/`$value` attributes. A single ActionSetFieldWidget can be used to set any number of fields by using attributes not starting with $.
 
 The ActionListopsWidget replaces or modifies a single field's value. The new value is generated using filters.
 
@@ -86,7 +86,7 @@ The following two examples are functionally equivalent:
 
 In general, ActionSetFieldWidget is better for setting multiple fields at once and for replacing a field's value. The ActionListopsWidget is better for modifying a field based on the field's existing value and for using a [[Filter Expression]] to derive the value.
 
-! Extended Filter Operators
+!! Extended Filter Operators
 
 A number of [[extended filter operators|The Extended Listops Filters]] are necessary for the manipulation of lists. These operators have been designed primarily for use in subfilter expressions whereby the modified current list is returned in place of the current list.
 
@@ -95,7 +95,7 @@ A number of [[extended filter operators|The Extended Listops Filters]] are neces
 <tr>
 <th align="left">Operator</th>
 <th align="left">Purpose</th>
-<th></th>
+<th>✓</th>
 </tr>
 <<.operator-rows "[tag[Filter Operators]tag[Listops Operators]tag[Order Operators]!tag[String Operators]!tag[Tag Operators]!tag[Special Operators]sort[]]">>
 </table>

--- a/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
@@ -8,18 +8,6 @@ tags: ActionWidgets Widgets
 title: ActionListopsWidget
 type: text/vnd.tiddlywiki
 
-\define .operator-rows(filter)
-<$list filter="$filter$"><tr>
-<td><$link>{{!!caption}}</$link></td>
-<td>{{!!op-purpose}} <$list filter="[all[current]tag[Common Operators]]">{{$:/core/images/done-button}}</$list></td>
-<td align="center"><$list filter="[all[current]tag[Negatable Operators]]">`!`</$list></td>
-</tr></$list>
-\end
-
-\define .group-heading(_)
-<tr class="doc-table-subheading"><th colspan="3" align="center">$_$</th></tr>
-\end
-
 ! Introduction
 
 The ''action-listops'' widget is an [[action widget|ActionWidgets]] that manipulates user lists in any field or data index. ActionWidgets are used within triggering widgets such as the ButtonWidget.
@@ -88,17 +76,7 @@ In general, ActionSetFieldWidget is better for setting multiple fields at once a
 
 !! Extended Filter Operators
 
-A number of [[extended filter operators|The Extended Listops Filters]] are necessary for the manipulation of lists. These operators have been designed primarily for use in subfilter expressions whereby the modified current list is returned in place of the current list.
-
-<table>
-<<.group-heading "Listops Operators">>
-<tr>
-<th align="left">Operator</th>
-<th align="left">Purpose</th>
-<th>✓</th>
-</tr>
-<<.operator-rows "[tag[Filter Operators]tag[Listops Operators]tag[Order Operators]!tag[String Operators]!tag[Tag Operators]!tag[Special Operators]sort[]]">>
-</table>
+A number of [[Extended Listops Filters]] are necessary for the manipulation of lists. These operators have been designed primarily for use in subfilter expressions whereby the modified current list is returned in place of the current list.
 
 ! Examples
 

--- a/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
@@ -75,7 +75,7 @@ Note that <<.value "abc 123">> in the first two cases is a literal string that i
 
 !! Extended Filter Operators
 
-A number of [[extended filter operators|The Extended Listops Filters]] are necessary for the manipulation of lists. These operators have been designed primarily for use in subfilter expressions whereby the modified current list is returned in place of the current list.
+A number of [[Extended Listops Filters]] are necessary for the manipulation of lists. These operators have been designed primarily for use in subfilter expressions whereby the modified current list is returned in place of the current list.
 
 !! Notes on de-duplication
 

--- a/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
@@ -22,7 +22,7 @@ The ''action-listops'' widget is invisible. Any content within it is ignored.
 |$index |Optional index of a property in a [[data tiddler|DataTiddlers]] index to be manipulated as a list |
 |$filter |An optional filter expression, the output of which will be saved to the field/index being manipulated |
 |$subfilter |An optional subfilter expression, which takes the list being manipulated as input, and saves the modified list back to the field/index being manipulated |
-|$tags |An optional subfilter expression, which takes the 'tags' field of the target tiddler as input, and saves the modified list of tags back to the 'tags' field |
+|$tags |An optional subfilter expression, which takes the <<.field tags>> field of the target tiddler as input, and saves the modified list of tags back to the <<.field tags>> field |
 
 !! Using $filter or $subfilter
 
@@ -37,7 +37,7 @@ For example, the items "abc" and "123" can be appended to the field `myfield` us
 The same can be achieved using the `$filter` attribute and prepending the [[Filter Run]] `[all[current]get[myfield]enlist-input[]]` to the [[Filter Expression]]:
 
 ```
-<$action-listops $field="myfield" $filter="[all[current]get[myfield]enlist-input[]] abc 123"/>
+<$action-listops $field="myfield" $filter="[enlist{!!myfield}] abc 123"/>
 ```
 
 The short form is more convenient, but the long form is useful for live-debugging complicated `$subfilter` values using the filter tab of [[$:/AdvancedSearch]]. By using [[$:/AdvancedSearch]], the [[Filter Expression]] can be tested before using ''action-listops'' to modify actual tiddler fields. For this use case, the `all[current]` portion of the expression needs to be changed to select the proper test tiddler.
@@ -77,13 +77,41 @@ Note that <<.value "abc 123">> in the first two cases is a literal string that i
 
 A number of [[extended filter operators|The Extended Listops Filters]] are necessary for the manipulation of lists. These operators have been designed primarily for use in subfilter expressions whereby the modified current list is returned in place of the current list.
 
+!! Notes on de-duplication
+
+In some cases, there may occur unexpected de-duplication of lists.
+
+!!! Assignments to the <<.field list>> field
+
+When assigning filter results to the <<.field list>> field (default), the generated list is automatically de-duplicated, so
+
+```
+<$action-listops $filter="[[1]] :and[[1]]"/>
+```
+will result in the <<.field list>> field of the current tiddler containing the string <<.value 1>>, but not <<.value "1 1">>.
+
+!!! Input to the subfilter expression
+
+The input to the subfilter expression in the `$subfilter` attribute is also de-duplicated. If you rely on lists containing duplicates, consider using this alternative using the `$filter` attribute:
+
+<$macrocall $name='wikitext-example-without-html'
+src="""<$button>
+<$action-listops $field="myfield" $filter="[enlist:raw{!!myfield}] :all[[abc]]" />
+Add 'abc' to 'myfield'
+</$button>
+
+<$list filter="[enlist:raw{!!myfield}]" template="$:/core/ui/ListItemTemplate" />
+"""/>
+The [[enlist Operator]] with `raw` suffix will enlist the list saved in <<.field myfield>> of the current tiddler without de-duplication, while e.g. the [[list Operator]] will always de-duplicate. The widget then adds the item <<.value abc>> -- whether or not it is already included in the list -- and replaces the original list in <<.field myfield>>.
+
+
 ! Examples
 
 In this example we shall populate and then clear a list in an ordinary field (myfield) of this tiddler (the default.)
 
 <$macrocall $name='wikitext-example-without-html'
 src="""<$button>
-<$action-listops $field="myfield" $subfilter="efg hlm pqr"/>
+<$action-listops $field="myfield" $filter="efg hlm pqr"/>
 Populate 'myfield'
 </$button>
 <$button>

--- a/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
@@ -58,25 +58,24 @@ is mostly equivalent to using `$subfilter` along with "tags" for the value of `$
 
 !! Comparison to [[ActionSetFieldWidget]]
 
-The [[ActionSetFieldWidget]] replaces a field's value using `$field`/`$value` attributes. A single ActionSetFieldWidget can be used to set any number of fields by using attributes not starting with $.
+In general, [[ActionSetFieldWidget]] is better for setting multiple fields at once and for replacing the value of a field, which can also be a list. The ActionListopsWidget is better for modifying a list field based on the existing list and for using a [[Filter Expression]] to derive the value of the field.
 
-The ActionListopsWidget replaces or modifies a single field's value. The new value is generated using filters.
+The ActionSetFieldWidget sets the value of a field using `$field` and `$value` attribute pairs or attributes that do not start with a `$`. A single ActionSetFieldWidget can be used to set any number of fields of a single tiddler.
 
-The following two examples are functionally equivalent:
+The ActionListopsWidget replaces or modifies a single field's value using filter expressions.
+
+The following widgets are functionally equivalent:
 
 ```
 <$action-setfield $field="myfield" $value="abc 123"/>
-```
-
-```
+<$action-setfield myfield="abc 123"/>
 <$action-listops $field="myfield" $filter="abc 123"/>
 ```
-
-In general, ActionSetFieldWidget is better for setting multiple fields at once and for replacing a field's value. The ActionListopsWidget is better for modifying a field based on the field's existing value and for using a [[Filter Expression]] to derive the value.
+Note that <<.value "abc 123">> in the first two cases is a literal string that is assigned to the field <<.field myfield>>, but in the third case a filter expression which evaluates to the same string.
 
 !! Extended Filter Operators
 
-A number of [[Extended Listops Filters]] are necessary for the manipulation of lists. These operators have been designed primarily for use in subfilter expressions whereby the modified current list is returned in place of the current list.
+A number of [[extended filter operators|The Extended Listops Filters]] are necessary for the manipulation of lists. These operators have been designed primarily for use in subfilter expressions whereby the modified current list is returned in place of the current list.
 
 ! Examples
 

--- a/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
@@ -1,9 +1,7 @@
 caption: action-listops
 created: 20141025120850184
-list: efg hlm pqr
-modified: 20230227170803513
+modified: 20230301183438774
 myfield: 
-revision: 0
 tags: ActionWidgets Widgets
 title: ActionListopsWidget
 type: text/vnd.tiddlywiki
@@ -105,78 +103,4 @@ Add 'abc' to 'myfield'
 The [[enlist Operator]] with `raw` suffix will enlist the list saved in <<.field myfield>> of the current tiddler without de-duplication, while e.g. the [[list Operator]] will always de-duplicate. The widget then adds the item <<.value abc>> -- whether or not it is already included in the list -- and replaces the original list in <<.field myfield>>.
 
 
-! Examples
-
-In this example we shall populate and then clear a list in an ordinary field (myfield) of this tiddler (the default.)
-
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $field="myfield" $filter="efg hlm pqr"/>
-Populate 'myfield'
-</$button>
-<$button>
-<$action-listops $field="myfield" $subfilter="abc xyz"/>
-Append More Items
-</$button>
-<$button>
-<$action-listops $field="myfield" $subfilter="-abc -hlm"/>
-Remove Items
-</$button>
-<$button>
-<$action-listops $field="myfield" $filter="[[]]"/>
-Clear 'myfield'
-</$button>
-
-<$list filter="[list[!!myfield]]">
-
-</$list>"""/>
-
----
-In this example we shall append and remove items from a list in an ordinary field (myfield) of this tiddler (the default) and sort the resultant list. We shall then remove some of the appended items and sort the resulting list in reverse order.
-
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $field="myfield" $subfilter="-efg ijk xyz [[this is a title]] +[sort[]]"/>
-Mangle List
-</$button>
-<$button>
-<$action-listops $field="myfield" $subfilter="-xyz -[[this is a title]] +[!sort[]]"/>
-Unmangle List
-</$button>
-
-<$list filter="[list[!!myfield]]">
-
-</$list>"""/>
-
----
-In this example we shall append a few tags to the 'tags' field of this tiddler (the default.) We shall then remove some of the appended tags. 
-
-<$macrocall $name='wikitext-example-without-html'
-src="""<$button>
-<$action-listops $tags="+[append{Days of the Week!!short}] $:/tag1 $:/tag2 $:/tag3"/>
-Populate 'tags'
-</$button>
-<$button>
-<$action-listops $tags="+[!remove:2{!!tags}]"/>
-Remove Last Two Tags
-</$button>
-<$button>
-<$action-listops $tags="+[!prefix[$:/]]"/>
-Remove System Tags
-</$button>
-<$button>
-<$action-listops $tags="-Mon -Tue"/>
-Remove Mon and Tue
-</$button>
-<$button>
-<$action-listops $tags="+[prefix[$:/]] ActionWidgets Widgets"/>
-Remove User Tags
-</$button>
-<$button>
-<$action-listops $tags="+[[]] ActionWidgets Widgets"/>
-Clear Tags
-</$button>
-
-<$list filter="[list[!!tags]]">
-
-</$list>"""/>
+! [[Examples|ActionListopsWidget (Examples)]]

--- a/editions/tw5.com/tiddlers/widgets/Extended Listops Filters.tid
+++ b/editions/tw5.com/tiddlers/widgets/Extended Listops Filters.tid
@@ -6,19 +6,43 @@ item2: seven
 item3: eight
 list: Yesterday Today Tomorrow
 marker: Thursday
-modified: 20211114011103356
+modified: 20230227175501965
 myfield: Monday Tuesday [[Middle of the Week]] Thursday Friday Saturday Sunday
 numbers: 1 2 3 4 five 6 7 8 9
 tags: Filters
-title: The Extended Listops Filters
+title: Extended Listops Filters
+
+\define .operator-rows(filter)
+<$list filter="$filter$"><tr>
+<td><$link>{{!!caption}}</$link></td>
+<td>{{!!op-purpose}}</td>
+<td align="center"><$list filter="[all[current]tag[Common Operators]]">✓</$list></td>
+<td align="center"><$list filter="[all[current]tag[Negatable Operators]]">`!`</$list></td>
+</tr></$list>
+\end
+
+\define .group-heading(_)
+<tr class="doc-table-subheading"><th colspan="4" align="center">$_$</th></tr>
+\end
 
 ! Introduction
 
-A number of extended filters are necessary to manipulate lists. 
+A number of filters are used to manipulate lists. 
 
-The first set of filters are designed to move items from the tail of the list and insert them at specified locations in the list. Items are often appended to the list before using these filters. In general, these filters accept a suffix specifying the number of items to move (default to 1.) 
+Some filters are designed to move items from the tail of the list and insert them at specified locations in the list, e.g. [[putafter|putafter Operator]] or [[putbefore|putbefore Operator]]. Items are often appended to the list before using these filters. In general, these filters accept a suffix specifying the number of items to move (default to 1.) 
 
-A second set of filters are designed to either add or remove from the list, a selected range of items from an array. These filters are best used with a reference to an array, stored in a field or data index elsewhere in the wiki (they may be used with a simple list of items, provided the items do not include white space.) In general, these filters accept a suffix specifying the number of items to move (default to All.)
+Some filters are designed to either add or remove from the list, a selected range of items from an array, e.g. [[append|append Operator]] or [[remove|remove Operator]]. These filters are best used with a reference to an array, stored in a field or data index elsewhere in the wiki (they may be used with a simple list of items, provided the items do not include white space.) In general, these filters accept a suffix specifying the number of items to move (default to All.)
+
+<table>
+<<.group-heading "Listops Operators">>
+<tr>
+<th align="left">Operator</th>
+<th align="left">Purpose</th>
+<th>✓</th>
+<th>`!`</th>
+</tr>
+<<.operator-rows "[tag[Filter Operators]tag[Listops Operators]tag[Order Operators]!tag[String Operators]!tag[Tag Operators]!tag[Special Operators]sort[]]">>
+</table>
 
 ! Examples
 

--- a/editions/tw5.com/tiddlers/widgets/The Extended Listops Filters.tid
+++ b/editions/tw5.com/tiddlers/widgets/The Extended Listops Filters.tid
@@ -1,0 +1,5 @@
+created: 20230301172832597
+modified: 20230301172832597
+title: The Extended Listops Filters
+
+See [[Extended Listops Filters]]

--- a/editions/tw5.com/tiddlers/widgets/examples/ActionListopsWidget (Examples).tid
+++ b/editions/tw5.com/tiddlers/widgets/examples/ActionListopsWidget (Examples).tid
@@ -1,0 +1,81 @@
+created: 20230301174431218
+list: efg hlm pqr
+modified: 20230301174431218
+myfield: 
+revision: 0
+title: ActionListopsWidget (Examples)
+type: text/vnd.tiddlywiki
+
+In this example we shall populate and then clear a list in an ordinary field (myfield) of this tiddler (the default).
+
+<$macrocall $name='wikitext-example-without-html'
+src="""<$button>
+<$action-listops $field="myfield" $filter="efg hlm pqr"/>
+Populate 'myfield'
+</$button>
+<$button>
+<$action-listops $field="myfield" $subfilter="abc xyz"/>
+Append More Items
+</$button>
+<$button>
+<$action-listops $field="myfield" $subfilter="-abc -hlm"/>
+Remove Items
+</$button>
+<$button>
+<$action-listops $field="myfield" $filter="[[]]"/>
+Clear 'myfield'
+</$button>
+
+<$list filter="[list[!!myfield]]">
+
+</$list>"""/>
+
+---
+In this example we shall append and remove items from a list in an ordinary field (myfield) of this tiddler (the default) and sort the resultant list. We shall then remove some of the appended items and sort the resulting list in reverse order.
+
+<$macrocall $name='wikitext-example-without-html'
+src="""<$button>
+<$action-listops $field="myfield" $subfilter="-efg ijk xyz [[this is a title]] +[sort[]]"/>
+Mangle List
+</$button>
+<$button>
+<$action-listops $field="myfield" $subfilter="-xyz -[[this is a title]] +[!sort[]]"/>
+Unmangle List
+</$button>
+
+<$list filter="[list[!!myfield]]">
+
+</$list>"""/>
+
+---
+In this example we shall append a few tags to the 'tags' field of this tiddler (the default). We shall then remove some of the appended tags. 
+
+<$macrocall $name='wikitext-example-without-html'
+src="""<$button>
+<$action-listops $tags="+[append{Days of the Week!!short}] $:/tag1 $:/tag2 $:/tag3"/>
+Populate 'tags'
+</$button>
+<$button>
+<$action-listops $tags="+[!remove:2{!!tags}]"/>
+Remove Last Two Tags
+</$button>
+<$button>
+<$action-listops $tags="+[!prefix[$:/]]"/>
+Remove System Tags
+</$button>
+<$button>
+<$action-listops $tags="-Mon -Tue"/>
+Remove Mon and Tue
+</$button>
+<$button>
+<$action-listops $tags="+[prefix[$:/]] ActionWidgets Widgets"/>
+Remove User Tags
+</$button>
+<$button>
+<$action-listops $tags="+[[]] ActionWidgets Widgets"/>
+Clear Tags
+</$button>
+
+<$list filter="[list[!!tags]]">
+
+</$list>"""/>


### PR DESCRIPTION
De-duplication happens automatically when working with `$action-listops` on the `list` field.

Also, the input to the `$subfilter` of `$action-listops` is de-duplicated without notice, so `$subfilter` cannot be used when the list possibly contains duplicates, and one currently has to resort to `$filter="[enlist:raw[...]"` to enlist the current list.

Corresponding notes have been added to the doc. I also streamlined it a bit and moved the table of listops filters to the "Extended Listops Filters" tiddler.

Two points worth discussing:

1. I renamed "The Extended Listops Filters" to "Extended Listops Filters" and updated all links to it. This might break links from outside, though, so I'll probably have to go back on that.
2. I would like to move the example section for ActionListopsWidget to its own tiddler, like for most filter operators (but no widgets). Would this be OK?

Closes #7266