### PR TITLE
Add `tabindex` to SelectWidget and docs

### DIFF
--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -145,6 +145,7 @@ SelectWidget.prototype.execute = function() {
 	this.selectDefault = this.getAttribute("default");
 	this.selectMultiple = this.getAttribute("multiple", false);
 	this.selectSize = this.getAttribute("size");
+	this.selectTabindex = this.getAttribute("tabindex");
 	this.selectTooltip = this.getAttribute("tooltip");
 	this.selectFocus = this.getAttribute("focus");
 	// Make the child widgets
@@ -161,6 +162,9 @@ SelectWidget.prototype.execute = function() {
 	}
 	if(this.selectSize) {
 		$tw.utils.addAttributeToParseTreeNode(selectNode,"size",this.selectSize);
+	}
+	if(this.selectTabindex) {
+		$tw.utils.addAttributeToParseTreeNode(selectNode,"tabindex",this.selectTabindex);
 	}
 	if(this.selectTooltip) {
 		$tw.utils.addAttributeToParseTreeNode(selectNode,"title",this.selectTooltip);

--- a/editions/tw5.com/tiddlers/widgets/SelectWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/SelectWidget.tid
@@ -41,7 +41,7 @@ The content of the `<$select>` widget should be one or more HTML `<option>` or `
 |size |The number of rows to display in multiple selection mode |
 |actions |A string containing ActionWidgets to be triggered when the key combination is detected |
 |focus |<<.from-version "5.2.4">> Optional. Set to "yes" to automatically focus the HTML select element after creation |
-
+|tabindex |<<.from-version "5.3.1">> Optional. Sets the `tabindex` attribute of the HTML select element to the given value |
 ! Examples
 
 !! Simple Lists


### PR DESCRIPTION
Closes #7593 by adding a `tabindex` property to the `<$select ...>` widget and passing it through to the DOM.

Three questions:

  - The order of the fields in the code seems fairly arbitrary.  I put it between "size' and "tooltip", thinking that if these were ever alphabetized, this would already be in place.  Is there some other scheme I didn't notice?
  - I found one location to document the change: `editions/tw5.com/tiddlers/widgets/SelectWidget.tid` .  Are there others I should also be updating?
  - I added `"<<.from-version "5.3.1">>"`.  Is this presumptuous?  Should I not add anything and wait for approval and change it then?
 
And more generally, what might I, a newcomer to this source, do better in a (simple!) pull request?