### PR TITLE
add archive HTML wikis, add index.html + css

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       TW5_BUILD_TIDDLYWIKI: "./node_modules/tiddlywiki/tiddlywiki.js"
       TW5_BUILD_MAIN_EDITION: "./editions/tw5.com"
       TW5_BUILD_OUTPUT: "./output"
-      TW5_BUILD_OUTPUT_ARCHIVE: "./output"
+      TW5_BUILD_ARCHIVE: "./output"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       TW5_BUILD_TIDDLYWIKI: "./node_modules/tiddlywiki/tiddlywiki.js"
       TW5_BUILD_MAIN_EDITION: "./editions/tw5.com"
       TW5_BUILD_OUTPUT: "./output"
+      TW5_BUILD_OUTPUT_ARCHIVE: "./output/archive"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       TW5_BUILD_TIDDLYWIKI: "./node_modules/tiddlywiki/tiddlywiki.js"
       TW5_BUILD_MAIN_EDITION: "./editions/tw5.com"
       TW5_BUILD_OUTPUT: "./output"
-      TW5_BUILD_OUTPUT_ARCHIVE: "./output/archive"
+      TW5_BUILD_OUTPUT_ARCHIVE: "./output"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -101,7 +101,7 @@ node $TW5_BUILD_TIDDLYWIKI \
 	--version \
 	--load $TW5_BUILD_OUTPUT/build.tid \
 	--output $TW5_BUILD_OUTPUT \
-	--build favicon static index \
+	--build favicon static index archive \
 	|| exit 1
 
 # /empty.html					Empty

--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -96,13 +96,13 @@ echo -e -n "title: $:/build\ncommit: $TW5_BUILD_COMMIT\n\n$TW5_BUILD_DETAILS\n" 
 #
 ######################################################
 
-# /index.html				Main site
-# /favicon.ico				Favicon for main site
-# /static.html				Static rendering of default tiddlers
-# /alltiddlers.html			Static rendering of all tiddlers
-# /static/*					Static single tiddlers
-# /static/static.css		Static stylesheet
-# /static/favicon.ico		Favicon for static pages
+# /index.html			Main site
+# /favicon.ico			Favicon for main site
+# /static.html			Static rendering of default tiddlers
+# /alltiddlers.html		Static rendering of all tiddlers
+# /static/*				Static single tiddlers
+# /static/static.css	Static stylesheet
+# /static/favicon.ico	Favicon for static pages
 # 
 # Conditionally build archive if $TW5_BUILD_ARCHIVE is set to "archive"
 #

--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -46,6 +46,13 @@ if [  -z "$TW5_BUILD_OUTPUT" ]; then
     TW5_BUILD_OUTPUT=./output
 fi
 
+# Chech if archive should be built
+
+if [[ "$TW5_BUILD_OUTPUT" = "./output"* ]]; then
+    echo 'Archive will be built'
+	TW5_BUILD_ARCHIVE=archive
+fi
+
 mkdir -p $TW5_BUILD_OUTPUT
 
 if [  ! -d "$TW5_BUILD_OUTPUT" ]; then
@@ -101,7 +108,7 @@ node $TW5_BUILD_TIDDLYWIKI \
 	--version \
 	--load $TW5_BUILD_OUTPUT/build.tid \
 	--output $TW5_BUILD_OUTPUT \
-	--build favicon static index archive \
+	--build favicon static index $TW5_BUILD_ARCHIVE\
 	|| exit 1
 
 # /empty.html					Empty

--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -84,9 +84,26 @@ echo -e -n "title: $:/build\ncommit: $TW5_BUILD_COMMIT\n\n$TW5_BUILD_DETAILS\n" 
 
 ######################################################
 #
-# Core distribution
+# Core distributions
 #
 ######################################################
+
+# Conditionally build archive if $TW5_BUILD_ARCHIVE variable is set, otherwise do nothing
+#
+# /archive/Empty-TiddlyWiki-<version>.html	Empty archived version
+# /archive/TiddlyWiki-<version>.html		Full archived version
+
+if [ -n "$TW5_BUILD_OUTPUT_ARCHIVE" ]; then
+
+node $TW5_BUILD_TIDDLYWIKI \
+	$TW5_BUILD_MAIN_EDITION \
+	--verbose \
+	--version \
+	--load $TW5_BUILD_OUTPUT/build.tid \
+	--output $TW5_BUILD_OUTPUT_ARCHIVE \
+	--build archive \
+	|| exit 1
+fi
 
 # /index.html			Main site
 # /favicon.ico			Favicon for main site
