### PR TITLE
Fix list widget when widget body used as template while `$list-empty` specified

### DIFF
--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -114,9 +114,21 @@ ListWidget.prototype.findExplicitTemplates = function() {
 			if(node.type === "list-template" || node.type === "list-empty") {
 				// Do nothing
 			} else if(node.type === "element" && node.tag === "p") {
-				var nodeWithoutTemplates = $tw.utils.extend({}, node);
-				nodeWithoutTemplates.children = removeTemplates(node.children);
-				result.push(nodeWithoutTemplates);
+				var childrenWithoutTemplates = removeTemplates(node.children);
+				if(node.children && node.children.length === childrenWithoutTemplates.length) {
+					// No changes
+					result.push(node);
+				} else {
+					// Special case: if the only child of the <p> tag was an explicit template, we remove the <p> tag as well
+					// This avoids polluting the output with empty <p></p> elements which can mess up formatting
+					if(childrenWithoutTemplates.length === 0 && node.children && node.children.length !== 0) {
+						// Do nothing
+					} else {
+						var nodeWithoutTemplates = $tw.utils.extend({}, node);
+						nodeWithoutTemplates.children = childrenWithoutTemplates;
+						result.push(nodeWithoutTemplates);
+					}
+				}
 			} else {
 				result.push(node);
 			}

--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -28,6 +28,18 @@ Inherit from the base widget class
 */
 ListWidget.prototype = new Widget();
 
+ListWidget.prototype.initialise = function(parseTreeNode,options) {
+	// Bail if parseTreeNode is undefined, meaning that the ListWidget constructor was called without any arguments so that it can be subclassed
+	if(parseTreeNode === undefined) {
+		return;
+	}
+	// First call parent constructor to set everything else up
+	Widget.prototype.initialise.call(this,parseTreeNode,options);
+	// Now look for <$list-template> and <$list-empty> widgets as immediate child widgets
+	// This is safe to do during initialization because parse trees never change after creation
+	this.findExplicitTemplates();
+}
+
 /*
 Render this widget into the DOM
 */
@@ -68,8 +80,6 @@ ListWidget.prototype.execute = function() {
 	this.counterName = this.getAttribute("counter");
 	this.storyViewName = this.getAttribute("storyview");
 	this.historyTitle = this.getAttribute("history");
-	// Look for <$list-template> and <$list-empty> widgets as immediate child widgets
-	this.findExplicitTemplates();
 	// Compose the list elements
 	this.list = this.getTiddlerList();
 	var members = [],

--- a/editions/test/tiddlers/tests/data/list-widget/WithBodyTemplate.tid
+++ b/editions/test/tiddlers/tests/data/list-widget/WithBodyTemplate.tid
@@ -1,0 +1,27 @@
+title: ListWidget/WithBodyTemplate
+description: List widget with body template and $list-empty
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
++
+title: Output
+
+\whitespace trim
+
+\procedure test(filter)
+<$list filter=<<filter>>>
+	Item:<<currentTiddler>>,
+	<$list-empty>
+		None!
+	</$list-empty>
+</$list>
+\end
+
+<<test "1 2 3">>
+
+<<test "">>
+
++
+title: ExpectedResult
+
+<p>Item:1,Item:2,Item:3,</p><p>None!</p>

--- a/editions/test/tiddlers/tests/data/list-widget/WithBodyTemplateInBlockMode.tid
+++ b/editions/test/tiddlers/tests/data/list-widget/WithBodyTemplateInBlockMode.tid
@@ -1,0 +1,29 @@
+title: ListWidget/WithBodyTemplateInBlockMode
+description: List widget with body template and $list-empty in block mode
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
++
+title: Output
+
+\whitespace trim
+
+\procedure test(filter)
+<$list filter=<<filter>>>
+
+	Item:<<currentTiddler>>,
+
+	<$list-empty>
+		None!
+	</$list-empty>
+</$list>
+\end
+
+<<test "1 2 3">>
+
+<<test "">>
+
++
+title: ExpectedResult
+
+<p>Item:1,</p><p>Item:2,</p><p>Item:3,</p>None!


### PR DESCRIPTION
If `<$list-empty>` is specified but `<$list-template>` is not, and the contents of the list widget are used as the template instead, then the result should be the same as if the emptyMessage attribute had been used.

Fixes #7804.