### PR TITLE
Add docs and examples for the new operators

### DIFF
--- a/editions/tw5.com/tiddlers/filters/applypatches Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/applypatches Operator.tid
@@ -1,0 +1,15 @@
+caption: applypatches
+created: 20230304154824762
+modified: 20230304154826621
+op-purpose: applies a set of patches to transform the input
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string containing patches from the [[makepatches Operator]]
+op-parameter-name: P
+op-output: the transformed input to which the patches <<.place P>> have been applied
+tags: [[Filter Operators]] [[String Operators]]
+title: applypatches Operator
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.2.6">>
+
+<<.operator-examples "makepatches and applypatches">>

--- a/editions/tw5.com/tiddlers/filters/examples/Hamlet.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/Hamlet.tid
@@ -1,0 +1,11 @@
+created: 20230304161453213
+modified: 20230304162156826
+tags: [[Operator Examples]]
+title: Hamlet
+type: application/json
+
+{
+    "Shakespeare-old": "Hamlet: Do you see yonder cloud that's almost in shape of a camel?\nPolonius: By the mass, and 'tis like a camel, indeed.\nHamlet: Methinks it is like a weasel.\nPolonius: It is backed like a weasel.\nHamlet: Or like a whale?\nPolonius: Very like a whale.\n-- Shakespeare",
+    "Shakespeare-new": "Hamlet: Do you see the cloud over there that's almost the shape of a camel?\nPolonius: By golly, it is like a camel, indeed.\nHamlet: I think it looks like a weasel.\nPolonius: It is shaped like a weasel.\nHamlet: Or like a whale?\nPolonius: It's totally like a whale.\n-- Shakespeare",
+    "Trekkie-old": "Kirk: Do you see yonder cloud that's almost in shape of a Klingon?\nSpock: By the mass, and 'tis like a Klingon, indeed.\nKirk: Methinks it is like a Vulcan.\nSpock: It is backed like a Vulcan.\nKirk: Or like a Romulan?\nSpock: Very like a Romulan.\n-- Trekkie"
+}

--- a/editions/tw5.com/tiddlers/filters/examples/levenshtein Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/levenshtein Operator (Examples).tid
@@ -1,0 +1,21 @@
+created: 20230304183158728
+modified: 20230304183159654
+tags: [[levenshtein Operator]] [[Operator Examples]]
+title: levenshtein Operator (Examples)
+type: text/vnd.tiddlywiki
+
+Determine the Levenshtein distance between two words:
+
+<<.operator-example 1 "[[motel]levenshtein[money]]">>
+
+List the 10 tiddler titles with the smallest Levenstein distance to "~TiddlyWiki":
+
+<$macrocall $name='wikitext-example-without-html'
+src="""<ul>
+<$list filter="[all[tiddlers]!is[system]] :sort:number[levenshtein[TiddlyWiki]] :and[first[10]]">
+<li>
+<$link /> (<$text text={{{ [all[current]levenshtein[TiddlyWiki]] }}} />)
+</li>
+</$list>
+</ul>
+"""/>

