### PR TITLE
make all list-* widgets readable for easier future improvements

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -3,18 +3,18 @@ tags: $:/tags/Macro
 
 \define list-links(filter,type:"ul",subtype:"li",class:"",emptyMessage,field:"caption")
 \whitespace trim
-<$genesis $type=<<__type__>> class=<<__class__>>>
-<$list filter=<<__filter__>> emptyMessage=<<__emptyMessage__>>>
-<$genesis $type=<<__subtype__>>>
-<$link to={{!!title}}>
-<$let tv-wikilinks="no">
-<$transclude field=<<__field__>>>
-<$view field="title"/>
-</$transclude>
-</$let>
-</$link>
-</$genesis>
-</$list>
+<$genesis $type=<<__type__>> class=<<__class__>> >
+	<$list filter=<<__filter__>> emptyMessage=<<__emptyMessage__>> >
+		<$genesis $type=<<__subtype__>> >
+			<$link to={{!!title}}>
+				<$let tv-wikilinks="no">
+					<$transclude field=<<__field__>> >
+						<$view field="title"/>
+					</$transclude>
+				</$let>
+			</$link>
+		</$genesis>
+	</$list>
 </$genesis>
 \end
 
@@ -25,34 +25,42 @@ tags: $:/tags/Macro
 \define list-links-draggable(tiddler,field:"list",emptyMessage,type:"ul",subtype:"li",class:"",itemTemplate)
 \whitespace trim
 <span class="tc-links-draggable-list">
-<$vars targetTiddler="""$tiddler$""" targetField="""$field$""">
-<$genesis $type=<<__type__>> class="$class$">
-<$list filter="[list[$tiddler$!!$field$]]" emptyMessage=<<__emptyMessage__>>>
-<$droppable actions=<<list-links-draggable-drop-actions>> tag="""$subtype$""" enable=<<tv-enable-drag-and-drop>>>
-<div class="tc-droppable-placeholder"/>
-<div>
-<$transclude tiddler="""$itemTemplate$""">
-<$link to={{!!title}}>
-<$let tv-wikilinks="no">
-<$transclude field="caption">
-<$view field="title"/>
-</$transclude>
-</$let>
-</$link>
-</$transclude>
-</div>
-</$droppable>
-</$list>
-<$tiddler tiddler="">
-<$droppable actions=<<list-links-draggable-drop-actions>> tag="div" enable=<<tv-enable-drag-and-drop>>>
-<div class="tc-droppable-placeholder">
-{{$:/core/images/blank}}
-</div>
-<div style="height:0.5em;"/>
-</$droppable>
-</$tiddler>
-</$genesis>
-</$vars>
+	<$vars targetTiddler="""$tiddler$""" targetField="""$field$""">
+		<$genesis $type=<<__type__>> class="$class$">
+			<$list filter="[list[$tiddler$!!$field$]]" emptyMessage=<<__emptyMessage__>> >
+				<$droppable
+					actions=<<list-links-draggable-drop-actions>>
+					tag="""$subtype$"""
+					enable=<<tv-enable-drag-and-drop>>
+				>
+					<div class="tc-droppable-placeholder"/>
+					<div>
+						<$transclude tiddler="""$itemTemplate$""">
+							<$link to={{!!title}}>
+								<$let tv-wikilinks="no">
+									<$transclude field="caption">
+										<$view field="title"/>
+									</$transclude>
+								</$let>
+							</$link>
+						</$transclude>
+					</div>
+				</$droppable>
+			</$list>
+			<$tiddler tiddler="">
+				<$droppable
+					actions=<<list-links-draggable-drop-actions>> 
+					tag="div"
+					enable=<<tv-enable-drag-and-drop>>
+				>
+					<div class="tc-droppable-placeholder">
+						{{$:/core/images/blank}}
+					</div>
+					<div style="height:0.5em;"/>
+				</$droppable>
+			</$tiddler>
+		</$genesis>
+	</$vars>
 </span>
 \end
 
@@ -60,50 +68,59 @@ tags: $:/tags/Macro
 \whitespace trim
 <!-- Save the current ordering of the tiddlers with this tag -->
 <$set name="order" filter="[<__tag__>tagging[]]">
