### PR TITLE
display: grid for editor toolbar, editor and preview

### DIFF
--- a/core/ui/EditTemplate/body/default.tid
+++ b/core/ui/EditTemplate/body/default.tid
@@ -18,7 +18,7 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 	importState=<<qualify $:/state/ImportImage>> >
 <$dropzone importTitle=<<importTitle>> autoOpenOnImport="no" contentTypesFilter={{$:/config/Editor/ImportContentTypesFilter}} class="tc-dropzone-editor" enable={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}} filesOnly="yes" actions=<<importFileActions>> >
 <div>
-<div class={{{ [function[edit-preview-state]match[yes]then[tc-tiddler-preview]else[tc-no-tiddler-preview]] [[tc-grid]] +[join[ ]] }}}>
+<div class={{{ [function[edit-preview-state]match[yes]then[tc-tiddler-preview]else[tc-tiddler-preview-hidden]] [[tc-tiddler-editor]] +[join[ ]] }}}>
 
 <$transclude tiddler="$:/core/ui/EditTemplate/body/editor" mode="inline"/>
 

--- a/core/ui/EditTemplate/body/default.tid
+++ b/core/ui/EditTemplate/body/default.tid
@@ -18,7 +18,7 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 	importState=<<qualify $:/state/ImportImage>> >
 <$dropzone importTitle=<<importTitle>> autoOpenOnImport="no" contentTypesFilter={{$:/config/Editor/ImportContentTypesFilter}} class="tc-dropzone-editor" enable={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}} filesOnly="yes" actions=<<importFileActions>> >
 <div>
-<div class={{{ [function[edit-preview-state]match[yes]then[tc-tiddler-preview]] +[join[ ]] }}}>
+<div class={{{ [function[edit-preview-state]match[yes]then[tc-tiddler-preview]else[tc-no-tiddler-preview]] [[tc-grid]] +[join[ ]] }}}>
 
 <$transclude tiddler="$:/core/ui/EditTemplate/body/editor" mode="inline"/>
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1580,8 +1580,11 @@ html body.tc-body.tc-single-tiddler-window {
 	overflow: auto;
 }
 
