### PR TITLE
Improve documentation for `get` and `getindex`

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/get.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/get.tid
@@ -1,9 +1,19 @@
 created: 20150118134611000
-modified: 20150124201839000
+modified: 20230309180521925
+myfield: 
 tags: [[get Operator]] [[Operator Examples]]
 title: get Operator (Examples)
 type: text/vnd.tiddlywiki
 
 <<.operator-example 1 "[all[current]get[draft.of]]" "the title of the tiddler of which the current tiddler is a draft">>
-<<.operator-example 2 "[get[tags]]">>
-<<.operator-example 3 "[each[tags]get[tags]]">>
+
+<<.operator-example 2 "[get[tags]]" "returns the tags of all tiddlers without de-duplication">>
+
+<<.operator-example 3 "[get[tags]unique[]]" "returns the tags of all tiddlers with de-duplication">>
+
+<<.tip """If a data tiddler contains a field with an empty value, the empty string is not appended to the results.""">>
+
+<<.operator-example 4 "[all[current]get[myfield]]" "the empty value of field <<.field myfield>> is not returned by the <<.olink get>> operator">>
+
+<<.operator-example 5 "[all[current]] :filter[has:field[myfield]] :map[get[myfield]]" "also returns the empty string">>
+The above example works by first using the [[Filter Filter Run Prefix]] to only select titles that have the field <<.field myfield>> and then using the [[Map Filter Run Prefix]] to replace those titles with their value of that field.  The [[Map Filter Run Prefix]] outputs an empty string when its filter run returns an empty [[selection|Title Selection]].

--- a/editions/tw5.com/tiddlers/filters/examples/getindex.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/getindex.tid
@@ -1,22 +1,19 @@
 created: 20150203140000000
-modified: 20230306140231272
+modified: 20230309180501044
 tags: [[getindex Operator]] [[Operator Examples]]
 title: getindex Operator (Examples)
 type: text/vnd.tiddlywiki
 
-<<.operator-example 1 "[[$:/palettes/Vanilla]getindex[background]]" "returns the value at index <<.value background>> of the [[DataTiddler|DataTiddlers]] [[$:/palettes/Vanilla]]">>
-<<.operator-example 2 "[all[shadows+tiddlers]tag[$:/tags/Palette]getindex[background]]" "returns all background colors defined in any of the ColourPalettes">>
+<<.operator-example 1 "[[$:/palettes/Vanilla]getindex[background]]" "returns the value of property <<.value background>> of the [[DataTiddler|DataTiddlers]] [[$:/palettes/Vanilla]]">>
 
-[[ListopsData]] contains an empty index <<.value ~DataIndex>> which is not returned by the filter operator:
-<<.operator-example 3 "[[ListopsData]getindex[DataIndex]]">>
+<<.operator-example 2 "[all[shadows+tiddlers]tag[$:/tags/Palette]getindex[background]]" "returns all background colors defined in any of the ColourPalettes (notice the duplicates in the resulting list)">>
 
-This filter expression can be used to return the value, even if it is an empty string:
-<<.operator-example 4 "[[ListopsData]] :filter[has:index[DataIndex]] :and[getindex[DataIndex]else[]]">>
+<<.tip """If a data tiddler contains a property with an empty value, the empty string is not appended to the results.""">>
 
-There are 5 palettes which define the index <<.value diff-equal-background>>, but none defines a value:
-<<.operator-example 5 "[all[shadows+tiddlers]tag[$:/tags/Palette]] :filter[has:index[diff-equal-background]] :map[getindex[diff-equal-background]else[]]">>
-In the above example, the [[Map Filter Run Prefix]] is used instead of `:and` as it does not de-duplicate its results.
+<<.operator-example 3 "[[ListopsData]getindex[DataIndex]]" "the empty value of the property <<.field ~DataIndex>> in [[ListopsData]] is not returned by the <<.olink getindex>> operator">>
 
