### PR TITLE
Restructure and optimize `CheckboxWidget` docs

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget (field Mode).tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget (field Mode).tid
@@ -1,0 +1,15 @@
+caption: ''field'' Mode
+created: 20230314171223911
+modified: 20230314200046885
+tags: CheckboxWidget
+title: CheckboxWidget (field Mode)
+
+!! <<.attr field>> Mode
+
+Using the checkbox widget in field mode requires the <<.attr field>> attribute to specify the name of the field. The <<.attr checked>> and <<.attr unchecked>> attributes specify the values to be assigned to the field to correspond to its checked and unchecked states respectively. The <<.attr default>> attribute is used as a fallback value if the field is missing or contains a value that does not correspond to the value of the <<.attr checked>> or <<.attr unchecked>> attributes.
+
+This example creates a checkbox that is checked if the field <<.field status>> is equal to <<.value open>> and unchecked if the field is equal to <<.value closed>>. If the field value is undefined then it defaults to <<.value closed>>.
+
+<<wikitext-example-without-html """<$checkbox field="status" checked="open" unchecked="closed" default="closed"> Is it open?</$checkbox>
+
+''status:'' {{!!status}}""">>

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget (filter Mode).tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget (filter Mode).tid
@@ -1,0 +1,22 @@
+caption: ''filter'' Mode
+created: 20230314174505003
+modified: 20230314195819839
+tags: CheckboxWidget
+title: CheckboxWidget (filter Mode)
+
+!! <<..attr filter>> Mode
+
+Using the checkbox widget in filter mode requires the <<.attr filter>> attribute to contain a filter whose output will determine the checked state of the checkbox. In filter mode, checking the checkbox will not automatically make changes to any field of any tiddler. Instead, you can use the <<.attr actions>> attribute (or the <<.attr checkactions>> and <<.attr uncheckactions>> attributes) to specify what should happen when the checkbox is toggled. It is your responsibility to make sure the actions cause changes to the tiddlers or fields that the filter results depend on, so that the checkbox becomes properly checked or unchecked after the actions have triggered and the filter has updated.
+
+If the filter returns an empty result, the checkbox will be unchecked. Otherwise, if the filter result is non-empty, the checkbox will be checked.
+
+However, if either the <<.attr checked>> or <<.attr unchecked>> attributes (or both) are specified, then their values will be looked for in the filter result, instead of considering any non-empty value to mean <<.value checked>>.
+
+This example creates the same checkbox as in the <$button class="tc-btn-invisible tc-tiddlylink" set="$:/state/tab/CheckboxWidget" setTo="CheckboxWidget (listField Mode)">list mode example</$button>, selecting between <<.value red>> and <<.value green>> in the <<.field colors>> list field, but using filters and actions to make the change.
+
+<<wikitext-example-without-html """\define checkActions() <$action-listops $field="colors" $subfilter="-red green"/>
+\define uncheckActions() <$action-listops $field="colors" $subfilter="red -green"/>
+<$checkbox filter="[list[!!colors]]" checked="green" unchecked="red" default="red" checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> > Is "green" in colors?</$checkbox>
+
+''colors:'' {{!!colors}}
+""">>

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget (index Mode).tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget (index Mode).tid
@@ -1,0 +1,13 @@
+caption: ''index'' Mode
+created: 20230314171351122
+modified: 20230314195837258
+tags: CheckboxWidget
+title: CheckboxWidget (index Mode)
+
+!! <<.attr index>> Mode
+
+To use the checkbox widget in index mode set the <<.attr index>> attribute to a property of a [[DataTiddler|DataTiddlers]]. The <<.attr checked>> and <<.attr unchecked>> attributes specify the values to be assigned to the property and correspond to its checked and unchecked states respectively. The <<.attr default>> attribute is used as a fallback value if the property is undefined.
+
+The example below creates a checkbox that is checked if the property in the tiddler [[ExampleData]] by the name of the current tiddler is equal to <<.value selected>> and unchecked if the property is an empty string. If the property is undefined then it defaults to an empty string, meaning the checkbox will be unchecked if the property is missing.
+
+<$macrocall $name="wikitext-example-without-html" src="""<$checkbox tiddler="ExampleData" index=<<currentTiddler>> checked="selected" unchecked="" default=""> Selected?</$checkbox>"""/>

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget (listField Mode).tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget (listField Mode).tid
@@ -1,0 +1,25 @@
+caption: ''listField'' Mode
+created: 20230314171331190
+modified: 20230314201028095
+tags: CheckboxWidget
+title: CheckboxWidget (listField Mode)
+
+!! <<.attr listField>> Mode
+
+Using the checkbox widget in list mode requires the <<.attr listField>> attribute to specify the name of a field containing a list. The <<.attr checked>> attribute specifies the value that should be present or absent in the list when the checkbox is checked or unchecked respectively. If <<.attr checked>> is absent (or empty) but <<.attr unchecked>> is present, then the logic will be inverted: the checkbox will be checked when the <<.attr unchecked>> value is missing from the list, and unchecked when the <<.attr unchecked>> value is found in the list. If both <<.attr checked>> and <<.attr unchecked>> are present, the checkbox will work like a toggle, replacing the <<.attr checked>> value with the <<.attr unchecked>> value and vice-versa. Finally, if neither <<.attr checked>> nor <<.attr unchecked>> is specified, the checkbox will be checked if the field has anything in it, but unchecked if the field is missing or empty. (This is rarely useful. Most of the time you want to specify <<.attr checked>> or <<.attr unchecked>> or both.)
+
+The <<.attr default>> attribute is used as a fallback for the checkbox state if the field is not defined.
+
+The following table summarizes the possible combinations:
+
+| !defined attributes| !<$checkbox tag="void" disabled="yes"/> | !<$checkbox field="tag" checked="void" default="void" disabled="yes" /> | !<$checkbox listField="tag" checked="void" unchecked="invalid" indeterminate="yes" disabled="yes" /> |
+| neither| field missing or list empty<br/>no <<.attr default>> defined | field has any value | -- |
+| <<.attr checked>>=<<.value item1>>| <<.value item1>> removed from list | <<.value item1>> added to list | -- |
+| <<.attr unchecked>>=<<.value item2>>| <<.value item2>> added to list | <<.value item2>> removed from list | -- |
+| both| <<.value item1>> removed from list<br/><<.value item2>> added to list | <<.value item1>> added to list<br/><<.value item2>> removed from list | <<.value item1>> not in list<br/><<.value item2>> not in list<br/>no <<.attr default>> defined |
+
+This example creates a checkbox that is checked if the list field named <<.field colors>> contains <<.value green>> and unchecked if the field contains <<.value red>>. If the field is undefined, or if neither <<.value green>> nor <<.value red>> appears in the field, then it defaults to <<.value green>>, meaning that the checkbox will be checked.
+
+<<wikitext-example-without-html """<$checkbox listField="colors" checked="green" unchecked="red" default="green"> Is "green" in colors?</$checkbox><br />''colors:'' {{!!colors}}""">>
+
+Try editing the <<.field colors>> field of this tiddler to see how the example changes.

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget (listIndex Mode).tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget (listIndex Mode).tid
@@ -1,0 +1,29 @@
+caption: ''listIndex'' Mode
+created: 20230314174442174
+modified: 20230314201100666
+tags: CheckboxWidget
+title: CheckboxWidget (listIndex Mode)
+
+!! <<.attr listIndex>> Mode
+
+Using the checkbox widget in index list mode requires the <<.attr listIndex>> attribute to specify the the property of a [[DataTiddler|DataTiddlers]]. This property contains a list. The <<.attr checked>> attribute specifies the value that should be present or absent in the list when the checkbox is checked or unchecked respectively. If <<.attr checked>> is absent (or empty) but <<.attr unchecked>> is present, then the logic will be inverted: the checkbox will be checked when the <<.attr unchecked>> value is missing from the list, and unchecked when the <<.attr unchecked>> value is found in the list. If both <<.attr checked>> and <<.attr unchecked>> are present, the checkbox will work like a toggle, replacing the <<.attr checked>> value with the <<.attr unchecked>> value and vice-versa. Finally, if neither <<.attr checked>> nor <<.attr unchecked>> is specified, the checkbox will be checked if the field has anything in it, but unchecked if the field is missing or empty. (This is rarely useful. Most of the time you want to specify <<.attr checked>> or <<.attr unchecked>> or both.)
+
+The <<.attr default>> attribute is used as a fallback for the checkbox state if the property is undefined.
+
+The following table summarizes the possible combinations:
+
+| !defined attributes| !<$checkbox tag="void" disabled="yes"/> | !<$checkbox field="tag" checked="void" default="void" disabled="yes" /> | !<$checkbox listField="tag" checked="void" unchecked="invalid" indeterminate="yes" disabled="yes" /> |
+| neither| property missing or list empty<br/>no <<.attr default>> defined | property has any value | -- |
+| <<.attr checked>>=<<.value item1>>| <<.value item1>> removed from list | <<.value item1>> added to list | -- |
+| <<.attr unchecked>>=<<.value item2>>| <<.value item2>> added to list | <<.value item2>> removed from list | -- |
+| both| <<.value item1>> removed from list<br/><<.value item2>> added to list | <<.value item1>> added to list<br/><<.value item2>> removed from list | <<.value item1>> not in list<br/><<.value item2>> not in list<br/>no <<.attr default>> defined |
+
+The example below creates three checkboxes that each control a different value in a property of the ExampleData tiddler.
+
+<$macrocall $name="wikitext-example-without-html" src="""<$set name=indexName filter="[<currentTiddler>addsuffix[ Colors]]" >
+<$checkbox tiddler="ExampleData" listIndex=<<indexName>> checked="green" unchecked="red" default="red"> Green or red?</$checkbox><br/>
+<$checkbox tiddler="ExampleData" listIndex=<<indexName>> checked="yellow" unchecked="blue" default="blue"> Yellow or blue?</$checkbox><br/>
+<$checkbox tiddler="ExampleData" listIndex=<<indexName>> checked="orange" unchecked="purple" default="purple"> Orange or purple?</$checkbox><br/>
+Colors list: <$text text={{{ [[ExampleData]getindex<indexName>] }}} />
+</$set>
+"""/>

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget (tag Mode).tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget (tag Mode).tid
@@ -1,0 +1,17 @@
+caption: ''tag'' Mode
+created: 20230314171205017
+modified: 20230314200104199
+tags: CheckboxWidget
+title: CheckboxWidget (tag Mode)
+
+!! <<.attr tag>> Mode
+
+Using the checkbox widget in tag mode requires the <<.attr tag>> attribute to specify the name of the tag. The checkbox will be checked if the tiddler specified in the <<.attr tiddler>> attribute has the specified tag and unchecked if it does not.
+
+This example creates a checkbox that flips the <<.tag done>> tag on the current tiddler:
+
+<<wikitext-example-without-html """<$checkbox tag="done"> Is it done?</$checkbox>""">>
+
+When the attribute <<.attr invertTag>> is set to <<.value yes>>, the checkbox will be checked if the tiddler does <<.em not>> have the specified tag and unchecked if it does.
+
+<<wikitext-example-without-html """<$checkbox tag="done" invertTag="yes"> Is it not done?</$checkbox>""">>

