### PR TITLE
Prevent infinite loop for single-word texts

### DIFF
--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -112,7 +112,7 @@ function diffPartsToChars(text1,text2,mode) {
 	        if(mode === "words") {
                 regexpResult = searchRegexp.exec(text);
                 lineEnd = searchRegexp.lastIndex;
-                if(lineEnd === null) {
+                if(regexpResult === null) {
                 lineEnd = text.length;
                 }
                 lineEnd = --lineEnd;


### PR DESCRIPTION
With regexpResult === null, lineEnd was always 0, so the comparison to null failed.