### PR TITLE
Docs: Creates a Deserializers tiddler with overview of core deserializer modules

### DIFF
--- a/editions/tw5.com/tiddlers/features/Deserializers.tid
+++ b/editions/tw5.com/tiddlers/features/Deserializers.tid
@@ -1,0 +1,20 @@
+created: 20230627093650105
+modified: 20230627094356394
+tags: Features
+title: Deserializers
+type: text/vnd.tiddlywiki
+
+Deserializer [[modules|Modules]] parse text in various formats into their JSON representation as tiddlers. The deserializer modules available in a wiki can be seen using the  [[deserializers operator|deserializers Operator]] and can be used with the [[deserialize Operator]].
+
+The TiddlyWiki core provides the following deserializers:
+
+|!Deserializer |!Description |
+|(DOM)|Extracts tiddlers from a DOM node, should not be used with the <<.op deserialize[]>> operator |
+|application/javascript|Parses a JavaScript module as a tiddler extracting fields from the header comment|
+|application/json|Parses [[JSON|JSON in TiddlyWiki]] into tiddlers|
+|application/x-tiddler|Parses the [[.tid file format|TiddlerFiles]] as a tiddler|
+|application/x-tiddler-html-div|Parses the [[<DIV>.tiddler file format|TiddlerFiles]] as a tiddler|
+|application/x-tiddlers|Parses the [[MultiTiddlerFile format|MultiTiddlerFiles]] as tiddlers|
+|text/css|Parses CSS as a tiddler extracting fields from the header comment|
+|text/html|Parses an HTML file into tiddlers. Supports ~TiddlyWiki Classic HTML files, ~TiddlyWiki5 HTML files and ordinary HTML files|
+|text/plain|Parses plain text as a tiddler|

--- a/editions/tw5.com/tiddlers/filters/deserialize Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/deserialize Operator.tid
@@ -1,7 +1,7 @@
 caption: deserialize
 created: 20230601195749377
 from-version: 5.3.0
-modified: 20230602105513132
+modified: 20230627094109762
 op-input: a selection of strings
 op-output: JSON representations of tiddlers extracted from input titles.
 op-parameter: the deserializer module to be used to extract tiddlers from the input
@@ -10,17 +10,8 @@ tags: [[Filter Operators]] [[Special Operators]]
 title: deserialize Operator
 type: text/vnd.tiddlywiki
 
-<<.tip "Deserializer modules parse text in various formats into their JSON representation as tiddlers. You can see the deserializers available in a wiki using the [[deserializers operator|deserializers Operator]].">>
+{{Deserializers}}
 
-|!Deserializer |!Description |
-|(DOM)|Extracts tiddlers from a DOM node, should not be used with the <<.op deserialize[]>> operator |
-|application/javascript|Parses a JavaScript module as a tiddler extracting fields from the header comment|
-|application/json|Parses [[JSON|JSON in TiddlyWiki]] into tiddlers|
-|application/x-tiddler|Parses the [[.tid file format|TiddlerFiles]] as a tiddler|
-|application/x-tiddler-html-div|Parses the [[<DIV>.tiddler file format|TiddlerFiles]] as a tiddler|
-|application/x-tiddlers|Parses the [[MultiTiddlerFile format|MultiTiddlerFiles]] as tiddlers|
-|text/css|Parses CSS as a tiddler extracting fields from the header comment|
-|text/html|Parses an HTML file into tiddlers. Supports ~TiddlyWiki Classic HTML files, ~TiddlyWiki5 HTML files and ordinary HTML files|
-|text/plain|Parses plain text as a tiddler|
+
 
 <<.operator-examples "deserialize">>

--- a/editions/tw5.com/tiddlers/filters/deserializers Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/deserializers Operator.tid
@@ -1,14 +1,14 @@
 caption: deserializers
 created: 20210506115203172
 from-version: 5.2.0
-modified: 20210506130322593
+modified: 20230627094238610
 op-input: ignored
 op-output: the title of each available deserializer
 op-parameter: none
-tags: [[Filter Operators]] [[Special Operators]] [[Selection Constructors]] 
+tags: [[Filter Operators]] [[Special Operators]] [[Selection Constructors]]
 title: deserializers Operator
 type: text/vnd.tiddlywiki
 
-<<.tip "You can specify a specific deserializer for a DropzoneWidget to use">>
+<<.tip "You can specify a specific [[deserializer|Deserializers]] for a DropzoneWidget to use">>
 
 <<.operator-examples "deserializers">>


### PR DESCRIPTION
This PR adds a new documentation tiddler called Deserializers and references it in the documentation for the deseralize[] and deserializers[] operators.