### PR TITLE
Update regexp.tid

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/regexp.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/regexp.tid
@@ -17,5 +17,5 @@ The regular expression `[0-9]{2}` matches two consecutive digits. Because it con
 <$macrocall
 $name="wikitext-example-without-html"
 src="""<$set name="digit-pattern" value="[0-9]{2}">
-<<list-links "[regexp:title<digit-pattern>]">>
+<<list-links "[regexp:title<digit-pattern>]" field:"title">>
 </$set>"""/>


### PR DESCRIPTION
The list-links by default show caption of listed tiddlers instead of their title. So in the example here

```
<$macrocall
$name="wikitext-example-without-html"
src="""<$set name="digit-pattern" value="[0-9]{2}">
<<list-links "[regexp:title<digit-pattern>]" field:"title">>
</$set>"""/>
```

you need to use field:"title" to see the correct results visually, if not the list-links show caption for those tiddlers have caption and this is confusing in this context.