### PR TITLE
CopyTiddler Toolbar Button & Clipboard Action Widget

### DIFF
--- a/core/modules/widgets/action-clipboard.js
+++ b/core/modules/widgets/action-clipboard.js
@@ -1,0 +1,76 @@
+/*\
+title: $:/core/modules/widgets/action-deletetiddler.js
+type: application/javascript
+module-type: widget
+
+Action widget to delete a tiddler.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var ClipboardWidget = function(parseTreeNode,options) {
+    this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+ClipboardWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+ClipboardWidget.prototype.render = function(parent,nextSibling) {
+    this.computeAttributes();
+    this.execute();
+};
+
+/*
+Compute the internal state of the widget
+*/
+ClipboardWidget.prototype.execute = function() {
+    this.actionTiddler = this.getAttribute("$tiddler");
+    this.actionTiddler = this.getAttribute("$text");
+    this.actionTiddler = this.getAttribute("$format");
+};
+
+/*
+Refresh the widget by ensuring our attributes are up to date
+*/
+ClipboardWidget.prototype.refresh = function(changedTiddlers) {
+    var changedAttributes = this.computeAttributes();
+    if(changedAttributes["$tiddler"] || changedAttributes["$text"] || changedAttributes["$format"]) {
+        this.refreshSelf();
+        return true;
+    }
+    return this.refreshChildren(changedTiddlers);
+};
+
+/*
+Invoke the action associated with this widget
+*/
+ClipboardWidget.prototype.invokeAction = function(triggeringWidget,event) {
+
+    const data = {
+        text: "I love TiddlyWiki",
+        title: "Copy Paste Test",
+        tags: "HelloThere",
+        apple: "Here is a test field"
+    };
+
+    e.clipboardData.setData("URL", "data:text/vnd.tiddler," + encodeURIComponent(JSON.stringify(data)));
+    e.preventDefault();
+
+    return true; // Action was invoked
+};
+
+exports["action-clipboard"] = ClipboardWidget;
+
+})();
+    

--- a/core/ui/ViewToolbar/copy-tiddler.tid
+++ b/core/ui/ViewToolbar/copy-tiddler.tid
@@ -1,0 +1,27 @@
+title: $:/core/ui/Buttons/new-here
+tags: $:/tags/ViewToolbar
+caption: {{$:/core/images/copy-clipboard}} {{$:/language/Buttons/CopyTiddler/Caption}}
+description: {{$:/language/Buttons/CopyTiddler/Hint}}
+
+\whitespace trim
+\define copyTiddlerAction()
+\whitespace trim
+<$action-clipboard $tiddler=<<currentTiddler>>/>
+\end
+
+\define copyTiddlerButton()
+\whitespace trim
+<$button actions=<<CopyTiddlerActions>> tooltip={{$:/language/Buttons/CopyTiddler/Hint}} aria-label={{$:/language/Buttons/CopyTiddler/Caption}} class=<<tv-config-toolbar-class>>>
+<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+{{$:/core/images/copy-clipboard}}
+</$list>
+<$list filter="[<tv-config-toolbar-text>match[yes]]">
+<span class="tc-btn-text">
+<$text text={{$:/language/Buttons/CopyTiddler/Caption}}/>
+</span>
+</$list>
+</$button>
+\end
+<<copyTiddlerButton>>
+
+

--- a/core/wiki/macros/copy-to-clipboard.tid
+++ b/core/wiki/macros/copy-to-clipboard.tid
@@ -1,6 +1,8 @@
 title: $:/core/macros/copy-to-clipboard
 tags: $:/tags/Macro
 
+<!-- These are possibly now deprecated in prefrence to the action widget -->
+
 \define copy-to-clipboard(src,class:"tc-btn-invisible",style)
 \whitespace trim
 <$button class=<<__class__>> style=<<__style__>> message="tm-copy-to-clipboard" param=<<__src__>> tooltip={{$:/language/Buttons/CopyToClipboard/Hint}}>


### PR DESCRIPTION
This PR adds a new view toolbar button "Copy Tiddler" which is implemented through a new action widget $action-clipboard.

There exists some infrastructure for handling the clipboard in TiddlyWiki, but it was inadequate for the use case, and this new action widget should allow additional flexibility for users as well.  