### PR TITLE
Fixes data attributes support for Select widget.

### DIFF
--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -179,7 +179,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 SelectWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	// If we're using a different tiddler/field/index then completely refresh ourselves
-	if($tw.utils.count(changedAttributes) > 0) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tooltip) {
 		this.refreshSelf();
 		return true;
 	} else {
@@ -188,6 +188,11 @@ SelectWidget.prototype.refresh = function(changedTiddlers) {
 			this.selectClass = this.getAttribute("class");
 			this.getSelectDomNode().setAttribute("class",this.selectClass); 
 		}
+		this.assignAttributes(this.getSelectDomNode(),{
+			changedAttributes: changedAttributes,
+			sourcePrefix: "data-",
+			destPrefix: "data-"
+		});
 		var childrenRefreshed = this.refreshChildren(changedTiddlers);
 		if(changedTiddlers[this.selectTitle] || childrenRefreshed) {
 			this.setSelectValue();

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -466,8 +466,10 @@ Widget.prototype.assignAttributesToParseTreeNode = function(parseTreeNode) {
 	var DATA_ATTRIBUTE_PREFIX = "data-",
 		STYLE_ATTRIBUTE_PREFIX = "style.";
 	$tw.utils.each(this.attributes,function(value,name) {
-		if(name.substr(0,DATA_ATTRIBUTE_PREFIX.length) === DATA_ATTRIBUTE_PREFIX || name.substr(0,STYLE_ATTRIBUTE_PREFIX.length) === STYLE_ATTRIBUTE_PREFIX) {
+		if(name.substr(0,DATA_ATTRIBUTE_PREFIX.length) === DATA_ATTRIBUTE_PREFIX) {
 			$tw.utils.addAttributeToParseTreeNode(parseTreeNode,name,value);
+		} else if(name.substr(0,STYLE_ATTRIBUTE_PREFIX.length) === STYLE_ATTRIBUTE_PREFIX && name.length > 6) {
+			$tw.utils.addStyleToParseTreeNode(parseTreeNode,$tw.utils.unHyphenateCss(name.substr(STYLE_ATTRIBUTE_PREFIX.length)),value);
 		}
 	});
 };

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/SelectWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/SelectWidget-DataAttributes.tid
@@ -1,0 +1,30 @@
+title: Widgets/DataAttributes/SelectWidget
+description: Data Attributes for SelectWidget
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$select tiddler='$:/SiteTitle' data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}}>
+<option>A Tale of Two Cities</option>
+<option>A New Kind of Science</option>
+<option>The Dice Man</option>
+</$select>
++
+title: $:/SiteTitle
+
+TiddlyWiki
++
+title: Actions
+
+<$action-setfield $tiddler="Temp" $field="text" $value="Title2" color="red"/>
++
+title: Temp
+color: black
+
+Title1
++
+title: ExpectedResult
+
+<p><select data-title="Title2" style="color:red;" value="TiddlyWiki"><option>A Tale of Two Cities</option><option>A New Kind of Science</option><option>The Dice Man</option></select></p>


### PR DESCRIPTION
**N.B! Test failing for style support, needs feedback.**

This PR fixes issues with the data and style attributes support introduced in #7769

Issues:
- Fixed: the refresh handling for data attributes in the select widget was short circuiting the code that updated the class of the DOM node in place instead of re-rendering the widget.
- Attempted fix: there was no support for `style.*` attributes for widgets that called `Widget.prototype.assignAttributesToParseTreeNode` since this method does not have the extra handling needed for `style.*` attributes

**Outstanding issue:**
- with the change to `assignAttributesToParseTreeNode` the `style.*` widget attributes are correctly applied to the DOM node. However, upon refresh when the style values change, the HTML output of the test shows two duplicate style attributes for the DOM node. Running the same code in the wiki in the browser, the output is as expected without the duplicate style attributes. However, this may be a case of the browser compensating for the duplicate attributes and sanitizing the HTML.

For example when changing the `style.color` from black to red, this output HTML
`<select data-title="Title2" style="color:black;" value="TiddlyWiki">`
changes to:
`<select data-title="Title2" style="color:black;" value="TiddlyWiki" style="color:red;">`

I was working on the Tour plugin when I came back to this as something was bothering my subconscious about this part of the implementation. @Jermolene @pmario any input would be appreciated. I will circle back to this later with fresher eyes.
