### PR TITLE
Remove duplicate release note

### DIFF
--- a/editions/prerelease/tiddlers/Release 5.3.0.tid
+++ b/editions/prerelease/tiddlers/Release 5.3.0.tid
@@ -79,7 +79,6 @@ Improvements to the following translations:
 * <<.link-badge-fixed "https://github.com/Jermolene/TiddlyWiki5/pull/7380">> crashes when using an invalid CSS selector for [[WidgetMessage: tm-focus-selector]] and [[WidgetMessage: tm-scroll]]
 * <<.link-badge-fixed "https://github.com/Jermolene/TiddlyWiki5/pull/7401">> bug whereby scrolling occurs if the linkcatcher widget triggers an action-navigate and the $scroll attribute is set to "no"
 * <<.link-badge-fixed "https://github.com/Jermolene/TiddlyWiki5/pull/7409">> problem switching between LTR and RTL text
-* <<.link-badge-fixed "https://github.com/Jermolene/TiddlyWiki5/pull/7448">> bug when checkbox widget's listField attribute was given the name of a date field (like <<.field created>> or <<.field modified>>)
 * <<.link-badge-fixed "https://github.com/Jermolene/TiddlyWiki5/issues/7529">> size of buttons in dropdown for editor "link" toolbar button
 * <<.link-badge-fixed "https://github.com/Jermolene/TiddlyWiki5/commit/8e132948b6bec623d81d300fbe6dc3a0307bcc6d">> crash when transcluding a lazily loaded tiddler as an attribute value
 * <<.link-badge-fixed "https://github.com/Jermolene/TiddlyWiki5/issues/7462">> DiffTextWidget crash with missing or empty attributes


### PR DESCRIPTION
https://github.com/Jermolene/TiddlyWiki5/commit/7b9915b5c237a577bc6931cd1619d5a615b35f39 added a release note for PR #7448, but it already had a release note, so now it has two. Let's remove one.

It's kind of arbitrary which one we should remove, so I chose to remove the one that I added a couple weeks ago, assuming that the one that @Jermolene added in commit 7b9915b5c237a577bc6931cd1619d5a615b35f39 reflects his preferred wording.