### PR TITLE
More image type support

### DIFF
--- a/core/modules/widgets/image.js
+++ b/core/modules/widgets/image.js
@@ -61,19 +61,19 @@ ImageWidget.prototype.render = function(parent,nextSibling) {
 				_canonical_uri = tiddler.fields._canonical_uri;
 			// If the tiddler has body text then it doesn't need to be lazily loaded
 			if(text) {
-                // Render the appropriate element for the image type by looking up the encoding in the content type info
-                var typeInfo = $tw.config.contentTypeInfo[type];
-                var encoding = typeInfo.encoding || "utf8";
-                if (encoding === "base64") {
-                    // .pdf .png .jpg etc.
-                    src = "data:" + type + ";base64," + text;
-                    if (type === "application/pdf") {
-                        tag = "embed";
-                    }
-                } else {
-                    // .svg .tid .xml etc.
-                    src = "data:" + type + "," + encodeURIComponent(text);
-                }
+				// Render the appropriate element for the image type by looking up the encoding in the content type info
+				var typeInfo = $tw.config.contentTypeInfo[type];
+				var encoding = typeInfo.encoding || "utf8";
+				if (encoding === "base64") {
+					// .pdf .png .jpg etc.
+					src = "data:" + type + ";base64," + text;
+					if (type === "application/pdf") {
+						tag = "embed";
+					}
+				} else {
+					// .svg .tid .xml etc.
+					src = "data:" + type + "," + encodeURIComponent(text);
+				}
 			} else if(_canonical_uri) {
 				switch(type) {
 					case "application/pdf":

--- a/core/modules/widgets/image.js
+++ b/core/modules/widgets/image.js
@@ -58,24 +58,25 @@ ImageWidget.prototype.render = function(parent,nextSibling) {
 		if(this.wiki.isImageTiddler(this.imageSource)) {
 			var type = tiddler.fields.type,
 				text = tiddler.fields.text,
-				_canonical_uri = tiddler.fields._canonical_uri;
+				_canonical_uri = tiddler.fields._canonical_uri,
+				typeInfo = $tw.config.contentTypeInfo[type] || {},
+				deserializerType = typeInfo.deserializerType || type;
 			// If the tiddler has body text then it doesn't need to be lazily loaded
 			if(text) {
 				// Render the appropriate element for the image type by looking up the encoding in the content type info
-				var typeInfo = $tw.config.contentTypeInfo[type];
 				var encoding = typeInfo.encoding || "utf8";
 				if (encoding === "base64") {
 					// .pdf .png .jpg etc.
-					src = "data:" + type + ";base64," + text;
-					if (type === "application/pdf") {
+					src = "data:" + deserializerType + ";base64," + text;
+					if (deserializerType === "application/pdf") {
 						tag = "embed";
 					}
 				} else {
 					// .svg .tid .xml etc.
-					src = "data:" + type + "," + encodeURIComponent(text);
+					src = "data:" + deserializerType + "," + encodeURIComponent(text);
 				}
 			} else if(_canonical_uri) {
-				switch(type) {
+				switch(deserializerType) {
 					case "application/pdf":
 						tag = "embed";
 						src = _canonical_uri;

--- a/core/modules/widgets/image.js
+++ b/core/modules/widgets/image.js
@@ -61,19 +61,19 @@ ImageWidget.prototype.render = function(parent,nextSibling) {
 				_canonical_uri = tiddler.fields._canonical_uri;
 			// If the tiddler has body text then it doesn't need to be lazily loaded
 			if(text) {
-				// Render the appropriate element for the image type
-				switch(type) {
-					case "application/pdf":
-						tag = "embed";
-						src = "data:application/pdf;base64," + text;
-						break;
-					case "image/svg+xml":
-						src = "data:image/svg+xml," + encodeURIComponent(text);
-						break;
-					default:
-						src = "data:" + type + ";base64," + text;
-						break;
-				}
+                // Render the appropriate element for the image type by looking up the encoding in the content type info
+                var typeInfo = $tw.config.contentTypeInfo[type];
+                var encoding = typeInfo.encoding || "utf8";
+                if (encoding === "base64") {
+                    // .pdf .png .jpg etc.
+                    src = "data:" + type + ";base64," + text;
+                    if (type === "application/pdf") {
+                        tag = "embed";
+                    }
+                } else {
+                    // .svg .tid .xml etc.
+                    src = "data:" + type + "," + encodeURIComponent(text);
+                }
 			} else if(_canonical_uri) {
 				switch(type) {
 					case "application/pdf":


### PR DESCRIPTION
## What I did

I found that the `<$image>` widget hardcoded how the src of the image tiddler was generated. If it's a `pdf` it uses `base64`, if it's a `svg` it's encoded using `encodeURIComponent`, if it's any other type it just defaults to `base64`. This makes it inconvenient to expand.

I've changed it to generate the src based on the encoding of the typeInfo corresponding to the type (`base64` or something else, default is `utf8`).

## Why

The purpose of this is to make tw more extensible to image formats.

For example, my [drawio plugin](https://talk.tiddlywiki.org/t/the-most-powerful-all-in-one-diagram-editor-for-uml-circuit-flowchart-etc/8099) customizes the `application/vnd.drawio` type. This format is essentially still `image/svg+xml` but I need to define it as a different type because I need to specify the use of a particular editor that way.

And at the moment such images can only be imported with transclude, not as `[img[]]`, because ImageWidget tries to treat them as base64 (missing an `encodeURIComponent` encoding) and thus can't display the image properly.

> You can look at this image, the src of the following image is `data:application/vnd.drawio;base64,<svg xmlns=...`
>
> ![image](https://github.com/Jermolene/TiddlyWiki5/assets/16955102/353c2684-82c6-4313-88f1-9f588b0270e1)
