### PR TITLE
Developer demo of alternate wiki store implementation

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1107,7 +1107,7 @@ Wiki constructor. State is stored in private members that only a small number of
 options include:
 enableIndexers - Array of indexer names to enable, or null to use all available indexers
 */
-$tw.Wiki = function(options) {
+$tw.Wiki = $tw.Wiki || function(options) {
 	options = options || {};
 	var self = this,
 		tiddlers = Object.create(null), // Hashmap of tiddlers
@@ -1466,10 +1466,10 @@ $tw.Wiki = function(options) {
 // Dummy methods that will be filled in after boot
 $tw.Wiki.prototype.clearCache =
 $tw.Wiki.prototype.clearGlobalCache =
-$tw.Wiki.prototype.enqueueTiddlerEvent = function() {};
+$tw.Wiki.prototype.enqueueTiddlerEvent = $tw.Wiki.prototype.enqueueTiddlerEvent || function() {};
 
 // Add an array of tiddlers
-$tw.Wiki.prototype.addTiddlers = function(tiddlers) {
+$tw.Wiki.prototype.addTiddlers = $tw.Wiki.prototype.addTiddlers || function(tiddlers) {
 	for(var t=0; t<tiddlers.length; t++) {
 		this.addTiddler(tiddlers[t]);
 	}
@@ -1478,7 +1478,7 @@ $tw.Wiki.prototype.addTiddlers = function(tiddlers) {
 /*
 Define all modules stored in ordinary tiddlers
 */
-$tw.Wiki.prototype.defineTiddlerModules = function() {
+$tw.Wiki.prototype.defineTiddlerModules = $tw.Wiki.prototype.defineTiddlerModules || function() {
 	this.each(function(tiddler,title) {
 		if(tiddler.hasField("module-type")) {
 			switch (tiddler.fields.type) {
@@ -1502,7 +1502,7 @@ $tw.Wiki.prototype.defineTiddlerModules = function() {
 /*
 Register all the module tiddlers that have a module type
 */
-$tw.Wiki.prototype.defineShadowModules = function() {
+$tw.Wiki.prototype.defineShadowModules = $tw.Wiki.prototype.defineShadowModules || function() {
 	var self = this;
 	this.eachShadow(function(tiddler,title) {
 		// Don't define the module if it is overidden by an ordinary tiddler
@@ -1516,7 +1516,7 @@ $tw.Wiki.prototype.defineShadowModules = function() {
 /*
 Enable safe mode by deleting any tiddlers that override a shadow tiddler
 */
-$tw.Wiki.prototype.processSafeMode = function() {
+$tw.Wiki.prototype.processSafeMode = $tw.Wiki.prototype.processSafeMode || function() {
 	var self = this,
 		overrides = [];
 	// Find the overriding tiddlers
@@ -1547,7 +1547,7 @@ $tw.Wiki.prototype.processSafeMode = function() {
 /*
 Extracts tiddlers from a typed block of text, specifying default field values
 */
-$tw.Wiki.prototype.deserializeTiddlers = function(type,text,srcFields,options) {
+$tw.Wiki.prototype.deserializeTiddlers = $tw.Wiki.prototype.deserializeTiddlers || function(type,text,srcFields,options) {
 	srcFields = srcFields || Object.create(null);
 	options = options || {};
 	var deserializer = $tw.Wiki.tiddlerDeserializerModules[options.deserializer],

--- a/editions/prerelease/tiddlywiki.info
+++ b/editions/prerelease/tiddlywiki.info
@@ -14,7 +14,8 @@
 		"tiddlywiki/dynannotate",
 		"tiddlywiki/codemirror",
 		"tiddlywiki/menubar",
-		"tiddlywiki/jszip"
+		"tiddlywiki/jszip",
+		"tiddlywiki/demo-alternate-store"
 	],
 	"themes": [
 		"tiddlywiki/vanilla",

--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -6,7 +6,8 @@
 		"tiddlywiki/railroad",
 		"tiddlywiki/evernote",
 		"tiddlywiki/internals",
-		"tiddlywiki/menubar"
+		"tiddlywiki/menubar",
+		"tiddlywiki/demo-alternate-store"
 	],
 	"themes": [
 		"tiddlywiki/vanilla",

--- a/plugins/tiddlywiki/demo-alternate-store/plugin.info
+++ b/plugins/tiddlywiki/demo-alternate-store/plugin.info
@@ -1,0 +1,6 @@
+{
+	"title": "$:/plugins/tiddlywiki/demo-alternate-store",
+	"name": "Demo alternate store",
+	"description": "Developer demo of an alternate wiki store implementation",
+	"list": "readme"
+}

--- a/plugins/tiddlywiki/demo-alternate-store/rawmarkup.js
+++ b/plugins/tiddlywiki/demo-alternate-store/rawmarkup.js
@@ -1,0 +1,22 @@
+/*\
+title: $:/plugins/tiddlywiki/demo-alternate-store/rawmarkup.js
+type: application/javascript
+module-type: library
+
+Startup code injected as raw markup
+
+\*/
+
+(function() {
+
+// Need to initialise these because we run before bootprefix.js and boot.js
+$tw = window.$tw || Object.create(null);
+$tw.hooks = $tw.hooks || { names: {}};
+$tw.boot = $tw.boot || {};
+$tw.boot.preloadDirty = $tw.boot.preloadDirty || [];
+
+$tw.Wiki = function() {
+	
+};
+
+})();

--- a/plugins/tiddlywiki/demo-alternate-store/rawmarkup.tid
+++ b/plugins/tiddlywiki/demo-alternate-store/rawmarkup.tid
@@ -1,0 +1,6 @@
+title: $:/plugins/tiddlywiki/demo-alternate-store/rawmarkup
+tags: $:/tags/RawMarkupWikified
+
+`<script>`
+{{$:/plugins/tiddlywiki/demo-alternate-store/rawmarkup.js}}
+`</script>`

--- a/plugins/tiddlywiki/demo-alternate-store/readme.tid
+++ b/plugins/tiddlywiki/demo-alternate-store/readme.tid
@@ -1,0 +1,3 @@
+title: $:/plugins/tiddlywiki/demo-alternate-store/readme
+
+Developer demo of an alternate wiki store implementation


### PR DESCRIPTION
This is the very barebones beginnings of a demo implementation of an alternate tiddler store. It is not functional. If using the Vercel builds, open developer tools in the browser to see it failing due to the absence of basic wiki methods.

The plan is to build it up into the smallest possible plain JS wiki store implementation, sharing as much implementation as possible with the existing core implementation with as little code duplication as possible. It could then serve as the basis for future experiments with wiki stores based on SQLite (@linonetwo), or a custom append only database (@yaisog).