### PR TITLE
implement browser light / dark theme switching detection

### DIFF
--- a/core/language/en-GB/ControlPanel.multids
+++ b/core/language/en-GB/ControlPanel.multids
@@ -57,6 +57,9 @@ LayoutSwitcher/Caption: Layout
 LoadedModules/Caption: Loaded Modules
 LoadedModules/Hint: These are the currently loaded tiddler modules linked to their source tiddlers. Any italicised modules lack a source tiddler, typically because they were setup during the boot process.
 Palette/Caption: Palette
+Palette/Config/DefaultDark/Caption: Default Dark Palette
+Palette/Config/DefaultLight/Caption: Default Light Palette
+Palette/Config/Detection/Caption: Detect Browser Ligh/Dark Setting
 Palette/Editor/Clone/Caption: clone
 Palette/Editor/Clone/Prompt: It is recommended that you clone this shadow palette before editing it
 Palette/Editor/Delete/Hint: delete this entry from the current palette
@@ -65,8 +68,14 @@ Palette/Editor/Prompt/Modified: This shadow palette has been modified
 Palette/Editor/Prompt: Editing
 Palette/Editor/Reset/Caption: reset
 Palette/HideEditor/Caption: hide editor
+Palette/Picker/Prompt: The automatic mode detection is activated. The following settings will be used to switch between light and dark palettes, according to the browser theme settings.<br>The defaults can be changed using the palette {{$:/core/images/palette|16px}} button.
+Palette/Picker/Prompt/Info: If the browser Light/Dark detection is activated TW will switch palettes according to the browser theme settings. 
+Palette/Picker/Enable: Enable Browser Light/Dark Mode Detection on Startup
+Palette/Picker/Heading: Automatic Light/Dark Mode Configuraton
 Palette/Prompt: Current palette:
 Palette/ShowEditor/Caption: show editor
