### PR TITLE
Add `$if`...`$then`...`$elseif`...`$else` widget

### DIFF
--- a/core/modules/widgets/if.js
+++ b/core/modules/widgets/if.js
@@ -16,7 +16,6 @@ var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var IfWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
-	this.conditions = [];
 };
 
 /*
@@ -25,91 +24,128 @@ Inherit from the base widget class
 IfWidget.prototype = new Widget();
 
 /*
-Render this widget into the DOM
+Prepare child then and/or else widgets before they are created
 */
-IfWidget.prototype.render = function(parent,nextSibling) {
-	this.parentDomNode = parent;
-	this.computeAttributes();
-	this.execute();
-	this.renderChildren(parent,nextSibling);
-};
-
-IfWidget.prototype.safelyComputeAttribute = function(attribute,defaultValue) {
-	return attribute ? this.computeAttribute(attribute) : defaultValue;
-}
-
-IfWidget.prototype.computeConditions = function() {
-	var self = this;
-	this.filterString = this.safelyComputeAttribute(this.parseTreeNode.attributes.filter,"");
-	this.conditions = [{filter: this.filterString, parseTree: undefined}];
+IfWidget.prototype.preprocessChildNodes = function() {
+	var filter = this.parseTreeNode.attributes.filter;
 	$tw.utils.each(this.parseTreeNode.children,function(childNode) {
 		if(childNode.type === "then") {
-			self.conditions[0].parseTree = childNode;
-		} else if(childNode.type === "elseif") {
-			var childFilter = self.safelyComputeAttribute(childNode.attributes && childNode.attributes.filter,"")
-			self.conditions.push({filter: childFilter, parseTree: childNode});
+			if(filter) {
+				$tw.utils.addAttributeToParseTreeNode(childNode,filter);
+			}
 		} else if(childNode.type === "else") {
-			self.conditions.push({filter: true, parseTree: childNode});
+			$tw.utils.addAttributeToParseTreeNode(childNode,"filter","yes");
 		}
+		// elseif widgets have their own filter and don't need to be pre-processed
 	});
-}
-
-IfWidget.prototype.findFirstCondition = function() {
-	var self = this;
-	var resultIdx = -1;
-	$tw.utils.each(this.conditions,function(condition,idx) {
-		var filter = condition && condition.filter || "";
-		if(filter === true) {
-			resultIdx = idx;
-			return false; // Short-circuit
-		}
-		var filterResult = self.wiki.filterTiddlers(filter,self) || [];
-		if(filterResult && filterResult.length) {
-			resultIdx = idx;
-			return false; // Short-circuit
-		}
-	})
-	return resultIdx;
 }
 
 /*
 Compute the internal state of the widget
 */
 IfWidget.prototype.execute = function() {
-	// Get our parameters
-	this.computeConditions();
-	// Choose the appropriate child widget to construct
-	this.activeConditionIdx = this.findFirstCondition();
-	if(this.activeConditionIdx < 0) {
-		this.activeChildNodes = [];
-	} else {
-		var condition = this.conditions[this.activeConditionIdx];
-		this.activeChildNodes = condition && condition.parseTree && condition.parseTree.children;
-	}
+	// Set up then and/or else filters in parse tree
+	this.preprocessChildNodes();
 	// Make the child widgets
-	this.makeChildWidgets(this.activeChildNodes || []);
+	this.makeChildWidgets();
+	// Ensure each condition widget knows its next sibling
+	this.linkConditions();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
-IfWidget.prototype.refresh = function(changedTiddlers) {
-	var previousConditions = this.conditions;
-	this.computeConditions();
-	var changed = previousConditions.length !== this.conditions.length;
-	var previousActiveIdx = this.activeConditionIdx;
-	this.activeConditionIdx = this.findFirstCondition();
-	changed = this.activeConditionIdx !== previousActiveIdx || changed;
-	// Refresh if an attribute has changed, or the type associated with the target tiddler has changed
-	if(changed) {
-		this.refreshSelf();
-		return true;
-	} else {
-		return this.refreshChildren(changedTiddlers);
-	}
+IfWidget.prototype.linkConditions = function() {
+	var self = this,
+		conditions = [];
+	$tw.utils.each(this.children,function(childWidget) {
+		if(self.isConditionChild(childWidget)) {
+			conditions.push(childWidget);
+		}
+	});
+	$tw.utils.each(conditions,function(childWidget,idx) {
+		if(idx > 0) {
+			conditions[idx-1].nextCondition = childWidget;
+		}
+	});
+	// Last one will have nextCondition still undefined, which is what we want
+}
+
+IfWidget.prototype.isConditionChild = function(childWidget) {
+	var type = childWidget.parseTreeNode.type;
+	return (type === "then" || type === "else" || type === "elseif");
+}
+
+var ConditionWidget = function(parseTreeNode,options) {
+	this.oldShouldRender = false;
+	this.shouldRender = false;
+	this.shortCircuited = false;
+	this.nextCondition = undefined;
+	this.initialise(parseTreeNode,options);
 };
+ConditionWidget.prototype = new Widget();
+
+ConditionWidget.prototype.shortCircuit = function() {
+	this.oldShouldRender = this.shouldRender;
+	this.shouldRender = false;
+	this.shortCircuited = true;
+	if(this.nextCondition) {
+		this.nextCondition.shortCircuit();
+	}
+}
+
+ConditionWidget.prototype.calculateFilter = function() {
+	if(this.shortCircuited) {
+		return;
+	}
+	this.oldShouldRender = this.shouldRender;
+	var result = this.wiki.filterTiddlers(this.filter,this);
+	this.shouldRender = !!(result && result.length);
+	if(this.shouldRender && this.nextCondition) {
+		this.nextCondition.shortCircuit();
+	}
+}
+
+ConditionWidget.prototype.render = function(parent,nextSibling) {
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
+	this.renderChildren(parent,nextSibling);
+};
+
+ConditionWidget.prototype.execute = function() {
+	this.filter = this.getAttribute("filter","");
+	this.calculateFilter();
+	this.shortCircuited = false;
+	var childNodes = this.shouldRender ? this.parseTreeNode.children : [];
+	this.makeChildWidgets(childNodes);
+};
+
+ConditionWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if(changedAttributes.filter) {
+		this.filter = this.getAttribute("filter","");
+	}
+	this.calculateFilter();
+	this.shortCircuited = false;
+	if(this.oldShouldRender === this.shouldRender) {
+		return this.refreshChildren(changedTiddlers);
+	} else {
+		if(this.shouldRender) {
+			// Went from false -> true, so we didn't have child widgets before
+			this.makeChildWidgets();
+			// Re-render self, but don't re-compute filter as it might be expensive and we already know the result
+			this.shortCircuited = true;
+			this.refreshSelf();
+			return true;
+		} else {
+			// Went from true -> false, so skip refreshSelf as there's no need for the this.findNextSiblingDomNode() step
+			this.removeChildDomNodes();
+			return true;
+		}
+	}
+}
 
 exports.if = IfWidget;
-// exports['if'] = IfWidget; // Uncomment if the above is a syntax error
+exports.then = ConditionWidget;
+exports.else = ConditionWidget;
+exports.elseif = ConditionWidget;
 
 })();

