### PR TITLE
fix index.html overwrites external wiki html

### DIFF
--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -52,7 +52,7 @@
 			"--render","[!is[system]]","[encodeuricomponent[]addprefix[static/]addsuffix[.html]]","text/plain","$:/core/templates/static.tiddler.html",			
 			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"],
 		"external-js": [
-			"--render","$:/core/save/offline-external-js","index.html","text/plain",
+			"--render","$:/core/save/offline-external-js","[[external-]addsuffix<version>addsuffix[.html]]","text/plain",
 			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"]
 	},
 	"config": {


### PR DESCRIPTION
IMO this is a bugfix, that should fixed as part of v5.2.6

If you have a look at: https://github.com/Jermolene/TiddlyWiki5/blob/master/editions/tw5.com/tiddlywiki.info you'll see, that there are 2 `index.html` files, which are crated. 

```
	"build": {
		"index": [
......
			"--setfield","[tag[external-image]] [tag[external-text]]","text","","text/plain",
			"--render","$:/core/save/all","index.html","text/plain"],
......
		"external-js": [
			"--render","$:/core/save/offline-external-js","index.html","text/plain",
			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"]
	},
```

- The first one is part of `--build index`
- The second one is `--build external-js` --> which will be overwritten by index.html. 

I suggest to rename it to eg: `external-<version>.html` ... This name is just a proposal and may be discussed. 
