### PR TITLE
Remove Dynannotate plugin's SelectionTracker configuration

### DIFF
--- a/plugins/tiddlywiki/dynannotate/config/LegacySelectionTracker.tid
+++ b/plugins/tiddlywiki/dynannotate/config/LegacySelectionTracker.tid
@@ -1,3 +1,0 @@
-title: $:/config/Dynannotate/LegacySelectionTracker/Enable
-
-no

--- a/plugins/tiddlywiki/dynannotate/config/SelectionTracker.tid
+++ b/plugins/tiddlywiki/dynannotate/config/SelectionTracker.tid
@@ -1,3 +1,0 @@
-title: $:/config/Dynannotate/SelectionTracker/Enable
-
-no


### PR DESCRIPTION
![image](https://github.com/Jermolene/TiddlyWiki5/assets/42492105/97393126-39dc-405c-b381-a0f237d3d151)

The plugin documentation says that the configuration defaults to "yes", but now it is "no".