### PR TITLE
Allow attribute substitution to handle variables containing non-word characters

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1086,7 +1086,7 @@ exports.getSubstitutedText = function(text,widget,options) {
 		output = $tw.utils.replaceString(output,new RegExp("\\$" + $tw.utils.escapeRegExp(substitute.name) + "\\$","mg"),substitute.value);
 	});
 	// Substitute any variable references with their values
-	return output.replace(/\$\((\w+)\)\$/g, function(match,varname) {
+	return output.replace(/\$\(([^\)\$]+)\)\$/g, function(match,varname) {
 		return widget.getVariable(varname,{defaultValue: ""})
 	});
 };

--- a/editions/test/tiddlers/tests/data/widgets/SubstitutedAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/SubstitutedAttributes.tid
@@ -6,9 +6,9 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \whitespace trim
-<$let project="TiddlyWiki" disabled="true">
+<$let project="TiddlyWiki" disabled="true" var-with-dashes="dashes">
 <div class=`$(project)$ 
-${ [[Hello]addsuffix[There]] }$` attrib=`myvalue` otherattrib=`$(1)$` blankattrib=`` quoted="here" disabled=```$(disabled)$```>
+${ [[Hello]addsuffix[There]] }$` attrib=`myvalue` otherattrib=`$(1)$` blankattrib=`` quoted="here" disabled=```$(disabled)$``` dashes=`$(var-with-dashes)$`>
 </div>
 </$let>
 
@@ -16,4 +16,4 @@ ${ [[Hello]addsuffix[There]] }$` attrib=`myvalue` otherattrib=`$(1)$` blankattri
 title: ExpectedResult
 
 <p><div attrib="myvalue" blankattrib="" class="TiddlyWiki 
-HelloThere" disabled="true" otherattrib="" quoted="here"></div></p>
+HelloThere" dashes="dashes" disabled="true" otherattrib="" quoted="here"></div></p>

--- a/editions/test/tiddlers/tests/data/widgets/SubstitutedAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/SubstitutedAttributes.tid
@@ -6,14 +6,16 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \whitespace trim
+<$set name="var with spaces" value="spaces">
 <$let project="TiddlyWiki" disabled="true" var-with-dashes="dashes">
 <div class=`$(project)$ 
-${ [[Hello]addsuffix[There]] }$` attrib=`myvalue` otherattrib=`$(1)$` blankattrib=`` quoted="here" disabled=```$(disabled)$``` dashes=`$(var-with-dashes)$`>
+${ [[Hello]addsuffix[There]] }$` attrib=`myvalue` otherattrib=`$(1)$` blankattrib=`` quoted="here" disabled=```$(disabled)$``` dashes=`$(var-with-dashes)$` spaces=`$(var with spaces)$`>
 </div>
 </$let>
+</$set>
 
 +
 title: ExpectedResult
 
 <p><div attrib="myvalue" blankattrib="" class="TiddlyWiki 
-HelloThere" dashes="dashes" disabled="true" otherattrib="" quoted="here"></div></p>
+HelloThere" dashes="dashes" disabled="true" otherattrib="" quoted="here" spaces="spaces"></div></p>


### PR DESCRIPTION
Use the same regexp for attribute substitution (and the substitute filter operator) as is already used for textual substitution in macros. This change allows substitution to work for variable names containing spaces, dashes, and any character other than `$` and `)`.

Fixes #7604.