### PR TITLE
change arrow-function to function call for HTA

### DIFF
--- a/plugins/tiddlywiki/codemirror/engine.js
+++ b/plugins/tiddlywiki/codemirror/engine.js
@@ -164,7 +164,7 @@ function CodeMirrorEngine(options) {
 			if (cm.state.draggingText && cm.doc.sel.contains(pos) > -1) {
 				cm.state.draggingText(event);
 				// Ensure the editor is re-focused
-				setTimeout(() => cm.display.input.focus(), 20);
+				setTimeout(function() {cm.display.input.focus();}, 20); 
 				return;
 			}
 			try {
@@ -176,13 +176,13 @@ function CodeMirrorEngine(options) {
 					}
 					cm.setCursor(cm.coordsChar({left:event.pageX,top:event.pageY}));
 					if (selected) {
-					 	for (var i = 0; i < selected.length; ++i) {
+						for (var i = 0; i < selected.length; ++i) {
 							replaceRange(cm.doc, "", selected[i].anchor, selected[i].head, "drag");
 						}
 					}
 					cm.replaceSelection(text, "around", "paste");
 					cm.display.input.focus();
-			  }
+				}
 			}
 			catch(e){}
 		}


### PR DESCRIPTION
This PR fixes:  **[BUG] CodeMirror plugin not working in HTA mode since TiddlyWiki v5.2.1** #7545 

This PR changes the arrow function call to a normal function call. The code itself is only executed in Chrome like browsers. 

I did the following tests as described in the original PR: https://github.com/Jermolene/TiddlyWiki5/pull/6278#issue-1063248880

>Things to test in CodeMirror - best to do this in a tiddler with some existing text:
>
>- dragging and dropping tiddler links
>- dragging and dropping external links
>- dragging and dropping text
>- whether the links or text are inserted at the correct place in the text
>- dragging and dropping an image and importing it.

It seems to work in Edge and FF ... I also did test it with HTA ... Should work again. 