### PR TITLE
Add another example for the `get` operator

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/get.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/get.tid
@@ -1,5 +1,5 @@
 created: 20150118134611000
-modified: 20230309180521925
+modified: 20230310154010278
 myfield: 
 tags: [[get Operator]] [[Operator Examples]]
 title: get Operator (Examples)
@@ -17,3 +17,6 @@ type: text/vnd.tiddlywiki
 
 <<.operator-example 5 "[all[current]] :filter[has:field[myfield]] :map[get[myfield]]" "also returns the empty string">>
 The above example works by first using the [[Filter Filter Run Prefix]] to only select titles that have the field <<.field myfield>> and then using the [[Map Filter Run Prefix]] to replace those titles with their value of that field.  The [[Map Filter Run Prefix]] outputs an empty string when its filter run returns an empty [[selection|Title Selection]].
+
+<<.operator-example 6 "[all[tiddlers]] :filter[get[created]compare:date:lt{HelloThere!!created}]" "return all tiddlers that are older than [[HelloThere]]">>
+The above example demonstrates two different ways of accessing field values in filters: Use <<.olink get>> when the title is not known in advance as with the [[Filter Filter Run Prefix]] where <<.var currentTiddler>> is set to the current input title. Use a [[TextReference]] as an indirect [[Filter Parameter]] when the title is known.


### PR DESCRIPTION
This example inspired by @kookma demonstrates two different methods of getting the value of a field within a filter expression.