### PR TITLE
improve WikiText docs add a Markdown tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/WikiText.tid
+++ b/editions/tw5.com/tiddlers/concepts/WikiText.tid
@@ -4,12 +4,16 @@ tags: Concepts Reference
 title: WikiText
 type: text/vnd.tiddlywiki
 
-~WikiText is a concise, expressive way of typing a wide range of text formatting, hypertext and interactive features. It allows you to focus on writing without a complex user interface getting in the way. It is designed to be familiar for users of [[MarkDown|http://daringfireball.net/projects/markdown/]], but with more of a focus on linking and the interactive features.
+~WikiText is a concise, expressive way of typing a wide range of text formatting, hypertext and interactive features. It allows you to focus on writing without a complex user interface getting in the way. It is designed to be familiar for users of [[Markdown]] but with more of a focus on linking and the interactive features.
 
-~WikiText can also be inserted to the text field using the [[Editor toolbar]].
+!! Elements
 
-See [[Formatting text in TiddlyWiki]] for an introduction to WikiText.
+~WikiText can also be inserted to the text field using the [[Editor toolbar]] buttons.
 
-The following elements of WikiText syntax are built into the core:
+See [[Formatting text in TiddlyWiki]] for an introduction to ~WikiText.
 
-<<list-links "[tag[WikiText]]">>
+The following elements of ~WikiText syntax are built into the core:
+
+@@.multi-columns
+<<list-links filter:"[tag[WikiText]]">>
+@@

--- a/editions/tw5.com/tiddlers/concepts/WikiText.tid
+++ b/editions/tw5.com/tiddlers/concepts/WikiText.tid
@@ -1,19 +1,15 @@
 created: 20131205155227468
-modified: 20140919191220377
+modified: 20230303214711802
 tags: Concepts Reference
 title: WikiText
 type: text/vnd.tiddlywiki
 
 ~WikiText is a concise, expressive way of typing a wide range of text formatting, hypertext and interactive features. It allows you to focus on writing without a complex user interface getting in the way. It is designed to be familiar for users of [[Markdown]] but with more of a focus on linking and the interactive features.
 
-!! Elements
-
 ~WikiText can also be inserted to the text field using the [[Editor toolbar]] buttons.
 
-See [[Formatting text in TiddlyWiki]] for an introduction to ~WikiText.
+See [[Formatting in WikiText]] and [[Formatting text in TiddlyWiki]] for an introduction to ~WikiText.
 
 The following elements of ~WikiText syntax are built into the core:
 
-@@.multi-columns
-<<list-links filter:"[tag[WikiText]]">>
-@@
+<<list-links filter:"[tag[WikiText]]" class:"multi-columns">>

--- a/editions/tw5.com/tiddlers/definitions/Markdown.tid
+++ b/editions/tw5.com/tiddlers/definitions/Markdown.tid
@@ -1,0 +1,10 @@
+created: 20220727090611178
+modified: 20220728191637376
+tags: Definitions
+title: Markdown
+
+<<<
+Markdown is a text-to-HTML conversion tool for web writers. Markdown allows you to write using an easy-to-read, easy-to-write plain text format, then convert it to structurally valid XHTML (or HTML).
+<<<https://daringfireball.net/projects/markdown/
+
+~TiddlyWiki and Markdown share some formatting rules eg: [[inline code|Formatting in WikiText]] and [[code blocks|Code Blocks in WikiText]] but WikiText also offers advanced functions like [[transclusions|Transclusion in WikiText]] and [[macros|Macro Calls in WikiText]]


### PR DESCRIPTION
**This PR depends on:**  move fourcolumns as multicolumns to tw5-styles for reuse #7318 

- It adds a new Markdown definition tiddler. 
- It uses the multi column view for the wikitext list