--- a/core/modules/widgets/if.js
+++ b/core/modules/widgets/if.js
@@ -1,0 +1,115 @@
+/*\
+title: $:/core/modules/widgets/if.js
+type: application/javascript
+module-type: widget
+
+If-then-elseif-else widget
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var IfWidget = function(parseTreeNode,options) {
+	this.initialise(parseTreeNode,options);
+	this.conditions = [];
+};
+
+/*
+Inherit from the base widget class
+*/
+IfWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+IfWidget.prototype.render = function(parent,nextSibling) {
+	this.parentDomNode = parent;
+	this.computeAttributes();
+	this.execute();
+	this.renderChildren(parent,nextSibling);
+};
+
+IfWidget.prototype.safelyComputeAttribute = function(attribute,defaultValue) {
+	return attribute ? this.computeAttribute(attribute) : defaultValue;
+}
+
+IfWidget.prototype.computeConditions = function() {
+	var self = this;
+	this.filterString = this.safelyComputeAttribute(this.parseTreeNode.attributes.filter,"");
+	this.conditions = [{filter: this.filterString, parseTree: undefined}];
+	$tw.utils.each(this.parseTreeNode.children,function(childNode) {
+		if(childNode.type === "then") {
+			self.conditions[0].parseTree = childNode;
+		} else if(childNode.type === "elseif") {
+			var childFilter = self.safelyComputeAttribute(childNode.attributes && childNode.attributes.filter,"")
+			self.conditions.push({filter: childFilter, parseTree: childNode});
+		} else if(childNode.type === "else") {
+			self.conditions.push({filter: true, parseTree: childNode});
+		}
+	});
+}
+
+IfWidget.prototype.findFirstCondition = function() {
+	var self = this;
+	var resultIdx = -1;
+	$tw.utils.each(this.conditions,function(condition,idx) {
+		var filter = condition && condition.filter || "";
+		if(filter === true) {
+			resultIdx = idx;
+			return false; // Short-circuit
+		}
+		var filterResult = self.wiki.filterTiddlers(filter,self) || [];
+		if(filterResult && filterResult.length) {
+			resultIdx = idx;
+			return false; // Short-circuit
+		}
+	})
+	return resultIdx;
+}
+
+/*
+Compute the internal state of the widget
+*/
+IfWidget.prototype.execute = function() {
+	// Get our parameters
+	this.computeConditions();
+	// Choose the appropriate child widget to construct
+	this.activeConditionIdx = this.findFirstCondition();
+	if(this.activeConditionIdx < 0) {
+		this.activeChildNodes = [];
+	} else {
+		var condition = this.conditions[this.activeConditionIdx];
+		this.activeChildNodes = condition && condition.parseTree && condition.parseTree.children;
+	}
+	// Make the child widgets
+	this.makeChildWidgets(this.activeChildNodes || []);
+};
+
+/*
+Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+*/
+IfWidget.prototype.refresh = function(changedTiddlers) {
+	var previousConditions = this.conditions;
+	this.computeConditions();
+	var changed = previousConditions.length !== this.conditions.length;
+	var previousActiveIdx = this.activeConditionIdx;
+	this.activeConditionIdx = this.findFirstCondition();
+	changed = this.activeConditionIdx !== previousActiveIdx || changed;
+	// Refresh if an attribute has changed, or the type associated with the target tiddler has changed
+	if(changed) {
+		this.refreshSelf();
+		return true;
+	} else {
+		return this.refreshChildren(changedTiddlers);
+	}
+};
+
+exports.if = IfWidget;
+// exports['if'] = IfWidget; // Uncomment if the above is a syntax error
+
+})();

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -660,6 +660,148 @@ describe("Widget module", function() {
 		expect(wrapper.innerHTML).toBe("<p>nothing</p>");
 	});
 
