### PR TITLE
Fixed typos in documentation for new pragma

### DIFF
--- a/editions/tw5.com/tiddlers/pragmas/Pragma_ _procedure.tid
+++ b/editions/tw5.com/tiddlers/pragmas/Pragma_ _procedure.tid
@@ -1,5 +1,5 @@
 created: 20221007132845007
-modified: 20230518152756112
+modified: 20230724184009153
 tags: Pragmas
 title: Pragma: \procedure
 type: text/vnd.tiddlywiki
@@ -19,7 +19,7 @@ Note that the `\end` marker can optionally specify the name of the procedure to 
 There is also a single line form for shorter procedures:
 
 ```
-\define <procedure-name>(<param-name>[:<param-default-value>],<param-name>[:<param-default-value>]...) <single-line-definition-text>
+\procedure <procedure-name>(<param-name>[:<param-default-value>],<param-name>[:<param-default-value>]...) <single-line-definition-text>
 ```
 
 The first line of the definition specifies the procedure name and any parameters. Each parameter has a name and, optionally, a default value that is used if no value is supplied on a particular call to the procedure. The lines that follow contain the text of the procedure text (i.e. the snippet represented by the procedure name), until `\end` appears on a line by itself:

--- a/editions/tw5.com/tiddlers/pragmas/Pragma_ _rules.tid
+++ b/editions/tw5.com/tiddlers/pragmas/Pragma_ _rules.tid
@@ -1,5 +1,5 @@
 created: 20220917112931273
-modified: 20230419103154329
+modified: 20230724184044642
 tags: Pragmas
 title: Pragma: \rules
 type: text/vnd.tiddlywiki
@@ -7,7 +7,7 @@ type: text/vnd.tiddlywiki
 The ''\rules'' [[pragma|Pragmas]] adjusts the set of parser rules used to parse the remaining text.
 
 ```
-\rules only|expect <rule-list>
+\rules only|except <rule-list>
 ```
 
 The list of available parser rules can be consulted in $:/ControlPanel -> Info -> Advanced -> Parsing.


### PR DESCRIPTION
Fixed the following two typos:
"expect" instead of "except" in \rules definition
"\define" instead of "\procedure" in procedure one-line format definition