### PR TITLE
Protect codemirror.css from wikitext parsing

### DIFF
--- a/plugins/tiddlywiki/codemirror/files/tiddlywiki.files
+++ b/plugins/tiddlywiki/codemirror/files/tiddlywiki.files
@@ -10,7 +10,7 @@
 		},{
 			"file": "codemirror.css",
 			"fields": {
-				"type": "text/vnd.tiddlywiki",
+				"type": "text/css",
 				"title": "$:/plugins/tiddlywiki/codemirror/lib/codemirror.css",
 				"tags": "[[$:/tags/Stylesheet]]"
 			}


### PR DESCRIPTION
Protect codemirror.css from wikitext parsing, otherwise 'CodeMirror' is considered a wikilink. In #3184 it looks like the file type was explicitly changed from text/css to text/vnd.tiddlywiki but it is difficult to tell if that was intended.

I inspected the parse tree of the tiddler and I see almost all are text and link types. At the end there is one "strong" tag but I do not think that is intended. Therefore, I do not think treating the css as wikitext is required.

Having wikilinks in the css does not appear to cause problems until a user overrides the link widget using the new 5.3 custom widget functionality. See https://talk.tiddlywiki.org/t/exploring-default-tiddler-links-hackability-in-v5-3-0/5745/38 for discussion