### PR TITLE
Change separators for "words" and "some" suffixes of the search operator

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1256,7 +1256,7 @@ exports.search = function(text,options) {
 			console.log("Regexp error parsing /(" + text + ")/" + flags + ": ",e);
 		}
 	} else if(options.some) {
-		terms = text.trim().split(/ +/);
+		terms = text.trim().split(/[^\S\xA0]+/);
 		if(terms.length === 1 && terms[0] === "") {
 			searchTermsRegExps = null;
 		} else {
@@ -1267,7 +1267,7 @@ exports.search = function(text,options) {
 			searchTermsRegExps.push(new RegExp("(" + regExpStr + ")",flags));
 		}
 	} else { // default: words
-		terms = text.split(/ +/);
+		terms = text.split(/[^\S\xA0]+/);
 		if(terms.length === 1 && terms[0] === "") {
 			searchTermsRegExps = null;
 		} else {


### PR DESCRIPTION
The doc for the `words` and `some` suffixes says that the operator "treats the search string as a list of tokens separated by whitespace". The current code only treats spaces as separators. This PR will change that to use any whitespace character except the non-breaking space.

This change is not strictly backwards compatible.

Also, the separator used in Dynannotate for `words` and `some` is `\s`. Whatever is eventually decided here should also be implemented in #7260.

Closes #7263 