### PR TITLE
Add the `words` and `lines` modes to `$diff-text`

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/DiffTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/DiffTextWidget.tid
@@ -1,6 +1,6 @@
 caption: diff-text
 created: 20180316162725329
-modified: 20180316162725329
+modified: 20230401114522914
 tags: Widgets
 title: DiffTextWidget
 type: text/vnd.tiddlywiki
@@ -59,3 +59,10 @@ src="""<$edit-text tiddler="SampleTiddlerFirst"/>
 <$edit-text tiddler="SampleTiddlerSecond"/>
 
 <$diff-text source={{SampleTiddlerFirst}} dest={{SampleTiddlerSecond}}/>"""/>
+
+!! Modes
+<$button set="!!myfield" setTo="chars">Chars</$button>
+<$button set="!!myfield" setTo="words">Words</$button>
+<$button set="!!myfield" setTo="lines">Lines</$button>
+
+<$diff-text source={{Hamlet##Shakespeare-old}} dest={{Hamlet##Shakespeare-new}} mode={{!!myfield}} />


### PR DESCRIPTION
Similar to their implementation in the new `makepatches` operator, `$diff-text`, using the same library, could also use the `words` and `lines`modes. I believe there are quite a few cases that will be more intelligible if `words` mode were used. Similarly, highlighting whole lines may also be beneficial in some cases.

This PR adds the same `diffLineWordMode` and `diffPartsToChars` functions to `$diff-text` that were also added to `strings.js` as part of the implementation for the `makepatches` operator. This duplication feels wrong. Should these functions maybe added to the diff-match-patch.js (minimized) file or some other file?

You can check out the differences by going to the DiffTextWidget documentation tiddler and clicking the corresponding buttons at the bottom. This doc tiddler extension is not finished yet. I just wanted to add a short demo somewhere for now.

- [ ] Decide what to do with the auxiliary functions
- [ ] Finish the doc tiddler