+	it("should deal with the if widget with no else clause", function() {
+		var wiki = new $tw.Wiki();
+		// Construct two widget nodes
+		var text = "<$if filter=''><$then>yes</$then></$if>";
+		var falsey = text;
+		var truthy = text.replace("filter=''","filter='true'");
+		var widgetNodeF = createWidgetNode(parseText(falsey,wiki),wiki);
+		var widgetNodeT = createWidgetNode(parseText(truthy,wiki),wiki);
+		// Render both widget nodes to the DOM
+		var wrapperF = renderWidgetNode(widgetNodeF);
+		var wrapperT = renderWidgetNode(widgetNodeT);
+		// Test the rendering of both
+		expect(wrapperF.innerHTML).toBe("<p></p>");
+		expect(wrapperT.innerHTML).toBe("<p>yes</p>");
+	});
+	it("should deal with the if widget with an else clause", function() {
+		var wiki = new $tw.Wiki();
+		// Construct two widget nodes
+		var text = "<$if filter=''><$then>yes</$then><$else>no</$else></$if>";
+		var falsey = text;
+		var truthy = text.replace("filter=''","filter='true'");
+		var widgetNodeF = createWidgetNode(parseText(falsey,wiki),wiki);
+		var widgetNodeT = createWidgetNode(parseText(truthy,wiki),wiki);
+		// Render both widget nodes to the DOM
+		var wrapperF = renderWidgetNode(widgetNodeF);
+		var wrapperT = renderWidgetNode(widgetNodeT);
+		// Test the rendering of both
+		expect(wrapperF.innerHTML).toBe("<p>no</p>");
+		expect(wrapperT.innerHTML).toBe("<p>yes</p>");
+	});
+	it("should deal with the if widget with an elseif but no else clause", function() {
+		var wiki = new $tw.Wiki();
+		// Construct three widget nodes
+		var text = "<$if filter='[[1]compare:number:eq[2]]'><$then>yes</$then><$elseif filter='[[3]compare:number:eq[4]]'>maybe</$elseif></$if>";
+		var falsey = text;
+		var truthy = text.replace("eq[2]]","eq[1]]");
+		var elseif = text.replace("eq[4]]","eq[3]]");
+		var widgetNodeF = createWidgetNode(parseText(falsey,wiki),wiki);
+		var widgetNodeT = createWidgetNode(parseText(truthy,wiki),wiki);
+		var widgetNodeE = createWidgetNode(parseText(elseif,wiki),wiki);
+		// Render three widget nodes to the DOM
+		var wrapperF = renderWidgetNode(widgetNodeF);
+		var wrapperT = renderWidgetNode(widgetNodeT);
+		var wrapperE = renderWidgetNode(widgetNodeE);
+		// Test the rendering of all three
+		expect(wrapperF.innerHTML).toBe("<p></p>");
+		expect(wrapperT.innerHTML).toBe("<p>yes</p>");
+		expect(wrapperE.innerHTML).toBe("<p>maybe</p>");
+	});
+	it("should deal with the if widget with two elseifs but no else clause", function() {
+		var wiki = new $tw.Wiki();
+		// Construct four widget nodes
+		var text = "<$if filter='[[1]compare:number:eq[2]]'><$then>yes</$then><$elseif filter='[[3]compare:number:eq[4]]'>maybe</$elseif><$elseif filter='[[5]compare:number:eq[6]]'>another</$elseif></$if>";
+		var falsey = text;
+		var truthy = text.replace("eq[2]]","eq[1]]");
+		var elseif1 = text.replace("eq[4]]","eq[3]]");
+		var elseif2 = text.replace("eq[6]]","eq[5]]");
+		var widgetNodeF = createWidgetNode(parseText(falsey,wiki),wiki);
+		var widgetNodeT = createWidgetNode(parseText(truthy,wiki),wiki);
+		var widgetNodeE1 = createWidgetNode(parseText(elseif1,wiki),wiki);
+		var widgetNodeE2 = createWidgetNode(parseText(elseif2,wiki),wiki);
+		// Render four widget nodes to the DOM
+		var wrapperF = renderWidgetNode(widgetNodeF);
+		var wrapperT = renderWidgetNode(widgetNodeT);
+		var wrapperE1 = renderWidgetNode(widgetNodeE1);
+		var wrapperE2 = renderWidgetNode(widgetNodeE2);
+		// Test the rendering of all four
+		expect(wrapperF.innerHTML).toBe("<p></p>");
+		expect(wrapperT.innerHTML).toBe("<p>yes</p>");
+		expect(wrapperE1.innerHTML).toBe("<p>maybe</p>");
+		expect(wrapperE2.innerHTML).toBe("<p>another</p>");
+	});
+	it("should deal with the if widget with an elseif and an else clause", function() {
+		var wiki = new $tw.Wiki();
+		// Construct four widget nodes
+		var text = "<$if filter='[[1]compare:number:eq[2]]'><$then>yes</$then><$elseif filter='[[3]compare:number:eq[4]]'>maybe</$elseif><$elseif filter='[[5]compare:number:eq[6]]'>another</$elseif><$else>no</$else></$if>";
+		var falsey = text;
+		var truthy = text.replace("eq[2]]","eq[1]]");
+		var elseif1 = text.replace("eq[4]]","eq[3]]");
+		var elseif2 = text.replace("eq[6]]","eq[5]]");
+		var widgetNodeF = createWidgetNode(parseText(falsey,wiki),wiki);
+		var widgetNodeT = createWidgetNode(parseText(truthy,wiki),wiki);
+		var widgetNodeE1 = createWidgetNode(parseText(elseif1,wiki),wiki);
+		var widgetNodeE2 = createWidgetNode(parseText(elseif2,wiki),wiki);
+		// Render four widget nodes to the DOM
+		var wrapperF = renderWidgetNode(widgetNodeF);
+		var wrapperT = renderWidgetNode(widgetNodeT);
+		var wrapperE1 = renderWidgetNode(widgetNodeE1);
+		var wrapperE2 = renderWidgetNode(widgetNodeE2);
+		// Test the rendering of all four
+		expect(wrapperF.innerHTML).toBe("<p>no</p>");
+		expect(wrapperT.innerHTML).toBe("<p>yes</p>");
+		expect(wrapperE1.innerHTML).toBe("<p>maybe</p>");
+		expect(wrapperE2.innerHTML).toBe("<p>another</p>");
+	});
+	it("should deal with the if widget with two elseifs and an else clause", function() {
+		var wiki = new $tw.Wiki();
+		// Construct four widget nodes
+		var text = "<$if filter='[[1]compare:number:eq[2]]'><$then>yes</$then><$elseif filter='[[3]compare:number:eq[4]]'>maybe</$elseif><$elseif filter='[[5]compare:number:eq[6]]'>another</$elseif><$else>no</$else></$if>";
+		var falsey = text;
+		var truthy = text.replace("eq[2]]","eq[1]]");
+		var elseif1 = text.replace("eq[4]]","eq[3]]");
+		var elseif2 = text.replace("eq[6]]","eq[5]]");
+		var widgetNodeF = createWidgetNode(parseText(falsey,wiki),wiki);
+		var widgetNodeT = createWidgetNode(parseText(truthy,wiki),wiki);
+		var widgetNodeE1 = createWidgetNode(parseText(elseif1,wiki),wiki);
+		var widgetNodeE2 = createWidgetNode(parseText(elseif2,wiki),wiki);
+		// Render four widget nodes to the DOM
+		var wrapperF = renderWidgetNode(widgetNodeF);
+		var wrapperT = renderWidgetNode(widgetNodeT);
+		var wrapperE1 = renderWidgetNode(widgetNodeE1);
+		var wrapperE2 = renderWidgetNode(widgetNodeE2);
+		// Test the rendering of all four
+		expect(wrapperF.innerHTML).toBe("<p>no</p>");
+		expect(wrapperT.innerHTML).toBe("<p>yes</p>");
+		expect(wrapperE1.innerHTML).toBe("<p>maybe</p>");
+		expect(wrapperE2.innerHTML).toBe("<p>another</p>");
+	});
+	it("if widget should short-circuit", function() {
+		var wiki = new $tw.Wiki();
+		// Construct four widget nodes
+		var text = "<$if filter='[[1]compare:number:eq[2]]'><$then>yes</$then><$elseif filter='[[3]compare:number:eq[4]]'>maybe</$elseif><$elseif filter='[[5]compare:number:eq[6]]'>another</$elseif><$else>no</$else></$if>";
+		var falsey = text;
+		var elseif2 = falsey.replace("eq[6]]","eq[5]]");
+		var elseif1 = elseif2.replace("eq[4]]","eq[3]]"); // Both second and first elseifs are true, first one wins
+		var truthy = elseif1.replace("eq[2]]","eq[1]]"); // The "main" if condition and both elseifs are true, "main" condition wins
+		var widgetNodeF = createWidgetNode(parseText(falsey,wiki),wiki);
+		var widgetNodeT = createWidgetNode(parseText(truthy,wiki),wiki);
+		var widgetNodeE1 = createWidgetNode(parseText(elseif1,wiki),wiki);
+		var widgetNodeE2 = createWidgetNode(parseText(elseif2,wiki),wiki);
+		// Render four widget nodes to the DOM
+		var wrapperF = renderWidgetNode(widgetNodeF);
+		var wrapperT = renderWidgetNode(widgetNodeT);
+		var wrapperE1 = renderWidgetNode(widgetNodeE1);
+		var wrapperE2 = renderWidgetNode(widgetNodeE2);
+		// Test the rendering of all four
+		expect(wrapperF.innerHTML).toBe("<p>no</p>");
+		expect(wrapperT.innerHTML).toBe("<p>yes</p>");
+		expect(wrapperE1.innerHTML).toBe("<p>maybe</p>");
+		expect(wrapperE2.innerHTML).toBe("<p>another</p>");
+	});
+
 	/**This test confirms that imported set variables properly refresh
 	 * if they use transclusion for their value. This relates to PR #4108.
 	 */

