### PR TITLE
Fixes Text Parser being impacted by overrides to codeblock widget

### DIFF
--- a/core/modules/parsers/textparser.js
+++ b/core/modules/parsers/textparser.js
@@ -8,28 +8,31 @@ The plain text parser processes blocks of source text into a degenerate parse tr
 \*/
 (function(){
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
-"use strict";
-
-var TextParser = function(type,text,options) {
-	this.tree = [{
-		type: "codeblock",
-		attributes: {
-			code: {type: "string", value: text},
-			language: {type: "string", value: type}
-		}
-	}];
-	this.source = text;
-	this.type = type;
-};
-
-exports["text/plain"] = TextParser;
-exports["text/x-tiddlywiki"] = TextParser;
-exports["application/javascript"] = TextParser;
-exports["application/json"] = TextParser;
-exports["text/css"] = TextParser;
-exports["application/x-tiddler-dictionary"] = TextParser;
-
-})();
-
+	/*jslint node: true, browser: true */
+	/*global $tw: false */
+	"use strict";
+	
+	var TextParser = function(type,text,options) {
+		this.tree = [{
+			type: "genesis",
+			attributes: {
+				$type: {name: "$type", type: "string", value: "$codeblock"},
+				code: {name: "code", type: "string", value: text},
+				language: {name: "language", type: "string", value: type},
+				$remappable: {name: "$remappable", type:"string", value: "no"}
+			}
+		}];
+		this.source = text;
+		this.type = type;
+	};
+	
+	exports["text/plain"] = TextParser;
+	exports["text/x-tiddlywiki"] = TextParser;
+	exports["application/javascript"] = TextParser;
+	exports["application/json"] = TextParser;
+	exports["text/css"] = TextParser;
+	exports["application/x-tiddler-dictionary"] = TextParser;
+	
+	})();
+	
+	

--- a/core/modules/parsers/textparser.js
+++ b/core/modules/parsers/textparser.js
@@ -8,31 +8,29 @@ The plain text parser processes blocks of source text into a degenerate parse tr
 \*/
 (function(){
 
-	/*jslint node: true, browser: true */
-	/*global $tw: false */
-	"use strict";
-	
-	var TextParser = function(type,text,options) {
-		this.tree = [{
-			type: "genesis",
-			attributes: {
-				$type: {name: "$type", type: "string", value: "$codeblock"},
-				code: {name: "code", type: "string", value: text},
-				language: {name: "language", type: "string", value: type},
-				$remappable: {name: "$remappable", type:"string", value: "no"}
-			}
-		}];
-		this.source = text;
-		this.type = type;
-	};
-	
-	exports["text/plain"] = TextParser;
-	exports["text/x-tiddlywiki"] = TextParser;
-	exports["application/javascript"] = TextParser;
-	exports["application/json"] = TextParser;
-	exports["text/css"] = TextParser;
-	exports["application/x-tiddler-dictionary"] = TextParser;
-	
-	})();
-	
-	
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var TextParser = function(type,text,options) {
+	this.tree = [{
+		type: "genesis",
+		attributes: {
+			$type: {name: "$type", type: "string", value: "$codeblock"},
+			code: {name: "code", type: "string", value: text},
+			language: {name: "language", type: "string", value: type},
+			$remappable: {name: "$remappable", type:"string", value: "no"}
+		}
+	}];
+	this.source = text;
+	this.type = type;
+};
+
+exports["text/plain"] = TextParser;
+exports["text/x-tiddlywiki"] = TextParser;
+exports["application/javascript"] = TextParser;
+exports["application/json"] = TextParser;
+exports["text/css"] = TextParser;
+exports["application/x-tiddler-dictionary"] = TextParser;
+
+})();

--- a/editions/test/tiddlers/tests/data/transclude/CustomWidget-CodeblockOverride-TextParser.tid
+++ b/editions/test/tiddlers/tests/data/transclude/CustomWidget-CodeblockOverride-TextParser.tid
@@ -1,0 +1,20 @@
+title: Transclude/CustomWidget/CodeblockOverride-TextParser
+description: Test that overriding codeblock widget does not impact text parser
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+\widget $codeblock(code)
+<$transclude $variable="copy-to-clipboard" src=<<code>>/>
+<$genesis $type="$codeblock" $remappable="no" code=<<code>>/>
+\end
+
+\procedure myvariable() hello
+
+<$transclude $variable="myvariable" $type="text/plain" $output="text/plain"/>
++
+title: ExpectedResult
+
+<p>hello</p>


### PR DESCRIPTION
This PR fixes an issue [reported in the forum](https://talk.tiddlywiki.org/t/how-highlight-js-works-on-codeblock/8083/10?u=saqimtiaz) where overriding the codeblock widget with a custom widget impacts transclusions and any other uses of the Text Parser.

The problem is caused by the transclude widget (and thus also by the macrocall widget which is used in the tabs macro) when used with the output type text/plain. The parser that wikifies the variable to retrieve the plain text output [wraps the variable in a codeblock](https://github.com/Jermolene/TiddlyWiki5/blob/master/core/modules/parsers/textparser.js#L15-L25)

This PR replaces the codeblock widget used in the Text Parser with a genesis widget with the remappable attribute set to "no", to create the codeblock widget, thus rendering it immune to custom widget overrides. A test has been added that fails before the PR is applied.