### PR TITLE
Update Jasmine website

### DIFF
--- a/core/acknowledgements.tid
+++ b/core/acknowledgements.tid
@@ -3,7 +3,7 @@ title: $:/Acknowledgements
 TiddlyWiki incorporates code from these fine OpenSource projects:
 
 * [[The Stanford Javascript Crypto Library|http://bitwiseshiftleft.github.io/sjcl/]]
-* [[The Jasmine JavaScript Test Framework|http://pivotal.github.io/jasmine/]]
+* [[The Jasmine JavaScript Test Framework|https://jasmine.github.io/]]
 * [[Normalize.css by Nicolas Gallagher|http://necolas.github.io/normalize.css/]]
 
 And media from these projects:

--- a/editions/dev/tiddlers/from tw5.com/mechanisms/TestingMechanism.tid
+++ b/editions/dev/tiddlers/from tw5.com/mechanisms/TestingMechanism.tid
@@ -2,7 +2,7 @@ modified: 20141013085608911
 tags: Mechanisms
 title: TestingMechanism
 
-TiddlyWiki5 incorporates the Jasmine JavaScript testing framework (see http://pivotal.github.io/jasmine/). It allows the same tests to be run both in the browser and under Node.js.
+TiddlyWiki5 incorporates the Jasmine JavaScript testing framework (see https://jasmine.github.io/). It allows the same tests to be run both in the browser and under Node.js.
 
 ! TiddlyWiki5 Testing Components
 

--- a/editions/es-ES/tiddlers/$__Acknowledgements.tid
+++ b/editions/es-ES/tiddlers/$__Acknowledgements.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 TiddlyWiki incorpora código de los siguientes proyectos OpenSource:
 
 * [[The Stanford Javascript Crypto Library|http://bitwiseshiftleft.github.io/sjcl/]]
-* [[The Jasmine JavaScript Test Framework|http://pivotal.github.io/jasmine/]]
+* [[The Jasmine JavaScript Test Framework|https://jasmine.github.io/]]
 * [[Normalize.css by Nicolas Gallagher|http://necolas.github.io/normalize.css/]]
 
 ...y materiales de estos otros proyectos:

--- a/editions/fr-FR/tiddlers/$__Acknowledgements.tid
+++ b/editions/fr-FR/tiddlers/$__Acknowledgements.tid
@@ -6,7 +6,7 @@ type: text/vnd.tiddlywiki
 TiddlyWiki intègre du code provenant de ces excellents projets OpenSource<<dp>>
 
 * [[The Stanford Javascript Crypto Library|http://bitwiseshiftleft.github.io/sjcl/]]
-* [[The Jasmine JavaScript Test Framework|http://pivotal.github.io/jasmine/]]
+* [[The Jasmine JavaScript Test Framework|https://jasmine.github.io/]]
 * [[Normalize.css by Nicolas Gallagher|http://necolas.github.io/normalize.css/]]
 
 Et des contenus provenenant de ces sources<<dp>>


### PR DESCRIPTION
pivotal.github.io/jasmine website does not exists anymore,
replaced with the current Jasmine website
