### PR TITLE
Update TranscludeWidget.tid to correct procedure name

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/TranscludeWidget.tid
@@ -18,11 +18,11 @@ Transclusion is the underlying mechanism for many higher level wikitext features
 Here is a complete example showing the important features of the <<.wlink TranscludeWidget>> widget:
 
 ```
-\procedure mymacro(name,age)
+\procedure myproc(name,age)
 My name is <<name>> and my age is <<age>>.
 \end
 
-<$transclude $variable="mymacro" name="James" age="19"/>
+<$transclude $variable="myproc" name="James" age="19"/>
 ```
 
 * `\procedure` defines a variable as a procedure with two parameters, ''name'' and ''age''


### PR DESCRIPTION
The copy pasted `mymacro` from old docs is changed to `myproc` in https://tiddlywiki.com/#TranscludeWidget