### PR TITLE
Add fillignore attribute to transclude widget to fix visible transclusion

### DIFF
--- a/core/modules/widgets/slot.js
+++ b/core/modules/widgets/slot.js
@@ -48,7 +48,7 @@ SlotWidget.prototype.execute = function() {
 	var pointer = this.parentWidget,
 		depth = this.slotDepth;
 	while(pointer) {
-		if(pointer instanceof TranscludeWidget) {
+		if(pointer instanceof TranscludeWidget && pointer.hasVisibleSlots()) {
 			depth--;
 			if(depth <= 0) {
 				break;

--- a/core/modules/widgets/transclude.js
+++ b/core/modules/widgets/transclude.js
@@ -388,7 +388,7 @@ TranscludeWidget.prototype.getTransclusionSlotFill = function(name,defaultParseT
 Return whether this transclusion should be visible to the slot widget
 */
 TranscludeWidget.prototype.hasVisibleSlots = function() {
-	return this.getAttribute("$slotignore","no") === "no";
+	return this.getAttribute("$fillignore","no") === "no";
 }
 
 /*

--- a/core/modules/widgets/transclude.js
+++ b/core/modules/widgets/transclude.js
@@ -385,6 +385,13 @@ TranscludeWidget.prototype.getTransclusionSlotFill = function(name,defaultParseT
 };
 
 /*
+Return whether this transclusion should be visible to the slot widget
+*/
+TranscludeWidget.prototype.hasVisibleSlots = function() {
+	return this.getAttribute("$slotignore","no") === "no";
+}
+
+/*
 Compose a string comprising the title, field and/or index to identify this transclusion for recursion detection
 */
 TranscludeWidget.prototype.makeRecursionMarker = function() {

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -557,7 +557,6 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 					children: parseTreeNode.children,
 					isBlock: parseTreeNode.isBlock
 				};
-				// $tw.utils.addAttributeToParseTreeNode(newParseTreeNode,"$slotignore","yes");
 				$tw.utils.addAttributeToParseTreeNode(newParseTreeNode,"$variable",variableDefinitionName);
 				$tw.utils.each(parseTreeNode.attributes,function(attr,name) {
 					// If the attribute starts with a dollar then add an extra dollar so that it doesn't clash with the $xxx attributes of transclude

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -557,6 +557,7 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 					children: parseTreeNode.children,
 					isBlock: parseTreeNode.isBlock
 				};
+				// $tw.utils.addAttributeToParseTreeNode(newParseTreeNode,"$slotignore","yes");
 				$tw.utils.addAttributeToParseTreeNode(newParseTreeNode,"$variable",variableDefinitionName);
 				$tw.utils.each(parseTreeNode.attributes,function(attr,name) {
 					// If the attribute starts with a dollar then add an extra dollar so that it doesn't clash with the $xxx attributes of transclude

--- a/core/ui/Components/VisibleTransclude.tid
+++ b/core/ui/Components/VisibleTransclude.tid
@@ -32,13 +32,13 @@ Block transclusions are shown in red, and inline transclusions are shown in gree
 					<!-- Legacy mode: we render the transclusion without a dollar sign for recursionMarker and mode -->
 					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" recursionMarker="no" mode=<<mode>> $$slotignore="yes">
 						<!-- Reach back up to the grandparent transclusion to get the correct slot value -->
-						<$slot $name="ts-raw" $depth="2"/>
+						<$slot $name="ts-raw"/>
 					</$genesis>
 				""">
 					<!-- Non-legacy mode: we use dollar signs for the recursionMarker and mode -->
 					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" $$recursionMarker="no" $$mode=<<mode>> $$slotignore="yes">
 						<!-- Reach back up to the grandparent transclusion to get the correct slot fill value -->
-						<$slot $name="ts-raw" $depth="2"/>
+						<$slot $name="ts-raw"/>
 					</$genesis>
 				</$list>
 			</$genesis>

--- a/core/ui/Components/VisibleTransclude.tid
+++ b/core/ui/Components/VisibleTransclude.tid
@@ -30,13 +30,13 @@ Block transclusions are shown in red, and inline transclusions are shown in gree
 				<!-- Look for a parameter starting with $ to determine if we are in legacy mode -->
 				<$list filter="[<@params>jsonindexes[]] :filter[<currentTiddler>prefix[$]] +[limit[1]]" variable="ignore" emptyMessage="""
 					<!-- Legacy mode: we render the transclusion without a dollar sign for recursionMarker and mode -->
-					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" recursionMarker="no" mode=<<mode>>>
+					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" recursionMarker="no" mode=<<mode>> $$slotignore="yes">
 						<!-- Reach back up to the grandparent transclusion to get the correct slot value -->
 						<$slot $name="ts-raw" $depth="2"/>
 					</$genesis>
 				""">
 					<!-- Non-legacy mode: we use dollar signs for the recursionMarker and mode -->
-					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" $$recursionMarker="no" $$mode=<<mode>>>
+					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" $$recursionMarker="no" $$mode=<<mode>> $$slotignore="yes">
 						<!-- Reach back up to the grandparent transclusion to get the correct slot fill value -->
 						<$slot $name="ts-raw" $depth="2"/>
 					</$genesis>

--- a/core/ui/Components/VisibleTransclude.tid
+++ b/core/ui/Components/VisibleTransclude.tid
@@ -30,13 +30,13 @@ Block transclusions are shown in red, and inline transclusions are shown in gree
 				<!-- Look for a parameter starting with $ to determine if we are in legacy mode -->
 				<$list filter="[<@params>jsonindexes[]] :filter[<currentTiddler>prefix[$]] +[limit[1]]" variable="ignore" emptyMessage="""
 					<!-- Legacy mode: we render the transclusion without a dollar sign for recursionMarker and mode -->
-					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" recursionMarker="no" mode=<<mode>> $$slotignore="yes">
+					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" recursionMarker="no" mode=<<mode>> $$fillignore="yes">
 						<!-- Reach back up to the grandparent transclusion to get the correct slot value -->
 						<$slot $name="ts-raw"/>
 					</$genesis>
 				""">
 					<!-- Non-legacy mode: we use dollar signs for the recursionMarker and mode -->
-					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" $$recursionMarker="no" $$mode=<<mode>> $$slotignore="yes">
+					<$genesis $type="$transclude" $remappable="no" $names="[<@params>jsonindexes[]]" $values="[<@params>jsonindexes[]] :map[<@params>jsonget<currentTiddler>]" $$recursionMarker="no" $$mode=<<mode>> $$fillignore="yes">
 						<!-- Reach back up to the grandparent transclusion to get the correct slot fill value -->
 						<$slot $name="ts-raw"/>
 					</$genesis>

--- a/editions/tw5.com/tiddlers/widgets/SlotWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SlotWidget.tid
@@ -17,7 +17,7 @@ The content of the <<.wlink SlotWidget>> widget is used as a fallback for the sl
 
 |!Attribute |!Description |
 |$name |The name of the slot being defined |
-|$depth |Optional number indicating how deep the <<.wlink SlotWidget>> widget is compared to the matching <<.wlink FillWidget>> widget as measured by the number of nested transclude widgets (defaults to 1) |
+|$depth |Optional number indicating how deep the <<.wlink SlotWidget>> widget is compared to the matching <<.wlink FillWidget>> widget as measured by the number of nested transclude widgets (defaults to 1). Transclude widgets whose <<.attr $slotignore>> attribute is set to ''yes'' are ignored, and do not affect the depth count |
 
 ! Examples
 

--- a/editions/tw5.com/tiddlers/widgets/SlotWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SlotWidget.tid
@@ -17,7 +17,7 @@ The content of the <<.wlink SlotWidget>> widget is used as a fallback for the sl
 
 |!Attribute |!Description |
 |$name |The name of the slot being defined |
-|$depth |Optional number indicating how deep the <<.wlink SlotWidget>> widget is compared to the matching <<.wlink FillWidget>> widget as measured by the number of nested transclude widgets (defaults to 1). Transclude widgets whose <<.attr $slotignore>> attribute is set to ''yes'' are ignored, and do not affect the depth count |
+|$depth |Optional number indicating how deep the <<.wlink SlotWidget>> widget is compared to the matching <<.wlink FillWidget>> widget as measured by the number of nested transclude widgets (defaults to 1). Transclude widgets whose <<.attr $fillignore>> attribute is set to ''yes'' are ignored, and do not affect the depth count |
 
 ! Examples
 

--- a/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
@@ -51,6 +51,7 @@ Modern mode is recommended for use in new applications.
 |$type |– |Optional ContentType used when transcluding variables, indexes or fields other than the ''text'' field|
 |$output |- |ContentType for the output rendering (defaults to `text/html`, can also be `text/plain` or `text/raw`) |
 |$recursionMarker |recursionMarker |Set to ''no'' to prevent creation of [[Legacy Transclusion Recursion Marker]] (defaults to ''yes'') |
+|$slotignore |- |Set to ''yes'' to make this transclusion invisible to the <<.attr $depth>> attribute of the <<.wlink SlotWidget>> widget (defaults to ''no'') |
 |//{attributes not starting with $}// |– |Any other attributes that do not start with a dollar are used as parameters to the transclusion |
 |//{other attributes starting with $}// |– |Other attributes starting with a single dollar sign are reserved for future use |
 |//{attributes starting with $$}// |– |Attributes starting with two dollar signs are used as parameters to the transclusion, but with the name changed to use a single dollar sign |

--- a/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
@@ -51,7 +51,7 @@ Modern mode is recommended for use in new applications.
 |$type |– |Optional ContentType used when transcluding variables, indexes or fields other than the ''text'' field|
 |$output |- |ContentType for the output rendering (defaults to `text/html`, can also be `text/plain` or `text/raw`) |
 |$recursionMarker |recursionMarker |Set to ''no'' to prevent creation of [[Legacy Transclusion Recursion Marker]] (defaults to ''yes'') |
-|$slotignore |- |Set to ''yes'' to make this transclusion invisible to the <<.attr $depth>> attribute of the <<.wlink SlotWidget>> widget (defaults to ''no'') |
+|$fillignore |- |Set to ''yes'' to make this transclusion invisible to the <<.attr $depth>> attribute of the <<.wlink SlotWidget>> widget (defaults to ''no'') |
 |//{attributes not starting with $}// |– |Any other attributes that do not start with a dollar are used as parameters to the transclusion |
 |//{other attributes starting with $}// |– |Other attributes starting with a single dollar sign are reserved for future use |
 |//{attributes starting with $$}// |– |Attributes starting with two dollar signs are used as parameters to the transclusion, but with the name changed to use a single dollar sign |


### PR DESCRIPTION
The slot widget reaches up to grab the contents of fill widgets within the immediate parent transclusion. The depth attribute allows the slot widget to reach up into transclusion widgets higher up the ancestor tree.

As discussed in #7449, overriding a built-in widget introduces an extra transclusion, which needs to be accounted for when using the depth attribute of the slot widget.

This PR introduces a new attribute for the transclude widget `$slotignore` that when set to `yes` causes a transclude widget to be ignored by the depth attribute of the slot widget.

I am not 100% happy with the name `$slotignore`. The concept that is being communicated is subtle, and it would be unwieldy to use a fully descriptive name like `$slotWidgetShouldIgnoreThisTransclusion`. Suggestions for alternatives are welcomed.

Fixes #7449