### PR TITLE
ignore visual studio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .c9/
+.vs/
 .vscode/
 tmp/
 output/


### PR DESCRIPTION
I plan on diving into some dev work in both VS Code and Visual Studio. This will prevent the git-history from getting spammed.