### PR TITLE
Safe mode layout

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1542,6 +1542,8 @@ $tw.Wiki.prototype.processSafeMode = function() {
 	this.addTiddler(new $tw.Tiddler({title: titleReportTiddler, text: report.join("\n\n")}));
 	// Set $:/DefaultTiddlers to point to our report
 	this.addTiddler(new $tw.Tiddler({title: "$:/DefaultTiddlers", text: "[[" + titleReportTiddler + "]]"}));
+	// Switch to the safe mode layout
+	this.addTiddler({title: "$:/layout", text: "$:/core/ui/SafeLayout"});
 };
 
 /*

--- a/core/language/en-GB/Misc.multids
+++ b/core/language/en-GB/Misc.multids
@@ -56,6 +56,7 @@ Manager/Controls/Show/Option/Tiddlers: tiddlers
 Manager/Controls/Show/Prompt: Show:
 Manager/Controls/Sort/Prompt: Sort by:
 Manager/Item/Colour: Colour
+Manager/Item/Editor: Editor
 Manager/Item/Fields: Fields
 Manager/Item/Icon/None: (none)
 Manager/Item/Icon: Icon

--- a/core/modules/startup/story.js
+++ b/core/modules/startup/story.js
@@ -214,7 +214,7 @@ function updateLocationHash(options) {
 			break;
 	}
 	// Only change the location hash if we must, thus avoiding unnecessary onhashchange events
-	if($tw.utils.getLocationHash() !== $tw.locationHash) {
+	if($tw.utils.getLocationHash() !== $tw.locationHash && !$tw.safeMode) {
 		if(options.updateHistory === "yes") {
 			// Assign the location hash so that history is updated
 			window.location.hash = $tw.locationHash;

--- a/core/ui/Manager/ItemMainEditor.tid
+++ b/core/ui/Manager/ItemMainEditor.tid
@@ -1,0 +1,5 @@
+title: $:/Manager/ItemMain/Editor
+tags: $:/tags/Manager/ItemMain
+caption: {{$:/language/Manager/Item/Editor}}
+
+<$edit-text tag="textarea" class="tc-edit-texteditor tc-edit-texteditor-body tc-max-width"/>

--- a/core/ui/Manager/ItemSidebarTools.tid
+++ b/core/ui/Manager/ItemSidebarTools.tid
@@ -13,3 +13,8 @@ caption: {{$:/language/Manager/Item/Tools}}
 {{$:/core/images/edit-button}}&#32;edit
 </$button>
 </p>
+<p>
+<$button message="tm-delete-tiddler" param=<<currentTiddler>>>
+{{$:/core/images/delete-button}}&#32;delete
+</$button>
+</p>

--- a/core/ui/SafeModeLayout.tid
+++ b/core/ui/SafeModeLayout.tid
@@ -1,0 +1,37 @@
+title: $:/core/ui/SafeLayout
+tags: $:/tags/Layout
+name: Safe Mode Layout
+description: Safe Mode Layout
+icon: $:/core/images/list
+
+\whitespace trim
+
+\import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
+
+\define tv-config-toolbar-class() tc-btn-invisible
+\define tv-config-toolbar-icons() yes
+\define tv-config-toolbar-text() no
+
+<div style="margin: 1em;">
+
+<$navigator story="$:/StoryList" history="$:/HistoryList">
+
+<h2>Layout</h2>
+
+{{$:/snippets/LayoutSwitcher}}
+
+<h2>Controls</h2>
+
+<div class="tc-page-controls">
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]">
+<$transclude mode="inline"/>
+</$list>
+</div>
+
+<h2>Tiddlers</h2>
+
+<$transclude tiddler="$:/Manager" mode="block"/>
+
+</$navigator>
+
+</div>

--- a/core/wiki/config/ManagerItemState.multids
+++ b/core/wiki/config/ManagerItemState.multids
@@ -1,3 +1,4 @@
 title: $:/state/popup/manager/item/$:/Manager/
 
 ItemMain/RawText: hide
+ItemMain/Editor: hide


### PR DESCRIPTION
I came across this draft PR from a couple of years ago which seems relevant to some recent discussions about "safe mode".

This PR introduces a new safe mode layout that essentially consists of the tiddler manager (`$:/Manager`) plus the page buttons, and the layout switcher. The tiddler manager is extended to provide an editor and a "delete" button.

The new layout is engaged automatically with safe mode. The idea is that it gives users enough functionality to be able to edit or delete problematic tiddlers and then save the wiki.

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/174761/224557323-5891ab7a-d3af-4451-98f1-bff097751542.png">
