### PR TITLE
Avoid skipping extra whitespace in wikiparser.js

### DIFF
--- a/core/modules/parsers/wikiparser/wikiparser.js
+++ b/core/modules/parsers/wikiparser/wikiparser.js
@@ -194,6 +194,7 @@ Parse any pragmas at the beginning of a block of parse text
 WikiParser.prototype.parsePragmas = function() {
 	var currentTreeBranch = this.tree;
 	while(true) {
+		var savedPos = this.pos;
 		// Skip whitespace
 		this.skipWhitespace();
 		// Check for the end of the text
@@ -204,6 +205,7 @@ WikiParser.prototype.parsePragmas = function() {
 		var nextMatch = this.findNextMatch(this.pragmaRules,this.pos);
 		// If not, just exit
 		if(!nextMatch || nextMatch.matchIndex !== this.pos) {
+			this.pos = savedPos;
 			break;
 		}
 		// Process the pragma rule


### PR DESCRIPTION
When wikiparser.js parses text looking for a pragma block, it skips whitespace before looking for the next pragma. If no pragma is found, we should return the parse position to the original location so that the skipped whitespace can be parsed as a text node. This allows the attribute `join=" and "` to parse as " and " (leading and trailing whitespace intact) rather than "and " (where the leading whitespace was skipped).