### PR TITLE
Correct an example description in the ActionListopsWidget documentation

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ActionListopsWidget.tid
@@ -32,7 +32,7 @@ For example, the items "abc" and "123" can be appended to the field `myfield` us
 <$action-listops $field="myfield" $subfilter="abc 123"/>
 ```
 
-The same can be achieved using the `$filter` attribute and prepending the [[Filter Run]] `[all[current]get[myfield]enlist-input[]]` to the [[Filter Expression]]:
+The same can be achieved using the `$filter` attribute and prepending the [[Filter Run]] `[enlist{!!myfield}]` to the [[Filter Expression]]:
 
 ```
 <$action-listops $field="myfield" $filter="[enlist{!!myfield}] abc 123"/>


### PR DESCRIPTION
This aligns the given example with its description, as [proposed by btheado](https://github.com/Jermolene/TiddlyWiki5/pull/7301/files/dbc74467c6eee0f4db2aaeabe002af05da22d7a6#r1125579088).