### PR TITLE
Make flexbox or grid layouts possible

### DIFF
--- a/core/ui/PageTemplate.tid
+++ b/core/ui/PageTemplate.tid
@@ -20,7 +20,7 @@ code-body: yes
 
 <$navigator story="$:/StoryList" history="$:/HistoryList" openLinkFromInsideRiver={{$:/config/Navigation/openLinkFromInsideRiver}} openLinkFromOutsideRiver={{$:/config/Navigation/openLinkFromOutsideRiver}} relinkOnRename={{$:/config/RelinkOnRename}}>
 
-<$dropzone enable=<<tv-enable-drag-and-drop>>>
+<$dropzone enable=<<tv-enable-drag-and-drop>> class="tc-dropzone tc-page-container-inner">
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/PageTemplate]!has[draft.of]]" variable="listItem">
 


### PR DESCRIPTION
Both flexbox and grid layouts need the container div to be the direct parent of the children it lays out. To enable that, we need a div around the list widget in PageTemplate.tid so that it can have `display: flex` or `display: grid` applied to it. The `tc-page-container` div is not suitable, because it contains a `<$dropzone>` inside it, and the dropzone widget creates a div so tc-page-container is no longer the direct parent of the list.

This PR creates a div in the right position with the `tc-page-container-inner` class applied to it, so that adding flexbox in a theme can be as simple as:

```css
.tc-page-container-inner {
    display: flex;
}
```

Resolves #7689.