--- a/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/CheckboxWidget.tid
@@ -1,12 +1,13 @@
 caption: checkbox
-created: 20131024141900000
-modified: 20220402023600000
-tags: Widgets TriggeringWidgets
 colors: red orange yellow blue
+created: 20131024141900000
 fruits: bananas oranges grapes
-vegetables: carrots potatoes
+list: [[CheckboxWidget (tag Mode)]] [[CheckboxWidget (field Mode)]] [[CheckboxWidget (listField Mode)]] [[CheckboxWidget (index Mode)]] [[CheckboxWidget (listIndex Mode)]] [[CheckboxWidget (filter Mode)]]
+modified: 20230314201744280
+tags: Widgets TriggeringWidgets
 title: CheckboxWidget
 type: text/vnd.tiddlywiki
+vegetables: carrots potatoes
 
 ! Introduction
 
@@ -20,93 +21,31 @@ The checkbox widget displays an HTML `<input type="checkbox">` element that is d
 The content of the `<$checkbox>` widget is displayed within an HTML `<label>` element immediately after the checkbox itself. This means that clicking on the content will toggle the checkbox.
 
 |!Attribute |!Description |
-|tiddler |Title of the tiddler to manipulate (defaults to the [[current tiddler|Current Tiddler]]) |
-|tag |The name of the tag to which the checkbox is bound |
-|invertTag |When set to ''yes'', flips the tag binding logic so that the absence of the tag causes the checkbox to be checked  |
+|tiddler |Title of the tiddler to manipulate (defaults to the [[Current Tiddler]]) |
+|tag |The name of the [[tag|Tagging]] to which the checkbox is bound |
+|invertTag |When set to <<.value yes>>, flips the tag binding logic so that the absence of the tag causes the checkbox to be checked  |
 |field |The name of the field to which the checkbox is bound |
 |listField |<<.from-version "5.2.3">> The name of the field that contains the list to which the checkbox is bound |
