### PR TITLE
Fix a dangling link in filter run prefix docs

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Expression.tid
@@ -50,7 +50,7 @@ In technical / logical terms:
 |`~run` |`:else[run]` |else |... ELSE run |
 ||`:intersection`|intersection of sets||
 
-For the difference between `+` and `:intersection`, see [[Filter Run Prefix (Examples)]].
+For the difference between `+` and `:intersection`, see [[Intersection Filter Run Prefix (Examples)]].
 
 The input of a run is normally a list of all the non-[[shadow|ShadowTiddlers]] tiddler titles in the wiki (in no particular order). But the `+` prefix can change this:
 


### PR DESCRIPTION
https://github.com/Jermolene/TiddlyWiki5/pull/6307 moved the docs for the difference between `+` and `:intersection` to a new tiddler, but there's a link in `Filter Expression.tid` that pointed to the old location which PR #6307 missed. This PR updates that link to point to the current location of that particular docs section.