### PR TITLE
Add usemap attribute to image widget

### DIFF
--- a/core/modules/widgets/image.js
+++ b/core/modules/widgets/image.js
@@ -99,6 +99,9 @@ ImageWidget.prototype.render = function(parent,nextSibling) {
 	if(this.imageClass) {
 		domNode.setAttribute("class",this.imageClass);
 	}
+	if(this.imageUsemap) {
+	    	domNode.setAttribute("usemap",this.imageUsemap);
+	}
 	if(this.imageWidth) {
 		domNode.setAttribute("width",this.imageWidth);
 	}
@@ -138,6 +141,7 @@ ImageWidget.prototype.execute = function() {
 	this.imageWidth = this.getAttribute("width");
 	this.imageHeight = this.getAttribute("height");
 	this.imageClass = this.getAttribute("class");
+    	this.imageUsemap = this.getAttribute("usemap");
 	this.imageTooltip = this.getAttribute("tooltip");
 	this.imageAlt = this.getAttribute("alt");
 	this.lazyLoading = this.getAttribute("loading");
@@ -148,7 +152,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 ImageWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.source || changedAttributes.width || changedAttributes.height || changedAttributes["class"] || changedAttributes.tooltip || changedTiddlers[this.imageSource]) {
+	if(changedAttributes.source || changedAttributes.width || changedAttributes.height || changedAttributes["class"] || changedAttributes.usemap || changedAttributes.tooltip || changedTiddlers[this.imageSource]) {
 		this.refreshSelf();
 		return true;
 	} else {

--- a/editions/tw5.com/tiddlers/widgets/ImageWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ImageWidget.tid
@@ -21,6 +21,7 @@ Any content of the `<$image>` widget is ignored.
 |alt |The alternative text to be associated with the image |
 |class |CSS classes to be assigned to the `<img>` element |
 |loading|<<.from-version "5.2.3">>Optional. Set to `lazy` to enable lazy loading of images loaded from an external URI |
+|usemap|<<.from-version "5.3.1">>Optional usemap attribute to be assigned to the `<img>` element for use with HTML image maps |
 
 The width and the height can be specified as pixel values (eg "23" or "23px") or percentages (eg "23%"). They are both optional; if not provided the browser will use CSS rules to size the image.
 

--- a/editions/tw5.com/tiddlers/widgets/ImageWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ImageWidget.tid
@@ -1,6 +1,6 @@
 caption: image
 created: 20140416160234142
-modified: 20220721102303815
+modified: 20231121114351165
 tags: Widgets
 title: ImageWidget
 type: text/vnd.tiddlywiki
@@ -21,7 +21,7 @@ Any content of the `<$image>` widget is ignored.
 |alt |The alternative text to be associated with the image |
 |class |CSS classes to be assigned to the `<img>` element |
 |loading|<<.from-version "5.2.3">>Optional. Set to `lazy` to enable lazy loading of images loaded from an external URI |
-|usemap|<<.from-version "5.3.1">>Optional usemap attribute to be assigned to the `<img>` element for use with HTML image maps |
+|usemap|<<.from-version "5.3.2">>Optional usemap attribute to be assigned to the `<img>` element for use with HTML image maps |
 
 The width and the height can be specified as pixel values (eg "23" or "23px") or percentages (eg "23%"). They are both optional; if not provided the browser will use CSS rules to size the image.
 


### PR DESCRIPTION
Allow for a usemap attribute on the $image macro call which is passed through to the resulting img tag. This makes the use of HTML image maps [1] possible.

[1]: <https://www.w3schools.com/html/html_images_imagemap.asp>