### PR TITLE
Improve translink macro, fixes 4877

### DIFF
--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -5,7 +5,7 @@ tags: $:/tags/Macro
 \whitespace trim
 <div class={{{ [[tc-translink]] [[$mode$]match[block]then[tc-translink-block]] [[$mode$]match[inline]then[tc-translink-inline]] +[join[ ]] }}}>
 <$link to="""$title$""">
-<h1><$text text="""$title$"""/></h1>
+<h1 style="font-weight: bold; font-size: 1.2em;"><$text text="""$title$"""/></h1>
 </$link>
 <$transclude tiddler="""$title$""" mode="$mode$">
 "<$text text="""$title$"""/>" is missing
@@ -22,9 +22,6 @@ tags: $:/tags/Macro
 	padding: 0em 1em;
 }.tc-translink-inline {
 	padding: 0em 1em 1em;
-}.tc-translink h1 {
-	font-weight: bold;
-	font-size: 1.2em;
 }
 </style>
 \end

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -3,7 +3,7 @@ tags: $:/tags/Macro
 
 \define translink(title,mode:"block")
 \whitespace trim
-<div class={{{ [[tc-translink]] [[$mode$]match[block]then[tc-translink-block]] [[$mode$]match[inline]then[tc-translink-inline]] +[join[ ]] }}}>
+<div class={{{ [[tc-translink]] [[$title$]is[missing]then[tc-translink-inline]] [[$mode$]match[block]then[tc-translink-block]] [[$mode$]match[inline]then[tc-translink-inline]] +[first[2]] +[join[ ]] }}}>
 <$link to="""$title$""">
 <h1 style="font-weight: bold; font-size: 1.2em;"><$text text="""$title$"""/></h1>
 </$link>

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -3,12 +3,14 @@ tags: $:/tags/Macro
 
 \define translink(title,mode:"block")
 \whitespace trim
-<div class="pre-border" style="padding: 0 1em;">
+<div class="tc-pre-background">
+<div class="tc-big-v-gap tc-big-gap">
 <$link to="""$title$""">
 <h1 class="tc-big-bold"><$text text="""$title$"""/></h1>
 </$link>
-<p><$transclude tiddler="""$title$""" mode="$mode$">
+<$transclude tiddler="""$title$""" mode="$mode$">
 <$set name="currentTiddler" value="""$title$"""><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>
-</$transclude></p>
+</$transclude>
+</div>
 </div>
 \end

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -3,25 +3,13 @@ tags: $:/tags/Macro
 
 \define translink(title,mode:"block")
 \whitespace trim
-<div class={{{ [[tc-translink]] [[$title$]is[missing]then[tc-translink-inline]] [[$mode$]match[block]then[tc-translink-block]] [[$mode$]match[inline]then[tc-translink-inline]] +[first[2]] +[join[ ]] }}}>
+<div class="pre-border" style="padding: 0 1em;">
 <$link to="""$title$""">
-<h1 style="font-weight: bold; font-size: 1.2em;"><$text text="""$title$"""/></h1>
+<h1 class="tc-big-bold"><$text text="""$title$"""/></h1>
 </$link>
 <$transclude tiddler="""$title$""" mode="$mode$">
 "<$text text="""$title$"""/>" is missing
 </$transclude>
+<$list filter="[<__title__>is[missing]] ~[<__mode__>match[inline]]"><p></p></$list>
 </div>
-<style>
-.tc-translink {
-    border: 1px solid;
-    border-color: <<colour "pre-border">>;
-    border-radius: 2px;
-    background: <<colour "pre-background">>;
-	padding: <<verticalPadding>> 1em;
-}.tc-translink-block {
-	padding: 0em 1em;
-}.tc-translink-inline {
-	padding: 0em 1em 1em;
-}
-</style>
 \end

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -20,11 +20,9 @@ tags: $:/tags/Macro
 <$link to="""$title$""">
 <$text text="""$title$"""/>
 </$link>
-<span>
-<$transclude tiddler="""$title$""" mode="inline">
+&#32;(<$transclude tiddler="""$title$""" mode="inline">
 <$set name="currentTiddler" value="""$title$"""><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>
-</$transclude>
-</span>
+</$transclude>)
 </span>
 </$list>
 \end

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -8,7 +8,7 @@ tags: $:/tags/Macro
 <h1 class="tc-big-bold"><$text text="""$title$"""/></h1>
 </$link>
 <p><$transclude tiddler="""$title$""" mode="$mode$">
-"<$text text="""$title$"""/>" is missing
+<$set name="currentTiddler" value="""$title$"""><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>
 </$transclude></p>
 </div>
 \end

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -3,7 +3,7 @@ tags: $:/tags/Macro
 
 \define translink(title,mode:"block")
 \whitespace trim
-<div class="pre-border" style="padding: 0 1em;">
+<div class="tc-pre-border" style="padding: 0 1em;">
 <$link to="""$title$""">
 <h1 class="tc-big-bold"><$text text="""$title$"""/></h1>
 </$link>

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -3,10 +3,10 @@ tags: $:/tags/Macro
 
 \define translink(title,mode:"block")
 \whitespace trim
-<div class="tc-pre-background">
-<div class="tc-big-v-gap tc-big-gap">
+<div class="tc-translink">
+<div>
 <$link to="""$title$""">
-<h1 class="tc-big-bold"><$text text="""$title$"""/></h1>
+<h1><$text text="""$title$"""/></h1>
 </$link>
 <$transclude tiddler="""$title$""" mode="$mode$">
 <$set name="currentTiddler" value="""$title$"""><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -3,14 +3,28 @@ tags: $:/tags/Macro
 
 \define translink(title,mode:"block")
 \whitespace trim
+<$list filter="[<__mode__>match[block]]">
 <div class="tc-translink">
 <div>
 <$link to="""$title$""">
 <h1><$text text="""$title$"""/></h1>
 </$link>
-<$transclude tiddler="""$title$""" mode="$mode$">
+<$transclude tiddler="""$title$""" mode="block">
 <$set name="currentTiddler" value="""$title$"""><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>
 </$transclude>
 </div>
 </div>
+</$list>
+<$list filter="[<__mode__>match[inline]]">
+<span class="tc-translink">
+<$link to="""$title$""">
+<$text text="""$title$"""/>
+</$link>
+<span>
+<$transclude tiddler="""$title$""" mode="inline">
+<$set name="currentTiddler" value="""$title$"""><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>
+</$transclude>
+</span>
+</span>
+</$list>
 \end

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -3,13 +3,12 @@ tags: $:/tags/Macro
 
 \define translink(title,mode:"block")
 \whitespace trim
-<div class="tc-pre-border" style="padding: 0 1em;">
+<div class="pre-border" style="padding: 0 1em;">
 <$link to="""$title$""">
 <h1 class="tc-big-bold"><$text text="""$title$"""/></h1>
 </$link>
-<$transclude tiddler="""$title$""" mode="$mode$">
+<p><$transclude tiddler="""$title$""" mode="$mode$">
 "<$text text="""$title$"""/>" is missing
-</$transclude>
-<$list filter="[<__title__>is[missing]] ~[<__mode__>match[inline]]"><p></p></$list>
+</$transclude></p>
 </div>
 \end

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -3,14 +3,28 @@ tags: $:/tags/Macro
 
 \define translink(title,mode:"block")
 \whitespace trim
-<div style="border:1px solid #ccc; padding: 0.5em; background: black; foreground; white;">
+<div class={{{ [[tc-translink]] [[$mode$]match[block]then[tc-translink-block]] [[$mode$]match[inline]then[tc-translink-inline]] +[join[ ]] }}}>
 <$link to="""$title$""">
-<$text text="""$title$"""/>
+<h1><$text text="""$title$"""/></h1>
 </$link>
-<div style="border:1px solid #ccc; padding: 0.5em; background: white; foreground; black;">
 <$transclude tiddler="""$title$""" mode="$mode$">
 "<$text text="""$title$"""/>" is missing
 </$transclude>
 </div>
-</div>
+<style>
+.tc-translink {
+    border: 1px solid;
+    border-color: <<colour "pre-border">>;
+    border-radius: 2px;
+    background: <<colour "pre-background">>;
+	padding: <<verticalPadding>> 1em;
+}.tc-translink-block {
+	padding: 0em 1em;
+}.tc-translink-inline {
+	padding: 0em 1em 1em;
+}.tc-translink h1 {
+	font-weight: bold;
+	font-size: 1.2em;
+}
+</style>
 \end

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -3138,6 +3138,18 @@ div.tc-translink > div > a:first-child > h1 {
 	font-weight: bold;
 }
 
+span.tc-translink > a {
+	font-weight: bold;
+}
+
+span.tc-translink > span::before {
+	content: " (";
+}
+
+span.tc-translink > span::after {
+	content: ")";
+}
+
 /*
 ** Classes for displaying globals
 */

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -145,14 +145,14 @@ pre {
 	word-break: normal;
 	word-wrap: break-word;
 	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
-	padding: 0 3px 2px;
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/codefontfamily}};
 }
 
-pre, .tc-pre-border {
-	border: 1px solid <<colour pre-border>>;
-	border-radius: 3px;
-	background-color: <<colour pre-background>>;
+pre, .tc-pre-background {
+    border: 1px solid <<colour pre-border>>;
+    border-radius: 3px;
+    background-color: <<colour pre-background>>;
+    padding: 0 3px 2px;
 }
 
 code {
@@ -3239,9 +3239,14 @@ select {
 	margin-bottom: 3px;
 }
 
-/* Emphasis */
+.tc-big-v-gap {
+	margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+/* Font styles */
 
 .tc-big-bold {
 	font-size: 1.2em;
-    font-weight: bold;    
+    font-weight: bold;
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -3125,7 +3125,7 @@ select {
 .tc-translink {
 	background-color: <<colour pre-background>>;
 	border: 1px solid <<colour pre-border>>;
-	padding: 0 3px 2px;
+	padding: 0 3px;
 	border-radius: 3px;
 }
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -145,11 +145,14 @@ pre {
 	word-break: normal;
 	word-wrap: break-word;
 	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
-	background-color: <<colour pre-background>>;
-	border: 1px solid <<colour pre-border>>;
 	padding: 0 3px 2px;
-	border-radius: 3px;
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/codefontfamily}};
+}
+
+pre, .tc-pre-border {
+	border: 1px solid <<colour pre-border>>;
+	border-radius: 3px;
+	background-color: <<colour pre-background>>;
 }
 
 code {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -3138,16 +3138,8 @@ div.tc-translink > div > a:first-child > h1 {
 	font-weight: bold;
 }
 
-span.tc-translink > a {
+span.tc-translink > a:first-child {
 	font-weight: bold;
-}
-
-span.tc-translink > span::before {
-	content: " (";
-}
-
-span.tc-translink > span::after {
-	content: ")";
 }
 
 /*

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -145,14 +145,11 @@ pre {
 	word-break: normal;
 	word-wrap: break-word;
 	white-space: {{$:/themes/tiddlywiki/vanilla/options/codewrapping}};
+	background-color: <<colour pre-background>>;
+	border: 1px solid <<colour pre-border>>;
+	padding: 0 3px 2px;
+	border-radius: 3px;
 	font-family: {{$:/themes/tiddlywiki/vanilla/settings/codefontfamily}};
-}
-
-pre, .tc-pre-background {
-    border: 1px solid <<colour pre-border>>;
-    border-radius: 3px;
-    background-color: <<colour pre-background>>;
-    padding: 0 3px 2px;
 }
 
 code {
@@ -3122,6 +3119,26 @@ select {
 }
 
 /*
+** Translink macro
+*/
+
+.tc-translink {
+	background-color: <<colour pre-background>>;
+	border: 1px solid <<colour pre-border>>;
+	padding: 0 3px 2px;
+	border-radius: 3px;
+}
+
+div.tc-translink > div {
+	margin: 1em;
+}
+
+div.tc-translink > div > a:first-child > h1 {
+	font-size: 1.2em;
+	font-weight: bold;
+}
+
+/*
 ** Classes for displaying globals
 */
 
@@ -3237,16 +3254,4 @@ select {
 
 .tc-tiny-v-gap-bottom {
 	margin-bottom: 3px;
-}
-
-.tc-big-v-gap {
-	margin-top: 1em;
-    margin-bottom: 1em;
-}
-
-/* Font styles */
-
-.tc-big-bold {
-	font-size: 1.2em;
-    font-weight: bold;
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -3238,3 +3238,10 @@ select {
 .tc-tiny-v-gap-bottom {
 	margin-bottom: 3px;
 }
+
+/* Emphasis */
+
+.tc-big-bold {
+	font-size: 1.2em;
+    font-weight: bold;    
+}


### PR DESCRIPTION
Changes:
- Change styles to adapt colours to the current palette, instead of hard-coded white inside black box with grey borders.
- Simplify the design to a single div (inspired by the Community links on tiddlywiki.com), instead of two nested contrasting divs.

Comments:
- I found pre-border and pre-background to be the most consistently readable across the default palettes (better than relying on e.g. tiddler-border, tiddler-background, page-background, code-border, code-background). Cupertino Dark, Gruvbox Dark, Nord, Solar Flare, Spartan Day, Spartan Night, Spartan Day, and Twilight have same or very similar pre-border and pre-background colours, so if the macro is nested (translinking a tiddler that contains a translink), the inner frames are not distinguishable, but I think it's an acceptable edge case.
- Padding is defined separately for block and inline modes of the macro to make it appear consistent.