### PR TITLE
fix 7757 vanilla styles should be first

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1,5 +1,6 @@
 title: $:/themes/tiddlywiki/vanilla/base
 tags: [[$:/tags/Stylesheet]]
+list-before:
 code-body: yes
 
 \define custom-background-datauri()


### PR DESCRIPTION
fix 7757 vanilla styles should be first

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/e214e027-34ce-471e-8976-9b07b0a68bb4)