-|index|<<.from-version "5.1.14">> The index of the //tiddler//, a [[DataTiddler|DataTiddlers]], to which the checkbox is bound<<.tip "be sure to set the //tiddler// correctly">>|
+|index|<<.from-version "5.1.14">> The property of the [[DataTiddler|DataTiddlers]] to which the checkbox is bound<<.warning "Make sure to set <<.attr tiddler>> correctly">>|
 |listIndex |<<.from-version "5.2.3">> Like <<.attr index>>, but treats the value as a list the same way that <<.attr listField>> does |
 |filter |<<.from-version "5.2.3">> A filter whose output determines the checked state of the checkbox |
 |checked |The value of the field corresponding to the checkbox being checked |
 |unchecked |The value of the field corresponding to the checkbox being unchecked |
 |default |The default value to use if the field is not defined |
 |indeterminate |Whether ambiguous values can produce indeterminate checkboxes (see below) |
-|class |The class that will be assigned to the label element <$macrocall $name=".tip" _="""<<.from-version "5.2.3">> `tc-checkbox` is always applied by default, as well as `tc-checkbox-checked` when checked"""/> |
+|class |The class that will be assigned to the `<label>` element <$macrocall $name=".tip" _="""<<.from-version "5.2.3">> `tc-checkbox` is always applied by default, as well as `tc-checkbox-checked` when checked"""/> |
 |actions |<<.from-version "5.1.14">> A string containing ActionWidgets to be triggered when the status of the checkbox changes (whether it is checked or unchecked) |
 |uncheckactions |<<.from-version "5.1.16">> A string containing ActionWidgets to be triggered when the checkbox is unchecked |
 |checkactions |<<.from-version "5.1.20">> A string containing ActionWidgets to be triggered when the checkbox is checked |
