### PR TITLE
remove ";" from $:/themes/tiddlywiki/vanilla/settings/fontfamily

### DIFF
--- a/themes/tiddlywiki/vanilla/settings.multids
+++ b/themes/tiddlywiki/vanilla/settings.multids
@@ -1,6 +1,6 @@
 title: $:/themes/tiddlywiki/vanilla/settings/
 
-fontfamily: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
+fontfamily: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji
 codefontfamily: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace
 backgroundimageattachment: fixed
 backgroundimagesize: auto


### PR DESCRIPTION
the tiddler gets transcluded in the stylesheets like so:

```
font-family: {{$:/themes/tiddlywiki/vanilla/settings/fontfamily}};
```

note - the semicolon at the end
So this semicolon is superfluous