### PR TITLE
Update Filter Run Prefix (Examples).tid

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Run Prefix (Examples).tid
@@ -4,18 +4,9 @@ tags: [[Filter Syntax]] [[Filter Run Prefix Examples]]
 title: Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
 
-!! `:filter` examples
+<$list filter='[all[shadows]module-type[filterrunprefix]] :map[<currentTiddler>split[/]last[]removesuffix[.js]]' variable=pfx>
 
-See [[Filter Filter Run Prefix (Examples)]]
+!!<code><$text text={{{ [<pfx>addprefix[:]] }}}/></code> examples
 
-!! `:intersection` examples
-
-See [[Intersection Filter Run Prefix (Examples)]]
-
-!! `:reduce` examples
-
-See [[Reduce Filter Run Prefix (Examples)]]
-
-!! `:sort` examples
-
-See [[Sort Filter Run Prefix (Examples)]]
+See {{{ [<pfx>sentencecase[]addsuffix[ Filter Run Prefix (Examples)]] }}} 
+</$list>


### PR DESCRIPTION
This catches all filter run prefixes. This is superior to the current hardcoded text that doesn't give any clues about non-documented prefixes.

My *actual* wish is to implement the more elaborate changes outlined [here](https://talk.tiddlywiki.org/t/ranty-proposal-for-docs-on-filter-run-prefixes/5772)... but this current PR is at least an improvement meanwhile.