### PR TITLE
fix the add field button tooltip

### DIFF
--- a/core/ui/EditTemplate/fields.tid
+++ b/core/ui/EditTemplate/fields.tid
@@ -54,7 +54,7 @@ $:/config/EditTemplateFields/Visibility/$(currentField)$
 \whitespace trim
 <$vars name={{{ [<newFieldNameTiddler>get[text]] }}}>
 <$reveal type="nomatch" text="" default=<<name>>>
-<$button tooltip=<<lingo Fields/Add/Button/Hint>>>
+<$button tooltip={{$:/language/EditTemplate/Fields/Add/Button/Hint}}>
 <$action-sendmessage $message="tm-add-field"
 $name=<<name>>
 $value={{{ [subfilter<get-field-value-tiddler-filter>get[text]] }}}/>


### PR DESCRIPTION
This PR fixes: **[BUG] The field editor ADD button shows wrong "hint" text** #7841

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/c2bca030-f29d-4bb9-aad2-0429848f2102)
