### PR TITLE
display: grid for toolbar, editor and preview - using inline styles

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -31,6 +31,9 @@ function FramedEngine(options) {
 	this.widget.domNodes.push(this.dummyTextArea);
 	// Create the iframe
 	this.iframeNode = this.widget.document.createElement("iframe");
+	$tw.utils.setStyle(this.iframeNode,[
+		{"grid-area": "editor"}
+	]);
 	this.parentNode.insertBefore(this.iframeNode,this.nextSibling);
 	this.iframeDoc = this.iframeNode.contentWindow.document;
 	// (Firefox requires us to put some empty content in the iframe)

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -50,6 +50,9 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		if(this.editShowToolbar) {
 			this.toolbarNode = this.document.createElement("div");
 			this.toolbarNode.className = "tc-editor-toolbar";
+			$tw.utils.setStyle(this.toolbarNode,[
+				{"grid-area": "toolbar"}
+			]);
 			parent.insertBefore(this.toolbarNode,nextSibling);
 			this.renderChildren(this.toolbarNode,null);
 			this.domNodes.push(this.toolbarNode);

--- a/core/modules/widgets/edit-bitmap.js
+++ b/core/modules/widgets/edit-bitmap.js
@@ -51,6 +51,9 @@ EditBitmapWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	// Create the wrapper for the toolbar and render its content
 	this.toolbarNode = this.document.createElement("div");
+	$tw.utils.setStyle(this.toolbarNode,[
+		{"grid-area": "toolbar"}
+	]);
 	this.toolbarNode.className = "tc-editor-toolbar";
 	parent.insertBefore(this.toolbarNode,nextSibling);
 	this.domNodes.push(this.toolbarNode);
@@ -75,6 +78,9 @@ EditBitmapWidget.prototype.render = function(parent,nextSibling) {
 	// Set the width and height variables
 	this.setVariable("tv-bitmap-editor-width",this.canvasDomNode.width + "px");
 	this.setVariable("tv-bitmap-editor-height",this.canvasDomNode.height + "px");
+	$tw.utils.setStyle(this.canvasDomNode,[
+		{"grid-area": "editor"}
+	]);
 	// Render toolbar child widgets
 	this.renderChildren(this.toolbarNode,null);
 	// // Insert the elements into the DOM

--- a/core/ui/EditTemplate/body/default.tid
+++ b/core/ui/EditTemplate/body/default.tid
@@ -32,7 +32,7 @@ grid-template-rows: auto 1fr;
 	importState=<<qualify $:/state/ImportImage>> >
 <$dropzone importTitle=<<importTitle>> autoOpenOnImport="no" contentTypesFilter={{$:/config/Editor/ImportContentTypesFilter}} class="tc-dropzone-editor" enable={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}} filesOnly="yes" actions=<<importFileActions>> >
 <div>
-<div class={{{ [function[edit-preview-state]match[yes]then[tc-tiddler-preview]] +[join[ ]] }}} style={{{ [function[edit-preview-state]match[yes]then<display-preview-grid-styles>else<display-no-preview-grid-styles>] }}}">
+<div class={{{ [function[edit-preview-state]match[yes]then[tc-tiddler-preview]] +[join[ ]] }}} style={{{ [function[edit-preview-state]match[yes]then<display-preview-grid-styles>else<display-no-preview-grid-styles>] }}}>
 
 <$transclude tiddler="$:/core/ui/EditTemplate/body/editor" mode="inline"/>
 

--- a/core/ui/EditTemplate/body/default.tid
+++ b/core/ui/EditTemplate/body/default.tid
@@ -14,14 +14,18 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 
 \procedure display-preview-grid-styles()
 display: grid;
-grid-template-areas: "toolbar toolbar" "editor preview";
+grid-template-areas:
+"toolbar toolbar"
+"editor preview";
 grid-template-columns: 1fr 1fr;
 grid-template-rows: auto 1fr;
 \end
 
 \procedure display-no-preview-grid-styles()
 display: grid;
-grid-template-areas: "toolbar" "editor";
+grid-template-areas:
+"toolbar"
+"editor";
 grid-template-columns: 1fr;
 grid-template-rows: auto 1fr;
 \end

--- a/core/ui/EditTemplate/body/default.tid
+++ b/core/ui/EditTemplate/body/default.tid
@@ -12,13 +12,27 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 <$action-popup $state=<<importState>> $coords="(0,0,0,0)" $floating="yes"/>
 \end
 
+\procedure display-preview-grid-styles()
+display: grid;
+grid-template-areas: "toolbar toolbar" "editor preview";
+grid-template-columns: 1fr 1fr;
+grid-template-rows: auto 1fr;
+\end
+
+\procedure display-no-preview-grid-styles()
+display: grid;
+grid-template-areas: "toolbar" "editor";
+grid-template-columns: 1fr;
+grid-template-rows: auto 1fr;
+\end
+
 \whitespace trim
 <$let
 	importTitle=<<qualify $:/ImportImage>>
 	importState=<<qualify $:/state/ImportImage>> >
 <$dropzone importTitle=<<importTitle>> autoOpenOnImport="no" contentTypesFilter={{$:/config/Editor/ImportContentTypesFilter}} class="tc-dropzone-editor" enable={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}} filesOnly="yes" actions=<<importFileActions>> >
 <div>
-<div class={{{ [function[edit-preview-state]match[yes]then[tc-tiddler-preview]] +[join[ ]] }}}>
+<div class={{{ [function[edit-preview-state]match[yes]then[tc-tiddler-preview]] +[join[ ]] }}} style={{{ [function[edit-preview-state]match[yes]then<display-preview-grid-styles>else<display-no-preview-grid-styles>] }}}">
 
 <$transclude tiddler="$:/core/ui/EditTemplate/body/editor" mode="inline"/>
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1577,8 +1577,8 @@ html body.tc-body.tc-single-tiddler-window {
 }
 
 .tc-tiddler-preview-preview {
-	float: right;
-	width: 49%;
+	overflow-wrap: anywhere;
+	word-break: normal;
 	border: 1px solid <<colour tiddler-editor-border>>;
 	margin: 4px 0 3px 3px;
 	padding: 3px 3px 3px 3px;
@@ -1593,12 +1593,8 @@ html body.tc-body.tc-single-tiddler-window {
 
 """>>
 
-.tc-tiddler-frame .tc-tiddler-preview .tc-edit-texteditor {
-	width: 49%;
-}
-
 .tc-tiddler-frame .tc-tiddler-preview canvas.tc-edit-bitmapeditor {
-	max-width: 49%;
+	max-width: 100%;
 }
 
 .tc-edit-fields {


### PR DESCRIPTION
This PR is an alternative to #7787 

it adds the necessary styles directly to the created dom nodes