### PR TITLE
Fix missing extension for audio/mpeg

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2408,7 +2408,7 @@ $tw.boot.initStartup = function(options) {
 	$tw.utils.registerFileType("video/webm","base64",".webm");
 	$tw.utils.registerFileType("video/mp4","base64",".mp4");
 	$tw.utils.registerFileType("audio/mp3","base64",".mp3");
-	$tw.utils.registerFileType("audio/mpeg","base64");
+	$tw.utils.registerFileType("audio/mpeg","base64",[".mp3",".m2a",".mp2",".mpa",".mpg",".mpga"]);
 	$tw.utils.registerFileType("text/markdown","utf8",[".md",".markdown"],{deserializerType:"text/x-markdown"});
 	$tw.utils.registerFileType("text/x-markdown","utf8",[".md",".markdown"]);
 	$tw.utils.registerFileType("application/enex+xml","utf8",".enex");


### PR DESCRIPTION
There should be multiple extensions for audio/mpeg like `.mp3`, `.mp2` and so on.
The missing extensions raised exception in Tiddloid, breaking the tweaks plugin. I'll patch it in case of another bug like this.