### PR TITLE
Improve file type names (TID, SVG, ICO) in hints

### DIFF
--- a/core/language/en-GB/Exporters.multids
+++ b/core/language/en-GB/Exporters.multids
@@ -3,4 +3,4 @@ title: $:/language/Exporters/
 StaticRiver: Static HTML
 JsonFile: JSON file
 CsvFile: CSV file
-TidFile: ".tid" file
+TidFile: TID text file

--- a/core/language/en-GB/Types/image_svg_xml.tid
+++ b/core/language/en-GB/Types/image_svg_xml.tid
@@ -1,5 +1,5 @@
 title: $:/language/Docs/Types/image/svg+xml
-description: Structured Vector Graphics image
+description: SVG image
 name: image/svg+xml
 group: Image
 group-sort: 1

--- a/core/language/en-GB/Types/image_x-icon.tid
+++ b/core/language/en-GB/Types/image_x-icon.tid
@@ -1,5 +1,5 @@
 title: $:/language/Docs/Types/image/x-icon
-description: ICO format icon file
+description: ICO icon
 name: image/x-icon
 group: Image
 group-sort: 1


### PR DESCRIPTION
Improve consistency of naming file types/extensions in some UI hints.

**Export tiddler**

- Change `".tid" file` to `TID text file`, to better match the neighboring `CSV file` and `JSON file`.


**Content type/image**

- Change `Structured Vector Graphics image` to `SVG image` and
- change `ICO format icon file` to `ICO icon`

for brevity and to better match the neighboring `JPEG image`, `PNG image`, `GIF image`.