### PR TITLE
Macros -- Make "New in 5.3.0" Info More Prominent

### DIFF
--- a/editions/tw5.com/tiddlers/concepts/Macros.tid
+++ b/editions/tw5.com/tiddlers/concepts/Macros.tid
@@ -6,7 +6,9 @@ type: text/vnd.tiddlywiki
 
 !! Important
 
-<<.from-version "5.3.0">> Macros have been [[superseded|Macro Pitfalls]] by [[Procedures]], [[Custom Widgets]] and [[Functions]] which together provide more robust and flexible ways to encapsulate and re-use code. It is now recommended to only use macros when textual substitution is specifically required.
+<<.from-version "5.3.0">> Macros have been [[superseded|Macro Pitfalls]] by [[Procedures]], [[Functions]] and [[Custom Widgets]] which together provide more robust and flexible ways to encapsulate and re-use code. 
+
+For text substitutions it is now recommended to use: [[Substituted Attribute Values]], [[substitute Operator]] and [[Transclusion and Substitution]]
 
 !! Introduction
 

--- a/editions/tw5.com/tiddlers/concepts/Macros.tid
+++ b/editions/tw5.com/tiddlers/concepts/Macros.tid
@@ -1,8 +1,12 @@
 created: 20140211171341271
-modified: 20230419103154328
+modified: 20230922094937115
 tags: Concepts Reference
 title: Macros
 type: text/vnd.tiddlywiki
+
+!! Important
+
+<<.from-version "5.3.0">> Macros have been [[superseded|Macro Pitfalls]] by [[Procedures]], [[Custom Widgets]] and [[Functions]] which together provide more robust and flexible ways to encapsulate and re-use code. It is now recommended to only use macros when textual substitution is specifically required.
 
 !! Introduction
 
@@ -25,8 +29,6 @@ The parameters that are specified in the macro call are substituted for special 
 
 *  `$parameter-name$` is replaced with the value of the named parameter
 * `$(variable-name)$` is replaced with the value of the named [[variable|Variables]]).
-
-<<.from-version "5.3.0">> Macros have been [[superseded|Macro Pitfalls]] by [[Procedures]], [[Custom Widgets]] and [[Functions]] which together provide more robust and flexible ways to encapsulate and re-use code. It is now recommended to only use macros when textual substitution is specifically required.
 
 !! How Macros Work
 

--- a/editions/tw5.com/tiddlers/macros/CoreMacros.tid
+++ b/editions/tw5.com/tiddlers/macros/CoreMacros.tid
@@ -5,4 +5,4 @@ type: text/vnd.tiddlywiki
 
 The following [[macros|Macros]] are built into ~TiddlyWiki's core:
 
-<<list-links "[tag[Core Macros]]">>
+<<list-links "[tag[Core Macros]]" class:"multi-columns">>

--- a/editions/tw5.com/tiddlers/wikitext/Transclusion and Substitution.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Transclusion and Substitution.tid
@@ -1,5 +1,5 @@
 created: 20141018090608643
-modified: 20230419103154329
+modified: 20231030124224424
 tags: WikiText
 title: Transclusion and Substitution
 type: text/vnd.tiddlywiki
@@ -55,6 +55,6 @@ As described in [[Introduction to filter notation]], you can also transclude a v
 
 ! Textual Substitution
 
-Textual substitution occurs when the value of a macro/variable is used. It is described in [[Macros]].
+Textual substitution occurs when the value of a macro/variable is used. It is described in [[Substituted Attribute Values]] and [[substitute Operator]]
 
-The key difference between substitution and transclusion is that substitution occurs before WikiText parsing. This means that you can use substitution to build WikiText constructions. Transclusions are processed independently, and cannot be combined with adjacent text to define WikiText constructions.
+The key difference between substitution and transclusion is that substitution occurs before WikiText parsing. This means that you can use substitution to build ~WikiText constructions. Transclusions are processed independently, and cannot be combined with adjacent text to define ~WikiText constructions.


### PR DESCRIPTION
I think the "Macros have been superseded by Procedures, Custom Widgets and Functions ..." should be more prominent.

This PR moves the info to the start of the tiddler.