### PR TITLE
Remove "direction" CSS property from framed version of editor

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -118,6 +118,8 @@ FramedEngine.prototype.copyStyles = function() {
 	this.domNode.style.margin = "0";
 	// In Chrome setting -webkit-text-fill-color overrides the placeholder text colour
 	this.domNode.style["-webkit-text-fill-color"] = "currentcolor";
+	// Ensure we don't force text direction to LTR
+	this.domNode.style.removeProperty("direction");
 };
 
 /*


### PR DESCRIPTION
As reported [on Google Groups](https://groups.google.com/g/tiddlywiki/c/BtpHC9wa7Ns/m/8Vc7j1msAAAJ), it is not possible to switch between RTL/TLR using the "Control+Shift" shortcut.

