### PR TITLE
fix #7579 PageTemplate/story can brick wiki

### DIFF
--- a/core/ui/AlertTemplate.tid
+++ b/core/ui/AlertTemplate.tid
@@ -1,3 +1,4 @@
+code-body: yes
 title: $:/core/ui/AlertTemplate
 
 \whitespace trim

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -1,3 +1,4 @@
+code-body: yes
 title: $:/core/ui/EditTemplate
 
 \define delete-edittemplate-state-tiddlers()

--- a/core/ui/ImportPreviews/Text.tid
+++ b/core/ui/ImportPreviews/Text.tid
@@ -1,5 +1,6 @@
 title: $:/core/ui/ImportPreviews/Text
 tags: $:/tags/ImportPreview
 caption: {{$:/language/Import/Listing/Preview/Text}}
+code-body: yes
 
 <$transclude tiddler=<<currentTiddler>> subtiddler=<<payloadTiddler>> mode="block"/>

--- a/core/ui/PageStylesheet.tid
+++ b/core/ui/PageStylesheet.tid
@@ -1,4 +1,5 @@
 title: $:/core/ui/PageStylesheet
+code-body: yes
 
 \import [subfilter{$:/core/config/GlobalImportFilter}]
 \whitespace trim

--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -2,6 +2,7 @@ title: $:/core/ui/PageTemplate
 name: {{$:/language/PageTemplate/Name}}
 description: {{$:/language/PageTemplate/Description}}
 icon: $:/core/images/layout-button
+code-body: yes
 
 \whitespace trim
 \import [subfilter{$:/core/config/GlobalImportFilter}]

--- a/core/ui/RootTemplate.tid
+++ b/core/ui/RootTemplate.tid
@@ -1,4 +1,5 @@
 title: $:/core/ui/RootTemplate
+code-body: yes
 
 <$transclude tiddler={{{ [{$:/layout}has[text]] ~[[$:/core/ui/PageTemplate]] }}} mode="inline"/>
 

--- a/core/ui/StoryTiddlerTemplate.tid
+++ b/core/ui/StoryTiddlerTemplate.tid
@@ -1,3 +1,4 @@
 title: $:/core/ui/StoryTiddlerTemplate
+code-body: yes
 
 <$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/StoryTiddlerTemplateFilter]!is[draft]get[text]] :and[has[title]else[$:/core/ui/ViewTemplate]] }}} />

--- a/core/ui/ViewTemplate.tid
+++ b/core/ui/ViewTemplate.tid
@@ -1,4 +1,5 @@
 title: $:/core/ui/ViewTemplate
+code-body: yes
 
 \whitespace trim
 \define folded-state()

--- a/core/ui/ViewTemplate/body/default.tid
+++ b/core/ui/ViewTemplate/body/default.tid
@@ -1,4 +1,5 @@
 title: $:/core/ui/ViewTemplate/body/default
+code-body: yes
 
 <$transclude>
 

--- a/core/wiki/config/ViewTemplateBodyFilters.multids
+++ b/core/wiki/config/ViewTemplateBodyFilters.multids
@@ -2,7 +2,8 @@ title: $:/config/ViewTemplateBodyFilters/
 tags: $:/tags/ViewTemplateBodyFilter
 
 stylesheet: [tag[$:/tags/Stylesheet]then[$:/core/ui/ViewTemplate/body/rendered-plain-text]]
