### PR TITLE
Fix overflow issue of codemirror editor within grid container

### DIFF
--- a/plugins/tiddlywiki/codemirror/styles.tid
+++ b/plugins/tiddlywiki/codemirror/styles.tid
@@ -56,6 +56,10 @@ name: tiddlywiki
   rendering-intent: auto;
 }
 
+.tc-tiddler-frame .tc-tiddler-editor .tc-edit-texteditor {
+	overflow: auto;
+}
+
 .cm-s-tiddlywiki.CodeMirror, .cm-s-tiddlywiki .CodeMirror-gutters { background-color: <<colour tiddler-editor-background>>; color: <<colour foreground>>; }
 .cm-s-tiddlywiki .CodeMirror-gutters {background: <<colour tiddler-editor-background>>; border-right: 1px solid <<colour tiddler-editor-border>>;}
 .cm-s-tiddlywiki .CodeMirror-linenumber {color: <<colour foreground>>;}

--- a/plugins/tiddlywiki/codemirror/styles.tid
+++ b/plugins/tiddlywiki/codemirror/styles.tid
@@ -56,7 +56,8 @@ name: tiddlywiki
   rendering-intent: auto;
 }
 
-.tc-tiddler-frame .tc-tiddler-editor .tc-edit-texteditor {
+.tc-tiddler-frame .tc-tiddler-editor .tc-edit-texteditor,
+.tc-tiddler-frame .tc-tiddler-editor .tc-tiddler-preview-preview {
 	overflow: auto;
 }
 


### PR DESCRIPTION
This PR addresses issue #7793 by adding `overflow: auto;` to the CodeMirror container