### PR TITLE
feat: decode url-encoded user name in authenticate request header to allow CJK username in header

### DIFF
--- a/core/language/en-GB/Help/listen.tid
+++ b/core/language/en-GB/Help/listen.tid
@@ -18,7 +18,7 @@ All parameters are optional with safe defaults, and can be specified in any orde
 * ''anon-username'' - the username for signing edits for anonymous users
 * ''username'' - optional username for basic authentication
 * ''password'' - optional password for basic authentication
-* ''authenticated-user-header'' - optional name of header to be used for trusted authentication
+* ''authenticated-user-header'' - optional name of header field to be used for trusted authentication.
 * ''readers'' - comma-separated list of principals allowed to read from this wiki
 * ''writers'' - comma-separated list of principals allowed to write to this wiki
 * ''csrf-disable'' - set to "yes" to disable CSRF checks (defaults to "no")

--- a/core/language/en-GB/Help/listen.tid
+++ b/core/language/en-GB/Help/listen.tid
@@ -18,7 +18,7 @@ All parameters are optional with safe defaults, and can be specified in any orde
 * ''anon-username'' - the username for signing edits for anonymous users
 * ''username'' - optional username for basic authentication
 * ''password'' - optional password for basic authentication
-* ''authenticated-user-header'' - optional name of header field to be used for trusted authentication.
+* ''authenticated-user-header'' - optional name of request header to be used for trusted authentication.
 * ''readers'' - comma-separated list of principals allowed to read from this wiki
 * ''writers'' - comma-separated list of principals allowed to write to this wiki
 * ''csrf-disable'' - set to "yes" to disable CSRF checks (defaults to "no")

--- a/core/modules/server/authenticators/header.js
+++ b/core/modules/server/authenticators/header.js
@@ -37,7 +37,7 @@ HeaderAuthenticator.prototype.authenticateRequest = function(request,response,st
 		return false;
 	} else {
 		// authenticatedUsername will be undefined for anonymous users
-		state.authenticatedUsername = username;
+		state.authenticatedUsername = decodeURIComponent(username);
 		return true;
 	}
 };

--- a/core/modules/server/authenticators/header.js
+++ b/core/modules/server/authenticators/header.js
@@ -37,7 +37,7 @@ HeaderAuthenticator.prototype.authenticateRequest = function(request,response,st
 		return false;
 	} else {
 		// authenticatedUsername will be undefined for anonymous users
-		state.authenticatedUsername = decodeURIComponent(username);
+		state.authenticatedUsername = $tw.utils.decodeURIComponentSafe(username);
 		return true;
 	}
 };

--- a/editions/tw5.com/tiddlers/webserver/WebServer Header Authentication.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer Header Authentication.tid
@@ -4,6 +4,10 @@ tags: [[WebServer Authentication]]
 title: WebServer Header Authentication
 type: text/vnd.tiddlywiki
 
-Header authentication is a web integration technique enabling external entities to securely pass details of the authenticated user to an application. It is commonly used for "single sign on" in corporate environments.
+Header authentication is a web integration technique enabling external entities to securely pass details of the authenticated user to an application.
 
 Header authentication is activated if is configured via the [[authenticated-user-header|WebServer Parameter: authenticated-user-header]]
+
+!! Usage in SSO
+
+It is commonly used for "single sign on" in corporate environments. When doing header authentication, the user is not prompted for a username and password on TiddlyWiki. Instead, user is required to login at a SSO proxy server. When the user authenticate themselves to a SSO proxy server, proxy server redirect user request to TiddlyWiki server with this additional header field. Then tiddlywiki server is able to use the value of this header field to identify the user.

--- a/editions/tw5.com/tiddlers/webserver/WebServer Header Authentication.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer Header Authentication.tid
@@ -10,4 +10,4 @@ Header authentication is activated if is configured via the [[authenticated-user
 
 !! Usage in SSO
 
-It is commonly used for "single sign on" in corporate environments. When doing header authentication, the user is not prompted for a username and password on TiddlyWiki. Instead, user is required to login at a SSO proxy server. When the user authenticate themselves to a SSO proxy server, proxy server redirect user request to TiddlyWiki server with this additional header field. Then tiddlywiki server is able to use the value of this header field to identify the user.
+Header authentication is commonly used for "single sign on" in corporate environments. When doing header authentication, the user is not prompted for a username and password on TiddlyWiki. Instead, the user is required to login at a SSO proxy server. When the user authenticates themselves to the SSO proxy server, the proxy server redirects the user request to the TiddlyWiki server with this additional header field containing the username. Then TiddlyWiki server is able to use the value of this header field to identify the user.

--- a/editions/tw5.com/tiddlers/webserver/WebServer Header Authentication.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer Header Authentication.tid
@@ -10,4 +10,4 @@ Header authentication is activated if is configured via the [[authenticated-user
 
 !! Usage in SSO
 
-Header authentication is commonly used for "single sign on" in corporate environments. When doing header authentication, the user is not prompted for a username and password on TiddlyWiki. Instead, the user is required to login at a SSO proxy server. When the user authenticates themselves to the SSO proxy server, the proxy server redirects the user request to the TiddlyWiki server with this additional header field containing the username. Then TiddlyWiki server is able to use the value of this header field to identify the user.
+Header authentication is commonly used for "single sign on" in corporate environments. When doing header authentication, the user is not prompted for a username and password on TiddlyWiki. Instead, the user is required to login at a SSO proxy server. When the user authenticates themselves to the SSO proxy server, the proxy server redirects the user request to the TiddlyWiki server with this additional request header containing the username. Then TiddlyWiki server is able to use the value of this request header to identify the user.

--- a/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ authenticated-user-header.tid
+++ b/editions/tw5.com/tiddlers/webserver/WebServer Parameter_ authenticated-user-header.tid
@@ -1,8 +1,16 @@
 caption: authenticated-user-header
 created: 20180630180213047
-modified: 20180702140416583
+modified: 20230522184416583
 tags: [[WebServer Parameters]]
 title: WebServer Parameter: authenticated-user-header
 type: text/vnd.tiddlywiki
 
-The [[web server configuration parameter|WebServer Parameters]] ''authenticated-user-header'' activates [[header authentication|WebServer Header Authentication]] by specifying the name of the HTTP header that will be used to pass the username to TiddlyWiki.
+The [[web server configuration parameter|WebServer Parameters]] ''authenticated-user-header'' activates [[header authentication|WebServer Header Authentication]] by specifying the name of the HTTP header field that will be used to pass the username to TiddlyWiki.
+
+For example, if the ''authenticated-user-header'' is set to ''X-Authenticated-User'', then the HTTP request must include a header field ''X-Authenticated-User'' with a value that is the username:
+
+```http
+X-Authenticated-User: JeremyRuston
+```
+
+<<.from-version "5.3.0">> Value of this header field should be URI-encoded before transit on the client (using `encodeURIComponent` JS function or [[encodeuricomponent Operator]]), and will be URI-decoded by the server.


### PR DESCRIPTION
Chinese Japanese Koren character is not allowed in request header

![](https://user-images.githubusercontent.com/3746270/239755746-02383b89-fdfc-4f44-b07d-9d7a98cf8046.png)

So they have to be encoded before added to the header. So on server side, they need to be decode to restore.

The usecase is https://github.com/Jermolene/TiddlyWiki5/discussions/7469