### PR TITLE
table-of-content macros -- make "exclude" an official macro parameter

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -186,13 +186,13 @@ tags: $:/tags/Macro
 </$let>
 \end
 
-\define toc-tabbed-external-nav(tag,sort:"",selectedTiddler:"$:/temp/toc/selectedTiddler",unselectedText,missingText,template:"")
+\define toc-tabbed-external-nav(tag,sort:"",selectedTiddler:"$:/temp/toc/selectedTiddler",unselectedText,missingText,template:"",exclude)
 \whitespace trim
 <$tiddler tiddler={{{ [<__selectedTiddler__>get[text]] }}}>
   <div class="tc-tabbed-table-of-contents">
     <$linkcatcher to=<<__selectedTiddler__>>>
       <div class="tc-table-of-contents">
-        <$macrocall $name="toc-selective-expandable" tag=<<__tag__>> sort=<<__sort__>> itemClassFilter="[all[current]] -[<__selectedTiddler__>get[text]]"/>
+        <$macrocall $name="toc-selective-expandable" tag=<<__tag__>> sort=<<__sort__>> itemClassFilter="[all[current]] -[<__selectedTiddler__>get[text]]" exclude=<<__exclude__>>/>
       </div>
     </$linkcatcher>
     <div class="tc-tabbed-table-of-contents-content">
@@ -210,9 +210,9 @@ tags: $:/tags/Macro
 </$tiddler>
 \end
 
-\define toc-tabbed-internal-nav(tag,sort:"",selectedTiddler:"$:/temp/toc/selectedTiddler",unselectedText,missingText,template:"")
+\define toc-tabbed-internal-nav(tag,sort:"",selectedTiddler:"$:/temp/toc/selectedTiddler",unselectedText,missingText,template:"",exclude)
 \whitespace trim
 <$linkcatcher to=<<__selectedTiddler__>>>
-  <$macrocall $name="toc-tabbed-external-nav" tag=<<__tag__>> sort=<<__sort__>> selectedTiddler=<<__selectedTiddler__>> unselectedText=<<__unselectedText__>> missingText=<<__missingText__>> template=<<__template__>>/>
+  <$macrocall $name="toc-tabbed-external-nav" tag=<<__tag__>> sort=<<__sort__>> selectedTiddler=<<__selectedTiddler__>> unselectedText=<<__unselectedText__>> missingText=<<__missingText__>> template=<<__template__>> exclude=<<__exclude__>> />
 </$linkcatcher>
 \end

--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -19,9 +19,9 @@ tags: $:/tags/Macro
 \define toc-body(tag,sort:"",itemClassFilter,exclude,path)
 \whitespace trim
 <ol class="tc-toc">
-  <$list filter="""[all[shadows+tiddlers]tag<__tag__>!has[draft.of]$sort$] -[<__tag__>] -[enlist<__exclude__>]""">
+  <$list filter="""[all[shadows+tiddlers]tag<__tag__>!has[draft.of]$sort$] -[<__tag__>] -[subfilter<__exclude__>]""">
     <$let item=<<currentTiddler>> path={{{ [<__path__>addsuffix[/]addsuffix<__tag__>] }}}>
-      <$set name="excluded" filter="""[enlist<__exclude__>] [<__tag__>]""">
+      <$set name="excluded" filter="[subfilter<__exclude__>] [<__tag__>]">
         <$set name="toc-item-class" filter=<<__itemClassFilter__>> emptyValue="toc-item-selected" value="toc-item">
           <li class=<<toc-item-class>>>
             <$list filter="[all[current]toc-link[no]]" emptyMessage="<$link to={{{ [<currentTiddler>get[target]else<currentTiddler>] }}}><<toc-caption>></$link>">
@@ -36,8 +36,8 @@ tags: $:/tags/Macro
 </ol>
 \end
 
-\define toc(tag,sort:"",itemClassFilter:"")
-<$macrocall $name="toc-body"  tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> />
+\define toc(tag,sort:"",itemClassFilter:"", exclude)
+<$macrocall $name="toc-body"  tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> exclude=<<__exclude__>>/>
 \end
 
 \define toc-linked-expandable-body(tag,sort:"",itemClassFilter,exclude,path)
@@ -75,7 +75,7 @@ tags: $:/tags/Macro
     <li class=<<toc-item-class>>>
       <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
         <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
-         <$transclude tiddler=<<toc-closed-icon>> />
+        <$transclude tiddler=<<toc-closed-icon>> />
           <<toc-caption>>
         </$button>
       </$reveal>
@@ -100,9 +100,9 @@ tags: $:/tags/Macro
 \define toc-expandable(tag,sort:"",itemClassFilter:"",exclude,path)
 \whitespace trim
 <$let tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> path={{{ [<__path__>addsuffix[/]addsuffix<__tag__>] }}}>
-  <$set name="excluded" filter="""[enlist<__exclude__>] [<__tag__>]""">
+  <$set name="excluded" filter="[subfilter<__exclude__>] [<__tag__>]">
     <ol class="tc-toc toc-expandable">