-system: [prefix[$:/boot/]] [prefix[$:/config/]] [prefix[$:/core/macros]] [prefix[$:/core/save/]] [prefix[$:/core/templates/]] [prefix[$:/core/ui/]split[/]count[]compare:number:eq[4]] [prefix[$:/info/]] [prefix[$:/language/]] [prefix[$:/languages/]] [prefix[$:/snippets/]] [prefix[$:/state/]] [prefix[$:/status/]] [prefix[$:/info/]] [prefix[$:/temp/]] +[!is[image]limit[1]then[$:/core/ui/ViewTemplate/body/code]]
+core-ui-tags: [tag[$:/tags/PageTemplate]] [tag[$:/tags/EditTemplate]] [tag[$:/tags/ViewTemplate]] [tag[$:/tags/KeyboardShortcut]] [tag[$:/tags/ImportPreview]] [tag[$:/tags/EditPreview]][tag[$:/tags/EditorToolbar]] [tag[$:/tags/Actions]] :then[[$:/core/ui/ViewTemplate/body/code]]
+system: [prefix[$:/boot/]] [prefix[$:/config/]] [prefix[$:/core/macros]] [prefix[$:/core/save/]] [prefix[$:/core/templates/]]  [prefix[$:/info/]] [prefix[$:/language/]] [prefix[$:/languages/]] [prefix[$:/snippets/]] [prefix[$:/state/]] [prefix[$:/status/]] [prefix[$:/info/]] [prefix[$:/temp/]] +[!is[image]limit[1]then[$:/core/ui/ViewTemplate/body/code]]
 code-body: [field:code-body[yes]then[$:/core/ui/ViewTemplate/body/code]]
 import: [field:plugin-type[import]then[$:/core/ui/ViewTemplate/body/import]]
 plugin: [has[plugin-type]then[$:/core/ui/ViewTemplate/body/plugin]]

--- a/core/wiki/tags/ViewTemplateBodyFilter.tid
+++ b/core/wiki/tags/ViewTemplateBodyFilter.tid
@@ -1,3 +1,2 @@
 title: $:/tags/ViewTemplateBodyFilter
-list: $:/config/ViewTemplateBodyFilters/hide-body $:/config/ViewTemplateBodyFilters/code-body $:/config/ViewTemplateBodyFilters/stylesheet $:/config/ViewTemplateBodyFilters/system $:/config/ViewTemplateBodyFilters/import $:/config/ViewTemplateBodyFilters/plugin $:/config/ViewTemplateBodyFilters/default
-
+list: $:/config/ViewTemplateBodyFilters/hide-body $:/config/ViewTemplateBodyFilters/code-body $:/config/ViewTemplateBodyFilters/stylesheet $:/config/ViewTemplateBodyFilters/core-ui-advanced-search $:/config/ViewTemplateBodyFilters/core-ui-tags $:/config/ViewTemplateBodyFilters/system $:/config/ViewTemplateBodyFilters/import $:/config/ViewTemplateBodyFilters/plugin $:/config/ViewTemplateBodyFilters/default


### PR DESCRIPTION
This PR fixes 
- #7579

There are 280 tiddlers that match the filter: `[all[shadows+tiddlers]prefix[$:/core/ui/]]`

**Testing**

- I did create a button that can open all of them. 
- The following button can be tested with the preview wiki created for this PR

```
\procedure openAll()
<$list filter="[all[shadows+tiddlers]prefix[$:/core/ui/]]">
<$action-navigate $to=<<currentTiddler>>/>
</$list>
\end

<$button actions=<<openAll>> >
Open all tiddlers `prefix[$:/core/ui/]`
</$button>
```

There are 9 of them which need a `code-body: yes`, because they can cause "catastrophic rendering" distortions.

- $:/core/ui/AlertTemplate
- $:/core/ui/EditTemplate
- $:/core/ui/ImportPreviews/Text
- $:/core/ui/PageStylesheet
- $:/core/ui/PageTemplate
- $:/core/ui/RootTemplate
- $:/core/ui/StoryTiddlerTemplate
- $:/core/ui/ViewTemplate
- $:/core/ui/ViewTemplate/body/default

The rest of them can be covered with tag filters. Linebreaks added to the filter here to improve readability.

```
core-ui-tags: [tag[$:/tags/PageTemplate]] 
[tag[$:/tags/EditTemplate]] 
[tag[$:/tags/ViewTemplate]] 
[tag[$:/tags/KeyboardShortcut]] 
[tag[$:/tags/ImportPreview]] 
[tag[$:/tags/EditPreview]] 
[tag[$:/tags/EditorToolbar]] 
[tag[$:/tags/Actions]] :then[[$:/core/ui/ViewTemplate/body/code]]
```

With those settings applied, the button will work fine and IMO the "view state" works as intended. 

