### PR TITLE
Tweak some examples for get and getindex

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/get.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/get.tid
@@ -1,5 +1,5 @@
 created: 20150118134611000
-modified: 20230310154010278
+modified: 20230325163424379
 myfield: 
 tags: [[get Operator]] [[Operator Examples]]
 title: get Operator (Examples)
@@ -15,8 +15,8 @@ type: text/vnd.tiddlywiki
 
 <<.operator-example 4 "[all[current]get[myfield]]" "the empty value of field <<.field myfield>> is not returned by the <<.olink get>> operator">>
 
-<<.operator-example 5 "[all[current]] :filter[has:field[myfield]] :map[get[myfield]]" "also returns the empty string">>
-The above example works by first using the [[Filter Filter Run Prefix]] to only select titles that have the field <<.field myfield>> and then using the [[Map Filter Run Prefix]] to replace those titles with their value of that field.  The [[Map Filter Run Prefix]] outputs an empty string when its filter run returns an empty [[selection|Title Selection]].
+<<.operator-example 5 "[all[current]has:field[myfield]] :map[get[myfield]]" "also returns the empty string">>
+The above example works by first checking if the input title has the field <<.field myfield>> and then using the [[Map Filter Run Prefix]] to replace the title with their value of that field. If the input tiddler does not have the field, an empty <<.em selection>> is returned. The subsequent [[Map Filter Run Prefix]] outputs an empty <<.em string>> when its run returns an empty [[selection|Title Selection]] (because the field is empty).
 
 <<.operator-example 6 "[all[tiddlers]] :filter[get[created]compare:date:lt{HelloThere!!created}]" "return all tiddlers that are older than [[HelloThere]]">>
 The above example demonstrates two different ways of accessing field values in filters: Use <<.olink get>> when the title is not known in advance as with the [[Filter Filter Run Prefix]] where <<.var currentTiddler>> is set to the current input title. Use a [[TextReference]] as an indirect [[Filter Parameter]] when the title is known.

--- a/editions/tw5.com/tiddlers/filters/examples/getindex.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/getindex.tid
@@ -1,5 +1,5 @@
 created: 20150203140000000
-modified: 20230309180501044
+modified: 20230325163543621
 tags: [[getindex Operator]] [[Operator Examples]]
 title: getindex Operator (Examples)
 type: text/vnd.tiddlywiki
@@ -12,8 +12,8 @@ type: text/vnd.tiddlywiki
 
 <<.operator-example 3 "[[ListopsData]getindex[DataIndex]]" "the empty value of the property <<.field ~DataIndex>> in [[ListopsData]] is not returned by the <<.olink getindex>> operator">>
 
-<<.operator-example 4 "[[ListopsData]] :filter[has:index[DataIndex]] :map[getindex[DataIndex]]" "also returns the empty string">>
-The above example works by first using the [[Filter Filter Run Prefix]] to only select titles that have the property <<.field ~DataIndex>> and then using the [[Map Filter Run Prefix]] to replace those titles with their value of that property.  The [[Map Filter Run Prefix]] outputs an empty string when its filter run returns an empty [[selection|Title Selection]].
+<<.operator-example 4 "[[ListopsData]has:index[DataIndex]] :map[getindex[DataIndex]]" "also returns the empty string">>
+The above example works by first checking if the input title has the property <<.field ~DataIndex>> and then using the [[Map Filter Run Prefix]] to replace the title with their value of that property. If the input tiddler does not have the property, an empty <<.em selection>> is returned. The subsequent [[Map Filter Run Prefix]] outputs an empty <<.em string>> when its run returns an empty [[selection|Title Selection]] (because the property is empty).
 
 <<.operator-example 5 "[[$:/palettes/Vanilla]indexes[]] :filter[[$:/palettes/Vanilla]getindex<currentTiddler>count[]compare:number:eq[0]]" "returns those colors in [[$:/palettes/Vanilla]] which are defined, but have no value assigned">>
 In the above example, <<.olink count>> is used to check if <<.olink getindex>> returns a result (i.e. the corresponding property has a value) or not.


### PR DESCRIPTION
The examples unnecessarily used a `:filter` run prefix when a simple filter step would have done.
The explanation has also been extended somewhat to make it clearer what's going on.