### PR TITLE
Request permission to protect local storage from eviction

### DIFF
--- a/plugins/tiddlywiki/browser-storage/settings.tid
+++ b/plugins/tiddlywiki/browser-storage/settings.tid
@@ -28,6 +28,16 @@ This setting allows a custom alert message to be displayed when an attempt to st
 
 <$link to="$:/config/BrowserStorage/QuotaExceededAlert">Quota Exceeded Alert</$link>: <$edit-text tiddler="$:/config/BrowserStorage/QuotaExceededAlert" default="" tag="input" size="50"/>
 
+! Prevent browser from evicting local storage
+
+Permission for local storage persistence: ''{{$:/info/browser/storage/persisted}}''
+
+The first time a tiddler is saved to local storage a request will be made to prevent automatic eviction of local storage for this site. This means the data will not be cleared unless the user manually clears it.
+
+Old browsers may not support this feature. New browsers might not support the feature if the wiki is hosted on a non-localhost unencrypted http connection.
+
+Some browsers will explicitly prompt the user for permission. Other browsers may automatically grant or deny the request based on site usage or based on whether the site is bookmarked.
+
 ! Startup Log
 
 The tiddler $:/temp/BrowserStorage/Log contains a log of the tiddlers that were loaded from local storage at startup:

--- a/plugins/tiddlywiki/browser-storage/startup.js
+++ b/plugins/tiddlywiki/browser-storage/startup.js
@@ -54,36 +54,47 @@ exports.startup = function() {
 		$tw.wiki.addTiddler({title: ENABLED_TITLE, text: "no"});
 		$tw.browserStorage.clearLocalStorage();
 	});
+	// Helpers for protecting storage from eviction
+	var setPersistedState = function(state) {
+			$tw.wiki.addTiddler({title: PERSISTED_STATE_TITLE, text: state});
+		},
+		requestPersistence = function() {
+			setPersistedState("requested");
+			navigator.storage.persist().then(function(persisted) {
+				console.log("Request for persisted storage " + (persisted ? "granted" : "denied"));
+				setPersistedState(persisted ? "granted" : "denied");
+			});
+		},
+		persistPermissionRequested = false,
+		requestPersistenceOnFirstSave = function() {
+			$tw.hooks.addHook("th-saving-tiddler", function(tiddler) {
+				if (!persistPermissionRequested) {
+					var filteredChanges = filterFn.call($tw.wiki, function(iterator) {
+						iterator(tiddler,tiddler.getFieldString("title"));
+					});
+					if (filteredChanges.length > 0) {
+						// The tiddler will be saved to local storage, so request persistence
+						requestPersistence();
+						persistPermissionRequested = true;
+					}
+				}
+				return tiddler;
+			});
+		};
 	// Request the browser to never evict the localstorage. Some browsers such as firefox
 	// will prompt the user. To make the decision easier for the user only prompt them
 	// when they click the save button on a tiddler which will be stored to localstorage.
 	if (navigator.storage && navigator.storage.persist) {
 		navigator.storage.persisted().then(function(isPersisted) {
 			if (!isPersisted) {
-				var persistPermissionRequested = false;
-				$tw.wiki.addTiddler({title: PERSISTED_STATE_TITLE, text: "not requested yet"});
-				$tw.hooks.addHook("th-saving-tiddler", function(tiddler) {
-					if (!persistPermissionRequested) {
-						var filteredChanges = filterFn.call($tw.wiki, function(iterator) {
-							iterator(tiddler,tiddler.getFieldString("title"));
-						});
-						if (filteredChanges.length > 0) {
-							$tw.wiki.addTiddler({title: PERSISTED_STATE_TITLE, text: "requested"});
-							navigator.storage.persist().then(function(persisted) {
-								console.log("Request for persisted storage " + (persisted ? "granted" : "denied"));
-								$tw.wiki.addTiddler({title: PERSISTED_STATE_TITLE, text: (persisted ? "granted" : "denied")});
-							});
-							persistPermissionRequested = true;
-						}
-					}
-					return tiddler;
-				});
+				setPersistedState("not requested yet");
+				requestPersistenceOnFirstSave();
 			} else {
-				$tw.wiki.addTiddler({title: PERSISTED_STATE_TITLE, text: "granted"});
+				setPersistedState("granted");
 			}
 		});
 	} else {
-		$tw.wiki.addTiddler({title: PERSISTED_STATE_TITLE, text: "feature not available"});
+		setPersistedState("feature not available");
 	}
 	// Track tiddler changes
 	$tw.wiki.addEventListener("change",function(changes) {


### PR DESCRIPTION
Add code to the browser storage plugin to request permission for the local storage to be protected from eviction.

Some browsers such as firefox will prompt the user. To make the decision easier for the user only prompt them when they click the save button on a tiddler which will be stored to localstorage.

Other browsers will not prompt the user and will instead automatically approve or deny the request based on other factors.
 
Resolves #7369.