--- a/editions/tw5.com/tiddlers/widgets/ElseIfWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ElseIfWidget.tid
@@ -1,0 +1,12 @@
+caption: elseif
+created: 20230822153600000
+modified: 20230823095659652
+tags: Widgets IfWidget
+title: ElseIfWidget
+type: text/vnd.tiddlywiki
+
+! Introduction
+
+<<.from-version "5.3.2">>
+
+The `<$elseif>` widget is part of the [[<$if> widget|IfWidget]], and is not valid on its own. See IfWidget for documentation.

--- a/editions/tw5.com/tiddlers/widgets/ElseWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ElseWidget.tid
@@ -1,0 +1,12 @@
+caption: else
+created: 20230822153600000
+modified: 20230823095659652
+tags: Widgets IfWidget
+title: ElseWidget
+type: text/vnd.tiddlywiki
+
+! Introduction
+
+<<.from-version "5.3.2">>
+
+The `<$else>` widget is part of the [[<$if> widget|IfWidget]], and is not valid on its own. See IfWidget for documentation.

--- a/editions/tw5.com/tiddlers/widgets/IfWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/IfWidget.tid
@@ -9,7 +9,9 @@ type: text/vnd.tiddlywiki
 
 <<.from-version "5.3.2">>
 
-The if widget determines its content depending upon the result of one or more [[filters|Filters]]. It must have a child widget named `<$then>`, and can optionally have child widgets named `<$elseif>` or `<$else>`.
+The `<$if>` widget determines its content depending upon the result of one or more [[filters|Filters]]. It must have a child widget named `<$then>`, and can optionally have child widgets named `<$elseif>` or `<$else>`.
+
+<<.tip """The `<$then>`, `<$elseif>`, and/or `<$else>` widgets cannot be used on their own. They must be direct children of an `<$if>` widget, or they will be ignored.""">>
 
 The content of the `<$if>` widget is determined by evaluating its filter, and the filters in any `<$elseif>` widgets it contains. The first filter to return a result (i.e., not an empty list) will determine the content of the `<$if>` widget, as follows.
 