@@ -104,25 +121,6 @@ node $TW5_BUILD_TIDDLYWIKI \
 	--output $TW5_BUILD_OUTPUT \
 	--build favicon static index \
 	|| exit 1
-
-
-# Conditionally build archive if $TW5_BUILD_ARCHIVE is set to "./output/archive"
-#
-# /archive/Empty-TiddlyWiki-<version>.html	Empty archived version
-# /archive/TiddlyWiki-<version>.html		Full archived version
-
-if [ -z "$TW5_BUILD_OUTPUT_ARCHIVE" ]; then
-
-node $TW5_BUILD_TIDDLYWIKI \
-	$TW5_BUILD_MAIN_EDITION \
-	--verbose \
-	--version \
-	--load $TW5_BUILD_OUTPUT/build.tid \
-	--output $TW5_BUILD_OUTPUT_ARCHIVE \
-	--build archive \
-	|| exit 1
-
-fi
 
 # /empty.html					Empty
 # /empty.hta					For Internet Explorer

--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -115,7 +115,7 @@ node $TW5_BUILD_TIDDLYWIKI \
 	--version \
 	--load $TW5_BUILD_OUTPUT/build.tid \
 	--output $TW5_BUILD_OUTPUT \
-	--build favicon static index $TW5_BUILD_ARCHIVE\
+	--build favicon static index $TW5_BUILD_ARCHIVE \
 	|| exit 1
 
 # /empty.html					Empty

--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -46,14 +46,6 @@ if [  -z "$TW5_BUILD_OUTPUT" ]; then
     TW5_BUILD_OUTPUT=./output
 fi
 
-# Check if archive should be built depending on environment variable TW5_BUILD_OUTPUT
-# see: https://github.com/Jermolene/TiddlyWiki5/blob/4b56cb42983d4134715eb7fe7b083fdcc04980f0/.github/workflows/ci.yml#L62
-
-if [[ $TW5_BUILD_OUTPUT = "./output" ]]; then
-    echo 'Archive HTMLs will be built'
-	TW5_BUILD_ARCHIVE=archive
-fi
-
 mkdir -p $TW5_BUILD_OUTPUT
 
 if [  ! -d "$TW5_BUILD_OUTPUT" ]; then
@@ -103,11 +95,6 @@ echo -e -n "title: $:/build\ncommit: $TW5_BUILD_COMMIT\n\n$TW5_BUILD_DETAILS\n" 
 # /static/*				Static single tiddlers
 # /static/static.css	Static stylesheet
 # /static/favicon.ico	Favicon for static pages
-# 
-# Conditionally build archive if $TW5_BUILD_ARCHIVE is set to "archive"
-#
-# /archive/Empty-TiddlyWiki-<version>.html	Empty archived version
-# /archive/TiddlyWiki-<version>.html		Full archived version
 
 node $TW5_BUILD_TIDDLYWIKI \
 	$TW5_BUILD_MAIN_EDITION \
@@ -115,8 +102,27 @@ node $TW5_BUILD_TIDDLYWIKI \
 	--version \
 	--load $TW5_BUILD_OUTPUT/build.tid \
 	--output $TW5_BUILD_OUTPUT \
-	--build favicon static index $TW5_BUILD_ARCHIVE \
+	--build favicon static index \
 	|| exit 1
+
+
+# Conditionally build archive if $TW5_BUILD_ARCHIVE is set to "./output/archive"
+#
+# /archive/Empty-TiddlyWiki-<version>.html	Empty archived version
+# /archive/TiddlyWiki-<version>.html		Full archived version
+
+if [ -z "$TW5_BUILD_OUTPUT_ARCHIVE" ]; then
+
+node $TW5_BUILD_TIDDLYWIKI \
+	$TW5_BUILD_MAIN_EDITION \
+	--verbose \
+	--version \
+	--load $TW5_BUILD_OUTPUT/build.tid \
+	--output $TW5_BUILD_OUTPUT_ARCHIVE \
+	--build archive \
+	|| exit 1
+
+fi
 
 # /empty.html					Empty
 # /empty.hta					For Internet Explorer

