### PR TITLE
fix toc indentation problem

### DIFF
--- a/core/wiki/macros/toc.tid
+++ b/core/wiki/macros/toc.tid
@@ -7,7 +7,7 @@ tags: $:/tags/Macro
 
 \define toc-caption()
 \whitespace trim
-<span class="tc-toc-caption">
+<span class="tc-toc-caption tc-tiny-gap-left">
 <$set name="tv-wikilinks" value="no">
   <$transclude field="caption">
     <$view field="title"/>
@@ -145,7 +145,7 @@ tags: $:/tags/Macro
 <$qualify name="toc-state" title={{{ [[$:/state/toc]addsuffix<__path__>addsuffix[-]addsuffix<currentTiddler>] }}}>
   <$set name="toc-item-class" filter=<<__itemClassFilter__>> emptyValue="toc-item-selected" value="toc-item">
     <li class=<<toc-item-class>>>
-      <$list filter="[all[current]tagging[]$sort$limit[1]]" variable="ignore" emptyMessage="<$button class='tc-btn-invisible'>{{$:/core/images/blank}}</$button> <$view field='caption'><$view field='title'/></$view>">
+      <$list filter="[all[current]tagging[]$sort$limit[1]]" variable="ignore" emptyMessage="""<$button class="tc-btn-invisible">{{$:/core/images/blank}}</$button><span class="toc-item-muted"><<toc-caption>></span>""">
         <$reveal type="nomatch" stateTitle=<<toc-state>> text="open">
           <$button setTitle=<<toc-state>> setTo="open" class="tc-btn-invisible tc-popup-keep">
             <$transclude tiddler=<<toc-closed-icon>> />

--- a/editions/tw5.com/tiddlers/demonstrations/TableOfContents/Fourth.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/TableOfContents/Fourth.tid
@@ -1,6 +1,8 @@
+caption: Fourth-Caption
 created: 20150221194405000
-modified: 20211114013601188
+modified: 20230721201835892
 tags: Contents [[Table-of-Contents Demonstrations]]
 title: Fourth
+type: text/vnd.tiddlywiki
 
 <<.toc-lorem>>

--- a/editions/tw5.com/tiddlers/demonstrations/TableOfContents/Fourth.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/TableOfContents/Fourth.tid
@@ -1,6 +1,6 @@
 caption: Fourth-Caption
 created: 20150221194405000
-modified: 20230721201835892
+modified: 20211114013601188
 tags: Contents [[Table-of-Contents Demonstrations]]
 title: Fourth
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/demonstrations/TableOfContents/SecondThreeThree.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/TableOfContents/SecondThreeThree.tid
@@ -1,6 +1,16 @@
 created: 20150221194423000
-modified: 20211114013601189
+modified: 20230721191043033
 tags: SecondThree [[Table-of-Contents Demonstrations]]
 title: SecondThreeThree
+toc-link: no
+type: text/vnd.tiddlywiki
 
-<<.toc-lorem>>
+''Important''
+
+It's important that this tiddler has no "child" to be able to visually test every possible toc code-path.
+
+* This tiddler has a field ''toc-link: no''
+* Do not tag any other tiddler with the title of this one
+
+
+

--- a/editions/tw5.com/tiddlers/demonstrations/TableOfContents/SecondThreeThree.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/TableOfContents/SecondThreeThree.tid
@@ -1,5 +1,5 @@
 created: 20150221194423000
-modified: 20230721191043033
+modified: 20211114013601189
 tags: SecondThree [[Table-of-Contents Demonstrations]]
 title: SecondThreeThree
 toc-link: no

--- a/editions/tw5.com/tiddlers/demonstrations/TableOfContents/Third.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/TableOfContents/Third.tid
@@ -1,7 +1,7 @@
 caption: Third-Caption
 created: 20150221194436000
 list: ThirdOne ThirdTwo ThirdThree
-modified: 20230721201857945
+modified: 20211114013601191
 tags: Contents [[Table-of-Contents Demonstrations]]
 title: Third
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/demonstrations/TableOfContents/Third.tid
+++ b/editions/tw5.com/tiddlers/demonstrations/TableOfContents/Third.tid
@@ -1,7 +1,9 @@
+caption: Third-Caption
 created: 20150221194436000
 list: ThirdOne ThirdTwo ThirdThree
-modified: 20211114013601191
+modified: 20230721201857945
 tags: Contents [[Table-of-Contents Demonstrations]]
 title: Third
+type: text/vnd.tiddlywiki
 
 <<.toc-lorem>>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -580,7 +580,7 @@ button svg, button img, label svg, label img {
 }
 
 button:disabled.tc-btn-invisible  {
-	cursor: default; 
+	cursor: default;
 	color: <<colour muted-foreground>>;
 }
 
@@ -2779,13 +2779,9 @@ input.tc-palette-manager-colour-input {
 	white-space: nowrap;
 }
 
-.tc-table-of-contents button {
+.tc-table-of-contents button,
+.tc-table-of-contents .toc-item-muted {
 	color: <<colour sidebar-foreground>>;
-}
-
-button + .tc-toc-caption,
-button > .tc-toc-caption{
-	margin-left: .25em;
 }
 
 .tc-table-of-contents svg {


### PR DESCRIPTION
This PR **fixes** issue:  *[BUG] removing tc-tiny-gap-left from the toc-caption element wikitext broke the whole TOC structure visually #7625*

- It does **revert** the CSS definitions from #7219, since they did not apply.
- It does **re-add** the `tc-tiny-gap-left` utility class to the `toc-caption` macro
- It adds the change to line 148, requested by [Alzacon](https://github.com/Jermolene/TiddlyWiki5/pull/7121#issuecomment-1354048662) and was [approved by Jeremy](https://github.com/Jermolene/TiddlyWiki5/pull/7121#issuecomment-1356829600)
  - It adds a `toc-link: no` field to the "SecondThreeThree" doc tiddler, so the code in line 148 will be active and can be tested
  - It adds the CSS definition needed for changes in line 148
- It adds captions to "Third" and "Fourth" tiddler so we can see caption handling

The TOC-macro example tiddler can be used to test all toc code-paths. It should look like this now: 

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/d50e2755-95a5-488e-ac55-1a9ddc85253e)

- The tiddlywiki-com table of content indentation works again. 
- Indentation alignment is OK now. 

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/05f76b00-922d-4fe0-af17-60d43432f0b0)
