### PR TITLE
Refactor variable invocation docs

### DIFF
--- a/editions/tw5.com/tiddlers/variables/Behaviour of invoked variables depends on how the variable was declared.tid
+++ b/editions/tw5.com/tiddlers/variables/Behaviour of invoked variables depends on how the variable was declared.tid
@@ -1,0 +1,52 @@
+created: 20230726145210484
+modified: 20230726145757234
+tags: [[Variable Usage]]
+title: Behaviour of invoked variables depends on how the variable was declared
+type: text/vnd.tiddlywiki
+
+\define m1(a1) $a1$ - <<__a1__>> - <<a1>>
+\procedure p1(a1) $a1$ - <<__a1__>> - <<a1>>
+\function f1(a1) "$a1$" "-" [<__a1__>] ="-" [<a1>] :and[join[ ]]
+
+Invoked in normal wikitext context: `<$transclude $variable=macro/>` or `<<macro>>`
+
+{{Behaviour of variables invoked via normal wikitext}}
+
+Invoked via widget attribute: `<div class=<<macro>>/>`
+
+{{Behaviour of variables invoked via widget attributes}}
+
+Invoked via filter operator parameter: `[<macro>]`
+
+{{Behaviour of variables invoked via filter operator parameter}}
+
+Invoked via function call in a filter expression: `[function[macro]]`
+
+{{Behaviour of variables invoked via filter expression function call}}
+
+!! Examples
+
+Below is an example macro, procedure and function definition.  All three forms of parameter substitution `$a1$`, `<<__a1__>>`, and `<<a1>>` are included in each definition. The output helps illustrate when each form of substitution will or will not have affect.
+
+```
+\define m1(a1) $a1$ - <<__a1__>> - <<a1>>
+\procedure p1(a1) $a1$ - <<__a1__>> - <<a1>>
+\function f1(a1) $a1$ "-" [<__a1__>] ="-" [<a1>] :and[join[ ]]
+```
+
+| !Variable transclusion|!output |
+| `<<m1 foo>>`|<<m1 foo>>|
+| `<<p1 foo>>`|<<p1 foo>>|
+| `<<f1 foo>>`|<<f1 foo>>|
+| !Widget attribute|!output |
+| `<$text text=<<m1 foo>>/>`|<$text text=<<m1 foo>>/>|
+| `<$text text=<<p1 foo>>/>`|<$text text=<<p1 foo>>/>|
+| `<$text text=<<f1 foo>>/>`|<$text text=<<f1 foo>>/>|
+| !Filter operator parameter|!output |
+| `[<m1 foo>]`|<$text text={{{[<m1 foo>]}}}/>|
+| `[<p1 foo>]`|<$text text={{{[<p1 foo>]}}}/>|
+| `[<f1 foo>]`|<$text text={{{[<f1 foo>]}}}/>|
+| !Function call in filter expression|!output |
+| `[function[m1],[foo]]`|<$text text={{{[function[m1],[foo]]}}}/>|
+| `[function[p1],[foo]]`|<$text text={{{[function[p1],[foo]]}}}/>|
+| `[function[f1],[foo]]`|<$text text={{{[function[f1],[foo]]}}}/>|

--- a/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via filter expression function call.tid
+++ b/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via filter expression function call.tid
@@ -1,0 +1,10 @@
+created: 20230726143929233
+modified: 20230726150604831
+tags: [[Variable Usage]]
+title: Behaviour of variables invoked via filter expression function call
+type: text/vnd.tiddlywiki
+
+|tc-first-col-min-width|k
+|!how declared|!behaviour|
+|\define, <<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|Every function is a variable, but only variables defined using \function are invokable using the <<.olink function>> filter operator. Attempts to use a non-function variable is the same as if the function doesn't exist. The behavior in this case is like the identity function. All filter input is passed unchanged to the output.|
+|\function|The body text of the function is treated as a filter expression and evaluated. This filter expression can itself contain a function call. Filter expressions can be factored out into functions arbitrarily deep.|

