### PR TITLE
Remove text subst from operator example macro

### DIFF
--- a/editions/tw5.com/tiddlers/system/operator-macros.tid
+++ b/editions/tw5.com/tiddlers/system/operator-macros.tid
@@ -1,5 +1,5 @@
 created: 20150117152607000
-modified: 20220227210111054
+modified: 20230617182415427
 tags: $:/tags/Macro
 title: $:/editions/tw5.com/operator-macros
 
@@ -8,10 +8,10 @@ title: $:/editions/tw5.com/operator-macros
 \define .operator-example-tryit-actions() <$action-setfield $tiddler=<<.state>> text="show" filter=<<__eg__>>/>
 \define .operator-example(n,eg,ie)
 <div class="doc-example">
-<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix[$n$]]" variable=".state">
+<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix<__n__>]" variable=".state">
 <$reveal state=<<.state>> type="nomatch" text="show">
-	`$eg$`
-	<$macrocall $name=".if" cond="""$ie$""" then="""<dd>&rarr; $ie$</dd>"""/>
+	<code><$text text=<<__eg__>>/></code>
+	<$macrocall $name=".if" cond=<<__ie__>> then={{{[[<dd>&rarr; ]addsuffix<__ie__>addsuffix[</dd>]]}}}/>
 	<dl>
 	<dd><$button actions=<<.operator-example-tryit-actions>>>Try it</$button></dd>
 	</dl>

--- a/editions/tw5.com/tiddlers/system/operator-macros.tid
+++ b/editions/tw5.com/tiddlers/system/operator-macros.tid
@@ -1,17 +1,17 @@
 created: 20150117152607000
-modified: 20230617182415427
+modified: 20230617183916622
 tags: $:/tags/Macro
 title: $:/editions/tw5.com/operator-macros
 
 \define .operator-examples(op,text:"Examples") <$link to="$op$ Operator (Examples)">$text$</$link>
 
-\define .operator-example-tryit-actions() <$action-setfield $tiddler=<<.state>> text="show" filter=<<__eg__>>/>
-\define .operator-example(n,eg,ie)
+\procedure .operator-example-tryit-actions() <$action-setfield $tiddler=<<.state>> text="show" filter=<<eg>>/>
+\procedure .operator-example(n,eg,ie)
 <div class="doc-example">
-<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix<__n__>]" variable=".state">
+<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix<n>]" variable=".state">
 <$reveal state=<<.state>> type="nomatch" text="show">
-	<code><$text text=<<__eg__>>/></code>
-	<$macrocall $name=".if" cond=<<__ie__>> then={{{[[<dd>&rarr; ]addsuffix<__ie__>addsuffix[</dd>]]}}}/>
+	<code><$text text=<<eg>>/></code>
+	<$macrocall $name=".if" cond=<<ie>> then={{{[[<dd>&rarr; ]addsuffix<ie>addsuffix[</dd>]]}}}/>
 	<dl>
 	<dd><$button actions=<<.operator-example-tryit-actions>>>Try it</$button></dd>
 	</dl>
@@ -21,7 +21,7 @@ title: $:/editions/tw5.com/operator-macros
 	<dl>
 	<dd>
 	<$button set=<<.state>> setTo="">Hide</$button>
-	<$reveal stateTitle=<<.state>> stateField="filter" type="nomatch" text=<<__eg__>>>
+	<$reveal stateTitle=<<.state>> stateField="filter" type="nomatch" text=<<eg>>>
 		<$button actions=<<.operator-example-tryit-actions>>>Reset</$button>
 	</$reveal>
 	</dd>


### PR DESCRIPTION
The textual substitution in the `.operator-example` macro prevents the macro from being used for some of the examples in the `substitute` operator (#7526). Remove the textual substitution syntax and convert from a macro to a procedure.