### PR TITLE
Change url link to archive of Jeffrey Kishner's site

### DIFF
--- a/editions/tw5.com/tiddlers/community/resources/TiddlyWiki Posts.tid
+++ b/editions/tw5.com/tiddlers/community/resources/TiddlyWiki Posts.tid
@@ -1,11 +1,11 @@
 created: 20140129085406905
-modified: 20210106151027268
+modified: 20230805140720289
 tags: [[Other Resources]] Articles
 title: "TiddlyWiki Posts" by Jeffrey Kishner
 type: text/vnd.tiddlywiki
-url: http://blog.jeffreykishner.com/tiddlywiki/
+url: https://web.archive.org/web/20221015011644/http://blog.jeffreykishner.com/tiddlywiki/
 
-A collection of articles covering integration with Fargo, Font Awesome and Google Calendar, and tips for managing task lists.
+A collection of articles covering integration with Fargo, Font Awesome and Google Calendar, and tips for managing task lists. The original site is missing, but a link to an archive is provided.
 
 {{!!url}}
 


### PR DESCRIPTION
Jeffrey's site has apparently been missing since 2022. This change notes the missing site, and substitutes a url to from the internet archive.