--- a/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via filter operator parameter.tid
+++ b/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via filter operator parameter.tid
@@ -1,0 +1,11 @@
+created: 20230726143617389
+modified: 20230726150625716
+tags: [[Variable Usage]]
+title: Behaviour of variables invoked via filter operator parameter
+type: text/vnd.tiddlywiki
+
+|tc-first-col-min-width|k
+|!how declared|!behaviour|
+|\define|Textual substitution of parameters is performed on the body text. No further processing takes place. The result after textual substitution is used as the filter operator's parameter.|
+|<<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|Body text is retrieved as-is and used as the filter operator's parameter.|
+|\function|The body text of the function is treated as a filter expression and evaluated. The first result is passed to the operator as a parameter. The remaining results are discarded.|

--- a/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via normal wikitext.tid
+++ b/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via normal wikitext.tid
@@ -1,0 +1,11 @@
+created: 20230726142925020
+modified: 20230726150648189
+tags: [[Variable Usage]]
+title: Behaviour of variables invoked via normal wikitext
+type: text/vnd.tiddlywiki
+
+|tc-first-col-min-width|k
+|!how declared|!behaviour|
+|\define|All wikitext and variable substitution and textual substitution takes place|
+|<<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|All wikitext and variable substitution takes place|
+|\function|Invoking a function in this way (`<<macro>>`) is a synonym for `<$text text={{{[function[macro]]}}}/>`. As with any filtered transclusion (i.e. triple curly braces), all results except the first are discarded|

--- a/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via widget attributes.tid
+++ b/editions/tw5.com/tiddlers/variables/Behaviour of variables invoked via widget attributes.tid
@@ -1,0 +1,11 @@
+created: 20230726143332803
+modified: 20230726150616232
+tags: [[Variable Usage]]
+title: Behaviour of variables invoked via widget attributes
+type: text/vnd.tiddlywiki
+
+|tc-first-col-min-width|k
+|!how declared|!behaviour|
+|\define|Textual substitution of parameters is performed on the body text. No further processing takes place. The result after textual substitution is used as the attribute's value|
+|<<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|Body text is retrieved as-is and used as the attribute's value.|
+|\function|When a function is invoked as `<div class=<<macro>>/>`, it is a synonym for `<div class={{{[function[macro]]}}}/>`. As with any filtered transclusion (i.e. triple curly braces), all results except the first are discarded. That first result is used as the attribute's value. Note that functions are recursively processed even when invoked in this form. In other words a filter expression in a function can invoke another function and the processing will continue|

--- a/editions/tw5.com/tiddlers/variables/Variable Usage.tid
+++ b/editions/tw5.com/tiddlers/variables/Variable Usage.tid
@@ -1,12 +1,8 @@
 created: 20230421020225031
-modified: 20230422144812613
+modified: 20230726145912019
 tags: 
 title: Variable Usage
 type: text/vnd.tiddlywiki
-
-\define m1(a1) $a1$ - <<__a1__>> - <<a1>>
-\procedure p1(a1) $a1$ - <<__a1__>> - <<a1>>
-\function f1(a1) "$a1$" "-" [<__a1__>] ="-" [<a1>] :and[join[ ]]
 
 !Ways to define variables and parameters
 |! how declared|! how parameters are defined|! accessing parameter values in the body|
@@ -100,50 +96,10 @@ These examples are meant to provide insight into the various ways of defining an
 </$let>
 
 
-!Behavior of invoked variables depends on how the variable was declared
+!Behaviour of invoked variables depends on how the variable was declared
 