-.tc-tiddler-edit-frame .tc-dropzone-editor > div > div.tc-tiddler-preview {
+.tc-tiddler-edit-frame .tc-dropzone-editor > div > div {
 	display: grid;
+}
+
+.tc-tiddler-edit-frame .tc-dropzone-editor > div > div.tc-tiddler-preview {
 	grid-template-areas: 
 	"toolbar toolbar"
 	"editor preview";
@@ -1590,7 +1593,6 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-tiddler-edit-frame .tc-dropzone-editor > div > div:not(.tc-tiddler-preview) {
-	display: grid;
 	grid-template-areas: 
 	"toolbar"
 	"editor";
@@ -1624,7 +1626,7 @@ html body.tc-body.tc-single-tiddler-window {
 
 .tc-tiddler-frame .tc-tiddler-preview canvas.tc-edit-bitmapeditor {
 	grid-area: editor;
-	width: 100%;
+	max-width: 100%;
 }
 
 .tc-edit-fields {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1365,6 +1365,10 @@ html body.tc-body.tc-single-tiddler-window {
 	margin-top: 8px;
 }
 
+.tc-tiddler-edit-frame .tc-dropzone-editor > div > div.tc-tiddler-preview > .tc-editor-toolbar {
+	grid-area: toolbar;
+}
+
 .tc-editor-toolbar button {
 	vertical-align: middle;
 	background-color: <<colour tiddler-controls-foreground>>;
@@ -1576,9 +1580,29 @@ html body.tc-body.tc-single-tiddler-window {
 	overflow: auto;
 }
 
-.tc-tiddler-preview-preview {
-	float: right;
-	width: 49%;
+.tc-tiddler-edit-frame .tc-dropzone-editor > div > div.tc-tiddler-preview {
+	display: grid;
+	grid-template-areas: 
+	"toolbar toolbar"
+	"editor preview";
+	grid-template-columns: 1fr 1fr;
+	grid-template-rows: auto 1fr;
+}
+
+.tc-tiddler-edit-frame .tc-dropzone-editor > div > div:not(.tc-tiddler-preview) {
+	display: grid;
+	grid-template-areas: 
+	"toolbar"
+	"editor";
+	grid-template-columns: 1fr;
+	grid-template-rows: auto 1fr;
+}
+
+.tc-tiddler-edit-frame .tc-dropzone-editor > div > div.tc-tiddler-preview > .tc-tiddler-preview-preview {
+	grid-area: preview;
+	width: calc(100% - 3px);
+	overflow-wrap: anywhere;
+	word-break: normal;
 	border: 1px solid <<colour tiddler-editor-border>>;
 	margin: 4px 0 3px 3px;
 	padding: 3px 3px 3px 3px;
@@ -1593,12 +1617,14 @@ html body.tc-body.tc-single-tiddler-window {
 
 """>>
 
-.tc-tiddler-frame .tc-tiddler-preview .tc-edit-texteditor {
-	width: 49%;
+.tc-tiddler-edit-frame .tc-dropzone-editor > div > div > .tc-edit-texteditor {
+	grid-area: editor;
+	width: 100%;
 }
 
 .tc-tiddler-frame .tc-tiddler-preview canvas.tc-edit-bitmapeditor {
-	max-width: 49%;
+	grid-area: editor;
+	width: 100%;
 }
 
 .tc-edit-fields {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1616,7 +1616,6 @@ html body.tc-body.tc-single-tiddler-window {
 
 .tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-edit-texteditor, .tc-tiddler-frame .tc-grid.tc-no-tiddler-preview .tc-edit-texteditor {
 	grid-area: editor;
-	width: 100%;
 }
 
 .tc-tiddler-frame .tc-grid.tc-tiddler-preview canvas.tc-edit-bitmapeditor, .tc-tiddler-frame .tc-grid.tc-no-tiddler-preview canvas.tc-edit-bitmapeditor {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1365,8 +1365,8 @@ html body.tc-body.tc-single-tiddler-window {
 	margin-top: 8px;
 }
 
-.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-editor-toolbar,
-.tc-tiddler-frame .tc-grid.tc-no-tiddler-preview .tc-editor-toolbar {
+.tc-tiddler-frame .tc-tiddler-editor.tc-tiddler-preview .tc-editor-toolbar,
+.tc-tiddler-frame .tc-tiddler-editor.tc-tiddler-preview-hidden .tc-editor-toolbar {
 	grid-area: toolbar;
 }
 
@@ -1581,11 +1581,11 @@ html body.tc-body.tc-single-tiddler-window {
 	overflow: auto;
 }
 
-.tc-grid {
+.tc-tiddler-editor {
 	display: grid;
 }
 
-.tc-tiddler-frame .tc-grid.tc-tiddler-preview {
+.tc-tiddler-frame .tc-tiddler-editor.tc-tiddler-preview {
 	grid-template-areas:
 		"toolbar toolbar"
 		"editor preview";
@@ -1593,7 +1593,7 @@ html body.tc-body.tc-single-tiddler-window {
 	grid-template-rows: auto 1fr;
 }
 
-.tc-tiddler-frame .tc-grid.tc-no-tiddler-preview {
+.tc-tiddler-frame .tc-tiddler-editor.tc-tiddler-preview-hidden {
 	grid-template-areas:
 		"toolbar"
 		"editor";
@@ -1601,7 +1601,7 @@ html body.tc-body.tc-single-tiddler-window {
 	grid-template-rows: auto 1fr;
 }
 
-.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-tiddler-preview-preview {
+.tc-tiddler-frame .tc-tiddler-editor.tc-tiddler-preview .tc-tiddler-preview-preview {
 	grid-area: preview;
 	overflow-wrap: anywhere;
 	word-break: normal;
@@ -1619,13 +1619,13 @@ html body.tc-body.tc-single-tiddler-window {
 
 """>>
 
-.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-edit-texteditor,
-.tc-tiddler-frame .tc-grid.tc-no-tiddler-preview .tc-edit-texteditor {
+.tc-tiddler-frame .tc-tiddler-editor.tc-tiddler-preview .tc-edit-texteditor,
+.tc-tiddler-frame .tc-tiddler-editor.tc-tiddler-preview-hidden .tc-edit-texteditor {
 	grid-area: editor;
 }
 
-.tc-tiddler-frame .tc-grid.tc-tiddler-preview canvas.tc-edit-bitmapeditor,
-.tc-tiddler-frame .tc-grid.tc-no-tiddler-preview canvas.tc-edit-bitmapeditor {
+.tc-tiddler-frame .tc-tiddler-editor.tc-tiddler-preview canvas.tc-edit-bitmapeditor,
+.tc-tiddler-frame .tc-tiddler-editor.tc-tiddler-preview-hidden canvas.tc-edit-bitmapeditor {
 	grid-area: editor;
 	max-width: 100%;
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1365,7 +1365,7 @@ html body.tc-body.tc-single-tiddler-window {
 	margin-top: 8px;
 }
 
-.tc-tiddler-edit-frame .tc-dropzone-editor > div > div.tc-tiddler-preview > .tc-editor-toolbar {
+.tc-tiddler-edit-frame .tc-dropzone-editor > div > div > .tc-editor-toolbar {
 	grid-area: toolbar;
 }
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1365,7 +1365,7 @@ html body.tc-body.tc-single-tiddler-window {
 	margin-top: 8px;
 }
 
-.tc-tiddler-edit-frame .tc-dropzone-editor > div > div > .tc-editor-toolbar {
+.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-editor-toolbar, .tc-tiddler-frame .tc-grid.tc-no-tiddler-preview .tc-editor-toolbar {
 	grid-area: toolbar;
 }
 
@@ -1580,29 +1580,24 @@ html body.tc-body.tc-single-tiddler-window {
 	overflow: auto;
 }
 
-.tc-tiddler-edit-frame .tc-dropzone-editor > div > div {
+.tc-grid {
 	display: grid;
 }
 
-.tc-tiddler-edit-frame .tc-dropzone-editor > div > div.tc-tiddler-preview {
-	grid-template-areas: 
-	"toolbar toolbar"
-	"editor preview";
+.tc-tiddler-frame .tc-grid.tc-tiddler-preview {
+	grid-template-areas: "toolbar toolbar" "editor preview";
 	grid-template-columns: 1fr 1fr;
 	grid-template-rows: auto 1fr;
 }
 
-.tc-tiddler-edit-frame .tc-dropzone-editor > div > div:not(.tc-tiddler-preview) {
-	grid-template-areas: 
-	"toolbar"
-	"editor";
+.tc-tiddler-frame .tc-grid.tc-no-tiddler-preview {
+	grid-template-areas: "toolbar" "editor";
 	grid-template-columns: 1fr;
 	grid-template-rows: auto 1fr;
 }
 
-.tc-tiddler-edit-frame .tc-dropzone-editor > div > div.tc-tiddler-preview > .tc-tiddler-preview-preview {
+.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-tiddler-preview-preview {
 	grid-area: preview;
-	width: calc(100% - 3px);
 	overflow-wrap: anywhere;
 	word-break: normal;
 	border: 1px solid <<colour tiddler-editor-border>>;
@@ -1619,12 +1614,12 @@ html body.tc-body.tc-single-tiddler-window {
 
 """>>
 
-.tc-tiddler-edit-frame .tc-dropzone-editor > div > div > .tc-edit-texteditor {
+.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-edit-texteditor, .tc-tiddler-frame .tc-grid.tc-no-tiddler-preview .tc-edit-texteditor {
 	grid-area: editor;
 	width: 100%;
 }
 
-.tc-tiddler-frame .tc-tiddler-preview canvas.tc-edit-bitmapeditor {
+.tc-tiddler-frame .tc-grid.tc-tiddler-preview canvas.tc-edit-bitmapeditor, .tc-tiddler-frame .tc-grid.tc-no-tiddler-preview canvas.tc-edit-bitmapeditor {
 	grid-area: editor;
 	max-width: 100%;
 }

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1365,7 +1365,8 @@ html body.tc-body.tc-single-tiddler-window {
 	margin-top: 8px;
 }
 
-.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-editor-toolbar, .tc-tiddler-frame .tc-grid.tc-no-tiddler-preview .tc-editor-toolbar {
+.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-editor-toolbar,
+.tc-tiddler-frame .tc-grid.tc-no-tiddler-preview .tc-editor-toolbar {
 	grid-area: toolbar;
 }
 
@@ -1585,13 +1586,17 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-tiddler-frame .tc-grid.tc-tiddler-preview {
-	grid-template-areas: "toolbar toolbar" "editor preview";
+	grid-template-areas:
+		"toolbar toolbar"
+		"editor preview";
 	grid-template-columns: 1fr 1fr;
 	grid-template-rows: auto 1fr;
 }
 
 .tc-tiddler-frame .tc-grid.tc-no-tiddler-preview {
-	grid-template-areas: "toolbar" "editor";
+	grid-template-areas:
+		"toolbar"
+		"editor";
 	grid-template-columns: 1fr;
 	grid-template-rows: auto 1fr;
 }
@@ -1614,11 +1619,13 @@ html body.tc-body.tc-single-tiddler-window {
 
 """>>
 
-.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-edit-texteditor, .tc-tiddler-frame .tc-grid.tc-no-tiddler-preview .tc-edit-texteditor {
+.tc-tiddler-frame .tc-grid.tc-tiddler-preview .tc-edit-texteditor,
+.tc-tiddler-frame .tc-grid.tc-no-tiddler-preview .tc-edit-texteditor {
 	grid-area: editor;
 }
 
-.tc-tiddler-frame .tc-grid.tc-tiddler-preview canvas.tc-edit-bitmapeditor, .tc-tiddler-frame .tc-grid.tc-no-tiddler-preview canvas.tc-edit-bitmapeditor {
+.tc-tiddler-frame .tc-grid.tc-tiddler-preview canvas.tc-edit-bitmapeditor,
+.tc-tiddler-frame .tc-grid.tc-no-tiddler-preview canvas.tc-edit-bitmapeditor {
 	grid-area: editor;
 	max-width: 100%;
 }


### PR DESCRIPTION
This PR makes the div surrounding the toolbar, editor and preview `display: grid`
It also adds the necessary styles so that editor and preview are displayed full width, not 49% as before
It also takes into account that the bitmap editor has variable width and height

see Idea #7771