### PR TITLE
Fixed v5.3.0 boot so module line numbers are correct again

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -596,11 +596,11 @@ $tw.utils.evalGlobal = function(code,context,filename,sandbox,allowGlobals) {
 	// Add the code prologue and epilogue
 	code = [
 		"(function(" + contextNames.join(",") + ") {",
-		"  (function(){\n" + code + "\n;})();",
+		"  (function(){" + code + "\n;})();\n",
 		(!$tw.browser && sandbox && !allowGlobals) ? globalCheck : "",
-		"  return exports;\n",
+		"\nreturn exports;\n",
 		"})"
-	].join("\n");
+	].join("");
 
 	// Compile the code into a function
 	var fn;


### PR DESCRIPTION
This is a small point, but ever since v5.3.0, the line numbers on stack traces have been off by 2 in nodeJS.

It's so minor, I know, but it irks the hell out of me. This change alters the sandbox formation so that line numbers both on nodeJS and the browser should be consistent with what the files actually are. This'll actually be an improvement over pre-v5.3.0, because the browser was always off by one.