### PR TITLE
make tag-macro and tag*-templates human readable for future improvements

### DIFF
--- a/core/ui/MoreSideBar/Tags.tid
+++ b/core/ui/MoreSideBar/Tags.tid
@@ -3,15 +3,14 @@ tags: $:/tags/MoreSideBar
 caption: {{$:/language/SideBar/Tags/Caption}}
 
 \whitespace trim
-
 <$let tv-config-toolbar-icons="yes" tv-config-toolbar-text="yes" tv-config-toolbar-class="">
 	<div class="tc-tiny-v-gap-bottom">
-    	{{$:/core/ui/Buttons/tag-manager}}
+		{{$:/core/ui/Buttons/tag-manager}}
 	</div>
 </$let>
 <$list filter={{$:/core/Filters/AllTags!!filter}}>
 	<div class="tc-tiny-v-gap-bottom">
-    	<$transclude tiddler="$:/core/ui/TagTemplate"/>
+		<$transclude tiddler="$:/core/ui/TagTemplate"/>
 	</div>
 </$list>
 <hr class="tc-untagged-separator">

--- a/core/ui/TagPickerTagTemplate.tid
+++ b/core/ui/TagPickerTagTemplate.tid
@@ -2,22 +2,29 @@ title: $:/core/ui/TagPickerTagTemplate
 
 \whitespace trim
 <$button class=<<button-classes>> tag="a" tooltip={{$:/language/EditTemplate/Tags/Add/Button/Hint}}>
-<$list filter="[<saveTiddler>minlength[1]]">
-<$action-listops $tiddler=<<saveTiddler>> $field=<<tagField>> $subfilter="[<tag>]"/>
-</$list>
-<$set name="currentTiddlerCSSEscaped" value={{{ [<saveTiddler>escapecss[]] }}}>
-<$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>> preventScroll="true"/>
-</$set>
-<<delete-tag-state-tiddlers>>
-<$list filter="[<refreshTitle>minlength[1]]">
-<$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
-</$list>
-<<actions>>
-<$set name="backgroundColor" value={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}}>
-<$wikify name="foregroundColor" text="""<$macrocall $name="contrastcolour" target=<<backgroundColor>> fallbackTarget=<<fallbackTarget>> colourA=<<colourA>> colourB=<<colourB>>/>""">
-<span class="tc-tag-label tc-btn-invisible" style=<<tag-pill-styles>> data-tag-title=<<currentTiddler>> >
-{{||$:/core/ui/TiddlerIcon}}<$view field="title" format="text"/>
-</span>
-</$wikify>
-</$set>
+	<$list filter="[<saveTiddler>minlength[1]]">
+		<$action-listops $tiddler=<<saveTiddler>> $field=<<tagField>> $subfilter="[<tag>]"/>
+	</$list>
+	<$set name="currentTiddlerCSSEscaped" value={{{ [<saveTiddler>escapecss[]] }}}>
+		<$action-sendmessage $message="tm-focus-selector" $param=<<get-tagpicker-focus-selector>> preventScroll="true"/>
+	</$set>
+	<<delete-tag-state-tiddlers>>
+	<$list filter="[<refreshTitle>minlength[1]]">
+		<$action-setfield $tiddler=<<refreshTitle>> text="yes"/>
+	</$list>
+	<<actions>>
+	<$set name="backgroundColor"
+		value={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}}
+	>
+		<$wikify name="foregroundColor"
+			text="""<$macrocall $name="contrastcolour" target=<<backgroundColor>> fallbackTarget=<<fallbackTarget>> colourA=<<colourA>> colourB=<<colourB>>/>"""
+		>
+			<span class="tc-tag-label tc-btn-invisible"
+				style=<<tag-pill-styles>>
+				data-tag-title=<<currentTiddler>>
+			>
+				{{||$:/core/ui/TiddlerIcon}}<$view field="title" format="text"/>
+			</span>
+		</$wikify>
+	</$set>
 </$button>

--- a/core/ui/TagTemplate.tid
+++ b/core/ui/TagTemplate.tid
@@ -3,16 +3,23 @@ title: $:/core/ui/TagTemplate
 \whitespace trim
 <span class="tc-tag-list-item" data-tag-title=<<currentTiddler>>>
 <$set name="transclusion" value=<<currentTiddler>>>
