### PR TITLE
Update Story Tiddler Template.tid

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/Story Tiddler Template.tid
+++ b/editions/tw5.com/tiddlers/concepts/Story Tiddler Template.tid
@@ -6,6 +6,8 @@ type: text/vnd.tiddlywiki
 
 "Story tiddler template" refers to the template used to display a tiddler within the story river.
 
+This is the core story tiddler template: $:/core/ui/StoryTiddlerTemplate
+
 The [[Story Tiddler Template Cascade]] is used to choose the template to be used for a particular tiddler. By default, the edit template is used for tiddlers in draft mode, and the view template used otherwise.
 
 See also:


### PR DESCRIPTION
An actual link to what is being talked about is needed.

@Jermolene - I note that *none* of the documented cascades, as listed in the table in the [Cascades](https://tiddlywiki.com/#Cascades) doc present an explicit link to the core tiddler that they talk about. Is this intentional? Not letting the user see the real stuff makes it difficult for someone actually trying to learn and use cascades. It is difficult to find the tiddlers referred to via Advanced Search as there are many hits to the possible keywords.

I'd be happy to provide PR's for all the concerned tiddlers, just like for the current, if you are OK with this?