### PR TITLE
Remove the 14px adjustment to textarea autoheight

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -162,13 +162,13 @@ FramedEngine.prototype.fixHeight = function() {
 		if(this.widget.editAutoHeight) {
 			if(this.domNode && !this.domNode.isTiddlyWikiFakeDom) {
 				var newHeight = $tw.utils.resizeTextAreaToFit(this.domNode,this.widget.editMinHeight);
-				this.iframeNode.style.height = (newHeight + 14) + "px"; // +14 for the border on the textarea
+				this.iframeNode.style.height = newHeight + "px";
 			}
 		} else {
 			var fixedHeight = parseInt(this.widget.wiki.getTiddlerText(HEIGHT_VALUE_TITLE,"400px"),10);
 			fixedHeight = Math.max(fixedHeight,20);
 			this.domNode.style.height = fixedHeight + "px";
-			this.iframeNode.style.height = (fixedHeight + 14) + "px";
+			this.iframeNode.style.height = fixedHeight + "px";
 		}
 	}
 };


### PR DESCRIPTION
Ever since the editor toolbar was introduced in #2315, there has been a mysterious adjustment applied within the `FramedEngine.prototype.fixHeight()` method. The original intention is unclear. It occasionally causes problems -- see for example #5768.

So, I think it's worth exploring the effects of removing this adjustment factor. It would be great for others to help with testing this fix and see if we can find any unexpected side effects.