@@ -22,10 +24,14 @@ The content of the `<$if>` widget is determined by evaluating its filter, and th
 
 ! Content and Attributes
 
-The `<$if>` widget and its `>$elseif>` children can have the following attributes:
+The `<$if>` widget and its `<$elseif>` children can have the following attributes:
 
 |!Attribute |!Description |
 |filter |A filter to be evaluated |
+
+The <<.attr filter>> attribute will treat an empty result as "false" and a non-empty result as "true" in a similar way to how the [[Conditional Operators]] work.
+
+The `<$then>` and `<$else>` widgets have no attributes.
 
 ! Examples
 
@@ -42,7 +48,7 @@ Try editing this example to remove the `<$else>` widget; then the `<$if>` widget
 
 !! Usage with elseif
 
-Note that multiple elseif widgets can be chained together. Also note the short-circuiting behaviour: the first condition to be true will end the evaluation. The remaining `<$elseif>` and `<$else>` widgets will not be considered.
+Note that multiple elseif widgets can be chained together. Also note the short-circuiting behaviour: the first condition to be true will end the evaluation. Any remaining `<$elseif>` and `<$else>` widgets will not be considered.
 
 <<wikitext-example-without-html '\define num() 2
 

--- a/editions/tw5.com/tiddlers/widgets/IfWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/IfWidget.tid
@@ -8,6 +8,8 @@ type: text/vnd.tiddlywiki
 
 ! Introduction
 
