### PR TITLE
Slightly speed up the `all` filter operator

### DIFF
--- a/core/modules/filters/all.js
+++ b/core/modules/filters/all.js
@@ -28,12 +28,8 @@ function getAllFilterOperators() {
 Export our filter function
 */
 exports.all = function(source,operator,options) {
-	// Get our suboperators
-	var allFilterOperators = getAllFilterOperators();
-	// Cycle through the suboperators accumulating their results
-	var results = new $tw.utils.LinkedList(),
-		subops = operator.operand.split("+");
 	// Check for common optimisations
+	var subops = operator.operand.split("+");
 	if(subops.length === 1 && subops[0] === "") {
 		return source;
 	} else if(subops.length === 1 && subops[0] === "tiddlers") {
@@ -46,6 +42,10 @@ exports.all = function(source,operator,options) {
 		return options.wiki.eachShadowPlusTiddlers;
 	}
 	// Do it the hard way
+	// Get our suboperators
+	var allFilterOperators = getAllFilterOperators();
+	// Cycle through the suboperators accumulating their results
+	var results = new $tw.utils.LinkedList();
 	for(var t=0; t<subops.length; t++) {
 		var subop = allFilterOperators[subops[t]];
 		if(subop) {


### PR DESCRIPTION
The `all` filter operator has shortcuts to optimise common patterns like `[all[shadows+tiddlers]]` or `[all[tiddlers]]`. In those cases, the filter operator function returns early and never uses the `result` linked list that was created, so it's immediately garbage-collected. This PR attempts to speed up the result of calling `all` in those common cases by only creating that linked list if it's actually going to be used, avoiding that garbage collection in the common cases that are optimised to return early. 
