### PR TITLE
Fix 7701 filtered transclusion fails if "}" follows somewhere in the text

### DIFF
--- a/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js
@@ -7,10 +7,7 @@ Wiki text rule for block-level filtered transclusion. For example:
 
 ```
 {{{ [tag[docs]] }}}
-{{{ [tag[docs]] |tooltip}}}
 {{{ [tag[docs]] ||TemplateTitle}}}
-{{{ [tag[docs]] |tooltip||TemplateTitle}}}
-{{{ [tag[docs]] }}width:40;height:50;}.class.class
 ```
 
 \*/
@@ -26,7 +23,8 @@ exports.types = {block: true};
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /\{\{\{([^\|]+?)(?:\|([^\|\{\}]+))?(?:\|\|([^\|\{\}]+))?\}\}([^\}]*)\}(?:\.(\S+))?(?:\r?\n|$)/mg;
+	// this.matchRegExp = /\{\{\{([^\|]+?)(?:\|([^\|\{\}]+))?(?:\|\|([^\|\{\}]+))?\}\}([^\}]*)\}(?:\.(\S+))?(?:\r?\n|$)/mg;
+	this.matchRegExp = /\{\{\{([^\|]+?)(?:\|\|([^\|\{\}]+))?\}\}\}(?:\r?\n|$)/mg;
 };
 
 exports.parse = function() {
@@ -34,10 +32,7 @@ exports.parse = function() {
 	this.parser.pos = this.matchRegExp.lastIndex;
 	// Get the match details
 	var filter = this.match[1],
-		tooltip = this.match[2],
-		template = $tw.utils.trim(this.match[3]),
-		style = this.match[4],
-		classes = this.match[5];
+		template = $tw.utils.trim(this.match[2]);
 	// Return the list widget
 	var node = {
 		type: "list",
@@ -46,17 +41,8 @@ exports.parse = function() {
 		},
 		isBlock: true
 	};
-	if(tooltip) {
-		node.attributes.tooltip = {type: "string", value: tooltip};
-	}
 	if(template) {
 		node.attributes.template = {type: "string", value: template};
-	}
-	if(style) {
-		node.attributes.style = {type: "string", value: style};
-	}
-	if(classes) {
-		node.attributes.itemClass = {type: "string", value: classes.split(".").join(" ")};
 	}
 	return [node];
 };

--- a/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js
@@ -7,7 +7,7 @@ Wiki text rule for block-level filtered transclusion. For example:
 
 ```
 {{{ [tag[docs]] }}}
-{{{ [tag[docs]] ||TemplateTitle}}}
+{{{ [tag[docs]] || TemplateTitle }}}
 ```
 
 \*/
@@ -22,8 +22,7 @@ exports.types = {block: true};
 
 exports.init = function(parser) {
 	this.parser = parser;
-	// Regexp to match
-	// this.matchRegExp = /\{\{\{([^\|]+?)(?:\|([^\|\{\}]+))?(?:\|\|([^\|\{\}]+))?\}\}([^\}]*)\}(?:\.(\S+))?(?:\r?\n|$)/mg;
+	// Regexp to match TW versions > v5.3.1
 	this.matchRegExp = /\{\{\{([^\|]+?)(?:\|\|([^\|\{\}]+))?\}\}\}(?:\r?\n|$)/mg;
 };
 

--- a/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js
@@ -7,10 +7,7 @@ Wiki text rule for inline filtered transclusion. For example:
 
 ```
 {{{ [tag[docs]] }}}
-{{{ [tag[docs]] |tooltip}}}
 {{{ [tag[docs]] ||TemplateTitle}}}
-{{{ [tag[docs]] |tooltip||TemplateTitle}}}
-{{{ [tag[docs]] }}width:40;height:50;}.class.class
 ```
 
 \*/
@@ -26,7 +23,8 @@ exports.types = {inline: true};
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
-	this.matchRegExp = /\{\{\{([^\|]+?)(?:\|([^\|\{\}]+))?(?:\|\|([^\|\{\}]+))?\}\}([^\}]*)\}(?:\.(\S+))?/mg;
+	// this.matchRegExp = /\{\{\{([^\|]+?)(?:\|([^\|\{\}]+))?(?:\|\|([^\|\{\}]+))?\}\}([^\}]*)\}(?:\.(\S+))?/mg;
+	this.matchRegExp = /\{\{\{([^\|]+?)(?:\|\|([^\|\{\}]+))?\}\}\}/mg;
 };
 
 exports.parse = function() {
@@ -34,10 +32,7 @@ exports.parse = function() {
 	this.parser.pos = this.matchRegExp.lastIndex;
 	// Get the match details
 	var filter = this.match[1],
-		tooltip = this.match[2],
-		template = $tw.utils.trim(this.match[3]),
-		style = this.match[4],
-		classes = this.match[5];
+		template = $tw.utils.trim(this.match[2]);
 	// Return the list widget
 	var node = {
 		type: "list",
@@ -45,17 +40,8 @@ exports.parse = function() {
 			filter: {type: "string", value: filter}
 		}
 	};
-	if(tooltip) {
-		node.attributes.tooltip = {type: "string", value: tooltip};
-	}
 	if(template) {
 		node.attributes.template = {type: "string", value: template};
-	}
-	if(style) {
-		node.attributes.style = {type: "string", value: style};
-	}
-	if(classes) {
-		node.attributes.itemClass = {type: "string", value: classes.split(".").join(" ")};
 	}
 	return [node];
 };

--- a/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js
@@ -7,7 +7,7 @@ Wiki text rule for inline filtered transclusion. For example:
 
 ```
 {{{ [tag[docs]] }}}
-{{{ [tag[docs]] ||TemplateTitle}}}
+{{{ [tag[docs]] || TemplateTitle }}}
 ```
 
 \*/
@@ -22,8 +22,7 @@ exports.types = {inline: true};
 
 exports.init = function(parser) {
 	this.parser = parser;
-	// Regexp to match
-	// this.matchRegExp = /\{\{\{([^\|]+?)(?:\|([^\|\{\}]+))?(?:\|\|([^\|\{\}]+))?\}\}([^\}]*)\}(?:\.(\S+))?/mg;
+	// Regexp to match TW versions > v5.3.1
 	this.matchRegExp = /\{\{\{([^\|]+?)(?:\|\|([^\|\{\}]+))?\}\}\}/mg;
 };
 

--- a/plugins/tiddlywiki/codemirror/styles.tid
+++ b/plugins/tiddlywiki/codemirror/styles.tid
@@ -56,6 +56,11 @@ name: tiddlywiki
   rendering-intent: auto;
 }
 