+<<.from-version "5.3.2">>
+
 The if widget determines its content depending upon the result of one or more [[filters|Filters]]. It must have a child widget named `<$then>`, and can optionally have child widgets named `<$elseif>` or `<$else>`.
 
 The content of the `<$if>` widget is determined by evaluating its filter, and the filters in any `<$elseif>` widgets it contains. The first filter to return a result (i.e., not an empty list) will determine the content of the `<$if>` widget, as follows.

--- a/editions/tw5.com/tiddlers/widgets/IfWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/IfWidget.tid
@@ -1,0 +1,80 @@
+caption: if
+created: 20230822153600000
+modified: 20230822170315584
+number: 2
+tags: Widgets
+title: IfWidget
+type: text/vnd.tiddlywiki
+
+! Introduction
+
+The if widget determines its content depending upon the result of one or more [[filters|Filters]]. It must have a child widget named `<$then>`, and can optionally have child widgets named `<$elseif>` or `<$else>`.
+
+The content of the `<$if>` widget is determined by evaluating its filter, and the filters in any `<$elseif>` widgets it contains. The first filter to return a result (i.e., not an empty list) will determine the content of the `<$if>` widget, as follows.
+
+* If the filter returns a non-empty result, the content of the `<$then>` widget will be displayed.
+* Otherwise, the filters in any `<$elseif>` widgets will be evaluated. The first `<$elseif>` whose filter returns a non-empty result will have its contents displayed.
+* If the `<$if>` widget still does not have any contents (all filters returned empty results), the content of the `<$else>` widget, if any, will be displayed.
+* If all filters returned empty results and there is no `<$else>` widget, the `<$if>` widget will be empty.
+
+<<.tip """The `<$if>` widget is ''short-circuiting'', so once the first filter returns a non-empty result, the rest of the elseif filters will ''not'' be evaluated.""">>
+
+! Content and Attributes
+
+The `<$if>` widget and its `>$elseif>` children can have the following attributes:
+
+|!Attribute |!Description |
+|filter |A filter to be evaluated |
+
+! Examples
+
+!! Simple true/false condition
+
+Here's a simple example of showing and hiding content with buttons:
+
+<<wikitext-example-without-html '\define num() 2
+
+<$if filter="[<num>compare:number:gt[3]]">
+<$then><<num>> is greater than 3</$then>
+<$else><<num>> is less than or equal to 3</$else>
+</$if>'>>
+
+Note that without an `<$else>` block, the `<$if>` widget will be empty if its condition is false:
+
+<<wikitext-example-without-html '\define num() 2
+
+<$if filter="[<num>compare:number:gt[3]]">
+<$then><<num>> is greater than 3</$then>
+</$if>'>>
+
+!! Chain of conditions: first one wins
+
+If multiple `<$elseif>` conditions are present, the first one whose condition is true will be used. Later `<$elseif>` conditions will not be evaluated, even if they would have also been true.
+
+<<wikitext-example-without-html '\define num() 2
+
+<$if filter="[<num>compare:number:gt[3]]">
+<$then><<num>> is greater than 3</$then>
+<$elseif filter="[<num>compare:number:gt[2]]"><<num>> is greater than 2</$elseif>
+<$elseif filter="[<num>compare:number:gt[1]]"><<num>> is greater than 1</$elseif>
+<$elseif filter="[<num>compare:number:gt[0]]"><<num>> is greater than 0</$elseif>
+<$else><<num>> is negative or zero</$else>
+</$if>'>>
+
+!! Short-circuiting example
+
+The `<$if>` widget is **short-circuiting**: only one of its child widgets will be selected and become the content of the `<$if>` widget. The contents of the other widgets are not evaluated. Try editing
+
+ No matter how many `<$then>`, `<$elseif>`, and `<$else>` [[JavaScript console|Web Developer Tools]]
+
+<<wikitext-example-without-html 'Number: <$edit field="number" />
+
+<$if filter="[{!!number}compare:number:gt[3]]">
+<$then><$log number={{!!number}} message="New value is greater than 3" /></$then>
+<$elseif filter="[{!!number}compare:number:gt[2]]"><$log number={{!!number}} message="New value is greater than 2" /></$elseif>
+<$elseif filter="[{!!number}compare:number:gt[1]]"><$log number={{!!number}} message="New value is greater than 1" /></$elseif>
+<$elseif filter="[{!!number}compare:number:gt[0]]"><$log number={{!!number}} message="New value is greater than 0" /></$elseif>
+<$else><$log number={{!!number}} message="New value is negative or zero" /></$else>
+</$if>
+Open the [[JavaScript console|Web Developer Tools]] and watch the log as you edit the number. Note how only one log message is shown for each edit you make.
+'>>