-Another way to check if an index has an empty value is to [[count|count Operator]] the results from the [[getindex Operator]]:
-<<.operator-example 6 "[[$:/palettes/Vanilla]indexes[]] :filter[[$:/palettes/Vanilla]getindex<currentTiddler>count[]compare:number:eq[0]]">>
-Here, the input to `:filter` is the [[list of indexes|indexes Operator]] which are contained in [[$:/palettes/Vanilla]].
+<<.operator-example 4 "[[ListopsData]] :filter[has:index[DataIndex]] :map[getindex[DataIndex]]" "also returns the empty string">>
+The above example works by first using the [[Filter Filter Run Prefix]] to only select titles that have the property <<.field ~DataIndex>> and then using the [[Map Filter Run Prefix]] to replace those titles with their value of that property.  The [[Map Filter Run Prefix]] outputs an empty string when its filter run returns an empty [[selection|Title Selection]].
+
+<<.operator-example 5 "[[$:/palettes/Vanilla]indexes[]] :filter[[$:/palettes/Vanilla]getindex<currentTiddler>count[]compare:number:eq[0]]" "returns those colors in [[$:/palettes/Vanilla]] which are defined, but have no value assigned">>
+In the above example, <<.olink count>> is used to check if <<.olink getindex>> returns a result (i.e. the corresponding property has a value) or not.

--- a/editions/tw5.com/tiddlers/filters/get.tid
+++ b/editions/tw5.com/tiddlers/filters/get.tid
@@ -1,17 +1,17 @@
+caption: get
 created: 20140426183123179
-modified: 20150203185001000
+modified: 20230309163844434
+op-input: a [[selection of titles|Title Selection]]
+op-output: the values of field <<.place F>> in each of the input titles
+op-parameter: the name of a [[field|TiddlerFields]]
+op-parameter-name: F
+op-purpose: select all values of a field in the input titles
 tags: [[Filter Operators]] [[Field Operators]]
 title: get Operator
 type: text/vnd.tiddlywiki
-caption: get
-op-purpose: select all values of a field in the input titles
-op-input: a [[selection of titles|Title Selection]]
-op-parameter: the name of a [[field|TiddlerFields]]
-op-parameter-name: F
-op-output: the values of field <<.place F>> in each of the input titles
 
 Each input title is processed in turn. If the corresponding tiddler contains field <<.place F>>, and the value of this field is not empty, then its value is appended to the output.
 
-Unlike most other [[Filter Operators]], the [[selection|Title Selection]] output by <<.op get>> can contain duplicates. To avoid duplicates, use `each[F]get[F]`.
+<<.tip "Unlike most other [[Filter Operators]], the [[selection|Title Selection]] output by <<.op get>> can contain duplicates. To avoid duplicates, use `get[F]unique[]`.">>
 
 <<.operator-examples "get">>

--- a/editions/tw5.com/tiddlers/filters/getindex.tid
+++ b/editions/tw5.com/tiddlers/filters/getindex.tid
@@ -1,20 +1,16 @@
 caption: getindex
 created: 20150203140000000
-modified: 20230306131335009
-op-purpose: select all values of a data property in the input titles
+modified: 20230309163838670
 op-input: a [[selection of titles|Title Selection]]
+op-output: the values of property <<.place P>> in each of the input titles
 op-parameter: the name of a [[property|DataTiddlers]]
 op-parameter-name: P
-op-output: the values of property <<.place P>> in each of the input titles
+op-purpose: select all values of a data property in the input titles
 tags: [[Filter Operators]] [[Field Operators]]
 title: getindex Operator
-caption: getindex
 
-Each input title is processed in turn, and is ignored if it does not denote a [[data tiddler|DataTiddlers]]. If the tiddler contains property <<.place P>>, the value of that property is [[dominantly appended|Dominant Append]] to the output.
+Each input title is processed in turn, and is ignored if it does not denote a [[data tiddler|DataTiddlers]]. If the corresponding tiddler contains property <<.place P>>, and the value of this property is not empty, then its value is appended to the output.
 
-<<.tip """If a data tiddler contains index <<.place P>> with an empty value, the empty string is not appended. The following [[Filter Expression]] can be used to also return an empty string
-<pre>:filter[has:index[P]] :and[getindex[P]else[]]</pre>""">>
+<<.tip "Unlike most other [[Filter Operators]], the [[selection|Title Selection]] output by <<.op getindex>> can contain duplicates. To avoid duplicates, use `getindex[P]unique[]`.">>
 
 <<.operator-examples "getindex">>
-
-


### PR DESCRIPTION
I apologize, but the filter originally given in the "tip" for `getindex` worked only correct with a single input tiddler, which I corrected. Also, I felt that the _Examples_ were a better container for this information, so I moved it there.

Since `get` and `getindex` operate very similar, I made their descriptions and examples much more congruent, and also added an example of how to optionally return an empty string with `get`.

I refined the wording and formatting to better align with the _Documentation Style Guide_ and make better use of the _Documentation Macros_.