### PR TITLE
Ensure {{}} doesn't cause a recursion error

### DIFF
--- a/core/modules/parsers/wikiparser/rules/transcludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeblock.js
@@ -81,6 +81,9 @@ exports.parse = function() {
 			}
 			return [tiddlerNode];
 		} else {
+			// No template or text reference is provided, so we'll use a blank target. Otherwise we'll generate
+			// a transclude widget that transcludes the current tiddler, often leading to recursion errors
+			transcludeNode.attributes["$tiddler"] = {name: "$tiddler", type: "string", value: ""};
 			return [transcludeNode];
 		}
 	}

--- a/core/modules/parsers/wikiparser/rules/transcludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeinline.js
@@ -79,6 +79,9 @@ exports.parse = function() {
 			}
 			return [tiddlerNode];
 		} else {
+			// No template or text reference is provided, so we'll use a blank target. Otherwise we'll generate
+			// a transclude widget that transcludes the current tiddler, often leading to recursion errors
+			transcludeNode.attributes["$tiddler"] = {name: "$tiddler", type: "string", value: ""};
 			return [transcludeNode];
 		}
 	}


### PR DESCRIPTION
Fixes #7767 

As [reported on talk.tiddlywiki.org](https://talk.tiddlywiki.org/t/curious-and-potentialy-dangerouse-empty-transclusions/8141), the following construction causes a recursion error:

```
something {{}}
```

The cause is that the blank transclusion generates a transclude widget with no attributes. This causes the transclude widget to transclude the current tiddler, which frequently leads to a recursion error.

This PR fixes things by ensuring that `{{}}` generates `<$transclude $tiddler=""/>`, which can be rendered without errors.

It is worth noting that this actually transcludes the tiddler titled with the empty string, if there is one. An existing flaw of the core is that it is actually possible to create such a tiddler.

