### PR TITLE
Fix encodebase64 and decodebase64 filters

### DIFF
--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -18,7 +18,7 @@ Export our filter functions
 
 exports.decodebase64 = function(source,operator,options) {
 	var results = [];
-	var binary = !operator.suffixes || operator.suffixes.indexOf("text") === -1;
+	var binary = operator.suffixes && operator.suffixes.indexOf("binary") !== -1;
 	var urlsafe = operator.suffixes && operator.suffixes.indexOf("urlsafe") !== -1;
 	source(function(tiddler,title) {
 		results.push($tw.utils.base64Decode(title,binary,urlsafe));
@@ -28,7 +28,7 @@ exports.decodebase64 = function(source,operator,options) {
 
 exports.encodebase64 = function(source,operator,options) {
 	var results = [];
-	var binary = !operator.suffixes || operator.suffixes.indexOf("text") === -1;
+	var binary = operator.suffixes && operator.suffixes.indexOf("binary") !== -1;
 	var urlsafe = operator.suffixes && operator.suffixes.indexOf("urlsafe") !== -1;
 	source(function(tiddler,title) {
 		results.push($tw.utils.base64Encode(title,binary,urlsafe));

--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -18,8 +18,8 @@ Export our filter functions
 
 exports.decodebase64 = function(source,operator,options) {
 	var results = [];
-	var binary = operator.suffixes.indexOf("text") === -1;
-	var urlsafe = operator.suffixes.indexOf("urlsafe") !== -1;
+	var binary = !operator.suffixes || operator.suffixes.indexOf("text") === -1;
+	var urlsafe = operator.suffixes && operator.suffixes.indexOf("urlsafe") !== -1;
 	source(function(tiddler,title) {
 		results.push($tw.utils.base64Decode(title,binary,urlsafe));
 	});
@@ -28,8 +28,8 @@ exports.decodebase64 = function(source,operator,options) {
 
 exports.encodebase64 = function(source,operator,options) {
 	var results = [];
-	var binary = operator.suffixes.indexOf("text") === -1;
-	var urlsafe = operator.suffixes.indexOf("urlsafe") !== -1;
+	var binary = !operator.suffixes || operator.suffixes.indexOf("text") === -1;
+	var urlsafe = operator.suffixes && operator.suffixes.indexOf("urlsafe") !== -1;
 	source(function(tiddler,title) {
 		results.push($tw.utils.base64Encode(title,binary,urlsafe));
 	});

--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -18,16 +18,20 @@ Export our filter functions
 
 exports.decodebase64 = function(source,operator,options) {
 	var results = [];
+	var binary = operator.suffixes.indexOf("text") === -1;
+	var urlsafe = operator.suffixes.indexOf("urlsafe") !== -1;
 	source(function(tiddler,title) {
-		results.push($tw.utils.base64Decode(title));
+		results.push($tw.utils.base64Decode(title,binary,urlsafe));
 	});
 	return results;
 };
 
 exports.encodebase64 = function(source,operator,options) {
 	var results = [];
+	var binary = operator.suffixes.indexOf("text") === -1;
+	var urlsafe = operator.suffixes.indexOf("urlsafe") !== -1;
 	source(function(tiddler,title) {
-		results.push($tw.utils.base64Encode(title));
+		results.push($tw.utils.base64Encode(title,binary,urlsafe));
 	});
 	return results;
 };

--- a/core/modules/savers/github.js
+++ b/core/modules/savers/github.js
@@ -31,7 +31,7 @@ GitHubSaver.prototype.save = function(text,method,callback) {
 		headers = {
 			"Accept": "application/vnd.github.v3+json",
 			"Content-Type": "application/json;charset=UTF-8",
-			"Authorization": "Basic " + window.btoa(username + ":" + password),
+			"Authorization": "Basic " + $tw.utils.base64Encode(username + ":" + password),
 			"If-None-Match": ""
 		};
 	// Bail if we don't have everything we need

--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -187,7 +187,7 @@ HttpClientRequest.prototype.send = function(callback) {
 					for (var i=0; i<len; i++) {
 						binary += String.fromCharCode(bytes[i]);
 					}
-					resultVariables.data = window.btoa(binary);
+					resultVariables.data = $tw.utils.base64Encode(binary,true);
 				}
 				self.wiki.addTiddler(new $tw.Tiddler(self.wiki.getTiddler(requestTrackerTitle),{
 					status: completionCode,

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -820,11 +820,26 @@ exports.hashString = function(str) {
 };
 
 /*
+Base64 utility functions that work in either browser or Node.js
+*/
+if(typeof window !== 'undefined') {
+	exports.btoa = window.btoa;
+	exports.atob = window.atob;
+} else {
+	exports.btoa = function(binstr) {
+		return Buffer.from(binstr, 'binary').toString('base64');
+	}
+	exports.atob = function(b64) {
+		return Buffer.from(b64, 'base64').toString('binary');
+	}
+}
+
+/*
 Decode a base64 string
 */
 exports.base64Decode = function(string64,binary,urlsafe) {
-	var encoded = urlsafe ? string64.replace('_','/').replace('-','+') : string64;
-	if(binary) return window.atob(encoded)
+	var encoded = urlsafe ? string64.replaceAll('_','/').replaceAll('-','+') : string64;
+	if(binary) return exports.atob(encoded)
 	else return base64utf8.base64.decode.call(base64utf8,encoded);
 };
 
@@ -832,15 +847,13 @@ exports.base64Decode = function(string64,binary,urlsafe) {
 Encode a string to base64
 */
 exports.base64Encode = function(string64,binary,urlsafe) {
-	if(binary) {
-		var encoded = window.btoa(string64);
-		if(urlsafe) {
-			encoded = encoded.replace('+','-').replace('/','_');
-		}
-		return encoded;
-	} else {
-		return base64utf8.base64.encode.call(base64utf8,string64);
+	var encoded;
+	if(binary) encoded = exports.btoa(string64);
+	else encoded = base64utf8.base64.encode.call(base64utf8,string64);
+	if(urlsafe) {
+		encoded = encoded.replaceAll('+','-').replaceAll('/','_');
 	}
+	return encoded;
 };
 
 /*

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -838,7 +838,7 @@ if(typeof window !== 'undefined') {
 Decode a base64 string
 */
 exports.base64Decode = function(string64,binary,urlsafe) {
-	var encoded = urlsafe ? string64.replaceAll('_','/').replaceAll('-','+') : string64;
+	var encoded = urlsafe ? string64.replace(/_/g,'/').replace(/-/g,'+') : string64;
 	if(binary) return exports.atob(encoded)
 	else return base64utf8.base64.decode.call(base64utf8,encoded);
 };
@@ -851,7 +851,7 @@ exports.base64Encode = function(string64,binary,urlsafe) {
 	if(binary) encoded = exports.btoa(string64);
 	else encoded = base64utf8.base64.encode.call(base64utf8,string64);
 	if(urlsafe) {
-		encoded = encoded.replaceAll('+','-').replaceAll('/','_');
+		encoded = encoded.replace(/\+/g,'-').replace(/\//g,'_');
 	}
 	return encoded;
 };

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -822,15 +822,25 @@ exports.hashString = function(str) {
 /*
 Decode a base64 string
 */
-exports.base64Decode = function(string64) {
-	return base64utf8.base64.decode.call(base64utf8,string64);
+exports.base64Decode = function(string64,binary,urlsafe) {
+	var encoded = urlsafe ? string64.replace('_','/').replace('-','+') : string64;
+	if(binary) return window.atob(encoded)
+	else return base64utf8.base64.decode.call(base64utf8,encoded);
 };
 
 /*
 Encode a string to base64
 */
-exports.base64Encode = function(string64) {
-	return base64utf8.base64.encode.call(base64utf8,string64);
+exports.base64Encode = function(string64,binary,urlsafe) {
+	if(binary) {
+		var encoded = window.btoa(string64);
+		if(urlsafe) {
+			encoded = encoded.replace('+','-').replace('/','_');
+		}
+		return encoded;
+	} else {
+		return base64utf8.base64.encode.call(base64utf8,string64);
+	}
 };
 
 /*

--- a/editions/test/tiddlers/tests/test-utils.js
+++ b/editions/test/tiddlers/tests/test-utils.js
@@ -48,6 +48,29 @@ describe("Utility tests", function() {
 		expect($tw.utils.base64Decode($tw.utils.base64Encode(booksEmoji))).toBe(booksEmoji, "should round-trip correctly");
 	});
 
+	it("should handle base64 encoding emojis in URL-safe variant", function() {
+		var booksEmoji = "📚";
+		expect($tw.utils.base64Encode(booksEmoji, false, true)).toBe("8J-Tmg==", "if surrogate pairs are correctly treated as a single code unit then base64 should be 8J+Tmg==");
+		expect($tw.utils.base64Decode("8J-Tmg==", false, true)).toBe(booksEmoji);
+		expect($tw.utils.base64Decode($tw.utils.base64Encode(booksEmoji, false, true), false, true)).toBe(booksEmoji, "should round-trip correctly");
+	});
+
+	it("should handle base64 encoding binary data", function() {
+		var binaryData = "\xff\xfe\xfe\xff";
+		var encoded = $tw.utils.base64Encode(binaryData,true);
+		expect(encoded).toBe("//7+/w==");
+		var decoded = $tw.utils.base64Decode(encoded,true);
+		expect(decoded).toBe(binaryData, "Binary data did not round-trip correctly");
+	});
+
+	it("should handle base64 encoding binary data in URL-safe variant", function() {
+		var binaryData = "\xff\xfe\xfe\xff";
+		var encoded = $tw.utils.base64Encode(binaryData,true,true);
+		expect(encoded).toBe("__7-_w==");
+		var decoded = $tw.utils.base64Decode(encoded,true,true);
+		expect(decoded).toBe(binaryData, "Binary data did not round-trip correctly");
+	});
+
 	it("should handle stringifying a string array", function() {
 		var str = $tw.utils.stringifyList;
 		expect(str([])).toEqual("");

--- a/editions/tw5.com/tiddlers/filters/decodebase64 Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/decodebase64 Operator.tid
@@ -1,7 +1,7 @@
 caption: decodebase64
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input with base 64 decoding applied
-op-suffix: optional: `text` to produce text output, `urlsafe` for URL-safe input
+op-suffix: optional: `binary` to produce binary output, `urlsafe` for URL-safe input
 op-parameter: 
 op-parameter-name: 
 op-purpose: apply base 64 decoding to a string
@@ -12,9 +12,9 @@ from-version: 5.2.6
 
 See Mozilla Developer Network for details of [[base 64 encoding|https://developer.mozilla.org/en-US/docs/Glossary/Base64]]. TiddlyWiki uses [[library code from @nijikokun|https://gist.github.com/Nijikokun/5192472]] to handle the conversion.
 
-The input strings must be base64 encoded. The output strings are binary data.
+The input strings must be base64 encoded. The output strings are the text (or binary data) decoded from base64 format.
 
-The optional `text` suffix, if present, causes the output string to be interpreted as UTF-8 encoded bytes instead of binary data. This means that an extra UTF-8 decoding step will be added before the base64 output is produced. (If you don't know what that means, just remember that the `text` suffix should be used if you're decoding base64 that was produced by <<.op "encodebase64:text">>, while it should be omitted if you're decoding base64 that came from somewhere else).
+The optional `binary` suffix, if present, changes how the input is processed. The input is normally assumed to be UTF-8 text encoded in base64 form (such as what the <<.op "encodebase64">> operator produces), so only certain byte sequences in the input are valid. If the input is binary data encoded in base64 format (such as an image, audio file, video file, etc.), then use the optional `binary` suffix, which will allow all byte sequences. Note that the output will then be binary, ''not'' text, and should probably not be passed into further filter operators.
 
 The optional `urlsafe` suffix, if present, causes the decoder to assume that the base64 input uses `-` and `_` instead of `+` and `/` for the 62nd and 63rd characters of the base64 "alphabet", which is usually referred to as "URL-safe base64" or "bae64url".
 

--- a/editions/tw5.com/tiddlers/filters/decodebase64 Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/decodebase64 Operator.tid
@@ -14,7 +14,7 @@ See Mozilla Developer Network for details of [[base 64 encoding|https://develope
 
 The input strings must be base64 encoded. The output strings are the text (or binary data) decoded from base64 format.
 
-The optional `binary` suffix, if present, changes how the input is processed. The input is normally assumed to be UTF-8 text encoded in base64 form (such as what the <<.op "encodebase64">> operator produces), so only certain byte sequences in the input are valid. If the input is binary data encoded in base64 format (such as an image, audio file, video file, etc.), then use the optional `binary` suffix, which will allow all byte sequences. Note that the output will then be binary, ''not'' text, and should probably not be passed into further filter operators.
+The optional `binary` suffix, if present, changes how the input is processed. The input is normally assumed to be [[UTF-8|https://developer.mozilla.org/en-US/docs/Glossary/UTF-8]] text encoded in base64 form (such as what the <<.op "encodebase64">> operator produces), so only certain byte sequences in the input are valid. If the input is binary data encoded in base64 format (such as an image, audio file, video file, etc.), then use the optional `binary` suffix, which will allow all byte sequences. Note that the output will then be binary, ''not'' text, and should probably not be passed into further filter operators.
 
 The optional `urlsafe` suffix, if present, causes the decoder to assume that the base64 input uses `-` and `_` instead of `+` and `/` for the 62nd and 63rd characters of the base64 "alphabet", which is usually referred to as "URL-safe base64" or "bae64url".
 

--- a/editions/tw5.com/tiddlers/filters/decodebase64 Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/decodebase64 Operator.tid
@@ -1,6 +1,7 @@
 caption: decodebase64
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input with base 64 decoding applied
+op-suffix: optional: `text` to produce text output, `urlsafe` for URL-safe input
 op-parameter: 
 op-parameter-name: 
 op-purpose: apply base 64 decoding to a string
@@ -12,5 +13,9 @@ from-version: 5.2.6
 See Mozilla Developer Network for details of [[base 64 encoding|https://developer.mozilla.org/en-US/docs/Glossary/Base64]]. TiddlyWiki uses [[library code from @nijikokun|https://gist.github.com/Nijikokun/5192472]] to handle the conversion.
 
 The input strings must be base64 encoded. The output strings are binary data.
+
+The optional `text` suffix, if present, causes the output string to be interpreted as UTF-8 encoded bytes instead of binary data. This means that an extra UTF-8 decoding step will be added before the base64 output is produced. (If you don't know what that means, just remember that the `text` suffix should be used if you're decoding base64 that was produced by <<.op "encodebase64:text">>, while it should be omitted if you're decoding base64 that came from somewhere else).
+
+The optional `urlsafe` suffix, if present, causes the decoder to assume that the base64 input uses `-` and `_` instead of `+` and `/` for the 62nd and 63rd characters of the base64 "alphabet", which is usually referred to as "URL-safe base64" or "bae64url".
 
 <<.operator-examples "decodebase64">>

--- a/editions/tw5.com/tiddlers/filters/encodebase64 Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/encodebase64 Operator.tid
@@ -1,6 +1,7 @@
 caption: encodebase64
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input with base 64 encoding applied
+op-suffix: optional: `text` to treat input as text, `urlsafe` for URL-safe output
 op-parameter: 
 op-parameter-name: 
 op-purpose: apply base 64 encoding to a string
@@ -12,5 +13,9 @@ from-version: 5.2.6
 See Mozilla Developer Network for details of [[base 64 encoding|https://developer.mozilla.org/en-US/docs/Glossary/Base64]]. TiddlyWiki uses [[library code from @nijikokun|https://gist.github.com/Nijikokun/5192472]] to handle the conversion.
 
 The input strings are interpreted as binary data. The output strings are base64 encoded.
+
+The optional `text` suffix, if present, causes the input string to be interpreted as text instead of binary data. This means that an extra UTF-8 encoding step will be added before the base64 output is produced. (If you don't know what that means, just remember that the `text` suffix should be used if you're encoding text, and omitted if you're encoding an image, audio file, or other kind of binary data).
+
+The optional `urlsafe` suffix, if present, will use the alternate "URL-safe" base64 encoding, where `-` and `_` are used instead of `+` and `/` respectively, allowing the result to be used in URL query parameters or filenames.
 
 <<.operator-examples "encodebase64">>

--- a/editions/tw5.com/tiddlers/filters/encodebase64 Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/encodebase64 Operator.tid
@@ -12,7 +12,7 @@ from-version: 5.2.6
 
 See Mozilla Developer Network for details of [[base 64 encoding|https://developer.mozilla.org/en-US/docs/Glossary/Base64]]. TiddlyWiki uses [[library code from @nijikokun|https://gist.github.com/Nijikokun/5192472]] to handle the conversion.
 
-The input strings are interpreted as text (or binary data instead if the `binary` suffix is present). The output strings are base64 encoded.
+The input strings are interpreted as [[UTF-8 encoded|https://developer.mozilla.org/en-US/docs/Glossary/UTF-8]] text (or binary data instead if the `binary` suffix is present). The output strings are base64 encoded.
 
 The optional `binary` suffix, if present, causes the input string to be interpreted as binary data instead of text. Normally, an extra UTF-8 encoding step will be added before the base64 output is produced, so that emojis and other Unicode characters will be encoded correctly. If the input is binary data, such as an image, audio file, video, etc., then the UTF-8 encoding step would produce incorrect results, so using the `binary` suffix causes the UTF-8 encoding step to be skipped.
 

--- a/editions/tw5.com/tiddlers/filters/encodebase64 Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/encodebase64 Operator.tid
@@ -1,7 +1,7 @@
 caption: encodebase64
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input with base 64 encoding applied
-op-suffix: optional: `text` to treat input as text, `urlsafe` for URL-safe output
+op-suffix: optional: `binary` to treat input as binary data, `urlsafe` for URL-safe output
 op-parameter: 
 op-parameter-name: 
 op-purpose: apply base 64 encoding to a string
@@ -12,9 +12,9 @@ from-version: 5.2.6
 
 See Mozilla Developer Network for details of [[base 64 encoding|https://developer.mozilla.org/en-US/docs/Glossary/Base64]]. TiddlyWiki uses [[library code from @nijikokun|https://gist.github.com/Nijikokun/5192472]] to handle the conversion.
 
-The input strings are interpreted as binary data. The output strings are base64 encoded.
+The input strings are interpreted as text (or binary data instead if the `binary` suffix is present). The output strings are base64 encoded.
 
-The optional `text` suffix, if present, causes the input string to be interpreted as text instead of binary data. This means that an extra UTF-8 encoding step will be added before the base64 output is produced. (If you don't know what that means, just remember that the `text` suffix should be used if you're encoding text, and omitted if you're encoding an image, audio file, or other kind of binary data).
+The optional `binary` suffix, if present, causes the input string to be interpreted as binary data instead of text. Normally, an extra UTF-8 encoding step will be added before the base64 output is produced, so that emojis and other Unicode characters will be encoded correctly. If the input is binary data, such as an image, audio file, video, etc., then the UTF-8 encoding step would produce incorrect results, so using the `binary` suffix causes the UTF-8 encoding step to be skipped.
 
 The optional `urlsafe` suffix, if present, will use the alternate "URL-safe" base64 encoding, where `-` and `_` are used instead of `+` and `/` respectively, allowing the result to be used in URL query parameters or filenames.
 


### PR DESCRIPTION
Fixes #7626.

The documentation for the `encodebase64` filter operator says that the input is treated as binary data, but in fact the input is being treated as text data, with an extra UTF-8 encoding step being performed first.

Likewise, the `decodebase64` documentation says that it outputs binary data, but in fact it will do a UTF-8 decoding step before producing output, which will in fact garble binary data.

This PR changes the behavior of encodebase64 and decodebase64 to match what the documentation says they do. It also adds an optional `text` suffix to both filters to keep the current behavior.

Finally, an optional `urlsafe` suffix is added to both filters to allow them to use the "URL-safe" variant of base64 (using `-` instead of `+` and `_` instead of `/`).