### PR TITLE
Procedure definition example should not say macro

### DIFF
--- a/editions/tw5.com/tiddlers/procedures/Procedure Definitions.tid
+++ b/editions/tw5.com/tiddlers/procedures/Procedure Definitions.tid
@@ -14,7 +14,7 @@ Procedures are created using the [[Pragma: \procedure]] at the start of a tiddle
 
 ```
 \define my-procedure(param)
-This is the macro text (param=<<param>>)
+This is the procedure text (param=<<param>>)
 \end
 ```
 


### PR DESCRIPTION
The word "macro" appears in the text of the procedure definition example, but it should be "procedure" instead.

This is a minor fix that https://github.com/Jermolene/TiddlyWiki5/pull/7463 missed.