### PR TITLE
Add a description and examples for "strict" results from getindex

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/getindex.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/getindex.tid
@@ -1,8 +1,18 @@
 created: 20150203140000000
-modified: 20170608150301791
+modified: 20230306140231272
 tags: [[getindex Operator]] [[Operator Examples]]
 title: getindex Operator (Examples)
 type: text/vnd.tiddlywiki
 
-<<.operator-example 1 "[[$:/palettes/Vanilla]getindex[background]]" "returns the value at index ''background'' of the [[DataTiddler|DataTiddlers]] [[$:/palettes/Vanilla]]">>
+<<.operator-example 1 "[[$:/palettes/Vanilla]getindex[background]]" "returns the value at index <<.value background>> of the [[DataTiddler|DataTiddlers]] [[$:/palettes/Vanilla]]">>
 <<.operator-example 2 "[all[shadows+tiddlers]tag[$:/tags/Palette]getindex[background]]" "returns all background colors defined in any of the ColourPalettes">>
+
+[[ListopsData]] contains an empty index <<.value ~DataIndex>> which is not returned by the filter operator:
+<<.operator-example 3 "[[ListopsData]getindex[DataIndex]]">>
+
+This filter expression can be used to return the value, even if it is an empty string:
+<<.operator-example 4 "[[ListopsData]] :filter[has:index[DataIndex]] :and[getindex[DataIndex]else[]]">>
+
+There are 5 palettes which define the index <<.value diff-equal-background>>, but none defines a value:
+<<.operator-example 5 "[all[shadows+tiddlers]tag[$:/tags/Palette]] :filter[has:index[diff-equal-background]] :map[getindex[diff-equal-background]else[]]">>
+In the above example, the [[Map Filter Run Prefix]] is used instead of `:and` as it does not de-duplicate its results.

--- a/editions/tw5.com/tiddlers/filters/getindex.tid
+++ b/editions/tw5.com/tiddlers/filters/getindex.tid
@@ -1,17 +1,20 @@
+caption: getindex
 created: 20150203140000000
-modified: 20150203140000000
+modified: 20230306131335009
+op-purpose: select all values of a data property in the input titles
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: the name of a [[property|DataTiddlers]]
+op-parameter-name: P
+op-output: the values of property <<.place P>> in each of the input titles
 tags: [[Filter Operators]] [[Field Operators]]
 title: getindex Operator
 caption: getindex
-op-purpose: select all values of a data property in the input titles
-
-<$macrocall $name=".operator-def"
-input="a [[selection of titles|Title Selection]]"
-parameter="the name of a [[property|DataTiddlers]]"
-paramName="P"
-output="the values of property <<.place P>> in each of the input titles"
-/>
 
 Each input title is processed in turn, and is ignored if it does not denote a [[data tiddler|DataTiddlers]]. If the tiddler contains property <<.place P>>, the value of that property is [[dominantly appended|Dominant Append]] to the output.
 
+<<.tip """If a data tiddler contains index <<.place P>> with an empty value, the empty string is not appended. The following [[Filter Expression]] can be used to also return an empty string
+<pre>:filter[has:index[P]] :and[getindex[P]else[]]</pre>""">>
+
 <<.operator-examples "getindex">>
+
+


### PR DESCRIPTION
The operator `getindex` does not return empty strings when an index is defined, but not set. There is a workaround using `:filter` and `:and` / `:map` which is described as a short tip and with some additional examples.

Closes #7331 