### PR TITLE
make import listing more configurable

### DIFF
--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -10,7 +10,10 @@ title: $:/core/ui/ImportListing
 \whitespace trim
 <$list filter="[<currentTiddler>!has<suppressedField>]">
 	<$list filter="[subfilter<payloadTitleFilter>is[tiddler]]" variable="ignore">
-		<$list filter="[all[shadows+tiddlers]tag[$:/tags/ImportOverwrite]]" variable="overwrite">
+		<$list filter="[all[shadows+tiddlers]!is[draft]tag[$:/tags/ImportOverwrite]]" 
+			variable="overwrite"
+			emptyMessage={{$:/core/ui/ImportListing/overwrite/default-text}}
+		>
 			<$transclude tiddler=<<overwrite>> mode="block"/>
 		</$list>
 	</$list>

--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -9,7 +9,11 @@ title: $:/core/ui/ImportListing
 \define overWriteWarning()
 \whitespace trim
 <$list filter="[<currentTiddler>!has<suppressedField>]">
-<$text text={{{[subfilter<payloadTitleFilter>!is[tiddler]then[]] ~[<lingo-base>addsuffix[Listing/Rename/OverwriteWarning]get[text]]}}}/>
+	<$list filter="[subfilter<payloadTitleFilter>is[tiddler]]" variable="ignore">
+		<$list filter="[all[shadows+tiddlers]tag[$:/tags/ImportOverwrite]]" variable="overwrite">
+			<$transclude tiddler=<<overwrite>> mode="block"/>
+		</$list>
+	</$list>
 </$list>
 \end
 

--- a/core/ui/ImportListing/overwrite/default-text.tid
+++ b/core/ui/ImportListing/overwrite/default-text.tid
@@ -1,4 +1,3 @@
 title: $:/core/ui/ImportListing/overwrite/default-text
-tags: $:/tags/ImportOverwrite
 
 <$text text={{{ [<lingo-base>addsuffix[Listing/Rename/OverwriteWarning]get[text]] }}}/>

--- a/core/ui/ImportListing/overwrite/default-text.tid
+++ b/core/ui/ImportListing/overwrite/default-text.tid
@@ -1,0 +1,4 @@
+title: $:/core/ui/ImportListing/overwrite/default-text
+tags: $:/tags/ImportOverwrite
+
+<$text text={{{ [<lingo-base>addsuffix[Listing/Rename/OverwriteWarning]get[text]] }}}/>


### PR DESCRIPTION
This PR is an alternative approach to closed PR #7306 
It does 2 things. 

- Create a new system tag: `$:/tags/ImportOverwrite`
- Moves the default text out from the overWriteWarning() macro to a new tiddler: `$:/core/ui/ImportListing/overwrite/default-text`

So users have the ability to extend the import message area with their own info by tagging their template with new system-tag.

This attachment contains a sample configuration to play with. This info is _not_ part of the PR. 
[import-listing-verbose.zip](https://github.com/Jermolene/TiddlyWiki5/files/10861321/import-listing-verbose.zip)

There should be no visual difference between this PR and the v5.2.5
You need to import the JSON above to see a difference. 

There is an import payload attachment, which creates a more realistic import dialogue with "state", "temp" and "blocked" tiddlers. 
[test-import.zip](https://github.com/Jermolene/TiddlyWiki5/files/10861344/test-import.zip)

@Jermolene if it can be merged, I'll add some docs about the new system-tag and how to use the new possibilities 