+.tc-tiddler-frame .tc-tiddler-editor .tc-edit-texteditor,
+.tc-tiddler-frame .tc-tiddler-editor .tc-tiddler-preview-preview {
+	overflow: auto;
+}
+
 .cm-s-tiddlywiki.CodeMirror, .cm-s-tiddlywiki .CodeMirror-gutters { background-color: <<colour tiddler-editor-background>>; color: <<colour foreground>>; }
 .cm-s-tiddlywiki .CodeMirror-gutters {background: <<colour tiddler-editor-background>>; border-right: 1px solid <<colour tiddler-editor-border>>;}
 .cm-s-tiddlywiki .CodeMirror-linenumber {color: <<colour foreground>>;}


### PR DESCRIPTION
This PR fixes #7701 and #7797

It contains 4 new tests. 

- The first 2 test should check the standard filtered transclusion parser modes
- Test 3 & 4 are specific tests for the issues mentioned above

- It removes the unused code in [filteredtranscludeblock.js](https://github.com/Jermolene/TiddlyWiki5/compare/master...pmario:fix-7701-filtered-transclusion?expand=1#diff-52d36893ad904e4fc22413858d81478b764b9ed192d4c476b9c61042fa6c30fc) and [filteredtranscludeinline.js](https://github.com/Jermolene/TiddlyWiki5/compare/master...pmario:fix-7701-filtered-transclusion?expand=1#diff-d1419c3a14f675c7134df98c550c79bf45ffc582ed920285ed0f39eb57190b1c) and changes the regexps accordingly. 
- All tests pass from the CLI **and** in the browser

---

The new **block mode regexp is** `\{\{\{([^\|]+?)(?:\|\|([^\|\{\}]+))?\}\}\}(?:\r?\n|$)`  

<details><summary>Block-mode full description</summary>

```
// \{\{\{([^\|]+?)(?:\|\|([^\|\{\}]+))?\}\}\}(?:\r?\n|$)
// 
// Options: Case insensitive; Dot matches line breaks; ^$ don’t match at line breaks
// 
// Match the character “{” literally «\{»
// Match the character “{” literally «\{»
// Match the character “{” literally «\{»
// Match the regex below and capture its match into backreference number 1 «([^\|]+?)»
//    Match any character that is NOT a “|” «[^\|]+?»
//       Between one and unlimited times, as few times as possible, expanding as needed (lazy) «+?»
// Match the regular expression below «(?:\|\|([^\|\{\}]+))?»
//    Between zero and one times, as many times as possible, giving back as needed (greedy) «?»
//    Match the character “|” literally «\|»
//    Match the character “|” literally «\|»
//    Match the regex below and capture its match into backreference number 2 «([^\|\{\}]+)»
//       Match any single character NOT present in the list below «[^\|\{\}]+»
//          Between one and unlimited times, as many times as possible, giving back as needed (greedy) «+»
//          The literal character “|” «\|»
//          The literal character “{” «\{»
//          The literal character “}” «\}»
// Match the character “}” literally «\}»
// Match the character “}” literally «\}»
// Match the character “}” literally «\}»
// Match the regular expression below «(?:\r?\n|$)»
//    Match this alternative (attempting the next alternative only if this one fails) «\r?\n»
//       Match the carriage return character «\r?»
//          Between zero and one times, as many times as possible, giving back as needed (greedy) «?»
//       Match the line feed character «\n»
//    Or match this alternative (the entire group fails if this one fails to match) «$»
//       Assert position at the very end of the string «$»
```
</details> 

The new **Inline regexp is:**: ` \{\{\{([^\|]+?)(?:\|\|([^\|\{\}]+))?\}\}\}`

<details><summary>Inline-mode full description</summary>

```
// \{\{\{([^\|]+?)(?:\|\|([^\|\{\}]+))?\}\}\}
// 
// Options: Case insensitive; Dot matches line breaks; ^$ don’t match at line breaks
// 
// Match the character “{” literally «\{»
// Match the character “{” literally «\{»
// Match the character “{” literally «\{»
// Match the regex below and capture its match into backreference number 1 «([^\|]+?)»
//    Match any character that is NOT a “|” «[^\|]+?»
//       Between one and unlimited times, as few times as possible, expanding as needed (lazy) «+?»
// Match the regular expression below «(?:\|\|([^\|\{\}]+))?»
//    Between zero and one times, as many times as possible, giving back as needed (greedy) «?»
//    Match the character “|” literally «\|»
//    Match the character “|” literally «\|»
//    Match the regex below and capture its match into backreference number 2 «([^\|\{\}]+)»
//       Match any single character NOT present in the list below «[^\|\{\}]+»
//          Between one and unlimited times, as many times as possible, giving back as needed (greedy) «+»
//          The literal character “|” «\|»
//          The literal character “{” «\{»
//          The literal character “}” «\}»
// Match the character “}” literally «\}»
// Match the character “}” literally «\}»
// Match the character “}” literally «\}»
```
</details> 