-<!-- Remove any list-after or list-before fields from the tiddlers with this tag -->
-<$list filter="[<__tag__>tagging[]]">
-<$action-deletefield $field="list-before"/>
-<$action-deletefield $field="list-after"/>
-</$list>
-<!-- Save the new order to the Tag Tiddler -->
-<$action-listops $tiddler=<<__tag__>> $field="list" $filter="+[enlist<order>] +[insertbefore<actionTiddler>,<currentTiddler>]"/>
-<!-- Make sure the newly added item has the right tag -->
-<!-- Removing this line makes dragging tags within the dropdown work as intended -->
-<!--<$action-listops $tiddler=<<actionTiddler>> $tags=<<__tag__>>/>-->
-<!-- Using the following 5 lines as replacement makes dragging titles from outside into the dropdown apply the tag -->
-<$list filter="[<actionTiddler>!contains:tags<__tag__>]">
-<$fieldmangler tiddler=<<actionTiddler>>>
-<$action-sendmessage $message="tm-add-tag" $param=<<__tag__>>/>
-</$fieldmangler>
-</$list>
+	<!-- Remove any list-after or list-before fields from the tiddlers with this tag -->
+	<$list filter="[<__tag__>tagging[]]">
+		<$action-deletefield $field="list-before"/>
+		<$action-deletefield $field="list-after"/>
+	</$list>
+	<!-- Save the new order to the Tag Tiddler -->
+	<$action-listops $tiddler=<<__tag__>> $field="list" $filter="+[enlist<order>] +[insertbefore<actionTiddler>,<currentTiddler>]"/>
+	<!-- Make sure the newly added item has the right tag -->
+	<!-- Removing this line makes dragging tags within the dropdown work as intended -->
+	<!--<$action-listops $tiddler=<<actionTiddler>> $tags=<<__tag__>>/>-->
+	<!-- Using the following 5 lines as replacement makes dragging titles from outside into the dropdown apply the tag -->
+	<$list filter="[<actionTiddler>!contains:tags<__tag__>]">
+		<$fieldmangler tiddler=<<actionTiddler>> >
+			<$action-sendmessage $message="tm-add-tag" $param=<<__tag__>>/>
+		</$fieldmangler>
+	</$list>
 </$set>
 \end
 
 \define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div",storyview:"")
 \whitespace trim
 <span class="tc-tagged-draggable-list">
-<$set name="tag" value=<<__tag__>>>
-<$list filter="[<__tag__>tagging[]$subFilter$]" emptyMessage=<<__emptyMessage__>> storyview=<<__storyview__>>>
-<$genesis $type=<<__elementTag__>> class="tc-menu-list-item">
-<$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""" enable=<<tv-enable-drag-and-drop>>>
-<$genesis $type=<<__elementTag__>> class="tc-droppable-placeholder"/>
-<$genesis $type=<<__elementTag__>>>
-<$transclude tiddler="""$itemTemplate$""">
-<$link to={{!!title}}>
-<$view field="title"/>
-</$link>
-</$transclude>
-</$genesis>
-</$droppable>
-</$genesis>
-</$list>
-<$tiddler tiddler="">
-<$droppable actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>""" enable=<<tv-enable-drag-and-drop>>>
-<$genesis $type=<<__elementTag__>> class="tc-droppable-placeholder"/>
-<$genesis $type=<<__elementTag__>> style="height:0.5em;">
-</$genesis>
-</$droppable>
-</$tiddler>
-</$set>
+	<$set name="tag" value=<<__tag__>> >
+		<$list
+			filter="[<__tag__>tagging[]$subFilter$]"
+			emptyMessage=<<__emptyMessage__>>
+			storyview=<<__storyview__>>
+		>
+			<$genesis $type=<<__elementTag__>> class="tc-menu-list-item">
+				<$droppable
+					actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>"""
+					enable=<<tv-enable-drag-and-drop>>
+				>
+					<$genesis $type=<<__elementTag__>> class="tc-droppable-placeholder"/>
+					<$genesis $type=<<__elementTag__>> >
+						<$transclude tiddler="""$itemTemplate$""">
+							<$link to={{!!title}}>
+								<$view field="title"/>
+							</$link>
+						</$transclude>
+					</$genesis>
+				</$droppable>
+			</$genesis>
+		</$list>
+		<$tiddler tiddler="">
+			<$droppable
+				actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>"""
+				enable=<<tv-enable-drag-and-drop>>
+			>
+				<$genesis $type=<<__elementTag__>> class="tc-droppable-placeholder"/>
+				<$genesis $type=<<__elementTag__>> style="height:0.5em;"/>
+			</$droppable>
+		</$tiddler>
+	</$set>
 </span>
 \end


### PR DESCRIPTION
>make all list-* widgets readable for easier future improvements

This PR adds indentation only. ... I would like to make the macros more consistent in the future. 

eg: list-links and list-links draggable use `tv-wikilinks=no` to render the `<$view field=title>` .... list-tagged-draggable does not, which prevents optimization. 

I would also like to make it easy to add a "search filter" to all list-* widgets without the need to change those macros again.

@Jermolene ... It would be nice if this PR could be merged.