### PR TITLE
Fixed issue with trailing newlines in macrodefs

### DIFF
--- a/core/modules/parsers/wikiparser/rules/macrodef.js
+++ b/core/modules/parsers/wikiparser/rules/macrodef.js
@@ -58,7 +58,7 @@ exports.parse = function() {
 	var reEnd;
 	if(this.match[3]) {
 		// If so, the end of the body is marked with \end
-		reEnd = new RegExp("(\\r?\\n\\s*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[1]) + ")?(?:$|\\r?\\n))","mg");
+		reEnd = new RegExp("(\\r?\\n[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[1]) + ")?(?:$|\\r?\\n))","mg");
 	} else {
 		// Otherwise, the end of the definition is marked by the end of the line
 		reEnd = /($|\r?\n)/mg;

--- a/editions/test/tiddlers/tests/data/macros/TrailingNewlines.tid
+++ b/editions/test/tiddlers/tests/data/macros/TrailingNewlines.tid
@@ -1,0 +1,22 @@
+title: Macros/TrailingNewlines
+description: Trailing newlines in macros must not be dropped
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define inner()
+Paragraph 1
+
+Paragraph 2
+\end
+\define outer()
+<$macrocall $name=inner />
+
+\end
+<<outer>>
+
++
+title: ExpectedResult
+
+<p>Paragraph 1</p><p>Paragraph 2</p>


### PR DESCRIPTION
[This commit concerning indentation of pragma](https://github.com/Jermolene/TiddlyWiki5/commit/dd6e00687b218ecc3091af2612c46593933d57ac) introduced a bug into the wikiparser where macrodefs would eat up all the newline characters at the end of its definition. This changed parser behavior, since trailing newlines can be important for distinguishing block from inline. Take this example:

```
\define macro()

<$macrocall $name=other />

\end
```

In v5.2.5 and earlier, that macrocall would be processed as a block. In v5.2.6, it cannot be in that circumstance. This problem is particularly concerning for my Uglify macro, which took advantage of removing unneeded closing elements (e.g. `</$reveal>`.

The following fixes the problem and tests. Instead of eating all whitespace at the end of a definition, it excludes newlines.

