### PR TITLE
Add a comparison table when existing tiddler is about to be imported

### DIFF
--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -7,13 +7,6 @@ title: $:/core/ui/ImportListing
 \define payloadTitleFilter() [<currentTiddler>get<renameField>minlength[1]else<payloadTiddler>]
 
 \define overWriteWarning()
-\whitespace trim
-<$list filter="[<currentTiddler>!has<suppressedField>]">
-<$text text={{{[subfilter<payloadTitleFilter>!is[tiddler]then[]] ~[<lingo-base>addsuffix[Listing/Rename/OverwriteWarning]get[text]]}}}/>
-</$list>
-\end
-
-\define overWriteWarning()
 \define date-format() YYYY-0MM-0DD 0hh:0mm:0ss
 <$list filter="[<currentTiddler>!has<suppressedField>]">
 <$list filter="[subfilter<payloadTitleFilter>is[tiddler]]" variable="void">

--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -13,6 +13,34 @@ title: $:/core/ui/ImportListing
 </$list>
 \end
 
+\define overWriteWarning()
+\define date-format() YYYY-0MM-0DD 0hh:0mm:0ss
+<$list filter="[<currentTiddler>!has<suppressedField>]">
+<$list filter="[subfilter<payloadTitleFilter>is[tiddler]]" variable="void">
+<$text text={{{ [<lingo-base>addsuffix[Listing/Rename/OverwriteWarning]get[text]] }}}/>
+<$set name="incomingDate" tiddler=<<currentTiddler>> subtiddler=<<payloadTiddler>> field="modified">
+<$set name="incomingText" tiddler=<<currentTiddler>> subtiddler=<<payloadTiddler>> field="text">
+<$let incomingLines={{{ [<incomingText>splitregexp[\n]count[]] }}}
+			currentLines={{{ [<payloadTiddler>get[text]splitregexp[\n]count[]] }}}
+			currentDate={{{ [<payloadTiddler>get[modified]] }}}
+			incomingDescription={{{ [<incomingDate>compare:date:gt<currentDate>then[newer]] [<incomingLines>compare:number:gt<currentLines>then[larger]] +[!is[blank]join[, ]addprefix[(]addsuffix[)]] }}}
+			currentDescription={{{ [<incomingDate>compare:date:lt<currentDate>then[newer]] [<incomingLines>compare:number:lt<currentLines>then[larger]] +[!is[blank]join[, ]addprefix[(]addsuffix[)]] }}}
+			>
+
+<div class={{{ [<incomingDate>compare:date:lt<currentDate>then[tc-import-older]] }}}>
+
+|tc-center tc-import-comparison |k
+|!existing <$text text=<<currentDescription>> />|!incoming <$text text=<<incomingDescription>> />|
+| <$text text={{{ [<currentDate>format:date<date-format>] }}}/> | <$text text={{{ [<incomingDate>format:date<date-format>] }}}/> |
+| <$text text=<<currentLines>> /> lines | <$text text=<<incomingLines>> /> lines |
+</div>
+</$let>
+</$set>
+</$set>
+</$list>
+</$list>
+\end
+
 \define selectionInfo()
 \whitespace trim
 <$set name="escUnselected" value={{{[{$:/language/Import/Upgrader/Tiddler/Unselected}escaperegexp[]addprefix[(?g)]]}}}>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2357,6 +2357,24 @@ html body.tc-body.tc-single-tiddler-window {
 	background: <<colour diff-delete-background>>50;
 }
 
+.tc-import-table .tc-import-comparison {
+	min-width: 80%;
+	max-width: 100%;
+	box-sizing: content-box;
+	padding: 0 1em;
+}
+
+.tc-import-table .tc-import-comparison th {
+	width: 50%;
+	padding: 0 1em;
+	background: none;
+}
+
+.tc-import-older table.tc-import-comparison {
+	border: 2px solid red;
+}
+
+
 /*
 ** Alerts
 */


### PR DESCRIPTION
This PR adds a table that compares the date and size (in lines) of the existing and incoming tiddler in those cases where an incoming tiddler already exists. It also gives a verbal indication which tiddler is older, newer, smaller, larger.

If the incoming tiddler is older, a red border is additionally drawn.

Closes #7211 