-|disabled|<<.from-version "5.1.23">> Optional, disables the checkbox if set to "yes". Defaults to "no"|
+|disabled|<<.from-version "5.1.23">> Optionally disables the checkbox if set to <<.value yes>> (defaults to <<.value no>>)|
 
-!! Tag Mode
+<$macrocall $name="tabs" tabsList="[tag[CheckboxWidget]]" default="CheckboxWidget (tag Mode)" explicitState="$:/state/tab/CheckboxWidget" />
 
-Using the checkbox widget in tag mode requires the ''tag'' attribute to specify the name of the tag. The ''tiddler'' attribute specifies the tiddler to target, defaulting to the current tiddler if not present.
-
-This example creates a checkbox that flips the ''done'' tag on the current tiddler:
-
-<<wikitext-example-without-html """<$checkbox tag="done"> Is it done?</$checkbox>""">>
-
-!! Field Mode
-
-Using the checkbox widget in field mode requires the ''field'' attribute to specify the name of the field. The ''checked'' and ''unchecked'' attributes specify the values to be assigned to the field to correspond to its checked and unchecked states respectively. The ''default'' attribute is used as a fallback value if the field is not defined.
-
-This example creates a checkbox that is checked if the field ''status'' is equal to ''open'' and unchecked if the field is equal to ''closed''. If the field is undefined then it defaults to ''closed'', meaning that the checkbox will be unchecked if the ''status'' field is missing.
-
-<<wikitext-example-without-html """<$checkbox field="status" checked="open" unchecked="closed" default="closed"> Is it open?</$checkbox><br />''status:'' {{!!status}}""">>
-
-!! List Mode
-
-Using the checkbox widget in list mode requires the ''listField'' attribute to specify the name of a field containing a list. The ''checked'' attribute specifies the value that should be present or absent in the list when the checkbox is checked or unchecked respectively. If ''checked'' is absent (or empty) but ''unchecked'' is present, then the logic will be inverted: the checkbox will be checked when the "unchecked" value is missing from the list, and unchecked when the "unchecked" value is found in the list. If both ''checked'' and ''unchecked'' are present, the checkbox will work like a toggle, replacing the ''checked'' value with the ''unchecked'' value and vice-versa. Finally, if neither ''checked'' nor ''unchecked'' is specified, the checkbox will be checked if the field has anything in it, but unchecked if the field is missing or empty. (This is rarely useful; most of the time you'll want to specify ''checked'' or ''unchecked'' or both.)
-
-The ''default'' attribute is used as a fallback for the checkbox state if the field is not defined.
-
-This example creates a checkbox that is checked if the list field named ''colors'' contains ''green'' and unchecked if the field contains ''red''. If the field is undefined, or if neither ''green'' nor ''red'' appears in the field, then it defaults to ''green'', meaning that the checkbox will be checked.
-
-<<wikitext-example-without-html """<$checkbox listField="colors" checked="green" unchecked="red" default="green"> Is it green?</$checkbox><br />''colors:'' {{!!colors}}""">>
-
-Try editing the ''colors'' field of this tiddler to see how the example changes.
-
-!! Index Mode
-
-To use the checkbox widget in index mode set the ''index'' attribute to the index of a [[DataTiddler|DataTiddlers]]. The ''checked'' and ''unchecked'' attributes specify the values to be assigned to the index and correspond to its checked and unchecked states respectively. The ''default'' attribute is used as a fallback value if the index is undefined.
-
-The example below creates a checkbox that is checked if the index by the name of this tiddler in the tiddler ExampleData is equal to ''selected'' and unchecked if the index is an empty string. If the index is undefined then it defaults to an empty string, meaning the checkbox will be unchecked if the index is missing.
-
-<$macrocall $name="wikitext-example-without-html" src="""<$checkbox tiddler="ExampleData" index=<<currentTiddler>> checked="selected" unchecked="" default=""> Selected?</$checkbox>"""/>
-
-!! Index List Mode
-
-Using the checkbox widget in index list mode requires the ''listIndex'' attribute to specify the the index of a [[DataTiddler|DataTiddlers]] containing a list. The ''checked'' attribute specifies the value that should be present or absent in the list when the checkbox is checked or unchecked respectively. If ''checked'' is absent (or empty) but ''unchecked'' is present, then the logic will be inverted: the checkbox will be checked when the "unchecked" value is missing from the list, and unchecked when the "unchecked" value is found in the list. If both ''checked'' and ''unchecked'' are present, the checkbox will work like a toggle, replacing the ''checked'' value with the ''unchecked'' value and vice-versa. Finally, if neither ''checked'' nor ''unchecked'' is specified, the checkbox will be checked if the field has anything in it, but unchecked if the field is missing or empty. (This is rarely useful; most of the time you'll want to specify ''checked'' or ''unchecked'' or both.)
-
-The ''default'' attribute is used as a fallback for the checkbox state if the index is undefined.
-
-The example below creates three checkboxes that each control a different value in an index field of the ExampleData tiddler.
-
-<$macrocall $name="wikitext-example-without-html" src="""
-<$set name=indexName filter="[<currentTiddler>addsuffix[ Colors]]" >
-<$checkbox tiddler="ExampleData" listIndex=<<indexName>> checked="green" unchecked="red" default="red"> Green or red?</$checkbox> <br/>
-<$checkbox tiddler="ExampleData" listIndex=<<indexName>> checked="yellow" unchecked="blue" default="blue"> Yellow or blue?</$checkbox> <br/>
-<$checkbox tiddler="ExampleData" listIndex=<<indexName>> checked="orange" unchecked="purple" default="purple"> Orange or purple?</$checkbox> <br />
-Colors list: {{{ [[ExampleData]getindex<indexName>] }}}
-</$set>
-"""/>
-
-!! Filter Mode
-
-Using the checkbox widget in filter mode requires the ''filter'' attribute to contain a filter whose output will determine the checked state of the checkbox. In filter mode, checking the checkbox will not automatically make changes to any field of any tiddler. Instead, you can use the ''actions'' attribute (or ''checkactions'' and ''uncheckactions'') to specify what should happen when the checkbox is toggled. It is your responsibility to make sure the actions cause changes to the tiddlers or fields that the filter results depend on, so that the checkbox becomes properly checked or unchecked after the actions have triggered.
-
-If the filter returns an empty result, the checkbox will be unchecked. Otherwise, if the filter result is non-empty, the checkbox will be checked. However, if either the ''checked'' or ''unchecked'' attributes (or both) are specified, then their values will be looked for in the filter result, instead of considering any non-empty value to mean "checked".
-
-This example creates the same checkbox as in the list mode example, selecting between ''red'' and ''green'' in the ''colors'' list field, but using filters and actions to make the change.
-
-<<wikitext-example-without-html """\define checkActions() <$action-listops $field="colors" $subfilter="-red green"/>
-\define uncheckActions() <$action-listops $field="colors" $subfilter="red -green"/>
-<$checkbox filter="[list[!!colors]]" checked="green" unchecked="red" default="red" checkactions=<<checkActions>> uncheckactions=<<uncheckActions>> > Is "green" in colors?</$checkbox><br />''colors:'' {{!!colors}}
-""">>
+---
 
 !! Indeterminate checkboxes
 
-If both the ''checked'' and ''unchecked'' attributes are specified, but neither one is found in the specified field (or index), the result can be ambiguous. Should the checkbox be checked or unchecked? Normally in such cases the checkbox will be unchecked, but if the ''indeterminate'' attribute is set to "yes" (default is "no"), the checkbox will instead be in an "indeterminate" state. An indeterminate checkbox counts as false for most purposes &mdash; if you click it, the checkbox will become checked and the ''checkactions'', if any, will be triggered &mdash; but indeterminate checkboxes are displayed differently in the browser.
+If both the <<.attr checked>> and <<.attr unchecked>> attributes are specified, but neither one is found in the specified field (or index), the result can be ambiguous. Should the checkbox be checked or unchecked? Normally in such cases the checkbox will be unchecked, but if the <<.attr indeterminate>> attribute is set to <<.value yes>> (default is <<.value no>>), the checkbox will instead be in an "indeterminate" state. An indeterminate checkbox counts as false for most purposes &mdash; if you click it, the checkbox will become checked and the <<.attr checkactions>>, if any, will be triggered &mdash; but indeterminate checkboxes are displayed differently in the browser.
 
 This example shows indeterminate checkboxes being used for categories in a shopping list (which could also be sub-tasks in a todo list, or many other things). If only some items in a category are selected, the category checkbox is indeterminate. You can click on the category checkboxes to see how indeterminate states are treated the same as the unchecked state, and clicking the box checks it and applies its check actions (in this case, checking all the boxes in that category). Try editing the <<.field fruits>> and <<.field vegetables>> fields on this tiddler and see what happens to the example when you do.
 


### PR DESCRIPTION
The doc tiddler for the CheckboxWidget was getting longer and longer with nearly every release for a while and has become a bit hard to navigate. Therefore, I put the various "modes" into tabs. Since this is a precedent for widget documentation, I'll mark this PR as a draft, in case that there arises the need for discussion.

I also put in Documentation Macros where appropriate, and changed the text (not the attributes) from "indexes" of DataTiddlers to "properties", as had been introduced in the `getindex` and `indexes` filter operator descriptions.

Furthermore, I added a table to `listField` and `listIndex` that summarizes how the checked and unchecked states are calculated for various attribute combinations. While the textual description is comprehensive and absolutely correct, by itself it may be a bit difficult to grasp.

I don't really like the horizontal line delimiting the tabs from the text below, but without that it was nearly impossible to discern where the tabs content ended. Any suggestions how to improve this are very welcome.