### PR TITLE
Trim whitespace when importing variables in $importvariables

### DIFF
--- a/core/modules/widgets/importvariables.js
+++ b/core/modules/widgets/importvariables.js
@@ -49,7 +49,7 @@ ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 	this.tiddlerList = tiddlerList || this.wiki.filterTiddlers(this.filter,this);
 	// Accumulate the <$set> widgets from each tiddler
 	$tw.utils.each(this.tiddlerList,function(title) {
-		var parser = widgetPointer.wiki.parseTiddler(title,{parseAsInline:true});
+		var parser = widgetPointer.wiki.parseTiddler(title,{parseAsInline:true, configTrimWhiteSpace:true});
 		if(parser) {
 			var parseTreeNode = parser.tree[0];
 			while(parseTreeNode && ["setvariable","set","parameters"].indexOf(parseTreeNode.type) !== -1) {


### PR DESCRIPTION
@Jermolene can you think of any undesirable consequences of trimming whitespace when parsing tiddlers to import variables?

It would make importing $set widgets much less error prone and would allow the following to be imported reliably:
```
<$set name="one" value="elephant">
<$set name="two" value="giraffe">
</$set>
</$set>

```