### PR TITLE
Add offline-external-js to empty edition

### DIFF
--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -104,13 +104,15 @@ node $TW5_BUILD_TIDDLYWIKI \
 	--build favicon static index \
 	|| exit 1
 
-# /empty.html			Empty
-# /empty.hta			For Internet Explorer
+# /empty.html					Empty
+# /empty.hta					For Internet Explorer
+# /empty-external-core.html		External core empty
+# /tiddlywikicore-<version>.js	Core plugin javascript
 node $TW5_BUILD_TIDDLYWIKI \
 	./editions/empty \
 	--verbose \
 	--output $TW5_BUILD_OUTPUT \
-	--build empty \
+	--build empty emptyexternalcore \
 	|| exit 1
 
 

--- a/editions/empty/tiddlywiki.info
+++ b/editions/empty/tiddlywiki.info
@@ -12,6 +12,9 @@
 		"empty": [
 			"--render","$:/core/save/all","empty.html","text/plain",
 			"--render","$:/core/save/all","empty.hta","text/plain"],
+		"emptyexternalcore": [
+			"--render","$:/core/save/offline-external-js","empty-external-core.html","text/plain",
+			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"],
 		"externalimages": [
 			"--savetiddlers","[is[image]]","images",
 			"--setfield","[is[image]]","_canonical_uri","$:/core/templates/canonical-uri-external-image","text/plain",


### PR DESCRIPTION
Currently I'm building these myself for use on tiddlyhost.com. I'm thinking it would be nicer if they were built and distributed by TiddlyWiki's own build automation, so this is a step towards that. WDYT?