-<$macrocall $name="tag-pill-body" tag=<<currentTiddler>> icon={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] }}} colour={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}} palette={{$:/palette}} element-tag="""$button""" element-attributes="""popup=<<qualify "$:/state/popup/tag">> dragFilter='[all[current]tagging[]]' tag='span'"""/>
-<$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes" class="tc-drop-down">
-<$set name="tv-show-missing-links" value="yes">
-<$transclude tiddler="$:/core/ui/ListItemTemplate"/>
-</$set>
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/TagDropdown]!has[draft.of]]" variable="listItem"> 
-<$transclude tiddler=<<listItem>>/> 
-</$list>
-<hr>
-<$macrocall $name="list-tagged-draggable" tag=<<currentTiddler>>/>
-</$reveal>
+	<$macrocall $name="tag-pill-body"
+		tag=<<currentTiddler>>
+		icon={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] }}}
+		colour={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}}
+		palette={{$:/palette}}
+		element-tag="$button"
+		element-attributes="""popup=<<qualify "$:/state/popup/tag">> dragFilter="[all[current]tagging[]]" tag='span'"""
+	/>
+	<$reveal state=<<qualify "$:/state/popup/tag">> type="popup" position="below" animate="yes" class="tc-drop-down">
+		<$set name="tv-show-missing-links" value="yes">
+			<$transclude tiddler="$:/core/ui/ListItemTemplate"/>
+		</$set>
+		<$list filter="[all[shadows+tiddlers]tag[$:/tags/TagDropdown]!has[draft.of]]" variable="listItem"> 
+			<$transclude tiddler=<<listItem>>/> 
+		</$list>
+		<hr>
+		<$macrocall $name="list-tagged-draggable" tag=<<currentTiddler>>/>
+	</$reveal>
 </$set>
 </span>

--- a/core/wiki/macros/tag.tid
+++ b/core/wiki/macros/tag.tid
@@ -9,26 +9,50 @@ color:$(foregroundColor)$;
 
 <!-- This has no whitespace trim to avoid modifying $actions$. Closing tags omitted for brevity. -->
 \define tag-pill-inner(tag,icon,colour,fallbackTarget,colourA,colourB,element-tag,element-attributes,actions)
+\whitespace trim
 <$vars
 	foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">>
-	backgroundColor="""$colour$"""
-><$element-tag$
+	backgroundColor=<<__colour__>>
+>
+<$element-tag$
 	$element-attributes$
 	class="tc-tag-label tc-btn-invisible"
 	style=<<tag-pill-styles>>
->$actions$<$transclude tiddler="""$icon$"""/><$view tiddler=<<__tag__>> field="title" format="text" /></$element-tag$>
+>
+	<<__actions__>>
+	<$transclude tiddler=<<__icon__>>/>
+	<$view tiddler=<<__tag__>> field="title" format="text" />
+</$element-tag$>
 \end
 
 \define tag-pill-body(tag,icon,colour,palette,element-tag,element-attributes,actions)
-<$macrocall $name="tag-pill-inner" tag=<<__tag__>> icon="""$icon$""" colour="""$colour$""" fallbackTarget={{$palette$##tag-background}} colourA={{$palette$##foreground}} colourB={{$palette$##background}} element-tag="""$element-tag$""" element-attributes="""$element-attributes$""" actions="""$actions$"""/>
+\whitespace trim
+<$macrocall $name="tag-pill-inner"
+	tag=<<__tag__>>
+	icon=<<__icon__>>
+	colour=<<__colour__>>
+	fallbackTarget={{$palette$##tag-background}}
+	colourA={{$palette$##foreground}}
+	colourB={{$palette$##background}}
+	element-tag=<<__element-tag__>>
+	element-attributes=<<__element-attributes__>>
+	actions=<<__actions__>>
+/>
 \end
 
 \define tag-pill(tag,element-tag:"span",element-attributes:"",actions:"")
 \whitespace trim
 <span class="tc-tag-list-item" data-tag-title=<<__tag__>>>
-<$let currentTiddler=<<__tag__>>>
-<$macrocall $name="tag-pill-body" tag=<<__tag__>> icon={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] }}} colour={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}} palette={{$:/palette}} element-tag="""$element-tag$""" element-attributes="""$element-attributes$""" actions="""$actions$"""/>
-</$let>
+	<$let currentTiddler=<<__tag__>>>
+		<$macrocall $name="tag-pill-body"
+			tag=<<__tag__>>
+			icon={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] }}}
+			colour={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}}
+			palette={{$:/palette}}
+			element-tag=<<__element-tag__>>
+			element-attributes=<<__element-attributes__>>
+			actions=<<__actions__>>/>
+	</$let>
 </span>
 \end
 


### PR DESCRIPTION
This PR rewrites `$variable$` to `<<__variable__>` for all elements where possible and makes the code human readable. 

GitHub has a new "Split" view which allows us to see the changes side by side. So it's possible to exactly see what's going on. 

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/2b958be2-0dbb-4dca-ae95-ac570e81984a)

