### PR TITLE
Don't set focus on field-name input field when deleting field using delete-field button

### DIFF
--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -89,7 +89,7 @@ $value={{{ [subfilter<get-field-value-tiddler-filter>get[text]] }}}/>
 </td>
 <td class="tc-edit-field-remove">
 <$button class="tc-btn-invisible" tooltip={{$:/language/EditTemplate/Field/Remove/Hint}} aria-label={{$:/language/EditTemplate/Field/Remove/Caption}}>
-<$action-deletefield $field=<<currentField>>/><$set name="currentTiddlerCSSescaped" value={{{ [<currentTiddler>escapecss[]] }}}><$action-sendmessage $message="tm-focus-selector" $param=<<current-tiddler-new-field-selector>>/></$set>
+<$action-deletefield $field=<<currentField>>/>
 {{$:/core/images/delete-button}}
 </$button>
 </td>


### PR DESCRIPTION
This PR removes the functionality that, when clicking the delete-field button, the focus gets set to the next field-name input field.
This addresses #7801 
This PR does NOT remove the functionality when deleting the field using the keyboard shortcut `((delete-field))`
There needs to be a consensus on which field to set the focus when using the keyboard shortcut.
I believe, when using the keyboard shortcut, focus should be set somewhere...