### PR TITLE
Update _Timimi_ Extension and executable by Riz.tid

### DIFF
--- a/editions/tw5.com/tiddlers/community/resources/_Timimi_ Extension and executable by Riz.tid
+++ b/editions/tw5.com/tiddlers/community/resources/_Timimi_ Extension and executable by Riz.tid
@@ -12,6 +12,7 @@ type: text/vnd.tiddlywiki
 url: https://ibnishak.github.io/Timimi/
 
 Timimi is a web-extension accompanied by a native host that allows you to save and backup your standalone HTML tiddlywiki files ''anywhere in your hard-drive''. Once installed, you can save the tiddlywiki files without any extra steps, like the original Tiddlyfox addon.
+* The native host requires a component installed on the host computer, outside the browser.
 
 {{!!url}}
 

--- a/editions/tw5.com/tiddlers/community/resources/_Timimi_ Extension and executable by Riz.tid
+++ b/editions/tw5.com/tiddlers/community/resources/_Timimi_ Extension and executable by Riz.tid
@@ -12,6 +12,7 @@ type: text/vnd.tiddlywiki
 url: https://ibnishak.github.io/Timimi/
 
 Timimi is a web-extension accompanied by a native host that allows you to save and backup your standalone HTML tiddlywiki files ''anywhere in your hard-drive''. Once installed, you can save the tiddlywiki files without any extra steps, like the original Tiddlyfox addon.
+
 * The native host requires a component installed on the host computer, outside the browser.
 
 {{!!url}}


### PR DESCRIPTION
Include the line

* The native host requires a component installed on the host computer, outside the browser.

So it is clearer there are two components to be installed and access to the local machine is implied.