### PR TITLE
Sortby add field suffix

### DIFF
--- a/core/modules/filters/x-listops.js
+++ b/core/modules/filters/x-listops.js
@@ -162,10 +162,18 @@ Extended filter operators to manipulate the current list.
 	/*
 	Returns all items from the current list sorted in the order of the items in the operand array
 	*/
-	exports.sortby = function (source, operator) {
+	exports.sortby = function (source, operator, options) {
 		var results = prepare_results(source);
 		if (!results || results.length < 2) {
 			return results;
+		}
+		var field = operator.suffix;
+		if (field && field !== "title") {
+			results = results.map(function (title) {
+				var tiddler = options.wiki.getTiddler(title);
+				if (!tiddler) return '';
+				return tiddler.fields[field] || '';
+			})
 		}
 		var lookup = $tw.utils.parseStringArray(operator.operand, "true");
 		results.sort(function (a, b) {


### PR DESCRIPTION
I want to sortby tmo_priority field, which is High, Medium, Low

I want to use it like this

```js
[filtersToGetSomeTitles[]sortby:tmo_priority[High Medium Low]]
```