### PR TITLE
Improve `jsonstringify` and `stringify` operators docs

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/jsonstringify Operator (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/jsonstringify Operator (Examples).tid
@@ -1,9 +1,0 @@
-created: 20171029155046637
-modified: 20171029155227382
-tags: [[Operator Examples]] [[stringify Operator]]
-title: jsonstringify Operator (Examples)
-type: text/vnd.tiddlywiki
-
-<<.operator-example 1 """[[Title with "double quotes" and single ' and \backslash]] +[jsonstringify[]]""">>
-<<.operator-example 2 """[[Accents and emojis -> äñøßπ ⌛🎄🍪🍓 without suffix]] +[jsonstringify[]]""">>
-<<.operator-example 3 """[[Accents and emojis -> äñøßπ ⌛🎄🍪🍓 with rawunicode suffix]] +[jsonstringify:rawunicode[]]""">>

--- a/editions/tw5.com/tiddlers/filters/examples/stringify_Operator_(Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/examples/stringify_Operator_(Examples).tid
@@ -1,5 +1,5 @@
 created: 20161017154944352
-modified: 20171029155233487
+modified: 20230919124059118
 tags: [[Operator Examples]] [[stringify Operator]]
 title: stringify Operator (Examples)
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/filters/jsonstringify Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/jsonstringify Operator.tid
@@ -1,36 +1,12 @@
 caption: jsonstringify
 created: 20171029155051467
 from-version: 5.1.14
-modified: 20171029155143797
-op-input: a [[selection of titles|Title Selection]]
-op-output: the input with JSON string encodings applied
+modified: 20230919124826880
 op-parameter: 
 op-parameter-name: 
-op-purpose: apply JSON string encoding to a string
-op-suffix: <<.from-version "5.1.23">> optionally, the keyword `rawunicode`
+op-purpose: deprecated, use <<.olink stringify>> instead
 op-suffix-name: R
 tags: [[Filter Operators]] [[String Operators]]
 title: jsonstringify Operator
 type: text/vnd.tiddlywiki
 
-The following substitutions are made:
-
-|!Character |!Replacement |!Condition |
-|`\` |`\\` |Always |
-|`"` |`\"` |Always |
-|Carriage return (0x0d) |`\\r` |Always |
-|Line feed (0x0a) |`\\n` |Always |
-|Backspace (0x08) |`\\b` |Always |
-|Form field (0x0c) |`\\f` |Always |
-|Tab (0x09) |`\\t` |Always |
-|Characters from 0x00 to 0x1f |`\\u####` where #### is four hex digits |Always |
-|Characters from 0x80 to 0xffff|`\\u####` where #### is four hex digits |If `rawunicode` suffix is not present (default) |
-|Characters from 0x80 to 0xffff|Unchanged |If `rawunicode` suffix is present <<.from-version "5.1.23">> |
-
-<<.from-version "5.1.23">> If the suffix `rawunicode` is present, Unicode characters above 0x80 (such as ß, ä, ñ or 🎄) will be passed through unchanged. Without the suffix, they will be substituted with `\\u` codes, which was the default behavior before 5.1.23.
-
-<<.note """Technical note: Characters outside the Basic Multilingual Plane, such as 🎄 and other emojis, will be encoded as a UTF-16 surrogate pair, i.e. with two `\u` sequences.""">>
-
-Also see the [[stringify Operator]].
-
-<<.operator-examples "jsonstringify">>

--- a/editions/tw5.com/tiddlers/filters/stringify_Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/stringify_Operator.tid
@@ -1,6 +1,7 @@
 caption: stringify
 created: 20161017153038029
-modified: 20171029155143797
+from-version: 5.1.14
+modified: 20230919130847809
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input with ~JavaScript string encodings applied
 op-parameter: 
@@ -11,26 +12,25 @@ op-suffix-name: R
 tags: [[Filter Operators]] [[String Operators]]
 title: stringify Operator
 type: text/vnd.tiddlywiki
-from-version: 5.1.14
 
 The following substitutions are made:
 
 |!Character |!Replacement |!Condition |
 |`\` |`\\` |Always |
 |`"` |`\"` |Always |
-|Carriage return (0x0d) |`\\r` |Always |
-|Line feed (0x0a) |`\\n` |Always |
-|Backspace (0x08) |`\\b` |Always |
-|Form field (0x0c) |`\\f` |Always |
-|Tab (0x09) |`\\t` |Always |
-|Characters from 0x00 to 0x1f |`\\x##` where ## is two hex digits |Always |
-|Characters from 0x80 to 0xffff|`\\u####` where #### is four hex digits |If `rawunicode` suffix is not present (default) |
+|Carriage return (0x0d) |`\r` |Always |
+|Line feed (0x0a) |`\n` |Always |
+|Backspace (0x08) |`\b` |Always |
+|Form field (0x0c) |`\f` |Always |
+|Tab (0x09) |`\t` |Always |
+|Characters from 0x00 to 0x1f |`\x##` where ## is two hex digits |Always |
+|Characters from 0x80 to 0xffff|`\u####` where #### is four hex digits |If `rawunicode` suffix is not present (default) |
 |Characters from 0x80 to 0xffff|<<.from-version "5.1.23">> Unchanged |If `rawunicode` suffix is present |
 
-<<.from-version "5.1.23">> If the suffix `rawunicode` is present, Unicode characters above 0x80 (such as ß, ä, ñ or 🎄) will be passed through unchanged. Without the suffix, they will be substituted with `\\u` codes, which was the default behavior before 5.1.23.
+<<.from-version "5.1.23">> If the suffix `rawunicode` is present, Unicode characters above 0x80 (such as ß, ä, ñ or 🎄) will be passed through unchanged. Without the suffix, they will be substituted with `\u` codes, which was the default behavior before 5.1.23.
 
-<<.note """Technical note: Characters outside the Basic Multilingual Plane, such as 🎄 and other emojis, will be encoded as a UTF-16 surrogate pair, i.e. with two `\u` sequences.""">>
+<<.note """Characters outside the Basic Multilingual Plane, such as 🎄 and other emojis, will be encoded as a UTF-16 surrogate pair, i.e. with two `\u` sequences.""">>
 
-Also see the [[jsonstringify Operator]].
+<<.olink jsonstringify>> is considered deprecated, as it duplicates the functionality of <<.op stringify>>.
 
 <<.operator-examples "stringify">>

--- a/editions/tw5.com/tiddlers/howtos/Constructing JSON tiddlers.tid
+++ b/editions/tw5.com/tiddlers/howtos/Constructing JSON tiddlers.tid
@@ -1,7 +1,7 @@
-title: Constructing JSON tiddlers
-tags: [[JSON in TiddlyWiki]] [[Learning]]
 created: 20220427174702859
-modified: 20220427174702859
+modified: 20230809113620964
+tags: [[JSON in TiddlyWiki]] Learning
+title: Constructing JSON tiddlers
 
 See [[JSON in TiddlyWiki]] for an overview of using JSON in TiddlyWiki.
 
@@ -13,4 +13,4 @@ At a high level, we have several ways to generate JSON data in TiddlyWiki's own 
 * [[jsontiddler Macro]]
 * [[jsontiddlers Macro]]
 
-When constructing JSON data manually, the [[jsonstringify Operator]] is needed to ensure that any special characters are properly escaped.
+When constructing JSON data manually, the [[stringify Operator]] is needed to ensure that any special characters are properly escaped.


### PR DESCRIPTION
Fix redundant double backward slashes in front of escaped characters, e.g. change incorrect escaped newline `\\n` to the correct `\n`.

In fixing the above issue I have discovered that the tiddlers `jsonstringify Operator` and `stringify Operator`, as well as their respective linked example tiddlers, have exactly the same content (except for the "Also see the other one" at the end). There is no transclusion in use, so any changes to one of those docs tiddlers has to be manually copied over to the corresponding tiddler for the other operator.

I see two possible solutions:

1. If the two filter operators `jsonstringify` and `stringify` work exactly the same (and the two different names exist for convenience or backwards compatibility only): full documentation should be written only for one of them, and the docs of the other one should only link to the first one. This way it should be clear that both operators are simply aliases for the same underlying function.

2. If there is a difference between these operators that is not yet documented: some sort of transclusion should be in use, along with at least a very brief description of the differences between them.  