### PR TITLE
external-js file naming adjusted. import docs form tw5.com. make extrnal-js more visible

### DIFF
--- a/core/templates/external-js/save-all-external-js.tid
+++ b/core/templates/external-js/save-all-external-js.tid
@@ -5,8 +5,8 @@ title: $:/core/save/all-external-js
 \define saveTiddlerFilter()
 [is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
-<!-- It's important to fully understand this PR https://github.com/Jermolene/TiddlyWiki5/pull/5570 -->
-<!-- and what tiddlers: $:/core/templates/tiddlywiki5.js and $:/core/templates/tiddlywiki5.js/tiddlers do -->
+
+<!-- Important: core library is provided by serving URI encoded $:/core/templates/tiddlywiki5.js -->
 \define defaultCoreURL() %24%3A%2Fcore%2Ftemplates%2Ftiddlywiki5.js
 
 <$let coreURL={{{ [[coreURL]is[variable]then<coreURL>else<defaultCoreURL>] }}}>

--- a/core/templates/external-js/save-all-external-js.tid
+++ b/core/templates/external-js/save-all-external-js.tid
@@ -5,7 +5,10 @@ title: $:/core/save/all-external-js
 \define saveTiddlerFilter()
 [is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
+<!-- It's important to fully understand this PR https://github.com/Jermolene/TiddlyWiki5/pull/5570 -->
+<!-- and what tiddlers: $:/core/templates/tiddlywiki5.js and $:/core/templates/tiddlywiki5.js/tiddlers do -->
 \define defaultCoreURL() %24%3A%2Fcore%2Ftemplates%2Ftiddlywiki5.js
+
 <$let coreURL={{{ [[coreURL]is[variable]then<coreURL>else<defaultCoreURL>] }}}>
 	{{$:/core/templates/tiddlywiki5-external-js.html}}
 </$let>

--- a/editions/server-external-js/tiddlers/config/$__DefaultTiddlers.tid
+++ b/editions/server-external-js/tiddlers/config/$__DefaultTiddlers.tid
@@ -1,0 +1,7 @@
+created: 20230314153132081
+modified: 20230314153243008
+title: $:/DefaultTiddlers
+type: text/vnd.tiddlywiki
+
+GettingStarted
+[[Using the external JavaScript template]]

--- a/editions/server-external-js/tiddlers/config/$__config_SaveWikiButton_Filename.tid
+++ b/editions/server-external-js/tiddlers/config/$__config_SaveWikiButton_Filename.tid
@@ -1,0 +1,4 @@
+title: $:/config/SaveWikiButton/Filename
+type: text/vnd.tiddlywiki
+
+external-<<version>>.html

--- a/editions/server-external-js/tiddlers/external/tiddlywiki.files
+++ b/editions/server-external-js/tiddlers/external/tiddlywiki.files
@@ -1,0 +1,8 @@
+{
+	"tiddlers": [
+		{
+			"file": "../../../tw5.com/tiddlers/webserver/Using the external JavaScript template.tid",
+			"isTiddlerFile": true
+		}
+	]
+}

--- a/editions/server-external-js/tiddlers/system/$__SiteTitle.tid
+++ b/editions/server-external-js/tiddlers/system/$__SiteTitle.tid
@@ -1,0 +1,6 @@
+created: 20230314153323056
+modified: 20230314153504240
+title: $:/SiteTitle
+type: text/vnd.tiddlywiki
+
+{{$:/config/SaveWikiButton/Filename}}

--- a/editions/server-external-js/tiddlers/system/$__SiteTitle.tid
+++ b/editions/server-external-js/tiddlers/system/$__SiteTitle.tid
@@ -1,6 +1,0 @@
-created: 20230314153323056
-modified: 20230314153504240
-title: $:/SiteTitle
-type: text/vnd.tiddlywiki
-
-{{$:/config/SaveWikiButton/Filename}}

--- a/editions/server-external-js/tiddlywiki.info
+++ b/editions/server-external-js/tiddlywiki.info
@@ -2,8 +2,7 @@
 	"description": "Client-server edition with external tiddlywiki.js",
 	"plugins": [
 		"tiddlywiki/tiddlyweb",
-		"tiddlywiki/filesystem",
-		"tiddlywiki/highlight"
+		"tiddlywiki/filesystem"
 	],
 	"themes": [
 		"tiddlywiki/vanilla",
@@ -13,7 +12,7 @@
 		"listen": [
 			"--listen","root-tiddler=$:/core/save/all-external-js","use-browser-cache=yes"],
 		"index": [
-			"--render","$:/core/save/offline-external-js","index.html","text/plain",
+			"--render","$:/core/save/offline-external-js","[[external-]addsuffix<version>addsuffix[.html]]","text/plain",
 			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"],
 		"static": [
 			"--render","$:/core/templates/static.template.html","static.html","text/plain",

--- a/editions/tw5.com/tiddlers/webserver/Using the external JavaScript template.tid
+++ b/editions/tw5.com/tiddlers/webserver/Using the external JavaScript template.tid
@@ -60,7 +60,7 @@ The "server-external-js" edition lets you save the snapshot from the command lin
 tiddlywiki YOUR_WIKI_FOLDER --build index
 ```
 
-The files `index.html` and `tiddlywikicore-5.x.x.js` will be saved in your wiki folder's `output` directory.
+The files `external-5-x-x.html` and `tiddlywikicore-5.x.x.js` will be saved in your wiki folder's `output` directory.
 
 !! Obtaining the ~TiddlyWiki core in the browser
 

--- a/editions/tw5.com/tiddlers/webserver/Using the external JavaScript template.tid
+++ b/editions/tw5.com/tiddlers/webserver/Using the external JavaScript template.tid
@@ -4,6 +4,10 @@ tags: [[WebServer Guides]]
 title: Using the external JavaScript template
 type: text/vnd.tiddlywiki
 
+<!--
+This tiddler is also included in the "server-external-js" edition. Take care before editing or moving it.
+-->
+
 You can use a special template to externalise ~TiddlyWiki's core code into a separate file. This configuration allows the browser to cache the core for improved efficiency. 
 
 ! Background

--- a/editions/tw5.com/tiddlers/webserver/Using the external JavaScript template.tid
+++ b/editions/tw5.com/tiddlers/webserver/Using the external JavaScript template.tid
@@ -1,5 +1,5 @@
 created: 20180905075846391
-modified: 20221207112242775
+modified: 20230319130830880
 tags: [[WebServer Guides]]
 title: Using the external JavaScript template
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
This PR fixes the issue: **[BUG] server-external-js does not have enough information to crate a working snapshot** #7366 

---

<details><summary>This PR does</summary>

- server-external-js -- tiddlywiki.info
  - renames index.html to `external-<version>.html`, to make it clear that there is something special going on
  - removed the highlight plugin .. The HTML file should be as small as possible
- imported "Using the external JavaScript template" from tw5-com -> **no duplication**
  - This tiddler also allows users to save the external core using the green button
- $:/DefaultTiddlers shows , GettingStarted and "Using the external JavaScript template" at startup

I did test

```
tiddlywiki ./myNewWiki --init server-external-js
tiddlywiki ./myNewWiki --build listen
```

- change some tiddlers
- reload page to see if they are saved -> OK
- Use the green-button to download `tiddlywikicore-5.2.6-prerelease.js`
- Use the "save snapshot" action to download `external-5.2.6-prerelease.html`
  - Open the .html in the browser
  - change some tiddlers
  - save
  - reload -> works

</details>