### PR TITLE
Improve the StoryTiddlerTemplate fallback

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -28,7 +28,7 @@ Basics/Title/Prompt: Title of this ~TiddlyWiki
 Basics/Username/Prompt: Username for signing edits
 Basics/Version/Prompt: ~TiddlyWiki version
 Cascades/Caption: Cascades
-Cascades/Hint: These global rules are used to dynamically choose certain templates. The result of the cascade is the result of the first filter in the sequence that returns a result. In case of problems with custom cascade filters, change their order in the corresponding tag dropdown or delete the changed cascade tiddlers to return to their original shadow versions.
+Cascades/Hint: These global rules are used to dynamically choose certain templates. The result of the cascade is the result of the first filter in the sequence that returns a result
 Cascades/TagPrompt: Filters tagged <$macrocall $name="tag" tag=<<currentTiddler>>/>
 EditorTypes/Caption: Editor Types
 EditorTypes/Editor/Caption: Editor

--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -28,7 +28,7 @@ Basics/Title/Prompt: Title of this ~TiddlyWiki
 Basics/Username/Prompt: Username for signing edits
 Basics/Version/Prompt: ~TiddlyWiki version
 Cascades/Caption: Cascades
-Cascades/Hint: These global rules are used to dynamically choose certain templates. The result of the cascade is the result of the first filter in the sequence that returns a result
+Cascades/Hint: These global rules are used to dynamically choose certain templates. The result of the cascade is the result of the first filter in the sequence that returns a result. In case of problems with custom cascade filters, change their order in the corresponding tag dropdown or delete the changed cascade tiddlers to return to their original shadow versions.
 Cascades/TagPrompt: Filters tagged <$macrocall $name="tag" tag=<<currentTiddler>>/>
 EditorTypes/Caption: Editor Types
 EditorTypes/Editor/Caption: Editor

--- a/core/ui/StoryTiddlerTemplate.tid
+++ b/core/ui/StoryTiddlerTemplate.tid
@@ -1,3 +1,3 @@
 title: $:/core/ui/StoryTiddlerTemplate
 
-<$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/StoryTiddlerTemplateFilter]!is[draft]get[text]] :and[!is[blank]else{$:/config/ui/ViewTemplate}] :and[has[title]else[$:/core/ui/ViewTemplate]] }}} />
+<$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/StoryTiddlerTemplateFilter]!is[draft]get[text]] :and[has[title]else[$:/core/ui/ViewTemplate]] }}} />

--- a/core/ui/StoryTiddlerTemplate.tid
+++ b/core/ui/StoryTiddlerTemplate.tid
@@ -1,3 +1,3 @@
 title: $:/core/ui/StoryTiddlerTemplate
 
-<$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/StoryTiddlerTemplateFilter]!is[draft]get[text]] :and[!is[blank]else{$:/config/ui/ViewTemplate}] }}} />
+<$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/StoryTiddlerTemplateFilter]!is[draft]get[text]] :and[!is[blank]else{$:/config/ui/ViewTemplate}] :and[has[title]else[$:/core/ui/ViewTemplate]] }}} />


### PR DESCRIPTION
I'm marking this as a draft PR, because this may be worth discussing.

Instead of adding _another_ fallback to the StoryTiddlerTemplate cascade, I _changed_ the existing fallback.

I believe those things could go wrong with the StoryTiddlerTemplate cascade due to user experimenting:
1) `draft` cascade entry is rendered unusable
2) `default` cascade entry is rendered unusable
3) `$:/config/ui/EditTemplate` is rendered unusable
4) `$:/config/ui/ViewTemplate` is rendered unusable

In the list, 3 will lead to 1 and 4 will lead to 2, because they are transcluded respectively. Also, 1 and 3 will lead to a ViewTemplate be used for the EditTemplate. In cases 1 and 2 the template falls back to `$:/config/ui/ViewTemplate`.

In all these cases, falling back to `$:/core/ui/ViewTemplate` would enable the user to delete faulty templates and configs to go back to the shadow versions, while currently 4 will brick the wiki.

Since falling back to the current `$:/config/ui/ViewTemplate` helps only in the edge case that 2 occurs without 4 occuring, I would _replace_ it to keep the logic simple.

Optionally, additionally, we could add a fallback to both cascades with the correct type (EditTemplate for `draft`, etc.), to catch problems with the config tiddlers.

Did I miss something?
Should we rather have two fallbacks, as in the initial commit?

I would also like to amend the cascade intro in the control panel to:
"These global rules are used to dynamically choose certain templates. The result of the cascade is the result of the first filter in the sequence that returns a result. _If there are problems with custom cascade filters, change their order in the corresponding tag dropdown or delete the changed cascade tiddlers to return to their shadow versions._

Closes #7311 