--- a/editions/tw5.com/tiddlers/widgets/IfWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/IfWidget.tid
@@ -1,7 +1,6 @@
 caption: if
 created: 20230822153600000
 modified: 20230822170315584
-number: 2
 tags: Widgets
 title: IfWidget
 type: text/vnd.tiddlywiki
@@ -30,9 +29,7 @@ The `<$if>` widget and its `>$elseif>` children can have the following attribute
 
 ! Examples
 
-!! Simple true/false condition
-
-Here's a simple example of showing and hiding content with buttons:
+!! Basic usage
 
 <<wikitext-example-without-html '\define num() 2
 
@@ -41,17 +38,11 @@ Here's a simple example of showing and hiding content with buttons:
 <$else><<num>> is less than or equal to 3</$else>
 </$if>'>>
 
-Note that without an `<$else>` block, the `<$if>` widget will be empty if its condition is false:
+Try editing this example to remove the `<$else>` widget; then the `<$if>` widget will be empty when the condition is false.
 
-<<wikitext-example-without-html '\define num() 2
+!! Usage with elseif
 
-<$if filter="[<num>compare:number:gt[3]]">
-<$then><<num>> is greater than 3</$then>
-</$if>'>>
-
-!! Chain of conditions: first one wins
-
-If multiple `<$elseif>` conditions are present, the first one whose condition is true will be used. Later `<$elseif>` conditions will not be evaluated, even if they would have also been true.
+Note that multiple elseif widgets can be chained together. Also note the short-circuiting behaviour: the first condition to be true will end the evaluation. The remaining `<$elseif>` and `<$else>` widgets will not be considered.
 
 <<wikitext-example-without-html '\define num() 2
 
@@ -63,20 +54,8 @@ If multiple `<$elseif>` conditions are present, the first one whose condition is
 <$else><<num>> is negative or zero</$else>
 </$if>'>>
 
-!! Short-circuiting example
+Try editing this example to change the number and see what happens.
 
-The `<$if>` widget is **short-circuiting**: only one of its child widgets will be selected and become the content of the `<$if>` widget. The contents of the other widgets are not evaluated. Try editing
+!! More advanced examples
 
- No matter how many `<$then>`, `<$elseif>`, and `<$else>` [[JavaScript console|Web Developer Tools]]
-
-<<wikitext-example-without-html 'Number: <$edit field="number" />
-
-<$if filter="[{!!number}compare:number:gt[3]]">
-<$then><$log number={{!!number}} message="New value is greater than 3" /></$then>
-<$elseif filter="[{!!number}compare:number:gt[2]]"><$log number={{!!number}} message="New value is greater than 2" /></$elseif>
-<$elseif filter="[{!!number}compare:number:gt[1]]"><$log number={{!!number}} message="New value is greater than 1" /></$elseif>
-<$elseif filter="[{!!number}compare:number:gt[0]]"><$log number={{!!number}} message="New value is greater than 0" /></$elseif>
-<$else><$log number={{!!number}} message="New value is negative or zero" /></$else>
-</$if>
-Open the [[JavaScript console|Web Developer Tools]] and watch the log as you edit the number. Note how only one log message is shown for each edit you make.
-'>>
+See [[IfWidget (Examples)]] for more advanced examples

