### PR TITLE
Chore: Add npm script for new core developers

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "dev": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
-    "test": "node ./tiddlywiki.js ./editions/test --verbose --version --rendertiddler $:/core/save/all test.html text/plain --test && echo To run the tests in a browser, open \"editions/test/output/test.html\"",
+    "test": "node ./tiddlywiki.js ./editions/test --verbose --version --build index",
     "lint:fix": "eslint . --fix",
     "lint": "eslint ."
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "test": "./bin/test.sh",
     "dev": "./bin/serve.sh ./editions/tw5.com-server",
+    "lint:fix": "eslint . --fix",
     "lint": "eslint ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "node": ">=0.8.2"
   },
   "scripts": {
-    "test": "./bin/test.sh",
     "dev": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
+    "test": "node ./tiddlywiki.js ./editions/test --verbose --version --rendertiddler $:/core/save/all test.html text/plain --test && echo To run the tests in a browser, open \"editions/test/output/test.html\"",
     "lint:fix": "eslint . --fix",
     "lint": "eslint ."
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "node": ">=0.8.2"
   },
   "scripts": {
+    "test": "./bin/test.sh",
+    "dev": "./bin/serve.sh ./editions/tw5.com-server",
     "lint": "eslint ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "test": "./bin/test.sh",
-    "dev": "./bin/serve.sh ./editions/tw5.com-server",
+    "dev": "node ./tiddlywiki.js ./editions/tw5.com-server --listen",
     "lint:fix": "eslint . --fix",
     "lint": "eslint ."
   }


### PR DESCRIPTION
When I first try to develop tw core, it was hard to find how to dev and how to test.

Other opensource projects use npm script as a "self-explained" way to provide dev methods. You don't need to look at ./bin/ folder, you just need to look at VSCode's 

<img width="446" alt="截屏2023-06-14 13 07 43" src="https://github.com/Jermolene/TiddlyWiki5/assets/3746270/c840a789-8e71-438d-8024-c127a3e93a26">

And click "test" button to run a test, this is very standardized. So I also add it to the tw for potential new developers (and me).