-      <$list filter="""[all[shadows+tiddlers]tag<__tag__>!has[draft.of]$sort$] -[<__tag__>] -[enlist<__exclude__>]""">
+      <$list filter="""[all[shadows+tiddlers]tag<__tag__>!has[draft.of]$sort$] -[<__tag__>] -[subfilter<__exclude__>]""">
         <$list filter="[all[current]toc-link[no]]" emptyMessage=<<toc-expandable-empty-message>> >
           <$macrocall $name="toc-unlinked-expandable-body" tag=<<__tag__>> sort=<<__sort__>> itemClassFilter="""itemClassFilter""" exclude=<<excluded>> path=<<path>> />
         </$list>
@@ -174,9 +174,9 @@ tags: $:/tags/Macro
 \define toc-selective-expandable(tag,sort:"",itemClassFilter,exclude,path)
 \whitespace trim
 <$let tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> path={{{ [<__path__>addsuffix[/]addsuffix<__tag__>] }}}>
-  <$set name="excluded" filter="[enlist<__exclude__>] [<__tag__>]">
+  <$set name="excluded" filter="[subfilter<__exclude__>] [<__tag__>]">
     <ol class="tc-toc toc-selective-expandable">
-      <$list filter="""[all[shadows+tiddlers]tag<__tag__>!has[draft.of]$sort$] -[<__tag__>] -[enlist<__exclude__>]""">
+      <$list filter="""[all[shadows+tiddlers]tag<__tag__>!has[draft.of]$sort$] -[<__tag__>] -[subfilter<__exclude__>]""">
         <$list filter="[all[current]toc-link[no]]" variable="ignore" emptyMessage=<<toc-selective-expandable-empty-message>> >
           <$macrocall $name="toc-unlinked-selective-expandable-body" tag=<<__tag__>> sort=<<__sort__>> itemClassFilter=<<__itemClassFilter__>> exclude=<<excluded>> path=<<path>>/>
         </$list>

--- a/editions/tw5.com/tiddlers/macros/TableOfContentsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TableOfContentsMacro.tid
@@ -1,5 +1,5 @@
 created: 20140919155729620
-modified: 20220819093733569
+modified: 20230425105848991
 tags: Macros [[Core Macros]]
 title: Table-of-Contents Macros
 type: text/vnd.tiddlywiki
@@ -53,14 +53,20 @@ These two parameters are combined into a single [[filter expression|Filter Expre
 
 <<.var toc-tabbed-internal-nav>> and <<.var toc-tabbed-external-nav>> take additional parameters:
 
-;selectedTiddler
+; selectedTiddler
 : The title of the [[state tiddler|StateMechanism]] for noting the currently selected tiddler, defaulting to `$:/temp/toc/selectedTiddler`. It is recommended that this be a [[system tiddler|SystemTiddlers]]
-;unselectedText
+
+; unselectedText
 : The text to display when no tiddler is selected in the tree
-;missingText
+
+; missingText
 : The text to display if the selected tiddler doesn't exist
-;template
+
+; template
 : Optionally, the title of a tiddler to use as a [[template|TemplateTiddlers]] for transcluding the selected tiddler into the right-hand panel
+
+; exclude
+: This optional parameter can be used to exclude tiddlers from the TOC list. It allows a [[Title List]] or a <<.olink subfilter>>. Eg: `exclude:"HelloThere [[Title with spaces]]"` or `exclude:"[has[excludeTOC]]"`. Where the former will exclude two tiddlers and the later would exclude every tiddler that has a field <<.field excludeTOC>> independent of its value.<br>''Be aware'' that eg: `[prefix[H]]` is a shortcut for `[all[tiddlers]prefix[H]]`, which can have a performance impact, if used carelessly. So use $:/AdvancedSearch -> ''Filters'' tab to test the <<.param exclude>> parameter
 
 !! Custom Icons
 

--- a/editions/tw5.com/tiddlers/macros/TableOfContentsMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TableOfContentsMacro.tid
@@ -1,5 +1,5 @@
 created: 20140919155729620
-modified: 20230425105848991
+modified: 20230427125500432
 tags: Macros [[Core Macros]]
 title: Table-of-Contents Macros
 type: text/vnd.tiddlywiki
@@ -65,7 +65,7 @@ These two parameters are combined into a single [[filter expression|Filter Expre
 ; template
 : Optionally, the title of a tiddler to use as a [[template|TemplateTiddlers]] for transcluding the selected tiddler into the right-hand panel
 
-; exclude
+; exclude <<.from-version "5.3.0">>
 : This optional parameter can be used to exclude tiddlers from the TOC list. It allows a [[Title List]] or a <<.olink subfilter>>. Eg: `exclude:"HelloThere [[Title with spaces]]"` or `exclude:"[has[excludeTOC]]"`. Where the former will exclude two tiddlers and the later would exclude every tiddler that has a field <<.field excludeTOC>> independent of its value.<br>''Be aware'' that eg: `[prefix[H]]` is a shortcut for `[all[tiddlers]prefix[H]]`, which can have a performance impact, if used carelessly. So use $:/AdvancedSearch -> ''Filters'' tab to test the <<.param exclude>> parameter
 
 !! Custom Icons


### PR DESCRIPTION
This PR contains 3 commitswill fix  

- #7239  ... first commit ... and
- docs update ... 2nd commit
- #7261  ... 3rd commit 

The "Table-of-Contents Macros" documentation has been updated with the new **exclude** parameter

@ericshulman, ... This should implement both of your ideas. Please test.
@Telumire, @kookma ... Can you also please test the different macro variations?

I did test most examples from "Table-of-Contents Macros (Examples)" ... But who knows. .. 
