### PR TITLE
Prevents shadow tiddlers from being saved to local storage

### DIFF
--- a/plugins/tiddlywiki/browser-storage/settings.tid
+++ b/plugins/tiddlywiki/browser-storage/settings.tid
@@ -17,8 +17,8 @@ Click this button to clear browser storage and disable its use:
 This filter determines which tiddlers will be saved to local storage.
 
 * `[prefix[$:/state/]] -[prefix[$:/state/popup/]]` - the default value. Save state tiddlers except popup state tiddlers, thus preserving selected tabs and the open/closed status of table of contents entries. Any other tiddlers created or changed will be lost after reloading the page.
-* `[all[]]` - attempt to save all changed tiddlers. This means even popup state tiddlers and temporary tiddlers will be saved. In addition, when a plugin is installed, all the shadow tiddlers are individually "exploded" into local storage. Deleting the plugin requires deleting all the tiddlers individually. Not recommended unless these issues are unimportant.
-* `[all[]] -[is[shadow]!is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]]` - save all tiddlers except unmodified shadow tiddlers, popup state tiddlers, temp tiddlers and the history list. Solves the aforementioned issues with `[all[]]`. Recommended.
+* `[all[]]` - attempt to save all changed tiddlers. This means even popup state tiddlers and temporary tiddlers will be saved.
+* `[all[]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]]` - save all tiddlers except popup state tiddlers, temp tiddlers and the history list.
 
 <$link to="$:/config/BrowserStorage/SaveFilter">Browser Storage Save Filter</$link>: <$edit-text tiddler="$:/config/BrowserStorage/SaveFilter" default="" tag="input" size="50"/>
 

--- a/plugins/tiddlywiki/browser-storage/util.js
+++ b/plugins/tiddlywiki/browser-storage/util.js
@@ -53,24 +53,31 @@ BrowserStorageUtil.prototype.saveTiddlerToLocalStorage = function(title) {
     // Get the tiddler
     var tiddler = $tw.wiki.getTiddler(title);
     if(tiddler) {
-        console.log("browser-storage: Saving",title);
-        // Get the JSON of the tiddler				
-        var json = JSON.stringify(tiddler.getFieldStrings());
-        // Try to save it to local storage
-        try {
-            window.localStorage.setItem(this.options.prefix + title,json);
-        } catch(e) {
-            if(e.name === "QuotaExceededError") {
-                // Complain if we failed
-                var msg = $tw.wiki.getTiddlerText(this.QUOTA_EXCEEDED_ALERT_TITLE,this.DEFAULT_QUOTA_EXCEEDED_ALERT_PREFIX + title + this.DEFAULT_QUOTA_EXCEEDED_ALERT_SUFFIX);
-                if(this.options.logger) {
-                    this.options.logger.alert(msg);
+        if (this.wiki.tiddlerExists(title)) {
+            // This is not a shadow tiddler
+            console.log("browser-storage: Saving",title);
+            // Get the JSON of the tiddler
+            var json = JSON.stringify(tiddler.getFieldStrings());
+            // Try to save it to local storage
+            try {
+                window.localStorage.setItem(this.options.prefix + title,json);
+            } catch(e) {
+                if(e.name === "QuotaExceededError") {
+                    // Complain if we failed
+                    var msg = $tw.wiki.getTiddlerText(this.QUOTA_EXCEEDED_ALERT_TITLE,this.DEFAULT_QUOTA_EXCEEDED_ALERT_PREFIX + title + this.DEFAULT_QUOTA_EXCEEDED_ALERT_SUFFIX);
+                    if(this.options.logger) {
+                        this.options.logger.alert(msg);
+                    }
+                    // No point in keeping old values around for this tiddler
+                    window.localStorage.removeItem(this.options.prefix + title);
+                } else {
+                    console.log("Browser-storage error:",e);
                 }
-                // No point in keeping old values around for this tiddler
-                window.localStorage.removeItem(this.options.prefix + title);
-            } else {
-                console.log("Browser-storage error:",e);
             }
+        } else {
+            // Shadow tiddler which is no longer overwritten (or never was)
+            // Ensure it is not in local storage
+            this.removeTiddlerFromLocalStorage(title);
         }
     } else {
         // In local storage, use the special value of empty string to mark the tiddler as deleted


### PR DESCRIPTION
If a tiddler is only a shadow tiddler, then do not save it to local storage. Otherwise when installing a plugin, each individual tiddler will be expanded and saved individually. In order to uninstall such a plugin, the plugin tiddler and each tiddler needs to be deleted.

This can be prevented by including a run like `-[is[shadow]!is[tiddler]]` in the save filter, but that has the side effect of preventing overwritten shadow tiddlers from being deleted from local storage.

Fixes #7364 