### PR TITLE
Allows all pragmas to be indented

### DIFF
--- a/core/modules/parsers/wikiparser/rules/fnprocdef.js
+++ b/core/modules/parsers/wikiparser/rules/fnprocdef.js
@@ -35,7 +35,7 @@ Instantiate parse rule
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^\\(function|procedure|widget)\s+([^(\s]+)\((\s*([^)]*))?\)(\s*\r?\n)?/mg;
+	this.matchRegExp = /\\(function|procedure|widget)\s+([^(\s]+)\((\s*([^)]*))?\)(\s*\r?\n)?/mg;
 };
 
 /*
@@ -53,7 +53,7 @@ exports.parse = function() {
 	var reEnd;
 	if(this.match[5]) {
 		// If so, the end of the body is marked with \end
-		reEnd = new RegExp("(\\r?\\n\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[2]) + ")?(?:$|\\r?\\n))","mg");
+		reEnd = new RegExp("(\\r?\\n[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[2]) + ")?(?:$|\\r?\\n))","mg");
 	} else {
 		// Otherwise, the end of the definition is marked by the end of the line
 		reEnd = /($|\r?\n)/mg;

--- a/core/modules/parsers/wikiparser/rules/parameters.js
+++ b/core/modules/parsers/wikiparser/rules/parameters.js
@@ -26,7 +26,7 @@ Instantiate parse rule
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /^\\parameters\s*\(([^)]*)\)(\s*\r?\n)?/mg;
+	this.matchRegExp = /\\parameters\s*\(([^)]*)\)(\s*\r?\n)?/mg;
 };
 
 /*

--- a/editions/test/tiddlers/tests/data/functions/IndentedFunctions.tid
+++ b/editions/test/tiddlers/tests/data/functions/IndentedFunctions.tid
@@ -1,0 +1,24 @@
+title: Functions/Function/Indented
+description: Indented function definition
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+    \whitespace trim
+    \function .dividebysomething(factor:0.5)
+    [divide<factor>]
+    \end
+
+    \function multiplebysomething(first:ignored,factor:2)
+    [multiply<factor>multiply[2].dividebysomething[0.25]]
+    \end
+
+<$text text={{{ [[4]function[multiplebysomething]] }}}/>
+|
+<$text text={{{ [[6]function[multiplebysomething],[ignored],[4]] }}}/>
+
++
+title: ExpectedResult
+
+<p>64|192</p>

--- a/editions/test/tiddlers/tests/data/procedures/Nested-indented.tid
+++ b/editions/test/tiddlers/tests/data/procedures/Nested-indented.tid
@@ -1,0 +1,20 @@
+title: Procedures/Nested/Indented
+description: Nested Procedures that are indented
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+\procedure alpha(x)
+    \procedure beta(y)
+    <$text text=<<y>>/>
+    \end beta
+<$transclude $variable="beta" y={{{ [<x>addprefix<x>] }}}/>
+\end alpha
+
+<<alpha "Elephant">>
++
+title: ExpectedResult
+
+<p>ElephantElephant</p>

--- a/editions/test/tiddlers/tests/data/procedures/TrailingNewlines.tid
+++ b/editions/test/tiddlers/tests/data/procedures/TrailingNewlines.tid
@@ -1,0 +1,22 @@
+title: Procedures/TrailingNewlines
+description: Trailing newlines in procedures must not be dropped
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure inner()
+Paragraph 1
+
+Paragraph 2
+\end
+\procedure outer()
+<$macrocall $name=inner />
+
+\end
+<<outer>>
+
++
+title: ExpectedResult
+
+<p>Paragraph 1</p><p>Paragraph 2</p>

--- a/editions/test/tiddlers/tests/data/transclude/CustomWidget-Simple-Indented.tid
+++ b/editions/test/tiddlers/tests/data/transclude/CustomWidget-Simple-Indented.tid
@@ -1,0 +1,33 @@
+title: Transclude/CustomWidget/Simple/Indented
+description: Custom widget definition indented
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$transclude $tiddler='TiddlerOne' one='Ferret'>
+</$transclude>
++
+title: TiddlerOne
+
+\whitespace trim
+<!-- Define the <$my.widget> widget by defining a transcludable variable with that name -->
+	\widget $my.widget(one:'Jaguar')
+	\whitespace trim
+	<$text text=<<one>>/>
+	<$slot $name="ts-raw">
+		Whale
+	</$slot>
+	\end
+<$my.widget one="Dingo">
+	Crocodile
+</$my.widget>
+<$my.widget one="BumbleBee">
+	Squirrel
+</$my.widget>
+<$my.widget/>
++
+title: ExpectedResult
+
+<p>DingoCrocodileBumbleBeeSquirrelJaguarWhale</p>

--- a/editions/test/tiddlers/tests/data/transclude/Parameterised-Shortcut-ParametersIndented.tid
+++ b/editions/test/tiddlers/tests/data/transclude/Parameterised-Shortcut-ParametersIndented.tid
@@ -1,0 +1,20 @@
+title: Transclude/Parameterised/Shortcut/ParametersIndented
+description: Simple parameterised transclusion using the parameters pragma (indented)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$transclude $tiddler='TiddlerOne' one='Ferret'/>
+<$transclude $tiddler='TiddlerOne'/>
++
+title: TiddlerOne
+
+\whitespace trim
+    \parameters(one:'Jaguar')
+<$text text=<<one>>/>
++
+title: ExpectedResult
+
+<p>FerretJaguar</p>

--- a/editions/tw5.com/tiddlers/pragmas/Pragmas.tid
+++ b/editions/tw5.com/tiddlers/pragmas/Pragmas.tid
@@ -1,5 +1,5 @@
 created: 20220917112416666
-modified: 20230419103154329
+modified: 20230721064409436
 tags: Concepts [[WikiText Parser Modes]]
 title: Pragmas
 type: text/vnd.tiddlywiki
@@ -7,6 +7,8 @@ type: text/vnd.tiddlywiki
 A <<.def pragma>> is a special component of WikiText that provides control over the way the remaining text is parsed.
 
 Pragmas occupy lines that start with `\`. They can only appear at the start of the text of a tiddler, but blank lines and comments are allowed between them. If a pragma appears in the main body of the text, it is treated as if it was ordinary text.
+
+<<.from-version "5.2.6">> Pragmas can have preceding optional whitespace characters.
 
 The following pragmas are available:
 


### PR DESCRIPTION
This PR allows the new pragmas introduced in v5.3.0 to be indented, includes tests, and restores the documentation for support for indented pragmas.

fixes #7602 

@flibbles a heads up in case this has any significance for your plugins.