### PR TITLE
Fixes refresh issues for checkbox and links widgets for data attributes

### DIFF
--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -8,338 +8,338 @@ Checkbox widget
 \*/
 (function(){
 
-	/*jslint node: true, browser: true */
-	/*global $tw: false */
-	"use strict";
-	
-	var Widget = require("$:/core/modules/widgets/widget.js").widget;
-	
-	var CheckboxWidget = function(parseTreeNode,options) {
-		this.initialise(parseTreeNode,options);
-	};
-	
-	/*
-	Inherit from the base widget class
-	*/
-	CheckboxWidget.prototype = new Widget();
-	
-	/*
-	Render this widget into the DOM
-	*/
-	CheckboxWidget.prototype.render = function(parent,nextSibling) {
-		var isChecked;
-		// Save the parent dom node
-		this.parentDomNode = parent;
-		// Compute our attributes
-		this.computeAttributes();
-		// Execute our logic
-		this.execute();
-		// Create our elements
-		this.labelDomNode = this.document.createElement("label");
-		this.labelDomNode.setAttribute("class","tc-checkbox " + this.checkboxClass);
-		this.inputDomNode = this.document.createElement("input");
-		this.inputDomNode.setAttribute("type","checkbox");
-		isChecked = this.getValue();
-		if(isChecked) {
-			this.inputDomNode.setAttribute("checked","true");
-			$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
-		}
-		if(isChecked === undefined && this.checkboxIndeterminate === "yes") {
-			this.inputDomNode.indeterminate = true;
-		}
-		if(this.isDisabled === "yes") {
-			this.inputDomNode.setAttribute("disabled",true);
-		}
-		this.labelDomNode.appendChild(this.inputDomNode);
-		this.spanDomNode = this.document.createElement("span");
-		this.labelDomNode.appendChild(this.spanDomNode);
-		// Assign data- attributes
-		this.assignAttributes(this.inputDomNode,{
-			sourcePrefix: "data-",
-			destPrefix: "data-"
-		});
-		// Add a click event handler
-		$tw.utils.addEventListeners(this.inputDomNode,[
-			{name: "change", handlerObject: this, handlerMethod: "handleChangeEvent"}
-		]);
-		// Insert the label into the DOM and render any children
-		parent.insertBefore(this.labelDomNode,nextSibling);
-		this.renderChildren(this.spanDomNode,null);
-		this.domNodes.push(this.labelDomNode);
-	};
-	
-	CheckboxWidget.prototype.getValue = function() {
-		var tiddler = this.wiki.getTiddler(this.checkboxTitle);
-		if(tiddler || this.checkboxFilter) {
-			if(tiddler && this.checkboxTag) {
-				if(this.checkboxInvertTag === "yes") {
-					return !tiddler.hasTag(this.checkboxTag);
-				} else {
-					return tiddler.hasTag(this.checkboxTag);
-				}
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var CheckboxWidget = function(parseTreeNode,options) {
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+CheckboxWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+CheckboxWidget.prototype.render = function(parent,nextSibling) {
+	var isChecked;
+	// Save the parent dom node
+	this.parentDomNode = parent;
+	// Compute our attributes
+	this.computeAttributes();
+	// Execute our logic
+	this.execute();
+	// Create our elements
+	this.labelDomNode = this.document.createElement("label");
+	this.labelDomNode.setAttribute("class","tc-checkbox " + this.checkboxClass);
+	this.inputDomNode = this.document.createElement("input");
+	this.inputDomNode.setAttribute("type","checkbox");
+	isChecked = this.getValue();
+	if(isChecked) {
+		this.inputDomNode.setAttribute("checked","true");
+		$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
+	}
+	if(isChecked === undefined && this.checkboxIndeterminate === "yes") {
+		this.inputDomNode.indeterminate = true;
+	}
+	if(this.isDisabled === "yes") {
+		this.inputDomNode.setAttribute("disabled",true);
+	}
+	this.labelDomNode.appendChild(this.inputDomNode);
+	this.spanDomNode = this.document.createElement("span");
+	this.labelDomNode.appendChild(this.spanDomNode);
+	// Assign data- attributes
+	this.assignAttributes(this.inputDomNode,{
+		sourcePrefix: "data-",
+		destPrefix: "data-"
+	});
+	// Add a click event handler
+	$tw.utils.addEventListeners(this.inputDomNode,[
+		{name: "change", handlerObject: this, handlerMethod: "handleChangeEvent"}
+	]);
+	// Insert the label into the DOM and render any children
+	parent.insertBefore(this.labelDomNode,nextSibling);
+	this.renderChildren(this.spanDomNode,null);
+	this.domNodes.push(this.labelDomNode);
+};
+
+CheckboxWidget.prototype.getValue = function() {
+	var tiddler = this.wiki.getTiddler(this.checkboxTitle);
+	if(tiddler || this.checkboxFilter) {
+		if(tiddler && this.checkboxTag) {
+			if(this.checkboxInvertTag === "yes") {
+				return !tiddler.hasTag(this.checkboxTag);
+			} else {
+				return tiddler.hasTag(this.checkboxTag);
 			}
-			if(tiddler && (this.checkboxField || this.checkboxIndex)) {
-				// Same logic applies to fields and indexes
-				var value;
-				if(this.checkboxField) {
-					if($tw.utils.hop(tiddler.fields,this.checkboxField)) {
-						value = tiddler.fields[this.checkboxField] || "";
-					} else {
-						value = this.checkboxDefault || "";
-					}
+		}
+		if(tiddler && (this.checkboxField || this.checkboxIndex)) {
+			// Same logic applies to fields and indexes
+			var value;
+			if(this.checkboxField) {
+				if($tw.utils.hop(tiddler.fields,this.checkboxField)) {
+					value = tiddler.fields[this.checkboxField] || "";
 				} else {
-					value = this.wiki.extractTiddlerDataItem(tiddler,this.checkboxIndex,this.checkboxDefault || "");
+					value = this.checkboxDefault || "";
 				}
-				if(value === this.checkboxChecked) {
-					return true;
-				}
-				if(value === this.checkboxUnchecked) {
-					return false;
-				}
-				// Neither value found: were both specified?
-				if(this.checkboxChecked && !this.checkboxUnchecked) {
-					return false; // Absence of checked value
-				}
-				if(this.checkboxUnchecked && !this.checkboxChecked) {
-					return true; // Absence of unchecked value
-				}
-				if(this.checkboxChecked && this.checkboxUnchecked) {
-					// Both specified but neither found: indeterminate or false, depending
-					if(this.checkboxIndeterminate === "yes") {
-						return undefined;
-					} else {
-						return false;
-					}
-				}
+			} else {
+				value = this.wiki.extractTiddlerDataItem(tiddler,this.checkboxIndex,this.checkboxDefault || "");
 			}
-			if(this.checkboxListField || this.checkboxListIndex || this.checkboxFilter) {
-				// Same logic applies to lists and filters
-				var list;
-				if(this.checkboxListField) {
-					if($tw.utils.hop(tiddler.fields,this.checkboxListField)) {
-						list = tiddler.getFieldList(this.checkboxListField) || [];
-					} else {
-						list = $tw.utils.parseStringArray(this.checkboxDefault || "") || [];
-					}
-				} else if(this.checkboxListIndex) {
-					list = $tw.utils.parseStringArray(this.wiki.extractTiddlerDataItem(tiddler,this.checkboxListIndex,this.checkboxDefault || "")) || [];
-				} else {
-					list = this.wiki.filterTiddlers(this.checkboxFilter,this) || [];
-				}
-				if(list.indexOf(this.checkboxChecked) !== -1) {
-					return true;
-				}
-				if(list.indexOf(this.checkboxUnchecked) !== -1) {
-					return false;
-				}
-				// Neither one present
-				if(this.checkboxChecked && !this.checkboxUnchecked) {
-					return false; // Absence of checked value
-				}
-				if(this.checkboxUnchecked && !this.checkboxChecked) {
-					return true; // Absence of unchecked value
-				}
-				if(this.checkboxChecked && this.checkboxUnchecked) {
-					// Both specified but neither found: indeterminate or false, depending
-					if(this.checkboxIndeterminate === "yes") {
-						return undefined;
-					} else {
-						return false;
-					}
-				}
-				// Neither specified, so empty list is false, non-empty is true
-				return !!list.length;
+			if(value === this.checkboxChecked) {
+				return true;
 			}
-		} else {
-			if(this.checkboxTag) {
+			if(value === this.checkboxUnchecked) {
 				return false;
 			}
-			if(this.checkboxField) {
-				if(this.checkboxDefault === this.checkboxChecked) {
-					return true;
-				}
-				if(this.checkboxDefault === this.checkboxUnchecked) {
+			// Neither value found: were both specified?
+			if(this.checkboxChecked && !this.checkboxUnchecked) {
+				return false; // Absence of checked value
+			}
+			if(this.checkboxUnchecked && !this.checkboxChecked) {
+				return true; // Absence of unchecked value
+			}
+			if(this.checkboxChecked && this.checkboxUnchecked) {
+				// Both specified but neither found: indeterminate or false, depending
+				if(this.checkboxIndeterminate === "yes") {
+					return undefined;
+				} else {
 					return false;
 				}
 			}
 		}
-		return false;
-	};
-	
-	CheckboxWidget.prototype.handleChangeEvent = function(event) {
-		var checked = this.inputDomNode.checked,
-			tiddler = this.wiki.getTiddler(this.checkboxTitle),
-			fallbackFields = {text: ""},
-			newFields = {title: this.checkboxTitle},
-			hasChanged = false,
-			tagCheck = false,
-			hasTag = tiddler && tiddler.hasTag(this.checkboxTag),
-			value = checked ? this.checkboxChecked : this.checkboxUnchecked,
-			notValue = checked ? this.checkboxUnchecked : this.checkboxChecked;
-		if(this.checkboxTag && this.checkboxInvertTag === "yes") {
-			tagCheck = hasTag === checked;
-		} else {
-			tagCheck = hasTag !== checked;
+		if(this.checkboxListField || this.checkboxListIndex || this.checkboxFilter) {
+			// Same logic applies to lists and filters
+			var list;
+			if(this.checkboxListField) {
+				if($tw.utils.hop(tiddler.fields,this.checkboxListField)) {
+					list = tiddler.getFieldList(this.checkboxListField) || [];
+				} else {
+					list = $tw.utils.parseStringArray(this.checkboxDefault || "") || [];
+				}
+			} else if(this.checkboxListIndex) {
+				list = $tw.utils.parseStringArray(this.wiki.extractTiddlerDataItem(tiddler,this.checkboxListIndex,this.checkboxDefault || "")) || [];
+			} else {
+				list = this.wiki.filterTiddlers(this.checkboxFilter,this) || [];
+			}
+			if(list.indexOf(this.checkboxChecked) !== -1) {
+				return true;
+			}
+			if(list.indexOf(this.checkboxUnchecked) !== -1) {
+				return false;
+			}
+			// Neither one present
+			if(this.checkboxChecked && !this.checkboxUnchecked) {
+				return false; // Absence of checked value
+			}
+			if(this.checkboxUnchecked && !this.checkboxChecked) {
+				return true; // Absence of unchecked value
+			}
+			if(this.checkboxChecked && this.checkboxUnchecked) {
+				// Both specified but neither found: indeterminate or false, depending
+				if(this.checkboxIndeterminate === "yes") {
+					return undefined;
+				} else {
+					return false;
+				}
+			}
+			// Neither specified, so empty list is false, non-empty is true
+			return !!list.length;
 		}
-		// Set the tag if specified
-		if(this.checkboxTag && (!tiddler || tagCheck)) {
-			newFields.tags = tiddler ? (tiddler.fields.tags || []).slice(0) : [];
-			var pos = newFields.tags.indexOf(this.checkboxTag);
-			if(pos !== -1) {
-				newFields.tags.splice(pos,1);
+	} else {
+		if(this.checkboxTag) {
+			return false;
+		}
+		if(this.checkboxField) {
+			if(this.checkboxDefault === this.checkboxChecked) {
+				return true;
 			}
-			if(this.checkboxInvertTag === "yes" && !checked) {
-				newFields.tags.push(this.checkboxTag);
-			} else if(this.checkboxInvertTag !== "yes" && checked) {
-				newFields.tags.push(this.checkboxTag);
+			if(this.checkboxDefault === this.checkboxUnchecked) {
+				return false;
 			}
+		}
+	}
+	return false;
+};
+
+CheckboxWidget.prototype.handleChangeEvent = function(event) {
+	var checked = this.inputDomNode.checked,
+		tiddler = this.wiki.getTiddler(this.checkboxTitle),
+		fallbackFields = {text: ""},
+		newFields = {title: this.checkboxTitle},
+		hasChanged = false,
+		tagCheck = false,
+		hasTag = tiddler && tiddler.hasTag(this.checkboxTag),
+		value = checked ? this.checkboxChecked : this.checkboxUnchecked,
+		notValue = checked ? this.checkboxUnchecked : this.checkboxChecked;
+	if(this.checkboxTag && this.checkboxInvertTag === "yes") {
+		tagCheck = hasTag === checked;
+	} else {
+		tagCheck = hasTag !== checked;
+	}
+	// Set the tag if specified
+	if(this.checkboxTag && (!tiddler || tagCheck)) {
+		newFields.tags = tiddler ? (tiddler.fields.tags || []).slice(0) : [];
+		var pos = newFields.tags.indexOf(this.checkboxTag);
+		if(pos !== -1) {
+			newFields.tags.splice(pos,1);
+		}
+		if(this.checkboxInvertTag === "yes" && !checked) {
+			newFields.tags.push(this.checkboxTag);
+		} else if(this.checkboxInvertTag !== "yes" && checked) {
+			newFields.tags.push(this.checkboxTag);
+		}
+		hasChanged = true;
+	}
+	// Set the field if specified
+	if(this.checkboxField) {
+		if(!tiddler || tiddler.fields[this.checkboxField] !== value) {
+			newFields[this.checkboxField] = value;
 			hasChanged = true;
 		}
-		// Set the field if specified
-		if(this.checkboxField) {
-			if(!tiddler || tiddler.fields[this.checkboxField] !== value) {
-				newFields[this.checkboxField] = value;
-				hasChanged = true;
-			}
+	}
+	// Set the index if specified
+	if(this.checkboxIndex) {
+		var indexValue = this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxIndex);
+		if(!tiddler || indexValue !== value) {
+			hasChanged = true;
 		}
-		// Set the index if specified
-		if(this.checkboxIndex) {
-			var indexValue = this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxIndex);
-			if(!tiddler || indexValue !== value) {
-				hasChanged = true;
-			}
+	}
+	// Set the list field (or index) if specified
+	if(this.checkboxListField || this.checkboxListIndex) {
+		var fieldContents, listContents, oldPos, newPos;
+		if(this.checkboxListField) {
+			fieldContents = (tiddler ? tiddler.fields[this.checkboxListField] : undefined) || [];
+		} else {
+			fieldContents = this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxListIndex);
 		}
-		// Set the list field (or index) if specified
-		if(this.checkboxListField || this.checkboxListIndex) {
-			var fieldContents, listContents, oldPos, newPos;
-			if(this.checkboxListField) {
-				fieldContents = (tiddler ? tiddler.fields[this.checkboxListField] : undefined) || [];
+		if($tw.utils.isArray(fieldContents)) {
+			// Make a copy so we can modify it without changing original that's refrenced elsewhere
+			listContents = fieldContents.slice(0);
+		} else if(fieldContents === undefined) {
+			listContents = [];
+		} else if(typeof fieldContents === "string") {
+			listContents = $tw.utils.parseStringArray(fieldContents);
+			// No need to copy since parseStringArray returns a fresh array, not refrenced elsewhere
+		} else {
+			// Field was neither an array nor a string; it's probably something that shouldn't become
+			// an array (such as a date field), so bail out *without* triggering actions
+			return;
+		}
+		oldPos = notValue ? listContents.indexOf(notValue) : -1;
+		newPos = value ? listContents.indexOf(value) : -1;
+		if(oldPos === -1 && newPos !== -1) {
+			// old value absent, new value present: no change needed
+		} else if(oldPos === -1) {
+			// neither one was present
+			if(value) {
+				listContents.push(value);
+				hasChanged = true;
 			} else {
-				fieldContents = this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxListIndex);
+				// value unspecified? then leave list unchanged
 			}
-			if($tw.utils.isArray(fieldContents)) {
-				// Make a copy so we can modify it without changing original that's refrenced elsewhere
-				listContents = fieldContents.slice(0);
-			} else if(fieldContents === undefined) {
-				listContents = [];
-			} else if(typeof fieldContents === "string") {
-				listContents = $tw.utils.parseStringArray(fieldContents);
-				// No need to copy since parseStringArray returns a fresh array, not refrenced elsewhere
+		} else if(newPos === -1) {
+			// old value present, new value absent
+			if(value) {
+				listContents[oldPos] = value;
+				hasChanged = true;
 			} else {
-				// Field was neither an array nor a string; it's probably something that shouldn't become
-				// an array (such as a date field), so bail out *without* triggering actions
-				return;
-			}
-			oldPos = notValue ? listContents.indexOf(notValue) : -1;
-			newPos = value ? listContents.indexOf(value) : -1;
-			if(oldPos === -1 && newPos !== -1) {
-				// old value absent, new value present: no change needed
-			} else if(oldPos === -1) {
-				// neither one was present
-				if(value) {
-					listContents.push(value);
-					hasChanged = true;
-				} else {
-					// value unspecified? then leave list unchanged
-				}
-			} else if(newPos === -1) {
-				// old value present, new value absent
-				if(value) {
-					listContents[oldPos] = value;
-					hasChanged = true;
-				} else {
-					listContents.splice(oldPos, 1)
-					hasChanged = true;
-				}
-			} else {
-				// both were present: just remove the old one, leave new alone
 				listContents.splice(oldPos, 1)
 				hasChanged = true;
 			}
-			if(this.checkboxListField) {
-				newFields[this.checkboxListField] = $tw.utils.stringifyList(listContents);
-			}
-			// The listIndex case will be handled in the if(hasChanged) block below
-		}
-		if(hasChanged) {
-			if(this.checkboxIndex) {
-				this.wiki.setText(this.checkboxTitle,"",this.checkboxIndex,value);
-			} else if(this.checkboxListIndex) {
-				var listIndexValue = (listContents && listContents.length) ? $tw.utils.stringifyList(listContents) : undefined;
-				this.wiki.setText(this.checkboxTitle,"",this.checkboxListIndex,listIndexValue);
-			} else {
-				this.wiki.addTiddler(new $tw.Tiddler(this.wiki.getCreationFields(),fallbackFields,tiddler,newFields,this.wiki.getModificationFields()));
-			}
-		}
-		// Trigger actions
-		if(this.checkboxActions) {
-			this.invokeActionString(this.checkboxActions,this,event);
-		}
-		if(this.checkboxCheckActions && checked) {
-			this.invokeActionString(this.checkboxCheckActions,this,event);
-		}
-		if(this.checkboxUncheckActions && !checked) {
-			this.invokeActionString(this.checkboxUncheckActions,this,event);
-		}
-	};
-	
-	/*
-	Compute the internal state of the widget
-	*/
-	CheckboxWidget.prototype.execute = function() {
-		// Get the parameters from the attributes
-		this.checkboxActions = this.getAttribute("actions");
-		this.checkboxCheckActions = this.getAttribute("checkactions");
-		this.checkboxUncheckActions = this.getAttribute("uncheckactions");
-		this.checkboxTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
-		this.checkboxTag = this.getAttribute("tag");
-		this.checkboxField = this.getAttribute("field");
-		this.checkboxIndex = this.getAttribute("index");
-		this.checkboxListField = this.getAttribute("listField");
-		this.checkboxListIndex = this.getAttribute("listIndex");
-		this.checkboxFilter = this.getAttribute("filter");
-		this.checkboxChecked = this.getAttribute("checked");
-		this.checkboxUnchecked = this.getAttribute("unchecked");
-		this.checkboxDefault = this.getAttribute("default");
-		this.checkboxIndeterminate = this.getAttribute("indeterminate","no");
-		this.checkboxClass = this.getAttribute("class","");
-		this.checkboxInvertTag = this.getAttribute("invertTag","");
-		this.isDisabled = this.getAttribute("disabled","no");
-		// Make the child widgets
-		this.makeChildWidgets();
-	};
-	
-	/*
-	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-	*/
-	CheckboxWidget.prototype.refresh = function(changedTiddlers) {
-		var changedAttributes = this.computeAttributes();
-		if(changedAttributes.tiddler || changedAttributes.tag || changedAttributes.invertTag || changedAttributes.field || changedAttributes.index || changedAttributes.listField || changedAttributes.listIndex || changedAttributes.filter || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes.indeterminate || changedAttributes["class"] || changedAttributes.disabled) {
-			this.refreshSelf();
-			return true;
 		} else {
-			var refreshed = false;
-			if(changedTiddlers[this.checkboxTitle]) {
-				var isChecked = this.getValue();
-				this.inputDomNode.checked = !!isChecked;
-				this.inputDomNode.indeterminate = (isChecked === undefined);
-				refreshed = true;
-				if(isChecked) {
-					$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
-				} else {
-					$tw.utils.removeClass(this.labelDomNode,"tc-checkbox-checked");
-				}
-			}
-			this.assignAttributes(this.inputDomNode,{
-				changedAttributes: changedAttributes,
-				sourcePrefix: "data-",
-				destPrefix: "data-"
-			});
-			return this.refreshChildren(changedTiddlers) || refreshed;
+			// both were present: just remove the old one, leave new alone
+			listContents.splice(oldPos, 1)
+			hasChanged = true;
 		}
-	};
-	
-	exports.checkbox = CheckboxWidget;
-	
-	})();
+		if(this.checkboxListField) {
+			newFields[this.checkboxListField] = $tw.utils.stringifyList(listContents);
+		}
+		// The listIndex case will be handled in the if(hasChanged) block below
+	}
+	if(hasChanged) {
+		if(this.checkboxIndex) {
+			this.wiki.setText(this.checkboxTitle,"",this.checkboxIndex,value);
+		} else if(this.checkboxListIndex) {
+			var listIndexValue = (listContents && listContents.length) ? $tw.utils.stringifyList(listContents) : undefined;
+			this.wiki.setText(this.checkboxTitle,"",this.checkboxListIndex,listIndexValue);
+		} else {
+			this.wiki.addTiddler(new $tw.Tiddler(this.wiki.getCreationFields(),fallbackFields,tiddler,newFields,this.wiki.getModificationFields()));
+		}
+	}
+	// Trigger actions
+	if(this.checkboxActions) {
+		this.invokeActionString(this.checkboxActions,this,event);
+	}
+	if(this.checkboxCheckActions && checked) {
+		this.invokeActionString(this.checkboxCheckActions,this,event);
+	}
+	if(this.checkboxUncheckActions && !checked) {
+		this.invokeActionString(this.checkboxUncheckActions,this,event);
+	}
+};
+
+/*
+Compute the internal state of the widget
+*/
+CheckboxWidget.prototype.execute = function() {
+	// Get the parameters from the attributes
+	this.checkboxActions = this.getAttribute("actions");
+	this.checkboxCheckActions = this.getAttribute("checkactions");
+	this.checkboxUncheckActions = this.getAttribute("uncheckactions");
+	this.checkboxTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
+	this.checkboxTag = this.getAttribute("tag");
+	this.checkboxField = this.getAttribute("field");
+	this.checkboxIndex = this.getAttribute("index");
+	this.checkboxListField = this.getAttribute("listField");
+	this.checkboxListIndex = this.getAttribute("listIndex");
+	this.checkboxFilter = this.getAttribute("filter");
+	this.checkboxChecked = this.getAttribute("checked");
+	this.checkboxUnchecked = this.getAttribute("unchecked");
+	this.checkboxDefault = this.getAttribute("default");
+	this.checkboxIndeterminate = this.getAttribute("indeterminate","no");
+	this.checkboxClass = this.getAttribute("class","");
+	this.checkboxInvertTag = this.getAttribute("invertTag","");
+	this.isDisabled = this.getAttribute("disabled","no");
+	// Make the child widgets
+	this.makeChildWidgets();
+};
+
+/*
+Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+*/
+CheckboxWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if(changedAttributes.tiddler || changedAttributes.tag || changedAttributes.invertTag || changedAttributes.field || changedAttributes.index || changedAttributes.listField || changedAttributes.listIndex || changedAttributes.filter || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes.indeterminate || changedAttributes["class"] || changedAttributes.disabled) {
+		this.refreshSelf();
+		return true;
+	} else {
+		var refreshed = false;
+		if(changedTiddlers[this.checkboxTitle]) {
+			var isChecked = this.getValue();
+			this.inputDomNode.checked = !!isChecked;
+			this.inputDomNode.indeterminate = (isChecked === undefined);
+			refreshed = true;
+			if(isChecked) {
+				$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
+			} else {
+				$tw.utils.removeClass(this.labelDomNode,"tc-checkbox-checked");
+			}
+		}
+		this.assignAttributes(this.inputDomNode,{
+			changedAttributes: changedAttributes,
+			sourcePrefix: "data-",
+			destPrefix: "data-"
+		});
+		return this.refreshChildren(changedTiddlers) || refreshed;
+	}
+};
+
+exports.checkbox = CheckboxWidget;
+
+})();
 	

--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -8,332 +8,338 @@ Checkbox widget
 \*/
 (function(){
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
-"use strict";
-
-var Widget = require("$:/core/modules/widgets/widget.js").widget;
-
-var CheckboxWidget = function(parseTreeNode,options) {
-	this.initialise(parseTreeNode,options);
-};
-
-/*
-Inherit from the base widget class
-*/
-CheckboxWidget.prototype = new Widget();
-
-/*
-Render this widget into the DOM
-*/
-CheckboxWidget.prototype.render = function(parent,nextSibling) {
-	var isChecked;
-	// Save the parent dom node
-	this.parentDomNode = parent;
-	// Compute our attributes
-	this.computeAttributes();
-	// Execute our logic
-	this.execute();
-	// Create our elements
-	this.labelDomNode = this.document.createElement("label");
-	this.labelDomNode.setAttribute("class","tc-checkbox " + this.checkboxClass);
-	this.inputDomNode = this.document.createElement("input");
-	this.inputDomNode.setAttribute("type","checkbox");
-	isChecked = this.getValue();
-	if(isChecked) {
-		this.inputDomNode.setAttribute("checked","true");
-		$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
-	}
-	if(isChecked === undefined && this.checkboxIndeterminate === "yes") {
-		this.inputDomNode.indeterminate = true;
-	}
-	if(this.isDisabled === "yes") {
-		this.inputDomNode.setAttribute("disabled",true);
-	}
-	this.labelDomNode.appendChild(this.inputDomNode);
-	this.spanDomNode = this.document.createElement("span");
-	this.labelDomNode.appendChild(this.spanDomNode);
-	// Assign data- attributes
-	this.assignAttributes(this.inputDomNode,{
-		sourcePrefix: "data-",
-		destPrefix: "data-"
-	});
-	// Add a click event handler
-	$tw.utils.addEventListeners(this.inputDomNode,[
-		{name: "change", handlerObject: this, handlerMethod: "handleChangeEvent"}
-	]);
-	// Insert the label into the DOM and render any children
-	parent.insertBefore(this.labelDomNode,nextSibling);
-	this.renderChildren(this.spanDomNode,null);
-	this.domNodes.push(this.labelDomNode);
-};
-
-CheckboxWidget.prototype.getValue = function() {
-	var tiddler = this.wiki.getTiddler(this.checkboxTitle);
-	if(tiddler || this.checkboxFilter) {
-		if(tiddler && this.checkboxTag) {
-			if(this.checkboxInvertTag === "yes") {
-				return !tiddler.hasTag(this.checkboxTag);
-			} else {
-				return tiddler.hasTag(this.checkboxTag);
-			}
+	/*jslint node: true, browser: true */
+	/*global $tw: false */
+	"use strict";
+	
+	var Widget = require("$:/core/modules/widgets/widget.js").widget;
+	
+	var CheckboxWidget = function(parseTreeNode,options) {
+		this.initialise(parseTreeNode,options);
+	};
+	
+	/*
+	Inherit from the base widget class
+	*/
+	CheckboxWidget.prototype = new Widget();
+	
+	/*
+	Render this widget into the DOM
+	*/
+	CheckboxWidget.prototype.render = function(parent,nextSibling) {
+		var isChecked;
+		// Save the parent dom node
+		this.parentDomNode = parent;
+		// Compute our attributes
+		this.computeAttributes();
+		// Execute our logic
+		this.execute();
+		// Create our elements
+		this.labelDomNode = this.document.createElement("label");
+		this.labelDomNode.setAttribute("class","tc-checkbox " + this.checkboxClass);
+		this.inputDomNode = this.document.createElement("input");
+		this.inputDomNode.setAttribute("type","checkbox");
+		isChecked = this.getValue();
+		if(isChecked) {
+			this.inputDomNode.setAttribute("checked","true");
+			$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
 		}
-		if(tiddler && (this.checkboxField || this.checkboxIndex)) {
-			// Same logic applies to fields and indexes
-			var value;
+		if(isChecked === undefined && this.checkboxIndeterminate === "yes") {
+			this.inputDomNode.indeterminate = true;
+		}
+		if(this.isDisabled === "yes") {
+			this.inputDomNode.setAttribute("disabled",true);
+		}
+		this.labelDomNode.appendChild(this.inputDomNode);
+		this.spanDomNode = this.document.createElement("span");
+		this.labelDomNode.appendChild(this.spanDomNode);
+		// Assign data- attributes
+		this.assignAttributes(this.inputDomNode,{
+			sourcePrefix: "data-",
+			destPrefix: "data-"
+		});
+		// Add a click event handler
+		$tw.utils.addEventListeners(this.inputDomNode,[
+			{name: "change", handlerObject: this, handlerMethod: "handleChangeEvent"}
+		]);
+		// Insert the label into the DOM and render any children
+		parent.insertBefore(this.labelDomNode,nextSibling);
+		this.renderChildren(this.spanDomNode,null);
+		this.domNodes.push(this.labelDomNode);
+	};
+	
+	CheckboxWidget.prototype.getValue = function() {
+		var tiddler = this.wiki.getTiddler(this.checkboxTitle);
+		if(tiddler || this.checkboxFilter) {
+			if(tiddler && this.checkboxTag) {
+				if(this.checkboxInvertTag === "yes") {
+					return !tiddler.hasTag(this.checkboxTag);
+				} else {
+					return tiddler.hasTag(this.checkboxTag);
+				}
+			}
+			if(tiddler && (this.checkboxField || this.checkboxIndex)) {
+				// Same logic applies to fields and indexes
+				var value;
+				if(this.checkboxField) {
+					if($tw.utils.hop(tiddler.fields,this.checkboxField)) {
+						value = tiddler.fields[this.checkboxField] || "";
+					} else {
+						value = this.checkboxDefault || "";
+					}
+				} else {
+					value = this.wiki.extractTiddlerDataItem(tiddler,this.checkboxIndex,this.checkboxDefault || "");
+				}
+				if(value === this.checkboxChecked) {
+					return true;
+				}
+				if(value === this.checkboxUnchecked) {
+					return false;
+				}
+				// Neither value found: were both specified?
+				if(this.checkboxChecked && !this.checkboxUnchecked) {
+					return false; // Absence of checked value
+				}
+				if(this.checkboxUnchecked && !this.checkboxChecked) {
+					return true; // Absence of unchecked value
+				}
+				if(this.checkboxChecked && this.checkboxUnchecked) {
+					// Both specified but neither found: indeterminate or false, depending
+					if(this.checkboxIndeterminate === "yes") {
+						return undefined;
+					} else {
+						return false;
+					}
+				}
+			}
+			if(this.checkboxListField || this.checkboxListIndex || this.checkboxFilter) {
+				// Same logic applies to lists and filters
+				var list;
+				if(this.checkboxListField) {
+					if($tw.utils.hop(tiddler.fields,this.checkboxListField)) {
+						list = tiddler.getFieldList(this.checkboxListField) || [];
+					} else {
+						list = $tw.utils.parseStringArray(this.checkboxDefault || "") || [];
+					}
+				} else if(this.checkboxListIndex) {
+					list = $tw.utils.parseStringArray(this.wiki.extractTiddlerDataItem(tiddler,this.checkboxListIndex,this.checkboxDefault || "")) || [];
+				} else {
+					list = this.wiki.filterTiddlers(this.checkboxFilter,this) || [];
+				}
+				if(list.indexOf(this.checkboxChecked) !== -1) {
+					return true;
+				}
+				if(list.indexOf(this.checkboxUnchecked) !== -1) {
+					return false;
+				}
+				// Neither one present
+				if(this.checkboxChecked && !this.checkboxUnchecked) {
+					return false; // Absence of checked value
+				}
+				if(this.checkboxUnchecked && !this.checkboxChecked) {
+					return true; // Absence of unchecked value
+				}
+				if(this.checkboxChecked && this.checkboxUnchecked) {
+					// Both specified but neither found: indeterminate or false, depending
+					if(this.checkboxIndeterminate === "yes") {
+						return undefined;
+					} else {
+						return false;
+					}
+				}
+				// Neither specified, so empty list is false, non-empty is true
+				return !!list.length;
+			}
+		} else {
+			if(this.checkboxTag) {
+				return false;
+			}
 			if(this.checkboxField) {
-				if($tw.utils.hop(tiddler.fields,this.checkboxField)) {
-					value = tiddler.fields[this.checkboxField] || "";
-				} else {
-					value = this.checkboxDefault || "";
+				if(this.checkboxDefault === this.checkboxChecked) {
+					return true;
 				}
-			} else {
-				value = this.wiki.extractTiddlerDataItem(tiddler,this.checkboxIndex,this.checkboxDefault || "");
-			}
-			if(value === this.checkboxChecked) {
-				return true;
-			}
-			if(value === this.checkboxUnchecked) {
-				return false;
-			}
-			// Neither value found: were both specified?
-			if(this.checkboxChecked && !this.checkboxUnchecked) {
-				return false; // Absence of checked value
-			}
-			if(this.checkboxUnchecked && !this.checkboxChecked) {
-				return true; // Absence of unchecked value
-			}
-			if(this.checkboxChecked && this.checkboxUnchecked) {
-				// Both specified but neither found: indeterminate or false, depending
-				if(this.checkboxIndeterminate === "yes") {
-					return undefined;
-				} else {
+				if(this.checkboxDefault === this.checkboxUnchecked) {
 					return false;
 				}
 			}
 		}
-		if(this.checkboxListField || this.checkboxListIndex || this.checkboxFilter) {
-			// Same logic applies to lists and filters
-			var list;
-			if(this.checkboxListField) {
-				if($tw.utils.hop(tiddler.fields,this.checkboxListField)) {
-					list = tiddler.getFieldList(this.checkboxListField) || [];
-				} else {
-					list = $tw.utils.parseStringArray(this.checkboxDefault || "") || [];
-				}
-			} else if(this.checkboxListIndex) {
-				list = $tw.utils.parseStringArray(this.wiki.extractTiddlerDataItem(tiddler,this.checkboxListIndex,this.checkboxDefault || "")) || [];
-			} else {
-				list = this.wiki.filterTiddlers(this.checkboxFilter,this) || [];
-			}
-			if(list.indexOf(this.checkboxChecked) !== -1) {
-				return true;
-			}
-			if(list.indexOf(this.checkboxUnchecked) !== -1) {
-				return false;
-			}
-			// Neither one present
-			if(this.checkboxChecked && !this.checkboxUnchecked) {
-				return false; // Absence of checked value
-			}
-			if(this.checkboxUnchecked && !this.checkboxChecked) {
-				return true; // Absence of unchecked value
-			}
-			if(this.checkboxChecked && this.checkboxUnchecked) {
-				// Both specified but neither found: indeterminate or false, depending
-				if(this.checkboxIndeterminate === "yes") {
-					return undefined;
-				} else {
-					return false;
-				}
-			}
-			// Neither specified, so empty list is false, non-empty is true
-			return !!list.length;
+		return false;
+	};
+	
+	CheckboxWidget.prototype.handleChangeEvent = function(event) {
+		var checked = this.inputDomNode.checked,
+			tiddler = this.wiki.getTiddler(this.checkboxTitle),
+			fallbackFields = {text: ""},
+			newFields = {title: this.checkboxTitle},
+			hasChanged = false,
+			tagCheck = false,
+			hasTag = tiddler && tiddler.hasTag(this.checkboxTag),
+			value = checked ? this.checkboxChecked : this.checkboxUnchecked,
+			notValue = checked ? this.checkboxUnchecked : this.checkboxChecked;
+		if(this.checkboxTag && this.checkboxInvertTag === "yes") {
+			tagCheck = hasTag === checked;
+		} else {
+			tagCheck = hasTag !== checked;
 		}
-	} else {
-		if(this.checkboxTag) {
-			return false;
+		// Set the tag if specified
+		if(this.checkboxTag && (!tiddler || tagCheck)) {
+			newFields.tags = tiddler ? (tiddler.fields.tags || []).slice(0) : [];
+			var pos = newFields.tags.indexOf(this.checkboxTag);
+			if(pos !== -1) {
+				newFields.tags.splice(pos,1);
+			}
+			if(this.checkboxInvertTag === "yes" && !checked) {
+				newFields.tags.push(this.checkboxTag);
+			} else if(this.checkboxInvertTag !== "yes" && checked) {
+				newFields.tags.push(this.checkboxTag);
+			}
+			hasChanged = true;
 		}
+		// Set the field if specified
 		if(this.checkboxField) {
-			if(this.checkboxDefault === this.checkboxChecked) {
-				return true;
-			}
-			if(this.checkboxDefault === this.checkboxUnchecked) {
-				return false;
-			}
-		}
-	}
-	return false;
-};
-
-CheckboxWidget.prototype.handleChangeEvent = function(event) {
-	var checked = this.inputDomNode.checked,
-		tiddler = this.wiki.getTiddler(this.checkboxTitle),
-		fallbackFields = {text: ""},
-		newFields = {title: this.checkboxTitle},
-		hasChanged = false,
-		tagCheck = false,
-		hasTag = tiddler && tiddler.hasTag(this.checkboxTag),
-		value = checked ? this.checkboxChecked : this.checkboxUnchecked,
-		notValue = checked ? this.checkboxUnchecked : this.checkboxChecked;
-	if(this.checkboxTag && this.checkboxInvertTag === "yes") {
-		tagCheck = hasTag === checked;
-	} else {
-		tagCheck = hasTag !== checked;
-	}
-	// Set the tag if specified
-	if(this.checkboxTag && (!tiddler || tagCheck)) {
-		newFields.tags = tiddler ? (tiddler.fields.tags || []).slice(0) : [];
-		var pos = newFields.tags.indexOf(this.checkboxTag);
-		if(pos !== -1) {
-			newFields.tags.splice(pos,1);
-		}
-		if(this.checkboxInvertTag === "yes" && !checked) {
-			newFields.tags.push(this.checkboxTag);
-		} else if(this.checkboxInvertTag !== "yes" && checked) {
-			newFields.tags.push(this.checkboxTag);
-		}
-		hasChanged = true;
-	}
-	// Set the field if specified
-	if(this.checkboxField) {
-		if(!tiddler || tiddler.fields[this.checkboxField] !== value) {
-			newFields[this.checkboxField] = value;
-			hasChanged = true;
-		}
-	}
-	// Set the index if specified
-	if(this.checkboxIndex) {
-		var indexValue = this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxIndex);
-		if(!tiddler || indexValue !== value) {
-			hasChanged = true;
-		}
-	}
-	// Set the list field (or index) if specified
-	if(this.checkboxListField || this.checkboxListIndex) {
-		var fieldContents, listContents, oldPos, newPos;
-		if(this.checkboxListField) {
-			fieldContents = (tiddler ? tiddler.fields[this.checkboxListField] : undefined) || [];
-		} else {
-			fieldContents = this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxListIndex);
-		}
-		if($tw.utils.isArray(fieldContents)) {
-			// Make a copy so we can modify it without changing original that's refrenced elsewhere
-			listContents = fieldContents.slice(0);
-		} else if(fieldContents === undefined) {
-			listContents = [];
-		} else if(typeof fieldContents === "string") {
-			listContents = $tw.utils.parseStringArray(fieldContents);
-			// No need to copy since parseStringArray returns a fresh array, not refrenced elsewhere
-		} else {
-			// Field was neither an array nor a string; it's probably something that shouldn't become
-			// an array (such as a date field), so bail out *without* triggering actions
-			return;
-		}
-		oldPos = notValue ? listContents.indexOf(notValue) : -1;
-		newPos = value ? listContents.indexOf(value) : -1;
-		if(oldPos === -1 && newPos !== -1) {
-			// old value absent, new value present: no change needed
-		} else if(oldPos === -1) {
-			// neither one was present
-			if(value) {
-				listContents.push(value);
+			if(!tiddler || tiddler.fields[this.checkboxField] !== value) {
+				newFields[this.checkboxField] = value;
 				hasChanged = true;
-			} else {
-				// value unspecified? then leave list unchanged
 			}
-		} else if(newPos === -1) {
-			// old value present, new value absent
-			if(value) {
-				listContents[oldPos] = value;
+		}
+		// Set the index if specified
+		if(this.checkboxIndex) {
+			var indexValue = this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxIndex);
+			if(!tiddler || indexValue !== value) {
 				hasChanged = true;
+			}
+		}
+		// Set the list field (or index) if specified
+		if(this.checkboxListField || this.checkboxListIndex) {
+			var fieldContents, listContents, oldPos, newPos;
+			if(this.checkboxListField) {
+				fieldContents = (tiddler ? tiddler.fields[this.checkboxListField] : undefined) || [];
 			} else {
+				fieldContents = this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxListIndex);
+			}
+			if($tw.utils.isArray(fieldContents)) {
+				// Make a copy so we can modify it without changing original that's refrenced elsewhere
+				listContents = fieldContents.slice(0);
+			} else if(fieldContents === undefined) {
+				listContents = [];
+			} else if(typeof fieldContents === "string") {
+				listContents = $tw.utils.parseStringArray(fieldContents);
+				// No need to copy since parseStringArray returns a fresh array, not refrenced elsewhere
+			} else {
+				// Field was neither an array nor a string; it's probably something that shouldn't become
+				// an array (such as a date field), so bail out *without* triggering actions
+				return;
+			}
+			oldPos = notValue ? listContents.indexOf(notValue) : -1;
+			newPos = value ? listContents.indexOf(value) : -1;
+			if(oldPos === -1 && newPos !== -1) {
+				// old value absent, new value present: no change needed
+			} else if(oldPos === -1) {
+				// neither one was present
+				if(value) {
+					listContents.push(value);
+					hasChanged = true;
+				} else {
+					// value unspecified? then leave list unchanged
+				}
+			} else if(newPos === -1) {
+				// old value present, new value absent
+				if(value) {
+					listContents[oldPos] = value;
+					hasChanged = true;
+				} else {
+					listContents.splice(oldPos, 1)
+					hasChanged = true;
+				}
+			} else {
+				// both were present: just remove the old one, leave new alone
 				listContents.splice(oldPos, 1)
 				hasChanged = true;
 			}
-		} else {
-			// both were present: just remove the old one, leave new alone
-			listContents.splice(oldPos, 1)
-			hasChanged = true;
+			if(this.checkboxListField) {
+				newFields[this.checkboxListField] = $tw.utils.stringifyList(listContents);
+			}
+			// The listIndex case will be handled in the if(hasChanged) block below
 		}
-		if(this.checkboxListField) {
-			newFields[this.checkboxListField] = $tw.utils.stringifyList(listContents);
-		}
-		// The listIndex case will be handled in the if(hasChanged) block below
-	}
-	if(hasChanged) {
-		if(this.checkboxIndex) {
-			this.wiki.setText(this.checkboxTitle,"",this.checkboxIndex,value);
-		} else if(this.checkboxListIndex) {
-			var listIndexValue = (listContents && listContents.length) ? $tw.utils.stringifyList(listContents) : undefined;
-			this.wiki.setText(this.checkboxTitle,"",this.checkboxListIndex,listIndexValue);
-		} else {
-			this.wiki.addTiddler(new $tw.Tiddler(this.wiki.getCreationFields(),fallbackFields,tiddler,newFields,this.wiki.getModificationFields()));
-		}
-	}
-	// Trigger actions
-	if(this.checkboxActions) {
-		this.invokeActionString(this.checkboxActions,this,event);
-	}
-	if(this.checkboxCheckActions && checked) {
-		this.invokeActionString(this.checkboxCheckActions,this,event);
-	}
-	if(this.checkboxUncheckActions && !checked) {
-		this.invokeActionString(this.checkboxUncheckActions,this,event);
-	}
-};
-
-/*
-Compute the internal state of the widget
-*/
-CheckboxWidget.prototype.execute = function() {
-	// Get the parameters from the attributes
-	this.checkboxActions = this.getAttribute("actions");
-	this.checkboxCheckActions = this.getAttribute("checkactions");
-	this.checkboxUncheckActions = this.getAttribute("uncheckactions");
-	this.checkboxTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
-	this.checkboxTag = this.getAttribute("tag");
-	this.checkboxField = this.getAttribute("field");
-	this.checkboxIndex = this.getAttribute("index");
-	this.checkboxListField = this.getAttribute("listField");
-	this.checkboxListIndex = this.getAttribute("listIndex");
-	this.checkboxFilter = this.getAttribute("filter");
-	this.checkboxChecked = this.getAttribute("checked");
-	this.checkboxUnchecked = this.getAttribute("unchecked");
-	this.checkboxDefault = this.getAttribute("default");
-	this.checkboxIndeterminate = this.getAttribute("indeterminate","no");
-	this.checkboxClass = this.getAttribute("class","");
-	this.checkboxInvertTag = this.getAttribute("invertTag","");
-	this.isDisabled = this.getAttribute("disabled","no");
-	// Make the child widgets
-	this.makeChildWidgets();
-};
-
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
-CheckboxWidget.prototype.refresh = function(changedTiddlers) {
-	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedAttributes.tag || changedAttributes.invertTag || changedAttributes.field || changedAttributes.index || changedAttributes.listField || changedAttributes.listIndex || changedAttributes.filter || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes.indeterminate || changedAttributes["class"] || changedAttributes.disabled) {
-		this.refreshSelf();
-		return true;
-	} else {
-		var refreshed = false;
-		if(changedTiddlers[this.checkboxTitle]) {
-			var isChecked = this.getValue();
-			this.inputDomNode.checked = !!isChecked;
-			this.inputDomNode.indeterminate = (isChecked === undefined);
-			refreshed = true;
-			if(isChecked) {
-				$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
+		if(hasChanged) {
+			if(this.checkboxIndex) {
+				this.wiki.setText(this.checkboxTitle,"",this.checkboxIndex,value);
+			} else if(this.checkboxListIndex) {
+				var listIndexValue = (listContents && listContents.length) ? $tw.utils.stringifyList(listContents) : undefined;
+				this.wiki.setText(this.checkboxTitle,"",this.checkboxListIndex,listIndexValue);
 			} else {
-				$tw.utils.removeClass(this.labelDomNode,"tc-checkbox-checked");
+				this.wiki.addTiddler(new $tw.Tiddler(this.wiki.getCreationFields(),fallbackFields,tiddler,newFields,this.wiki.getModificationFields()));
 			}
 		}
-		return this.refreshChildren(changedTiddlers) || refreshed;
-	}
-};
-
-exports.checkbox = CheckboxWidget;
-
-})();
+		// Trigger actions
+		if(this.checkboxActions) {
+			this.invokeActionString(this.checkboxActions,this,event);
+		}
+		if(this.checkboxCheckActions && checked) {
+			this.invokeActionString(this.checkboxCheckActions,this,event);
+		}
+		if(this.checkboxUncheckActions && !checked) {
+			this.invokeActionString(this.checkboxUncheckActions,this,event);
+		}
+	};
+	
+	/*
+	Compute the internal state of the widget
+	*/
+	CheckboxWidget.prototype.execute = function() {
+		// Get the parameters from the attributes
+		this.checkboxActions = this.getAttribute("actions");
+		this.checkboxCheckActions = this.getAttribute("checkactions");
+		this.checkboxUncheckActions = this.getAttribute("uncheckactions");
+		this.checkboxTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
+		this.checkboxTag = this.getAttribute("tag");
+		this.checkboxField = this.getAttribute("field");
+		this.checkboxIndex = this.getAttribute("index");
+		this.checkboxListField = this.getAttribute("listField");
+		this.checkboxListIndex = this.getAttribute("listIndex");
+		this.checkboxFilter = this.getAttribute("filter");
+		this.checkboxChecked = this.getAttribute("checked");
+		this.checkboxUnchecked = this.getAttribute("unchecked");
+		this.checkboxDefault = this.getAttribute("default");
+		this.checkboxIndeterminate = this.getAttribute("indeterminate","no");
+		this.checkboxClass = this.getAttribute("class","");
+		this.checkboxInvertTag = this.getAttribute("invertTag","");
+		this.isDisabled = this.getAttribute("disabled","no");
+		// Make the child widgets
+		this.makeChildWidgets();
+	};
+	
+	/*
+	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+	*/
+	CheckboxWidget.prototype.refresh = function(changedTiddlers) {
+		var changedAttributes = this.computeAttributes();
+		if(changedAttributes.tiddler || changedAttributes.tag || changedAttributes.invertTag || changedAttributes.field || changedAttributes.index || changedAttributes.listField || changedAttributes.listIndex || changedAttributes.filter || changedAttributes.checked || changedAttributes.unchecked || changedAttributes["default"] || changedAttributes.indeterminate || changedAttributes["class"] || changedAttributes.disabled) {
+			this.refreshSelf();
+			return true;
+		} else {
+			var refreshed = false;
+			if(changedTiddlers[this.checkboxTitle]) {
+				var isChecked = this.getValue();
+				this.inputDomNode.checked = !!isChecked;
+				this.inputDomNode.indeterminate = (isChecked === undefined);
+				refreshed = true;
+				if(isChecked) {
+					$tw.utils.addClass(this.labelDomNode,"tc-checkbox-checked");
+				} else {
+					$tw.utils.removeClass(this.labelDomNode,"tc-checkbox-checked");
+				}
+			}
+			this.assignAttributes(this.inputDomNode,{
+				changedAttributes: changedAttributes,
+				sourcePrefix: "data-",
+				destPrefix: "data-"
+			});
+			return this.refreshChildren(changedTiddlers) || refreshed;
+		}
+	};
+	
+	exports.checkbox = CheckboxWidget;
+	
+	})();
+	

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -8,223 +8,223 @@ Link widget
 \*/
 (function(){
 
-	/*jslint node: true, browser: true */
-	/*global $tw: false */
-	"use strict";
-	
-	var Widget = require("$:/core/modules/widgets/widget.js").widget;
-	
-	var LinkWidget = function(parseTreeNode,options) {
-		this.initialise(parseTreeNode,options);
-	};
-	
-	/*
-	Inherit from the base widget class
-	*/
-	LinkWidget.prototype = new Widget();
-	
-	/*
-	Render this widget into the DOM
-	*/
-	LinkWidget.prototype.render = function(parent,nextSibling) {
-		// Save the parent dom node
-		this.parentDomNode = parent;
-		// Compute our attributes
-		this.computeAttributes();
-		// Execute our logic
-		this.execute();
-		// Get the value of the tv-wikilinks configuration macro
-		var wikiLinksMacro = this.getVariable("tv-wikilinks"),
-			useWikiLinks = wikiLinksMacro ? (wikiLinksMacro.trim() !== "no") : true,
-			missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow);
-		// Render the link if required
-		if(useWikiLinks && missingLinksEnabled) {
-			this.renderLink(parent,nextSibling);
-		} else {
-			// Just insert the link text
-			var domNode = this.document.createElement("span");
-			// Assign data- attributes
-			this.assignAttributes(domNode,{
-				sourcePrefix: "data-",
-				destPrefix: "data-"
-			});
-			parent.insertBefore(domNode,nextSibling);
-			this.renderChildren(domNode,null);
-			this.domNodes.push(domNode);
-		}
-	};
-	
-	/*
-	Render this widget into the DOM
-	*/
-	LinkWidget.prototype.renderLink = function(parent,nextSibling) {
-		var self = this;
-		// Sanitise the specified tag
-		var tag = this.linkTag;
-		if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-			tag = "a";
-		}
-		// Create our element
-		var namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"}),
-			domNode = this.document.createElementNS(namespace,tag);
-		// Assign classes
-		var classes = [];
-		if(this.overrideClasses === undefined) {
-			classes.push("tc-tiddlylink");
-			if(this.isShadow) {
-				classes.push("tc-tiddlylink-shadow");
-			}
-			if(this.isMissing && !this.isShadow) {
-				classes.push("tc-tiddlylink-missing");
-			} else {
-				if(!this.isMissing) {
-					classes.push("tc-tiddlylink-resolves");
-				}
-			}
-			if(this.linkClasses) {
-				classes.push(this.linkClasses);
-			}
-		} else if(this.overrideClasses !== "") {
-			classes.push(this.overrideClasses)
-		}
-		if(classes.length > 0) {
-			domNode.setAttribute("class",classes.join(" "));
-		}
-		// Set an href
-		var wikilinkTransformFilter = this.getVariable("tv-filter-export-link"),
-			wikiLinkText;
-		if(wikilinkTransformFilter) {
-			// Use the filter to construct the href
-			wikiLinkText = this.wiki.filterTiddlers(wikilinkTransformFilter,this,function(iterator) {
-				iterator(self.wiki.getTiddler(self.to),self.to)
-			})[0];
-		} else {
-			// Expand the tv-wikilink-template variable to construct the href
-			var wikiLinkTemplateMacro = this.getVariable("tv-wikilink-template"),
-				wikiLinkTemplate = wikiLinkTemplateMacro ? wikiLinkTemplateMacro.trim() : "#$uri_encoded$";
-			wikiLinkText = $tw.utils.replaceString(wikiLinkTemplate,"$uri_encoded$",$tw.utils.encodeURIComponentExtended(this.to));
-			wikiLinkText = $tw.utils.replaceString(wikiLinkText,"$uri_doubleencoded$",$tw.utils.encodeURIComponentExtended($tw.utils.encodeURIComponentExtended(this.to)));
-		}
-		// Override with the value of tv-get-export-link if defined
-		wikiLinkText = this.getVariable("tv-get-export-link",{params: [{name: "to",value: this.to}],defaultValue: wikiLinkText});
-		if(tag === "a") {
-			var namespaceHref = (namespace === "http://www.w3.org/2000/svg") ? "http://www.w3.org/1999/xlink" : undefined;
-			domNode.setAttributeNS(namespaceHref,"href",wikiLinkText);
-		}
-		// Set the tabindex
-		if(this.tabIndex) {
-			domNode.setAttribute("tabindex",this.tabIndex);
-		}
-		// Set the tooltip
-		// HACK: Performance issues with re-parsing the tooltip prevent us defaulting the tooltip to "<$transclude field='tooltip'><$transclude field='title'/></$transclude>"
-		var tooltipWikiText = this.tooltip || this.getVariable("tv-wikilink-tooltip");
-		if(tooltipWikiText) {
-			var tooltipText = this.wiki.renderText("text/plain","text/vnd.tiddlywiki",tooltipWikiText,{
-					parseAsInline: true,
-					variables: {
-						currentTiddler: this.to
-					},
-					parentWidget: this
-				});
-			domNode.setAttribute("title",tooltipText);
-		}
-		if(this["aria-label"]) {
-			domNode.setAttribute("aria-label",this["aria-label"]);
-		}
-		// Add a click event handler
-		$tw.utils.addEventListeners(domNode,[
-			{name: "click", handlerObject: this, handlerMethod: "handleClickEvent"},
-		]);
-		// Make the link draggable if required
-		if(this.draggable === "yes") {
-			$tw.utils.makeDraggable({
-				domNode: domNode,
-				dragTiddlerFn: function() {return self.to;},
-				widget: this
-			});
-		}
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+var Widget = require("$:/core/modules/widgets/widget.js").widget;
+
+var LinkWidget = function(parseTreeNode,options) {
+	this.initialise(parseTreeNode,options);
+};
+
+/*
+Inherit from the base widget class
+*/
+LinkWidget.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+LinkWidget.prototype.render = function(parent,nextSibling) {
+	// Save the parent dom node
+	this.parentDomNode = parent;
+	// Compute our attributes
+	this.computeAttributes();
+	// Execute our logic
+	this.execute();
+	// Get the value of the tv-wikilinks configuration macro
+	var wikiLinksMacro = this.getVariable("tv-wikilinks"),
+		useWikiLinks = wikiLinksMacro ? (wikiLinksMacro.trim() !== "no") : true,
+		missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow);
+	// Render the link if required
+	if(useWikiLinks && missingLinksEnabled) {
+		this.renderLink(parent,nextSibling);
+	} else {
+		// Just insert the link text
+		var domNode = this.document.createElement("span");
 		// Assign data- attributes
 		this.assignAttributes(domNode,{
 			sourcePrefix: "data-",
 			destPrefix: "data-"
 		});
-		// Insert the link into the DOM and render any children
 		parent.insertBefore(domNode,nextSibling);
 		this.renderChildren(domNode,null);
 		this.domNodes.push(domNode);
-	};
-	
-	LinkWidget.prototype.handleClickEvent = function(event) {
-		// Send the click on its way as a navigate event
-		var bounds = this.domNodes[0].getBoundingClientRect();
-		this.dispatchEvent({
-			type: "tm-navigate",
-			navigateTo: this.to,
-			navigateFromTitle: this.getVariable("storyTiddler"),
-			navigateFromNode: this,
-			navigateFromClientRect: { top: bounds.top, left: bounds.left, width: bounds.width, right: bounds.right, bottom: bounds.bottom, height: bounds.height
-			},
-			navigateFromClientTop: bounds.top,
-			navigateFromClientLeft: bounds.left,
-			navigateFromClientWidth: bounds.width,
-			navigateFromClientRight: bounds.right,
-			navigateFromClientBottom: bounds.bottom,
-			navigateFromClientHeight: bounds.height,
-			navigateSuppressNavigation: event.metaKey || event.ctrlKey || (event.button === 1),
-			metaKey: event.metaKey,
-			ctrlKey: event.ctrlKey,
-			altKey: event.altKey,
-			shiftKey: event.shiftKey,
-			event: event
-		});
-		if(this.domNodes[0].hasAttribute("href")) {
-			event.preventDefault();
+	}
+};
+
+/*
+Render this widget into the DOM
+*/
+LinkWidget.prototype.renderLink = function(parent,nextSibling) {
+	var self = this;
+	// Sanitise the specified tag
+	var tag = this.linkTag;
+	if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
+		tag = "a";
+	}
+	// Create our element
+	var namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"}),
+		domNode = this.document.createElementNS(namespace,tag);
+	// Assign classes
+	var classes = [];
+	if(this.overrideClasses === undefined) {
+		classes.push("tc-tiddlylink");
+		if(this.isShadow) {
+			classes.push("tc-tiddlylink-shadow");
 		}
-		event.stopPropagation();
-		return false;
-	};
-	
-	/*
-	Compute the internal state of the widget
-	*/
-	LinkWidget.prototype.execute = function() {
-		// Pick up our attributes
-		this.to = this.getAttribute("to",this.getVariable("currentTiddler"));
-		this.tooltip = this.getAttribute("tooltip");
-		this["aria-label"] = this.getAttribute("aria-label");
-		this.linkClasses = this.getAttribute("class");
-		this.overrideClasses = this.getAttribute("overrideClass");
-		this.tabIndex = this.getAttribute("tabindex");
-		this.draggable = this.getAttribute("draggable","yes");
-		this.linkTag = this.getAttribute("tag","a");
-		// Determine the link characteristics
-		this.isMissing = !this.wiki.tiddlerExists(this.to);
-		this.isShadow = this.wiki.isShadowTiddler(this.to);
-		this.hideMissingLinks = (this.getVariable("tv-show-missing-links") || "yes") === "no";
-		// Make the child widgets
-		var templateTree;
-		if(this.parseTreeNode.children && this.parseTreeNode.children.length > 0) {
-			templateTree = this.parseTreeNode.children;
+		if(this.isMissing && !this.isShadow) {
+			classes.push("tc-tiddlylink-missing");
 		} else {
-			// Default template is a link to the title
-			templateTree = [{type: "text", text: this.to}];
+			if(!this.isMissing) {
+				classes.push("tc-tiddlylink-resolves");
+			}
 		}
-		this.makeChildWidgets(templateTree);
-	};
-	
-	/*
-	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-	*/
-	LinkWidget.prototype.refresh = function(changedTiddlers) {
-		var changedAttributes = this.computeAttributes();
-		if($tw.utils.count(changedAttributes) > 0) {
-			this.refreshSelf();
-			return true;
+		if(this.linkClasses) {
+			classes.push(this.linkClasses);
 		}
-		return this.refreshChildren(changedTiddlers);
-	};
-	
-	exports.link = LinkWidget;
-	
-	})();
+	} else if(this.overrideClasses !== "") {
+		classes.push(this.overrideClasses)
+	}
+	if(classes.length > 0) {
+		domNode.setAttribute("class",classes.join(" "));
+	}
+	// Set an href
+	var wikilinkTransformFilter = this.getVariable("tv-filter-export-link"),
+		wikiLinkText;
+	if(wikilinkTransformFilter) {
+		// Use the filter to construct the href
+		wikiLinkText = this.wiki.filterTiddlers(wikilinkTransformFilter,this,function(iterator) {
+			iterator(self.wiki.getTiddler(self.to),self.to)
+		})[0];
+	} else {
+		// Expand the tv-wikilink-template variable to construct the href
+		var wikiLinkTemplateMacro = this.getVariable("tv-wikilink-template"),
+			wikiLinkTemplate = wikiLinkTemplateMacro ? wikiLinkTemplateMacro.trim() : "#$uri_encoded$";
+		wikiLinkText = $tw.utils.replaceString(wikiLinkTemplate,"$uri_encoded$",$tw.utils.encodeURIComponentExtended(this.to));
+		wikiLinkText = $tw.utils.replaceString(wikiLinkText,"$uri_doubleencoded$",$tw.utils.encodeURIComponentExtended($tw.utils.encodeURIComponentExtended(this.to)));
+	}
+	// Override with the value of tv-get-export-link if defined
+	wikiLinkText = this.getVariable("tv-get-export-link",{params: [{name: "to",value: this.to}],defaultValue: wikiLinkText});
+	if(tag === "a") {
+		var namespaceHref = (namespace === "http://www.w3.org/2000/svg") ? "http://www.w3.org/1999/xlink" : undefined;
+		domNode.setAttributeNS(namespaceHref,"href",wikiLinkText);
+	}
+	// Set the tabindex
+	if(this.tabIndex) {
+		domNode.setAttribute("tabindex",this.tabIndex);
+	}
+	// Set the tooltip
+	// HACK: Performance issues with re-parsing the tooltip prevent us defaulting the tooltip to "<$transclude field='tooltip'><$transclude field='title'/></$transclude>"
+	var tooltipWikiText = this.tooltip || this.getVariable("tv-wikilink-tooltip");
+	if(tooltipWikiText) {
+		var tooltipText = this.wiki.renderText("text/plain","text/vnd.tiddlywiki",tooltipWikiText,{
+				parseAsInline: true,
+				variables: {
+					currentTiddler: this.to
+				},
+				parentWidget: this
+			});
+		domNode.setAttribute("title",tooltipText);
+	}
+	if(this["aria-label"]) {
+		domNode.setAttribute("aria-label",this["aria-label"]);
+	}
+	// Add a click event handler
+	$tw.utils.addEventListeners(domNode,[
+		{name: "click", handlerObject: this, handlerMethod: "handleClickEvent"},
+	]);
+	// Make the link draggable if required
+	if(this.draggable === "yes") {
+		$tw.utils.makeDraggable({
+			domNode: domNode,
+			dragTiddlerFn: function() {return self.to;},
+			widget: this
+		});
+	}
+	// Assign data- attributes
+	this.assignAttributes(domNode,{
+		sourcePrefix: "data-",
+		destPrefix: "data-"
+	});
+	// Insert the link into the DOM and render any children
+	parent.insertBefore(domNode,nextSibling);
+	this.renderChildren(domNode,null);
+	this.domNodes.push(domNode);
+};
+
+LinkWidget.prototype.handleClickEvent = function(event) {
+	// Send the click on its way as a navigate event
+	var bounds = this.domNodes[0].getBoundingClientRect();
+	this.dispatchEvent({
+		type: "tm-navigate",
+		navigateTo: this.to,
+		navigateFromTitle: this.getVariable("storyTiddler"),
+		navigateFromNode: this,
+		navigateFromClientRect: { top: bounds.top, left: bounds.left, width: bounds.width, right: bounds.right, bottom: bounds.bottom, height: bounds.height
+		},
+		navigateFromClientTop: bounds.top,
+		navigateFromClientLeft: bounds.left,
+		navigateFromClientWidth: bounds.width,
+		navigateFromClientRight: bounds.right,
+		navigateFromClientBottom: bounds.bottom,
+		navigateFromClientHeight: bounds.height,
+		navigateSuppressNavigation: event.metaKey || event.ctrlKey || (event.button === 1),
+		metaKey: event.metaKey,
+		ctrlKey: event.ctrlKey,
+		altKey: event.altKey,
+		shiftKey: event.shiftKey,
+		event: event
+	});
+	if(this.domNodes[0].hasAttribute("href")) {
+		event.preventDefault();
+	}
+	event.stopPropagation();
+	return false;
+};
+
+/*
+Compute the internal state of the widget
+*/
+LinkWidget.prototype.execute = function() {
+	// Pick up our attributes
+	this.to = this.getAttribute("to",this.getVariable("currentTiddler"));
+	this.tooltip = this.getAttribute("tooltip");
+	this["aria-label"] = this.getAttribute("aria-label");
+	this.linkClasses = this.getAttribute("class");
+	this.overrideClasses = this.getAttribute("overrideClass");
+	this.tabIndex = this.getAttribute("tabindex");
+	this.draggable = this.getAttribute("draggable","yes");
+	this.linkTag = this.getAttribute("tag","a");
+	// Determine the link characteristics
+	this.isMissing = !this.wiki.tiddlerExists(this.to);
+	this.isShadow = this.wiki.isShadowTiddler(this.to);
+	this.hideMissingLinks = (this.getVariable("tv-show-missing-links") || "yes") === "no";
+	// Make the child widgets
+	var templateTree;
+	if(this.parseTreeNode.children && this.parseTreeNode.children.length > 0) {
+		templateTree = this.parseTreeNode.children;
+	} else {
+		// Default template is a link to the title
+		templateTree = [{type: "text", text: this.to}];
+	}
+	this.makeChildWidgets(templateTree);
+};
+
+/*
+Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+*/
+LinkWidget.prototype.refresh = function(changedTiddlers) {
+	var changedAttributes = this.computeAttributes();
+	if($tw.utils.count(changedAttributes) > 0) {
+		this.refreshSelf();
+		return true;
+	}
+	return this.refreshChildren(changedTiddlers);
+};
+
+exports.link = LinkWidget;
+
+})();
 	

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -8,217 +8,223 @@ Link widget
 \*/
 (function(){
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
-"use strict";
-
-var Widget = require("$:/core/modules/widgets/widget.js").widget;
-
-var LinkWidget = function(parseTreeNode,options) {
-	this.initialise(parseTreeNode,options);
-};
-
-/*
-Inherit from the base widget class
-*/
-LinkWidget.prototype = new Widget();
-
-/*
-Render this widget into the DOM
-*/
-LinkWidget.prototype.render = function(parent,nextSibling) {
-	// Save the parent dom node
-	this.parentDomNode = parent;
-	// Compute our attributes
-	this.computeAttributes();
-	// Execute our logic
-	this.execute();
-	// Get the value of the tv-wikilinks configuration macro
-	var wikiLinksMacro = this.getVariable("tv-wikilinks"),
-		useWikiLinks = wikiLinksMacro ? (wikiLinksMacro.trim() !== "no") : true,
-		missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow);
-	// Render the link if required
-	if(useWikiLinks && missingLinksEnabled) {
-		this.renderLink(parent,nextSibling);
-	} else {
-		// Just insert the link text
-		var domNode = this.document.createElement("span");
+	/*jslint node: true, browser: true */
+	/*global $tw: false */
+	"use strict";
+	
+	var Widget = require("$:/core/modules/widgets/widget.js").widget;
+	
+	var LinkWidget = function(parseTreeNode,options) {
+		this.initialise(parseTreeNode,options);
+	};
+	
+	/*
+	Inherit from the base widget class
+	*/
+	LinkWidget.prototype = new Widget();
+	
+	/*
+	Render this widget into the DOM
+	*/
+	LinkWidget.prototype.render = function(parent,nextSibling) {
+		// Save the parent dom node
+		this.parentDomNode = parent;
+		// Compute our attributes
+		this.computeAttributes();
+		// Execute our logic
+		this.execute();
+		// Get the value of the tv-wikilinks configuration macro
+		var wikiLinksMacro = this.getVariable("tv-wikilinks"),
+			useWikiLinks = wikiLinksMacro ? (wikiLinksMacro.trim() !== "no") : true,
+			missingLinksEnabled = !(this.hideMissingLinks && this.isMissing && !this.isShadow);
+		// Render the link if required
+		if(useWikiLinks && missingLinksEnabled) {
+			this.renderLink(parent,nextSibling);
+		} else {
+			// Just insert the link text
+			var domNode = this.document.createElement("span");
+			// Assign data- attributes
+			this.assignAttributes(domNode,{
+				sourcePrefix: "data-",
+				destPrefix: "data-"
+			});
+			parent.insertBefore(domNode,nextSibling);
+			this.renderChildren(domNode,null);
+			this.domNodes.push(domNode);
+		}
+	};
+	
+	/*
+	Render this widget into the DOM
+	*/
+	LinkWidget.prototype.renderLink = function(parent,nextSibling) {
+		var self = this;
+		// Sanitise the specified tag
+		var tag = this.linkTag;
+		if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
+			tag = "a";
+		}
+		// Create our element
+		var namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"}),
+			domNode = this.document.createElementNS(namespace,tag);
+		// Assign classes
+		var classes = [];
+		if(this.overrideClasses === undefined) {
+			classes.push("tc-tiddlylink");
+			if(this.isShadow) {
+				classes.push("tc-tiddlylink-shadow");
+			}
+			if(this.isMissing && !this.isShadow) {
+				classes.push("tc-tiddlylink-missing");
+			} else {
+				if(!this.isMissing) {
+					classes.push("tc-tiddlylink-resolves");
+				}
+			}
+			if(this.linkClasses) {
+				classes.push(this.linkClasses);
+			}
+		} else if(this.overrideClasses !== "") {
+			classes.push(this.overrideClasses)
+		}
+		if(classes.length > 0) {
+			domNode.setAttribute("class",classes.join(" "));
+		}
+		// Set an href
+		var wikilinkTransformFilter = this.getVariable("tv-filter-export-link"),
+			wikiLinkText;
+		if(wikilinkTransformFilter) {
+			// Use the filter to construct the href
+			wikiLinkText = this.wiki.filterTiddlers(wikilinkTransformFilter,this,function(iterator) {
+				iterator(self.wiki.getTiddler(self.to),self.to)
+			})[0];
+		} else {
+			// Expand the tv-wikilink-template variable to construct the href
+			var wikiLinkTemplateMacro = this.getVariable("tv-wikilink-template"),
+				wikiLinkTemplate = wikiLinkTemplateMacro ? wikiLinkTemplateMacro.trim() : "#$uri_encoded$";
+			wikiLinkText = $tw.utils.replaceString(wikiLinkTemplate,"$uri_encoded$",$tw.utils.encodeURIComponentExtended(this.to));
+			wikiLinkText = $tw.utils.replaceString(wikiLinkText,"$uri_doubleencoded$",$tw.utils.encodeURIComponentExtended($tw.utils.encodeURIComponentExtended(this.to)));
+		}
+		// Override with the value of tv-get-export-link if defined
+		wikiLinkText = this.getVariable("tv-get-export-link",{params: [{name: "to",value: this.to}],defaultValue: wikiLinkText});
+		if(tag === "a") {
+			var namespaceHref = (namespace === "http://www.w3.org/2000/svg") ? "http://www.w3.org/1999/xlink" : undefined;
+			domNode.setAttributeNS(namespaceHref,"href",wikiLinkText);
+		}
+		// Set the tabindex
+		if(this.tabIndex) {
+			domNode.setAttribute("tabindex",this.tabIndex);
+		}
+		// Set the tooltip
+		// HACK: Performance issues with re-parsing the tooltip prevent us defaulting the tooltip to "<$transclude field='tooltip'><$transclude field='title'/></$transclude>"
+		var tooltipWikiText = this.tooltip || this.getVariable("tv-wikilink-tooltip");
+		if(tooltipWikiText) {
+			var tooltipText = this.wiki.renderText("text/plain","text/vnd.tiddlywiki",tooltipWikiText,{
+					parseAsInline: true,
+					variables: {
+						currentTiddler: this.to
+					},
+					parentWidget: this
+				});
+			domNode.setAttribute("title",tooltipText);
+		}
+		if(this["aria-label"]) {
+			domNode.setAttribute("aria-label",this["aria-label"]);
+		}
+		// Add a click event handler
+		$tw.utils.addEventListeners(domNode,[
+			{name: "click", handlerObject: this, handlerMethod: "handleClickEvent"},
+		]);
+		// Make the link draggable if required
+		if(this.draggable === "yes") {
+			$tw.utils.makeDraggable({
+				domNode: domNode,
+				dragTiddlerFn: function() {return self.to;},
+				widget: this
+			});
+		}
 		// Assign data- attributes
 		this.assignAttributes(domNode,{
 			sourcePrefix: "data-",
 			destPrefix: "data-"
 		});
+		// Insert the link into the DOM and render any children
 		parent.insertBefore(domNode,nextSibling);
 		this.renderChildren(domNode,null);
 		this.domNodes.push(domNode);
-	}
-};
-
-/*
-Render this widget into the DOM
-*/
-LinkWidget.prototype.renderLink = function(parent,nextSibling) {
-	var self = this;
-	// Sanitise the specified tag
-	var tag = this.linkTag;
-	if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-		tag = "a";
-	}
-	// Create our element
-	var namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"}),
-		domNode = this.document.createElementNS(namespace,tag);
-	// Assign classes
-	var classes = [];
-	if(this.overrideClasses === undefined) {
-		classes.push("tc-tiddlylink");
-		if(this.isShadow) {
-			classes.push("tc-tiddlylink-shadow");
-		}
-		if(this.isMissing && !this.isShadow) {
-			classes.push("tc-tiddlylink-missing");
-		} else {
-			if(!this.isMissing) {
-				classes.push("tc-tiddlylink-resolves");
-			}
-		}
-		if(this.linkClasses) {
-			classes.push(this.linkClasses);
-		}
-	} else if(this.overrideClasses !== "") {
-		classes.push(this.overrideClasses)
-	}
-	if(classes.length > 0) {
-		domNode.setAttribute("class",classes.join(" "));
-	}
-	// Set an href
-	var wikilinkTransformFilter = this.getVariable("tv-filter-export-link"),
-		wikiLinkText;
-	if(wikilinkTransformFilter) {
-		// Use the filter to construct the href
-		wikiLinkText = this.wiki.filterTiddlers(wikilinkTransformFilter,this,function(iterator) {
-			iterator(self.wiki.getTiddler(self.to),self.to)
-		})[0];
-	} else {
-		// Expand the tv-wikilink-template variable to construct the href
-		var wikiLinkTemplateMacro = this.getVariable("tv-wikilink-template"),
-			wikiLinkTemplate = wikiLinkTemplateMacro ? wikiLinkTemplateMacro.trim() : "#$uri_encoded$";
-		wikiLinkText = $tw.utils.replaceString(wikiLinkTemplate,"$uri_encoded$",$tw.utils.encodeURIComponentExtended(this.to));
-		wikiLinkText = $tw.utils.replaceString(wikiLinkText,"$uri_doubleencoded$",$tw.utils.encodeURIComponentExtended($tw.utils.encodeURIComponentExtended(this.to)));
-	}
-	// Override with the value of tv-get-export-link if defined
-	wikiLinkText = this.getVariable("tv-get-export-link",{params: [{name: "to",value: this.to}],defaultValue: wikiLinkText});
-	if(tag === "a") {
-		var namespaceHref = (namespace === "http://www.w3.org/2000/svg") ? "http://www.w3.org/1999/xlink" : undefined;
-		domNode.setAttributeNS(namespaceHref,"href",wikiLinkText);
-	}
-	// Set the tabindex
-	if(this.tabIndex) {
-		domNode.setAttribute("tabindex",this.tabIndex);
-	}
-	// Set the tooltip
-	// HACK: Performance issues with re-parsing the tooltip prevent us defaulting the tooltip to "<$transclude field='tooltip'><$transclude field='title'/></$transclude>"
-	var tooltipWikiText = this.tooltip || this.getVariable("tv-wikilink-tooltip");
-	if(tooltipWikiText) {
-		var tooltipText = this.wiki.renderText("text/plain","text/vnd.tiddlywiki",tooltipWikiText,{
-				parseAsInline: true,
-				variables: {
-					currentTiddler: this.to
-				},
-				parentWidget: this
-			});
-		domNode.setAttribute("title",tooltipText);
-	}
-	if(this["aria-label"]) {
-		domNode.setAttribute("aria-label",this["aria-label"]);
-	}
-	// Add a click event handler
-	$tw.utils.addEventListeners(domNode,[
-		{name: "click", handlerObject: this, handlerMethod: "handleClickEvent"},
-	]);
-	// Make the link draggable if required
-	if(this.draggable === "yes") {
-		$tw.utils.makeDraggable({
-			domNode: domNode,
-			dragTiddlerFn: function() {return self.to;},
-			widget: this
+	};
+	
+	LinkWidget.prototype.handleClickEvent = function(event) {
+		// Send the click on its way as a navigate event
+		var bounds = this.domNodes[0].getBoundingClientRect();
+		this.dispatchEvent({
+			type: "tm-navigate",
+			navigateTo: this.to,
+			navigateFromTitle: this.getVariable("storyTiddler"),
+			navigateFromNode: this,
+			navigateFromClientRect: { top: bounds.top, left: bounds.left, width: bounds.width, right: bounds.right, bottom: bounds.bottom, height: bounds.height
+			},
+			navigateFromClientTop: bounds.top,
+			navigateFromClientLeft: bounds.left,
+			navigateFromClientWidth: bounds.width,
+			navigateFromClientRight: bounds.right,
+			navigateFromClientBottom: bounds.bottom,
+			navigateFromClientHeight: bounds.height,
+			navigateSuppressNavigation: event.metaKey || event.ctrlKey || (event.button === 1),
+			metaKey: event.metaKey,
+			ctrlKey: event.ctrlKey,
+			altKey: event.altKey,
+			shiftKey: event.shiftKey,
+			event: event
 		});
-	}
-	// Insert the link into the DOM and render any children
-	parent.insertBefore(domNode,nextSibling);
-	this.renderChildren(domNode,null);
-	this.domNodes.push(domNode);
-};
-
-LinkWidget.prototype.handleClickEvent = function(event) {
-	// Send the click on its way as a navigate event
-	var bounds = this.domNodes[0].getBoundingClientRect();
-	this.dispatchEvent({
-		type: "tm-navigate",
-		navigateTo: this.to,
-		navigateFromTitle: this.getVariable("storyTiddler"),
-		navigateFromNode: this,
-		navigateFromClientRect: { top: bounds.top, left: bounds.left, width: bounds.width, right: bounds.right, bottom: bounds.bottom, height: bounds.height
-		},
-		navigateFromClientTop: bounds.top,
-		navigateFromClientLeft: bounds.left,
-		navigateFromClientWidth: bounds.width,
-		navigateFromClientRight: bounds.right,
-		navigateFromClientBottom: bounds.bottom,
-		navigateFromClientHeight: bounds.height,
-		navigateSuppressNavigation: event.metaKey || event.ctrlKey || (event.button === 1),
-		metaKey: event.metaKey,
-		ctrlKey: event.ctrlKey,
-		altKey: event.altKey,
-		shiftKey: event.shiftKey,
-		event: event
-	});
-	if(this.domNodes[0].hasAttribute("href")) {
-		event.preventDefault();
-	}
-	event.stopPropagation();
-	return false;
-};
-
-/*
-Compute the internal state of the widget
-*/
-LinkWidget.prototype.execute = function() {
-	// Pick up our attributes
-	this.to = this.getAttribute("to",this.getVariable("currentTiddler"));
-	this.tooltip = this.getAttribute("tooltip");
-	this["aria-label"] = this.getAttribute("aria-label");
-	this.linkClasses = this.getAttribute("class");
-	this.overrideClasses = this.getAttribute("overrideClass");
-	this.tabIndex = this.getAttribute("tabindex");
-	this.draggable = this.getAttribute("draggable","yes");
-	this.linkTag = this.getAttribute("tag","a");
-	// Determine the link characteristics
-	this.isMissing = !this.wiki.tiddlerExists(this.to);
-	this.isShadow = this.wiki.isShadowTiddler(this.to);
-	this.hideMissingLinks = (this.getVariable("tv-show-missing-links") || "yes") === "no";
-	// Make the child widgets
-	var templateTree;
-	if(this.parseTreeNode.children && this.parseTreeNode.children.length > 0) {
-		templateTree = this.parseTreeNode.children;
-	} else {
-		// Default template is a link to the title
-		templateTree = [{type: "text", text: this.to}];
-	}
-	this.makeChildWidgets(templateTree);
-};
-
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
-LinkWidget.prototype.refresh = function(changedTiddlers) {
-	var changedAttributes = this.computeAttributes();
-	if($tw.utils.count(changedAttributes) > 0) {
-		this.refreshSelf();
-		return true;
-	}
-	return this.refreshChildren(changedTiddlers);
-};
-
-exports.link = LinkWidget;
-
-})();
+		if(this.domNodes[0].hasAttribute("href")) {
+			event.preventDefault();
+		}
+		event.stopPropagation();
+		return false;
+	};
+	
+	/*
+	Compute the internal state of the widget
+	*/
+	LinkWidget.prototype.execute = function() {
+		// Pick up our attributes
+		this.to = this.getAttribute("to",this.getVariable("currentTiddler"));
+		this.tooltip = this.getAttribute("tooltip");
+		this["aria-label"] = this.getAttribute("aria-label");
+		this.linkClasses = this.getAttribute("class");
+		this.overrideClasses = this.getAttribute("overrideClass");
+		this.tabIndex = this.getAttribute("tabindex");
+		this.draggable = this.getAttribute("draggable","yes");
+		this.linkTag = this.getAttribute("tag","a");
+		// Determine the link characteristics
+		this.isMissing = !this.wiki.tiddlerExists(this.to);
+		this.isShadow = this.wiki.isShadowTiddler(this.to);
+		this.hideMissingLinks = (this.getVariable("tv-show-missing-links") || "yes") === "no";
+		// Make the child widgets
+		var templateTree;
+		if(this.parseTreeNode.children && this.parseTreeNode.children.length > 0) {
+			templateTree = this.parseTreeNode.children;
+		} else {
+			// Default template is a link to the title
+			templateTree = [{type: "text", text: this.to}];
+		}
+		this.makeChildWidgets(templateTree);
+	};
+	
+	/*
+	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+	*/
+	LinkWidget.prototype.refresh = function(changedTiddlers) {
+		var changedAttributes = this.computeAttributes();
+		if($tw.utils.count(changedAttributes) > 0) {
+			this.refreshSelf();
+			return true;
+		}
+		return this.refreshChildren(changedTiddlers);
+	};
+	
+	exports.link = LinkWidget;
+	
+	})();
+	

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/ButtonWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/ButtonWidget-DataAttributes.tid
@@ -1,0 +1,27 @@
+title: Widgets/DataAttributes/ButtonWidget
+description: Data Attributes for ButtonWidget
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$button tag="div" class="myclass" data-title="mytiddler" style.color="red">
+my tiddler
+</$button>
+<$button tag="div" class="myclass" data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}}>
+hello
+</$button>
++
+title: Actions
+
+<$action-setfield $tiddler="Temp" $field="text" $value="Title2" color="red"/>
++
+title: Temp
+color: black
+
+Title1
++
+title: ExpectedResult
+
+<p><div class="myclass" data-title="mytiddler" style="color:red;">my tiddler</div><div class="myclass" data-title="Title2" style="color:red;">hello</div></p>

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/CheckboxWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/CheckboxWidget-DataAttributes.tid
@@ -1,0 +1,22 @@
+title: Widgets/DataAttributes/CheckboxWidget
+description: Data Attributes for CheckboxWidget
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$checkbox tag="done" data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}}> Is it done?</$checkbox>
++
+title: Actions
+
+<$action-setfield $tiddler="Temp" $field="text" $value="Title2" color="red"/>
++
+title: Temp
+color: black
+
+Title1
++
+title: ExpectedResult
+
+<p><label class="tc-checkbox "><input data-title="Title2" type="checkbox" style="color:red;"><span>Is it done?</span></label></p>

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/LinkWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/LinkWidget-DataAttributes.tid
@@ -1,0 +1,27 @@
+title: Widgets/DataAttributes/LinkWidget
+description: Data Attributes for LinkWidget
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$link data-id="mytiddler" style.color="red" to="Temp">
+link to Temp
+</$link>
+<$link tag="button" data-id={{Temp}} style.color={{{ [[Temp]get[color]] }}} to="SomeTiddler">
+some tiddler
+</$link>
++
+title: Actions
+
+<$action-setfield $tiddler="Temp" $field="text" $value="Title2" color="red"/>
++
+title: Temp
+color: black
+
+Title1
++
+title: ExpectedResult
+
+<p><a class="tc-tiddlylink tc-tiddlylink-resolves" data-id="mytiddler" href="#Temp" style="color:red;">link to Temp</a><button class="tc-tiddlylink tc-tiddlylink-missing" data-id="Title2" draggable="true" style="color:red;">some tiddler</button></p>


### PR DESCRIPTION
This PR fixes refresh issues for the data attributes introduced in #7769

Checkbox widget: missing refresh for data attributes added
Link widget: fixed issue where the data attributes were only added when `tv-wikilinks` was set to no. Now  data attributes are supported in both when the variable is set to no or yes.

Bonus: refresh test for ButtonWidget.