### PR TITLE
Fixes tests for deserialize[] so they can be run on browser and node.js

### DIFF
--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -1066,7 +1066,11 @@ Tests the filtering mechanism.
 		});
 	
 		it("should handle the deserializers operator", function() {
-		expect(wiki.filterTiddlers("[deserializers[]]").join(",")).toBe("application/javascript,application/json,application/x-tiddler,application/x-tiddler-html-div,application/x-tiddlers,text/css,text/html,text/plain");
+		var expectedDeserializers = ["application/javascript","application/json","application/x-tiddler","application/x-tiddler-html-div","application/x-tiddlers","text/css","text/html","text/plain"];
+		if($tw.browser) {
+			expectedDeserializers.unshift("(DOM)");
+		}
+		expect(wiki.filterTiddlers("[deserializers[]]").join(",")).toBe(expectedDeserializers.join(","));
 		});
 		
 		it("should handle the charcode operator", function() {


### PR DESCRIPTION
This PR fixes the tests for the deserialize[] operator which returns different output on node.js as compared to the browser, so that they can be used on both platforms.