-|!how invoked|!how declared|!behavior|
-|`<$transclude $variable=macro/>` or `<<macro>>` in normal wikitext context|\define|All wikitext and variable substitution and textual substitution takes place|
-|~|<<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|All wikitext and variable substitution takes place|
-|~|\function|Invoking a function in this way (`<<macro>>`) is a synonym for `<$text text={{{[function[macro]]}}}/>`. As with any filtered transclusion (i.e. triple curly braces), all results except the first are discarded.|
-||||
-|widget attribute: `<div class=<<macro>>/>`|\define|Textual substitution of parameters is performed on the body text. No further processing takes place. The result after textual substitution is used as the attribute's value|
-|~|<<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|Body text is retrieved as-is and used as the attribute's value.|
-|~|\function|When a function is invoked as `<div class=<<macro>>/>`, it is a synonym for `<div class={{{[function[macro]]}}}/>`. As with any filtered transclusion (i.e. triple curly braces), all results except the first are discarded. That first result is used as the attribute's value. Note that functions are recursively processed even when invoked in this form. In other words a filter expression in a function can invoke another function and the processing will continue|
-||||
-|filter operator parameter: `[<macro>]`|\define|Textual substitution of parameters is performed on the body text. No further processing takes place. The result after textual substitution is used as the filter operator's parameter.|
-|~|<<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|Body text is retrieved as-is and used as the filter operator's parameter.|
-|~|\function|The body text of the function is treated as a filter expression and evaluated. The first result is passed to the operator as a parameter. The remaining results are discarded|
-||||
-|function call in a filter expression: `[function[macro]]`|\define, <<.wlink SetWidget>>, <<.wlink LetWidget>>, <<.wlink VarsWidget>>, \procedure, \widget|Every function is a variable, but only variables defined using \function are invokable using the <<.olink function>> filter operator. Attempts to use a non-function variable is the same as if the function doesn't exist. The behavior in this case is like the identity function. All filter input is passed unchanged to the output.|
-|~|\function|The body text of the function is treated as a filter expression and evaluated. This filter expression can itself contain a function call. Filter expressions can be factored out into functions arbitrarily deep.|
+{{Behaviour of invoked variables depends on how the variable was declared}}
 
-!! Examples
-
-Below is an example macro, procedure and function definition.  All three forms of parameter substitution `$a1$`, `<<__a1__>>`, and `<<a1>>` are included in each definition. The output helps illustrate when each form of substitution will or will not have affect.
-
-```
-\define m1(a1) $a1$ - <<__a1__>> - <<a1>>
-\procedure p1(a1) $a1$ - <<__a1__>> - <<a1>>
-\function f1(a1) $a1$ "-" [<__a1__>] ="-" [<a1>] :and[join[ ]]
-```
-
-| !Variable transclusion|!output |
-| `<<m1 foo>>`|<<m1 foo>>|
-| `<<p1 foo>>`|<<p1 foo>>|
-| `<<f1 foo>>`|<<f1 foo>>|
-| !Widget attribute|!output |
-| `<$text text=<<m1 foo>>/>`|<$text text=<<m1 foo>>/>|
-| `<$text text=<<p1 foo>>/>`|<$text text=<<p1 foo>>/>|
-| `<$text text=<<f1 foo>>/>`|<$text text=<<f1 foo>>/>|
-| !Filter operator parameter|!output |
-| `[<m1 foo>]`|<$text text={{{[<m1 foo>]}}}/>|
-| `[<p1 foo>]`|<$text text={{{[<p1 foo>]}}}/>|
-| `[<f1 foo>]`|<$text text={{{[<f1 foo>]}}}/>|
-| !Function call in filter expression|!output |
-| `[function[m1],[foo]]`|<$text text={{{[function[m1],[foo]]}}}/>|
-| `[function[p1],[foo]]`|<$text text={{{[function[p1],[foo]]}}}/>|
-| `[function[f1],[foo]]`|<$text text={{{[function[f1],[foo]]}}}/>|
 
 !Namespaces
 

--- a/editions/tw5.com/tiddlers/wikitext/Variable Attribute Values.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Variable Attribute Values.tid
@@ -1,5 +1,5 @@
 created: 20230615045239825
-modified: 20230615045312961
+modified: 20230726151053593
 tags: [[Widget Attributes]] WikiText
 title: Variable Attribute Values
 type: text/vnd.tiddlywiki
@@ -11,4 +11,7 @@ Variable attribute values are indicated with double angle brackets around a [[ma
 ...
 </div>
 ```
-<<.warning "The text from the definition of the macro will be retrieved and text substitution will be performed (i.e. <<.param $param$>> and <<.param &#36;(...)&#36;>> syntax). The value of the attribute value will be the resulting text. Any wiki syntax in that text (including further macro calls and variable references) will be left as-is.">>
+
+The behaviour of variables invoked via widget attributes is not the same as when they are [[invoked via normal wikitext|Behaviour of variables invoked via normal wikitext]]. In addition, the behaviour depends on how the variable is declared:
+
+{{Behaviour of variables invoked via widget attributes}}


### PR DESCRIPTION
The "Variable Attribute Values" tiddler contained a warning specific to `\define` based variables. Factored out the "Behavior of invoked variables depends on how the variable was declared" section of "Variable Usage" into separate tiddlers so the complete information can be referred to in both places.