### PR TITLE
Make the "Contents" menu item caption configurable in MenuBar plugin

### DIFF
--- a/plugins/tiddlywiki/menubar/config.tid
+++ b/plugins/tiddlywiki/menubar/config.tid
@@ -1,6 +1,8 @@
-title: $:/plugins/tiddlywiki/menubar/config
-tags: $:/tags/ControlPanel/Toolbars
 caption: Menu Bar
+created: 20230519012218346
+modified: 20230712224614730
+tags: $:/tags/ControlPanel/Toolbars
+title: $:/plugins/tiddlywiki/menubar/config
 
 \define config-base() $:/config/plugins/menubar/MenuItems/Visibility/
 
@@ -28,7 +30,7 @@ The breakpoint position between narrow and wide screens. Should include CSS unit
 
 !! Contents Tag
 
-The tag for the ~TableOfContents used in the Contents dropdown
+The tag for the ~TableOfContents used in the Contents dropdown. Add //caption// and //description// fields to the tag tiddler to change ~TableOfContents' menu label.
 
 <$edit-text tiddler="$:/config/plugins/menubar/TableOfContents/Tag" default="" tag="input"/>
 

--- a/plugins/tiddlywiki/menubar/items/contents.tid
+++ b/plugins/tiddlywiki/menubar/items/contents.tid
@@ -1,8 +1,10 @@
-title: $:/plugins/tiddlywiki/menubar/items/contents
-caption: Contents
-description: Table of Contents
+caption: <$text text={{{ [{$:/config/plugins/menubar/TableOfContents/Tag}get[caption]else[Contents]] }}}/>
+created: 20230519010904497
+description: <$text text={{{ [{$:/config/plugins/menubar/TableOfContents/Tag}get[description]else[Table of Contents]] }}}/>
 is-dropdown: yes
+modified: 20230712225429073
 tags: $:/tags/MenuBar
+title: $:/plugins/tiddlywiki/menubar/items/contents
 
 <div class="tc-table-of-contents">
 


### PR DESCRIPTION
The purpose of this PR is to enable "Contents" menu item caption to be configurable by adding a "caption" field to the custom ToC tag. A "description" field can also be added to the tag for the plugin configuration tiddler.