--- a/editions/tw5.com/tiddlers/widgets/ThenWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ThenWidget.tid
@@ -1,0 +1,12 @@
+caption: then
+created: 20230822153600000
+modified: 20230823095659652
+tags: Widgets IfWidget
+title: ThenWidget
+type: text/vnd.tiddlywiki
+
+! Introduction
+
+<<.from-version "5.3.2">>
+
+The `<$then>` widget is part of the [[<$if> widget|IfWidget]], and is not valid on its own. See IfWidget for documentation.

--- a/editions/tw5.com/tiddlers/widgets/examples/IfWidget (Examples).tid
+++ b/editions/tw5.com/tiddlers/widgets/examples/IfWidget (Examples).tid
@@ -1,0 +1,46 @@
+created: 20230822153600000
+modified: 20230822170315584
+number: 2
+tags: IfWidget
+title: IfWidget (Examples)
+type: text/vnd.tiddlywiki
+
+!! Advanced example: no else block
+
+If the condition is false but there is no `<$else>` block, the `<$if>` widget will be empty:
+
+<<wikitext-example-without-html '\define num() 2
+
+<$if filter="[<num>compare:number:gt[3]]">
+<$then><<num>> is greater than 3</$then>
+</$if>'>>
+
+!! Advanced example: inverting the filter
+
+The `<$then>` block is required, so you can't omit a `<$then>` block. If you want an `<$if>` widget that will be empty if the condition is true, one way to do it is to invert the filter so that it becomes false (empty) when the condition is true:
+
+<<wikitext-example-without-html '\define num() 5
+
+<$if filter="[<num>compare:number:gt[3]then[]else[x]]">
+<$then>We want to avoid printing this</$then>
+<$else>Condition was false</$else>
+</$if>'>>
+
+Note that it doesn't matter what you put in the `else` filter operator: as long as the `then` operator produces an empty result and the `else` operator produces a non-empty result, the `<$if>` widget will have its condition inverted. Try editing this example and experiment with different filter conditions.
+
+!! Advanced example: short-circuiting evaluates only one child widget
+
+The `<$if>` widget is **short-circuiting**: only one of its child widgets will be selected and become the content of the `<$if>` widget. The contents of the other widgets are not evaluated.
+
+<<wikitext-example-without-html 'Number: <$edit field="number" />
+
+<$if filter="[{!!number}compare:number:gt[3]]">
+<$then><$log number={{!!number}} message="New value is greater than 3" /></$then>
+<$elseif filter="[{!!number}compare:number:gt[2]]"><$log number={{!!number}} message="New value is greater than 2" /></$elseif>
+<$elseif filter="[{!!number}compare:number:gt[1]]"><$log number={{!!number}} message="New value is greater than 1" /></$elseif>
+<$elseif filter="[{!!number}compare:number:gt[0]]"><$log number={{!!number}} message="New value is greater than 0" /></$elseif>
+<$else><$log number={{!!number}} message="New value is negative or zero" /></$else>
+</$if>
+'>>
+
+Open the [[JavaScript console|Web Developer Tools]] and watch the log as you edit the number. Note how only one log message is shown for each edit you make, because only one `<$log>` widget is evaluated.


### PR DESCRIPTION
The `<$reveal>` widget is useful when you want to show or hide some text (or widgets) based on a state tiddler, but what if you want to show or hide something based on the results of a filter? Enter the `<$if>` widget.

Usage example:

```
\define num() 2

<$if filter="[<num>compare:number:gt[3]]">
<$then><<num>> is greater than 3</$then>
<$elseif filter="[<num>compare:number:gt[2]]"><<num>> is greater than 2</$elseif>
<$elseif filter="[<num>compare:number:gt[1]]"><<num>> is greater than 1</$elseif>
<$elseif filter="[<num>compare:number:gt[0]]"><<num>> is greater than 0</$elseif>
<$else><<num>> is negative or zero</$else>
</$if>
```

Note that the `$if` widget is short-circuiting: the first filter to evaluate to a true (non-empty) result will cause that child widget to be selected, and the contents of all other child widgets will be ignored. If there were `<$log>` widgets in every single one of those `<$then>`, `<$elseif>`, and `<$else>` blocks, only one `<$log>` widget would have been rendered. To achieve this result, the `<$then>`, `<$elseif>`, and `<$else>` widgets are actually *pseudo-widgets*: they do not have separate widget definitions and cannot exist outside an `<$if>` widget. Instead, the `<$if>` widget works at the parse tree level, choosing just one child pseudo-widget to render and ignoring all the others. So if the `<$else>` block contains a widget that's particularly expensive to render, that cost will only be paid if the `<$if>` condition evaluates to false (i.e., its filter returns an empty result).

Resolves #7570.