--- a/editions/tw5.com/tiddlers/filters/examples/makepatches and applypatches Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/makepatches and applypatches Operator (Examples).tid
@@ -1,0 +1,43 @@
+created: 20230304160331362
+modified: 20230304160332927
+tags: [[makepatches Operator]] [[applypatches Operator]] [[Operator Examples]]
+title: makepatches and applypatches Operator (Examples)
+type: text/vnd.tiddlywiki
+
+These examples use the example texts in [[Hamlet]], taken from [[https://neil.fraser.name/software/diff_match_patch/demos/patch.html]]
+
+|^!Shakespeare's original |@@white-space: pre-wrap;{{Hamlet##Shakespeare-old}}@@ |
+|^!Modern English |@@white-space: pre-wrap;{{Hamlet##Shakespeare-new}}@@ |
+|^!Trekkie's Copy |@@white-space: pre-wrap;{{Hamlet##Trekkie-old}}@@ |
+
+<div class="doc-examples-hard-breaks">
+
+Use `makepatches` to generate the set of patches to transform Shakepeare's original into Modern English:
+
+<<.operator-example 1 "[{Hamlet##Shakespeare-old}makepatches{Hamlet##Shakespeare-new}]">>
+
+Use `applypatches` to apply the patches to Shakespeare's original text:
+
+<<.operator-example 2 "[{Hamlet##Shakespeare-old}makepatches{Hamlet##Shakespeare-new}] :map[{Hamlet##Shakespeare-old}applypatches<currentTiddler>]">>
+
+In the above example, the [[Map Filter Run Prefix]] is used to pass the patches information as a parameter to `applypatches`. Inside `:map`, <<.value currentTiddler>> is set to the input title (i.e. the previously generated patches).
+
+The patch information from the Shakepeare texts can also be used to transform the //Trekkie's Copy// to a Modern English version:
+
+<<.operator-example 3 "[{Hamlet##Shakespeare-old}makepatches{Hamlet##Shakespeare-new}] :map[{Hamlet##Trekkie-old}applypatches<currentTiddler>]">>
+
+The above examples used the character mode of `makepatches`. The `word` mode yields very similar results in this case, even when applied to the //Trekkie's Copy//.
+
+<<.operator-example 4 "[{Hamlet##Shakespeare-old}makepatches:words{Hamlet##Shakespeare-new}]">>
+
+<<.operator-example 5 "[{Hamlet##Shakespeare-old}makepatches:words{Hamlet##Shakespeare-new}] :map[{Hamlet##Trekkie-old}applypatches<currentTiddler>]">>
+
+The `lines` mode doesn't work as well in this application:
+
+<<.operator-example 6 "[{Hamlet##Shakespeare-old}makepatches:lines{Hamlet##Shakespeare-new}]">>
+
+<<.operator-example 7 "[{Hamlet##Shakespeare-old}makepatches:lines{Hamlet##Shakespeare-new}] :map[{Hamlet##Trekkie-old}applypatches<currentTiddler>]">>
+
+It is better suited as a very fast algorithm to detect line-wise incremental changes to texts and store only the changes instead of multiple versions of the whole texts.
+
+</div>

--- a/editions/tw5.com/tiddlers/filters/levenshtein Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/levenshtein Operator.tid
@@ -1,0 +1,17 @@
+caption: levenshtein
+created: 20230304181639768
+modified: 20230304181642365
+op-purpose: determine the Levenshtein distance of the input title(s) and a given string
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string
+op-parameter-name: S
+op-output: the Levenshtein distance between the input title(s) and <<.place S>>
+tags: [[Filter Operators]] [[String Operators]]
+title: levenshtein Operator
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.2.6">>
+
+The Levenshtein distance is a metric for measuring the difference between two strings. Informally, the Levenshtein distance between two strings is the //minimum// number of single-character edits required to change one string into the other.
+
+<<.operator-examples "levenshtein">>

--- a/editions/tw5.com/tiddlers/filters/makepatches Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/makepatches Operator.tid
@@ -1,0 +1,23 @@
+caption: makepatches
+created: 20230304122354967
+modified: 20230304122400128
+op-purpose: returns a set of patches that transform the input to a given string
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: a string of characters
+op-parameter-name: S
+op-output: a set of patch instructions per input title to be used by the [[applypatches Operator]] to transform the input title(s) into the string <<.place S>>
+op-suffix: `lines` to operate in line mode, `words` to operate in word mode. If omitted (default), the algorithm operates in character mode. See notes below.
+op-suffix-name: T
+tags: [[Filter Operators]] [[String Operators]]
+title: makepatches Operator
+type: text/vnd.tiddlywiki
+
+<<.from-version "5.2.6">>
+
+The difference algorithm operates in character mode by default. This produces the most detailed diff possible. In `words` mode, each word in the input text is transformed into a meta-character, upon which the algorithm then operates. In the default character mode, the filter would find two patches between "ActionWidget" and "Action-Widgets" (the hyphen and the plural s), while in `words` mode, the whole word is found to be changed. In `lines` mode, the meta-character is formed from the whole line, and a whole line, delimited by newline characters, is found to be changed independent of the number of changes within the line.
+
+The different mode influence the result when the patches are applied to texts other than the original, as well as the runtime.
+
+<<.tip "The calculation in `words` mode is roughly 10 times as fast as the default character mode, while `lines` mode can be more than 100 times faster than the default.">>
+
+<<.operator-examples "makepatches and applypatches">>

--- a/editions/tw5.com/tiddlers/filters/makepatches Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/makepatches Operator.tid
@@ -14,10 +14,10 @@ type: text/vnd.tiddlywiki
 
 <<.from-version "5.2.6">>
 
-The difference algorithm operates in character mode by default. This produces the most detailed diff possible. In `words` mode, each word in the input text is transformed into a meta-character, upon which the algorithm then operates. In the default character mode, the filter would find two patches between "ActionWidget" and "Action-Widgets" (the hyphen and the plural s), while in `words` mode, the whole word is found to be changed. In `lines` mode, the meta-character is formed from the whole line, and a whole line, delimited by newline characters, is found to be changed independent of the number of changes within the line.
+The difference algorithm operates in character mode by default. This produces the most detailed diff possible. In `words` mode, each word in the input text is transformed into a meta-character, upon which the algorithm then operates. In the default character mode, the filter would find two patches between "ActionWidget" and "Action-Widgets" (the hyphen and the plural s), while in `words` mode, the whole word is found to be changed. In `lines` mode, the meta-character is formed from the whole line, delimited by newline characters, and is found to be changed independent of the number of changes within the line.
 
-The different mode influence the result when the patches are applied to texts other than the original, as well as the runtime.
+The different modes influence the result when the patches are applied to texts other than the original, as well as the runtime.
 
-<<.tip "The calculation in `words` mode is roughly 10 times as fast as the default character mode, while `lines` mode can be more than 100 times faster than the default.">>
+<<.tip "The calculation in `words` mode is roughly 10 times faster than the default character mode, while `lines` mode can be more than 100 times faster than the default.">>
 
 <<.operator-examples "makepatches and applypatches">>

--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -133,6 +133,10 @@ td svg {
 	padding-left: 20px;
 }
 
+.doc-examples-hard-breaks .doc-example-result li {
+    white-space: pre-wrap;
+}
+
 .doc-bad-example code, .doc-bad-example pre, table.doc-bad-example {
   background-color:#ffff80;
 }


### PR DESCRIPTION
The `applypatches` examples result in pretty long lines when written as a single filter expression.
Alternatively, I could make something similar to the ActionWidget examples: Multiple lines and a button to initiate, or even leave out the button and just show the result, as in the second `levenshtein` example (will use more space upon opening the tiddler).
In this case I'd use a `$let` to put the patches into a variable and reference that in the filter that generates the actual output. This is closer to what one would do in a "real-world" wiki...