### PR TITLE
Use 'translink' macro on widget attribute documentation

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/Widget Attributes.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Widget Attributes.tid
@@ -4,7 +4,7 @@ tags: WikiText
 title: Widget Attributes
 type: text/vnd.tiddlywiki
 
-Attributes of HTML elements and widgets can be specified in several different ways:
+Attributes of [[HTML elements|HTML in WikiText]] and widgets can be specified in several different ways:
 
 * [[a literal string|Literal Attribute Values]]
 * [[a transclusion of a textReference|Transcluded Attribute Values]]
@@ -19,3 +19,9 @@ Attributes of HTML elements and widgets can be specified in several different wa
 |filtered |triple curly braces around a filter expression|
 |substituted|single or triple backticks around the text to be processed for substitutions|
 
+
+<<translink "Literal Attribute Values">>
+<<translink "Transcluded Attribute Values">>
+<<translink "Variable Attribute Values">>
+<<translink "Filtered Attribute Values">>
+<<translink "Substituted Attribute Values">>


### PR DESCRIPTION
The Widget Attributes tiddler contains links to separate tiddlers which explain the 5 different attribute syntaxes. I find that clicking so many links is enough friction that transcluding the content is a worthwhile thing to do.

Use the translink macro to transclude and link to the tiddlers.