### PR TITLE
Fix checkbox widget when listIndex field undefined

### DIFF
--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -116,7 +116,7 @@ CheckboxWidget.prototype.getValue = function() {
 				} else {
 					list = $tw.utils.parseStringArray(this.checkboxDefault || "") || [];
 				}
-			} else if (this.checkboxListIndex) {
+			} else if(this.checkboxListIndex) {
 				list = $tw.utils.parseStringArray(this.wiki.extractTiddlerDataItem(tiddler,this.checkboxListIndex,this.checkboxDefault || "")) || [];
 			} else {
 				list = this.wiki.filterTiddlers(this.checkboxFilter,this) || [];
@@ -215,6 +215,8 @@ CheckboxWidget.prototype.handleChangeEvent = function(event) {
 		if($tw.utils.isArray(fieldContents)) {
 			// Make a copy so we can modify it without changing original that's refrenced elsewhere
 			listContents = fieldContents.slice(0);
+		} else if(fieldContents == undefined) {
+			listContents = [];
 		} else if(typeof fieldContents === "string") {
 			listContents = $tw.utils.parseStringArray(fieldContents);
 			// No need to copy since parseStringArray returns a fresh array, not refrenced elsewhere

--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -215,7 +215,7 @@ CheckboxWidget.prototype.handleChangeEvent = function(event) {
 		if($tw.utils.isArray(fieldContents)) {
 			// Make a copy so we can modify it without changing original that's refrenced elsewhere
 			listContents = fieldContents.slice(0);
-		} else if(fieldContents == undefined) {
+		} else if(fieldContents === undefined) {
 			listContents = [];
 		} else if(typeof fieldContents === "string") {
 			listContents = $tw.utils.parseStringArray(fieldContents);


### PR DESCRIPTION
When listIndex was pointing to an entry that didn't exist yet, so that extractTiddlerDataItem returned undefined, the checkbox widget was aborting and refusing to proceed. This is not the desired behavior: we want it to create the index if it didn't exist yet. So now we explicitly check for undefined and treat it the same as an empty list.

Also fixed one code-style issue in the same file while I was in here.

Fixes #7678.