### PR TITLE
Fix check for globalThis

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -580,7 +580,7 @@ var polyfill =[
 	"	});",
 	"	if (typeof __temp__.globalThis !== 'object') {",
 	"		__temp__.globalThis = __temp__;",
-	"	}"
+	"	}",
 	"	delete Object.prototype.__temp__;",
 	"}());"
 ].join("\n");

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -574,12 +574,13 @@ var polyfill =[
 	"// using the this variable on a getter ",
 	"// inserted into the prototype of globalThis",
 	"(function() {",
-	"	if (typeof globalThis === 'object') return;",
 	"	// node.green says this is available since 0.10.48",
 	"	Object.prototype.__defineGetter__('__temp__', function() {",
 	"		return this;",
 	"	});",
-	"	__temp__.globalThis = __temp__;",
+	"	if (typeof __temp__.globalThis !== 'object') {",
+	"		__temp__.globalThis = __temp__;",
+	"	}"
 	"	delete Object.prototype.__temp__;",
 	"}());"
 ].join("\n");


### PR DESCRIPTION
Untested, but this should bypass the error in old node versions where globalThis is not available. I don't understand why this wasn't an issue before, but hopefully this fixes it. 