--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -46,10 +46,11 @@ if [  -z "$TW5_BUILD_OUTPUT" ]; then
     TW5_BUILD_OUTPUT=./output
 fi
 
-# Chech if archive should be built
+# Check if archive should be built depending on environment variable TW5_BUILD_OUTPUT
+# see: https://github.com/Jermolene/TiddlyWiki5/blob/4b56cb42983d4134715eb7fe7b083fdcc04980f0/.github/workflows/ci.yml#L62
 
-if [[ "$TW5_BUILD_OUTPUT" = "./output"* ]]; then
-    echo 'Archive will be built'
+if [[ $TW5_BUILD_OUTPUT = "./output" ]]; then
+    echo 'Archive HTMLs will be built'
 	TW5_BUILD_ARCHIVE=archive
 fi
 
@@ -95,13 +96,19 @@ echo -e -n "title: $:/build\ncommit: $TW5_BUILD_COMMIT\n\n$TW5_BUILD_DETAILS\n" 
 #
 ######################################################
 
-# /index.html			Main site
-# /favicon.ico			Favicon for main site
-# /static.html			Static rendering of default tiddlers
-# /alltiddlers.html		Static rendering of all tiddlers
-# /static/*				Static single tiddlers
-# /static/static.css	Static stylesheet
-# /static/favicon.ico	Favicon for static pages
+# /index.html				Main site
+# /favicon.ico				Favicon for main site
+# /static.html				Static rendering of default tiddlers
+# /alltiddlers.html			Static rendering of all tiddlers
+# /static/*					Static single tiddlers
+# /static/static.css		Static stylesheet
+# /static/favicon.ico		Favicon for static pages
+# 
+# Conditionally build archive if $TW5_BUILD_ARCHIVE is set to "archive"
+#
+# /archive/Empty-TiddlyWiki-<version>.html	Empty archived version
+# /archive/TiddlyWiki-<version>.html		Full archived version
+
 node $TW5_BUILD_TIDDLYWIKI \
 	$TW5_BUILD_MAIN_EDITION \
 	--verbose \

--- a/bin/build-site.sh
+++ b/bin/build-site.sh
@@ -93,14 +93,14 @@ echo -e -n "title: $:/build\ncommit: $TW5_BUILD_COMMIT\n\n$TW5_BUILD_DETAILS\n" 
 # /archive/Empty-TiddlyWiki-<version>.html	Empty archived version
 # /archive/TiddlyWiki-<version>.html		Full archived version
 
-if [ -n "$TW5_BUILD_OUTPUT_ARCHIVE" ]; then
+if [ -n "$TW5_BUILD_ARCHIVE" ]; then
 
 node $TW5_BUILD_TIDDLYWIKI \
 	$TW5_BUILD_MAIN_EDITION \
 	--verbose \
 	--version \
 	--load $TW5_BUILD_OUTPUT/build.tid \
-	--output $TW5_BUILD_OUTPUT_ARCHIVE \
+	--output $TW5_BUILD_ARCHIVE \
 	--build archive \
 	|| exit 1
 fi

--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -53,7 +53,12 @@
 			"--render","$:/core/templates/static.template.css","static/static.css","text/plain"],
 		"external-js": [
 			"--render","$:/core/save/offline-external-js","[[external-]addsuffix<version>addsuffix[.html]]","text/plain",
-			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"]
+			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"],
+		"archive":[
+			"--render","$:/core/save/all","[[archive/TiddlyWiki-]addsuffix<version>addsuffix[.html]]","text/plain",
+			"--render","$:/editions/tw5.com/download-empty","[[archive/Empty-TiddlyWiki-]addsuffix<version>addsuffix[.html]]","text/plain",
+			"--render","[[TiddlyWiki Archive]]","archive/index.html","text/plain","$:/core/templates/static.tiddler.html",
+			"--render","$:/core/templates/static.template.css","archive/static.css","text/plain"]
 	},
 	"config": {
 		"retain-original-tiddler-path": true


### PR DESCRIPTION
- This PR should add the archive versions to the `archive` directory
- It should create an `index.html` + `static.css` file in the archive dir

@Jermolene ... I do not know it works with your workflow of creating a new major release, because I do not know how you activate it. Please test if the files are created in the right directories. 
