### PR TITLE
Refactors Select widget to directly create DOM node

### DIFF
--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -182,16 +182,21 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 SelectWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	// If we're using a different tiddler/field/index then completely refresh ourselves
-	if($tw.utils.count(changedAttributes) > 0) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tooltip || changedAttributes.tabindex) {
 		this.refreshSelf();
 		return true;
 	} else {
-		// If the target tiddler value has changed, just update setting and refresh the children
 		if(changedAttributes.class) {
 			this.selectClass = this.getAttribute("class");
 			this.getSelectDomNode().setAttribute("class",this.selectClass); 
 		}
+		this.assignAttributes(this.getSelectDomNode(),{
+			changedAttributes: changedAttributes,
+			sourcePrefix: "data-",
+			destPrefix: "data-"
+		});
 		var childrenRefreshed = this.refreshChildren(changedTiddlers);
+		// If the target tiddler value has changed, just update setting and refresh the children
 		if(changedTiddlers[this.selectTitle] || childrenRefreshed) {
 			this.setSelectValue();
 		} 

--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -40,7 +40,31 @@ SelectWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
-	this.renderChildren(parent,nextSibling);
+	//Create element
+	var domNode = this.document.createElement("select");
+	if(this.selectClass) {
+		domNode.classname = this.selectClass;
+	}
+	// Assign data- attributes
+	this.assignAttributes(domNode,{
+		sourcePrefix: "data-",
+		destPrefix: "data-"
+	});
+	if(this.selectMultiple) {
+		domNode.setAttribute("multiple","multiple");
+	}
+	if(this.selectSize) {
+		domNode.setAttribute("size",this.selectSize);
+	}
+	if(this.selectTabindex) {
+		domNode.setAttribute("tabindex",this.selectTabindex);
+	}
+	if(this.selectTooltip) {
+		domNode.setAttribute("title",this.selectTooltip);
+	}
+	this.renderChildren(domNode,nextSibling);
+	this.parentDomNode.insertBefore(domNode,nextSibling);
+	this.domNodes.push(domNode);
 	this.setSelectValue();
 	if(this.selectFocus == "yes") {
 		this.getSelectDomNode().focus();
@@ -113,7 +137,7 @@ SelectWidget.prototype.setSelectValue = function() {
 Get the DOM node of the select element
 */
 SelectWidget.prototype.getSelectDomNode = function() {
-	return this.children[0].domNodes[0];
+	return this.domNodes[0];
 };
 
 // Return an array of the selected opion values
@@ -149,6 +173,7 @@ SelectWidget.prototype.execute = function() {
 	this.selectTooltip = this.getAttribute("tooltip");
 	this.selectFocus = this.getAttribute("focus");
 	// Make the child widgets
+	/*
 	var selectNode = {
 		type: "element",
 		tag: "select",
@@ -170,7 +195,8 @@ SelectWidget.prototype.execute = function() {
 		$tw.utils.addAttributeToParseTreeNode(selectNode,"title",this.selectTooltip);
 	}
 	this.assignAttributesToParseTreeNode(selectNode);
-	this.makeChildWidgets([selectNode]);
+	*/
+	this.makeChildWidgets();
 };
 
 /*

--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -173,29 +173,6 @@ SelectWidget.prototype.execute = function() {
 	this.selectTooltip = this.getAttribute("tooltip");
 	this.selectFocus = this.getAttribute("focus");
 	// Make the child widgets
-	/*
-	var selectNode = {
-		type: "element",
-		tag: "select",
-		children: this.parseTreeNode.children
-	};
-	if(this.selectClass) {
-		$tw.utils.addAttributeToParseTreeNode(selectNode,"class",this.selectClass);
-	}
-	if(this.selectMultiple) {
-		$tw.utils.addAttributeToParseTreeNode(selectNode,"multiple","multiple");
-	}
-	if(this.selectSize) {
-		$tw.utils.addAttributeToParseTreeNode(selectNode,"size",this.selectSize);
-	}
-	if(this.selectTabindex) {
-		$tw.utils.addAttributeToParseTreeNode(selectNode,"tabindex",this.selectTabindex);
-	}
-	if(this.selectTooltip) {
-		$tw.utils.addAttributeToParseTreeNode(selectNode,"title",this.selectTooltip);
-	}
-	this.assignAttributesToParseTreeNode(selectNode);
-	*/
 	this.makeChildWidgets();
 };
 

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -459,20 +459,6 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 };
 
 /*
-Set the data- and style. attributes of a parse tree node according to the attributes of the widget
-*/
-Widget.prototype.assignAttributesToParseTreeNode = function(parseTreeNode) {
-	var self = this;
-	var DATA_ATTRIBUTE_PREFIX = "data-",
-		STYLE_ATTRIBUTE_PREFIX = "style.";
-	$tw.utils.each(this.attributes,function(value,name) {
-		if(name.substr(0,DATA_ATTRIBUTE_PREFIX.length) === DATA_ATTRIBUTE_PREFIX || name.substr(0,STYLE_ATTRIBUTE_PREFIX.length) === STYLE_ATTRIBUTE_PREFIX) {
-			$tw.utils.addAttributeToParseTreeNode(parseTreeNode,name,value);
-		}
-	});
-};
-
-/*
 Get the number of ancestor widgets for this widget
 */
 Widget.prototype.getAncestorCount = function() {

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/SelectWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/SelectWidget-DataAttributes.tid
@@ -1,0 +1,27 @@
+title: Widgets/DataAttributes/SelectWidget
+description: Data Attributes for SelectWidget
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<$select tiddler='New Tiddler' field='text' default='Choose a new text' data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}}>
+<option disabled>Choose a new text</option>
+<option>A Tale of Two Cities</option>
+<option>A New Kind of Science</option>
+<option>The Dice Man</option>
+</$select>
++
+title: Actions
+
+<$action-setfield $tiddler="Temp" $field="text" $value="Title2" color="red"/>
++
+title: Temp
+color: black
+
+Title1
++
+title: ExpectedResult
+
+<p><select data-title="Title2" value="Choose a new text" style="color:red;"><option disabled="true">Choose a new text</option><option>A Tale of Two Cities</option><option>A New Kind of Science</option><option>The Dice Man</option></select></p>


### PR DESCRIPTION
This PR refactors the select widget to directly create its DOM node and fixes support for data and style attributes introduced in #7769 

The `Widget.prototype.assignAttributesToParseTreeNode()` method has been removed.