### PR TITLE
move fourcolumns as multicolumns to tw5-styles for reuse

### DIFF
--- a/editions/tw5.com/tiddlers/howtos/Formatting List Results as Tables with CSS - Specified Columns Methods.tid
+++ b/editions/tw5.com/tiddlers/howtos/Formatting List Results as Tables with CSS - Specified Columns Methods.tid
@@ -33,29 +33,17 @@ Note the various places you need to indicate the number of columns
 
 ```
 @@.fourcolumns
-<$list filter="[tag[Filter Operators]]" variable="foo"><br>
-<<foo>>
+<$list filter="[tag[Filter Operators]]" variable="foo">
+<<foo>><br>
 </$list>
 @@
 ```
 
 !! Example showing partial list of filter operators
 
-<style>
-.fourcolumns {
-   display:block;
-   column-count:4;
-   column-gap:1em;
-   -moz-column-count:4;
-   -moz-column-gap:1em;
-   -webkit-column-count: 4;
-   -webkit-column-gap:1em;
-}
-</style>
-
-
 @@.fourcolumns
-<$list filter="[tag[Filter Operators]limit[24]]" variable="foo"><br>
-<<foo>>
+<$list filter="[tag[Filter Operators]limit[24]]" variable="foo">
+<<foo>><br>
 </$list>
 @@
+

--- a/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
+++ b/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
@@ -325,3 +325,22 @@ type: text/vnd.tiddlywiki
 .tc-btn-download:active {
 	box-shadow: none;
 }
+
+/* WikiText rules */
+
+.multi-columns,
+.fourcolumns {
+	display: block;
+	column-count: 4;
+	column-gap: 1em;
+	-moz-column-count: 4;
+	-moz-column-gap: 1em;
+	-webkit-column-count: 4;
+	-webkit-column-gap: 1em;
+}
+
+@media (max-width: {{$:/themes/tiddlywiki/vanilla/metrics/sidebarbreakpoint}}) {
+	.multi-columns {
+		column-count: 2;
+	}
+}


### PR DESCRIPTION
This PR moves a  hardcoded `fourcolumn` CSS definition to the tw5-styles.css for reuse in other examples. 
It also adds a media query to change from 4 columns to 2 columns on small screens. 

The goal is to reuse a `multicolumn` class for more examples eg: for the WikiText docs tiddler. 