+Palette/Switcher/Heading: Switch Palette
+Palette/Switcher/Prompt: ''This setting will be overwritten, since "Browser Light/Dark Mode" detection is activated.'' The switcher can still be used for testing.
 Parsing/Caption: Parsing
 Parsing/Hint: Here you can globally disable/enable wiki parser rules. For changes to take effect, save and reload your wiki. Disabling certain parser rules can prevent <$text text="TiddlyWiki"/> from functioning correctly. Use [[safe mode|https://tiddlywiki.com/#SafeMode]] to restore normal operation.
 Parsing/Block/Caption: Block Parse Rules

--- a/core/ui/ControlPanel/Palette.tid
+++ b/core/ui/ControlPanel/Palette.tid
@@ -3,6 +3,15 @@ tags: $:/tags/ControlPanel/Appearance
 caption: {{$:/language/ControlPanel/Palette/Caption}}
 
 \define lingo-base() $:/language/ControlPanel/Palette/
+\whitespace trim
+
+{{$:/core/ui/ControlPanel/Palette/LightDarkPicker}}
+
+!! <<lingo "Switcher/Heading">>
+
+<$list filter="[{$:/config/palette/enable-light-dark-detection}match[yes]]" variable="ignore">
+<<lingo "Switcher/Prompt">>
+</$list>
 
 {{$:/snippets/paletteswitcher}}
 

--- a/core/ui/ControlPanel/PaletteLightDarkPicker.tid
+++ b/core/ui/ControlPanel/PaletteLightDarkPicker.tid
@@ -23,7 +23,7 @@ title: $:/core/ui/ControlPanel/Palette/LightDarkPicker
 <<lingo "Picker/Prompt">>
 
 |tc-first-col-min-width tc-first-link-nowrap|k
-|<$link to="$:/config/palette/default-light" >{{$:/config/palette/default-light!!caption}}</$link> |<<palette-info "$:/config/palette/default-light">> | <<palette-picker "$:/config/palette/default-light">> |
-|<$link to="$:/config/palette/default-dark">{{$:/config/palette/default-dark!!caption}} </$link>|<<palette-info "$:/config/palette/default-dark">> | <<palette-picker "$:/config/palette/default-dark">> |
+|<$link to="$:/config/palette/default-light" >{{$:/config/palette/default-light!!caption}}</$link> |<<palette-info "$:/config/palette/default-light">> | <<palette-picker tiddler:"$:/config/palette/default-light" postFilter:":filter[color-scheme[light]]" >> |
+|<$link to="$:/config/palette/default-dark">{{$:/config/palette/default-dark!!caption}} </$link>|<<palette-info "$:/config/palette/default-dark">> | <<palette-picker tiddler:"$:/config/palette/default-dark" postFilter:":filter[color-scheme[dark]]">> |
 
 </$reveal>

--- a/core/ui/ControlPanel/PaletteLightDarkPicker.tid
+++ b/core/ui/ControlPanel/PaletteLightDarkPicker.tid
@@ -1,0 +1,29 @@
+title: $:/core/ui/ControlPanel/Palette/LightDarkPicker
+
+\define lingo-base() $:/language/ControlPanel/Palette/
+\whitespace trim
+
+!! <<lingo "Picker/Heading">>
+
+<!-- The following text should be shown if the config tiddler does not exist or contains the text "no" -->
+<$list filter="[[$:/config/palette/enable-light-dark-detection]has[text]get[text]else[no]] :filter[match[no]]" variable="ignore">
+<<lingo "Picker/Prompt/Info">>
+</$list>
+
+<$checkbox tiddler="$:/config/palette/enable-light-dark-detection" field="text" checked="yes" unchecked="no" default="no" >
+	<span class="tc-tiny-gap-left tc-small-gap-right"><<lingo "Picker/Enable">></span>
+	<$link to="$:/config/palette/enable-light-dark-detection">
+		{{$:/core/images/open-window|12}}
+	</$link>
+</$checkbox>
+
+<!-- This section should be animated, so users do not loose focus -->
+<$reveal type="match" state="$:/config/palette/enable-light-dark-detection" text="yes" retain="yes" animate="yes">
+
+<<lingo "Picker/Prompt">>
+
+|tc-first-col-min-width tc-first-link-nowrap|k
+|<$link to="$:/config/palette/default-light" >{{$:/config/palette/default-light!!caption}}</$link> |<<palette-info "$:/config/palette/default-light">> | <<palette-picker "$:/config/palette/default-light">> |
+|<$link to="$:/config/palette/default-dark">{{$:/config/palette/default-dark!!caption}} </$link>|<<palette-info "$:/config/palette/default-dark">> | <<palette-picker "$:/config/palette/default-dark">> |
+
+</$reveal>

--- a/core/wiki/config/palette/default-dark.tid
+++ b/core/wiki/config/palette/default-dark.tid
@@ -1,0 +1,4 @@
+caption: {{$:/language/ControlPanel/Palette/Config/DefaultDark/Caption}}
+title: $:/config/palette/default-dark
+
+$:/palettes/GruvboxDark

--- a/core/wiki/config/palette/default-light.tid
+++ b/core/wiki/config/palette/default-light.tid
@@ -1,0 +1,4 @@
+caption: {{$:/language/ControlPanel/Palette/Config/DefaultLight/Caption}}
+title: $:/config/palette/default-light
+
+$:/palettes/Vanilla

--- a/core/wiki/config/palette/startup-light-dark-detection.tid
+++ b/core/wiki/config/palette/startup-light-dark-detection.tid
@@ -1,0 +1,9 @@
+caption: {{$:/language/ControlPanel/Palette/Config/Detection/Caption}}
+tags: $:/tags/StartupAction/Browser
+title: $:/config/startup/light-dark/detection
+
+<$reveal type="match" stateTitle="$:/config/palette/enable-light-dark-detection" text="yes">
+	<$set name=default filter="[{$:/info/darkmode}match[yes]then[$:/config/palette/default-dark]else[$:/config/palette/default-light]]">
+		<$action-setfield $tiddler="$:/palette" text={{{ [<default>get[text]] }}}/>
+	</$set>
+</$reveal>

--- a/core/wiki/macros/palette-picker.tid
+++ b/core/wiki/macros/palette-picker.tid
@@ -1,0 +1,36 @@
+tags: $:/tags/Global
+title: $:/core/macros/palette-picker
+
+\whitespace trim
+
+\procedure palette-info(tiddler)
+\define tv-wikilinks() no
+<$tiddler tiddler={{{ [<tiddler>get[text]] }}} >
+	''{{!!name}}'' <span class="tc-tiny-gap">-</span> {{!!description}}
+	{{||$:/snippets/currpalettepreview}}
+</$tiddler>
+\end
+
+\procedure palette-picker(tiddler)
+<div class="tc-popup-keep" style="position:relative;">
+	<$button
+		popup=`$:/state/popup/$(tiddler)$`
+		tooltip={{$:/language/Buttons/Palette/Hint}}
+		aria-label={{$:/language/Buttons/Palette/Caption}}
+		class=<<tv-config-toolbar-class>>
+		selectedClass="tc-selected"
+	>
+		<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+			{{$:/core/images/palette}}
+		</$list>
+		<$list filter="[<tv-config-toolbar-text>match[yes]]">
+		<span class="tc-btn-text">
+			<$text text={{$:/language/Buttons/Palette/Caption}}/>
+		</span>
+		</$list>
+	</$button>
+	<$reveal state=`$:/state/popup/$(tiddler)$` type="popup" position="belowleft" tag=div class="tc-drop-down" style="font-size:0.7em;">
+		<$transclude $tiddler="$:/snippets/paletteswitcher" palette=<<tiddler>> />
+	</$reveal>
+</div>
+\end

--- a/core/wiki/macros/palette-picker.tid
+++ b/core/wiki/macros/palette-picker.tid
@@ -11,7 +11,7 @@ title: $:/core/macros/palette-picker
 </$tiddler>
 \end
 
-\procedure palette-picker(tiddler)
+\procedure palette-picker(tiddler, postFilter, style)
 <div class="tc-popup-keep" style="position:relative;">
 	<$button
 		popup=`$:/state/popup/$(tiddler)$`
@@ -29,8 +29,15 @@ title: $:/core/macros/palette-picker
 		</span>
 		</$list>
 	</$button>
-	<$reveal state=`$:/state/popup/$(tiddler)$` type="popup" position="belowleft" tag=div class="tc-drop-down" style="font-size:0.7em;">
-		<$transclude $tiddler="$:/snippets/paletteswitcher" palette=<<tiddler>> />
+	<$reveal state=`$:/state/popup/$(tiddler)$`
+		type="popup"
+		position="belowleft"
+		positionAllowNegative="yes"
+		tag="div"
+		class="tc-drop-down"
+		style=`$(style)$`
+	>
+		<$transclude $tiddler="$:/snippets/paletteswitcher" palette=<<tiddler>> postFilter=<<postFilter>> />
 	</$reveal>
 </div>
 \end

--- a/core/wiki/paletteswitcher.tid
+++ b/core/wiki/paletteswitcher.tid
@@ -1,11 +1,11 @@
 title: $:/snippets/paletteswitcher
 
-\parameters (palette:"$:/palette")
+\parameters (palette:"$:/palette" postFilter:"")
 \whitespace trim
 <$linkcatcher to=<<palette>> >
 	<div class="tc-chooser">
-		<$list filter="[all[shadows+tiddlers]tag[$:/tags/Palette]sort[name]]">
-			<$let pre={{{ [<palette>get[text]] }}} >
+		<$let pre={{{ [<palette>get[text]] }}} >
+			<$list filter=`[all[shadows+tiddlers]tag[$:/tags/Palette]sort[name]] $(postFilter)$`>
 				<$set name="class" filter="[all[current]prefix<pre>]" value="tc-chooser-item tc-chosen" emptyValue="tc-chooser-item">
 					<div class=<<class>> >
 						<$link to={{!!title}}>
@@ -16,7 +16,7 @@ title: $:/snippets/paletteswitcher
 						</$link>
 					</div>
 				</$set>
-			</$let>
-		</$list>
+			</$list>
+		</$let>
 	</div>
 </$linkcatcher>

--- a/core/wiki/paletteswitcher.tid
+++ b/core/wiki/paletteswitcher.tid
@@ -1,19 +1,22 @@
 title: $:/snippets/paletteswitcher
 
+\parameters (palette:"$:/palette")
 \whitespace trim
-<$linkcatcher to="$:/palette">
-<div class="tc-chooser">
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/Palette]sort[name]]">
-<$set name="cls" filter="[all[current]prefix{$:/palette}]" value="tc-chooser-item tc-chosen" emptyValue="tc-chooser-item">
-<div class=<<cls>>>
-<$link to={{!!title}}>
-''<$view field="name" format="text"/>''
-&#32;-&#32;
-<$view field="description" format="text"/>
-{{||$:/snippets/currpalettepreview}}
-</$link>
-</div>
-</$set>
-</$list>
-</div>
+<$linkcatcher to=<<palette>> >
+	<div class="tc-chooser">
+		<$list filter="[all[shadows+tiddlers]tag[$:/tags/Palette]sort[name]]">
+			<$let pre={{{ [<palette>get[text]] }}} >
+				<$set name="class" filter="[all[current]prefix<pre>]" value="tc-chooser-item tc-chosen" emptyValue="tc-chooser-item">
+					<div class=<<class>> >
+						<$link to={{!!title}}>
+							''<$view field="name" format="text"/>''
+							&#32;-&#32;
+							<$view field="description" format="text"/>
+							{{||$:/snippets/currpalettepreview}}
+						</$link>
+					</div>
+				</$set>
+			</$let>
+		</$list>
+	</div>
 </$linkcatcher>


### PR DESCRIPTION
This PR fixes:  **[IDEA] Automatically Switch Between Dark / Light Palette Depending on Browser Setting** #7754 

- At the moment the setting can only be activated on browser startup. 
- Once this PR is merged, there can be new functionality that dynamically switches setting, when the browser themes are changed.

**The ControlPanel looks like this atm**

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/256903fa-bb4b-48ec-bb5b-111519214b50)

**If the Configuration Detection is on**

- Showing the configuration is animated, so users do not loose focus
- There should be enough explanatory text for users to understand what's going on
- The configuration detection got its own tiddler

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/2a088c8c-705e-4e9d-a125-e88b9ccb5ddd)

**New Macros**

There are 2 new macros, that allow plugin authors and users to use the same UI as the core for configuring palette settings.

- `<<palette-picker tiddler:abc>>` ... Creates a dropdown dialogue that allows the user to define the tiddler which will contain the palette name. Defaults to: `$:/palette`
- `<<palette-info tiddler>>` ... Shows the selected palette swatches -> `$:/snippets/currpalettepreview`

**Internationalisation**

- All texts are translatable -- Wording can be improved. Just let me know.
