### PR TITLE
Fixes issues in the PR "Button widget data attributes"

### DIFF
--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -84,6 +84,12 @@ Object.defineProperty(TW_Element.prototype, "style", {
 				self._style[$tw.utils.convertStyleNameToPropertyName(name)] = value;
 			}
 		});
+	},
+	setAttribute: function(name,value) {
+		var self = this;
+		if(name && value) {
+			self._style[$tw.utils.convertStyleNameToPropertyName(name)] = value;
+		}
 	}
 });
 
@@ -104,7 +110,11 @@ TW_Element.prototype.setAttribute = function(name,value) {
 	if(this.isRaw) {
 		throw "Cannot setAttribute on a raw TW_Element";
 	}
-	this.attributes[name] = value + "";
+	if(name === "style") {
+		this.style = value;
+	} else {
+		this.attributes[name] = value + "";
+	}
 };
 
 TW_Element.prototype.setAttributeNS = function(namespace,name,value) {

--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -84,12 +84,6 @@ Object.defineProperty(TW_Element.prototype, "style", {
 				self._style[$tw.utils.convertStyleNameToPropertyName(name)] = value;
 			}
 		});
-	},
-	setAttribute: function(name,value) {
-		var self = this;
-		if(name && value) {
-			self._style[$tw.utils.convertStyleNameToPropertyName(name)] = value;
-		}
 	}
 });
 

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -436,7 +436,7 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 			value = undefined;
 		}
 		// Check for excluded attribute names
-		if(options.excludeEventAttributes && name.substr(0,2) === EVENT_ATTRIBUTE_PREFIX) {
+		if(options.excludeEventAttributes && name.substr(0,2).toLowerCase() === EVENT_ATTRIBUTE_PREFIX) {
 			value = undefined;
 		}
 		if(value !== undefined) {

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -431,7 +431,7 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 		// Check if the sourcePrefix is a match
 		if(name.substr(0,sourcePrefix.length) === sourcePrefix) {
 			name = destPrefix + name.substr(sourcePrefix.length);
-		// Check for attribute names that are not prefix style. and are thus excluded
+		// Check for attribute names that are not prefixed style. and are thus excluded
 		} else if(name.substr(0,6) !== "style." || name.length <= 6) {
 			value = undefined;
 		}

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -428,11 +428,15 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 		destPrefix = options.destPrefix || "",
 		EVENT_ATTRIBUTE_PREFIX = "on";
 	var assignAttribute = function(name,value) {
+		// Process any style attributes before considering sourcePrefix and destPrefix
+		if(name.substr(0,6) === "style." && name.length > 6) {
+			domNode.style[$tw.utils.unHyphenateCss(name.substr(6))] = value;
+			return;
+		}
 		// Check if the sourcePrefix is a match
 		if(name.substr(0,sourcePrefix.length) === sourcePrefix) {
 			name = destPrefix + name.substr(sourcePrefix.length);
-		// Check for attribute names that are not prefixed style. and are thus excluded
-		} else if(name.substr(0,6) !== "style.") {
+		} else {
 			value = undefined;
 		}
 		// Check for excluded attribute names
@@ -446,15 +450,10 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 				namespace = "http://www.w3.org/1999/xlink";
 				name = name.substr(6);
 			}
-			// Handle styles
-			if(name.substr(0,6) === "style." && name.length > 6) {
-				domNode.style[$tw.utils.unHyphenateCss(name.substr(6))] = value;
-			} else {
-				// Setting certain attributes can cause a DOM error (eg xmlns on the svg element)
-				try {
-					domNode.setAttributeNS(namespace,name,value);
-				} catch(e) {
-				}
+			// Setting certain attributes can cause a DOM error (eg xmlns on the svg element)
+			try {
+				domNode.setAttributeNS(namespace,name,value);
+			} catch(e) {
 			}
 		}
 	};

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -428,13 +428,15 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 		destPrefix = options.destPrefix || "",
 		EVENT_ATTRIBUTE_PREFIX = "on";
 	var assignAttribute = function(name,value) {
+		// Check if the sourcePrefix is a match
 		if(name.substr(0,sourcePrefix.length) === sourcePrefix) {
 			name = destPrefix + name.substr(sourcePrefix.length);
+		// Check for attribute names that are not prefix style. and are thus excluded
 		} else if(name.substr(0,6) !== "style." || name.length <= 6) {
 			value = undefined;
 		}
 		// Check for excluded attribute names
-		if(options.excludeEventAttributes && name.substr(0,2) === "on") {
+		if(options.excludeEventAttributes && name.substr(0,2) === EVENT_ATTRIBUTE_PREFIX) {
 			value = undefined;
 		}
 		if(value !== undefined) {
@@ -456,31 +458,19 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 			}
 		}
 	};
-	// Not all parse tree nodes have the orderedAttributes property
+	// If the parse tree node has the orderedAttributes property then use that order
 	if(this.parseTreeNode.orderedAttributes) {
 		$tw.utils.each(this.parseTreeNode.orderedAttributes,function(attribute,index) {
 			if(attribute.name in changedAttributes) {
 				assignAttribute(attribute.name,self.getAttribute(attribute.name));
 			}
-		});	
+		});
+	// Otherwise update each changed attribute ignoring the order
 	} else {
 		$tw.utils.each(changedAttributes,function(value,name) {
 			assignAttribute(name,self.getAttribute(name));
 		});	
 	}
-
-/*
-	$tw.utils.each(changedAttributes,function(value,name) {
-		value = self.getAttribute(name);
-		// Check for a prefixed attribute
-		if(name.substr(0,sourcePrefix.length) === sourcePrefix) {
-			assignAttribute(destPrefix + name.substr(sourcePrefix.length),value);
-		// Check for a style attribute
-		} else if(name.substr(0,6) === "style." && name.length > 6) {
-			domNode.style[$tw.utils.unHyphenateCss(name.substr(6))] = value;
-		}
-	});
-*/
 };
 
 /*

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -432,7 +432,7 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 		if(name.substr(0,sourcePrefix.length) === sourcePrefix) {
 			name = destPrefix + name.substr(sourcePrefix.length);
 		// Check for attribute names that are not prefixed style. and are thus excluded
-		} else if(name.substr(0,6) !== "style." || name.length <= 6) {
+		} else if(name.substr(0,6) !== "style.") {
 			value = undefined;
 		}
 		// Check for excluded attribute names

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -465,7 +465,7 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 				assignAttribute(attribute.name,self.getAttribute(attribute.name));
 			}
 		});
-	// Otherwise update each changed attribute ignoring the order
+	// Otherwise update each changed attribute irrespective of order
 	} else {
 		$tw.utils.each(changedAttributes,function(value,name) {
 			assignAttribute(name,self.getAttribute(name));

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/ButtonWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/ButtonWidget-DataAttributes.tid
@@ -6,7 +6,7 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \whitespace trim
-<$button tag="div" class="myclass" data-title="mytiddler" style.color="red">
+<$button tag="div" class="myclass" data-title="mytiddler" style.color="red" onclick="clicked">
 my tiddler
 </$button>
 <$button tag="div" class="myclass" data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}}>

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/CheckboxWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/CheckboxWidget-DataAttributes.tid
@@ -6,7 +6,7 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \whitespace trim
-<$checkbox tag="done" data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}}> Is it done?</$checkbox>
+<$checkbox tag="done" data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}} onclick="clicked"> Is it done?</$checkbox>
 +
 title: Actions
 

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/DraggableWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/DraggableWidget-DataAttributes.tid
@@ -6,7 +6,7 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \whitespace trim
-<$draggable tag="div" class="myclass" data-title="mytiddler" style.color="red">
+<$draggable tag="div" class="myclass" data-title="mytiddler" style.color="red" onclick="clicked">
 my tiddler
 </$draggable>
 <$draggable tag="div" class="myclass" data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}}>

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/DroppableWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/DroppableWidget-DataAttributes.tid
@@ -6,7 +6,7 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \whitespace trim
-<$droppable tag="div" class="myclass" data-title="mytiddler" style.color="red">
+<$droppable tag="div" class="myclass" data-title="mytiddler" style.color="red" onclick="clicked">
 my tiddler
 </$droppable>
 <$droppable tag="div" class="myclass" data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}}>

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/LinkWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/LinkWidget-DataAttributes.tid
@@ -6,7 +6,7 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \whitespace trim
-<$link data-id="mytiddler" style.color="red" to="Temp">
+<$link data-id="mytiddler" style.color="red" to="Temp" onclick="clicked">
 link to Temp
 </$link>
 <$link tag="button" data-id={{Temp}} style.color={{{ [[Temp]get[color]] }}} to="SomeTiddler">

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/OrderedStyleAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/OrderedStyleAttributes.tid
@@ -1,0 +1,15 @@
+title: Widgets/DataAttributes/OrderedStyleAttributes
+description: Ordered style attributes
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<div style="background:red;color:blue;" style.background="green">
+hello
+</div>
++
+title: ExpectedResult
+
+<p><div style="background:green;color:blue;">hello</div></p>

--- a/editions/test/tiddlers/tests/data/widgets/DataAttributes/SelectWidget-DataAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/DataAttributes/SelectWidget-DataAttributes.tid
@@ -6,7 +6,7 @@ tags: [[$:/tags/wiki-test-spec]]
 title: Output
 
 \whitespace trim
-<$select tiddler='New Tiddler' field='text' default='Choose a new text' data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}}>
+<$select tiddler='New Tiddler' field='text' default='Choose a new text' data-title={{Temp}} style.color={{{ [[Temp]get[color]] }}} onclick="clicked">
 <option disabled>Choose a new text</option>
 <option>A Tale of Two Cities</option>
 <option>A New Kind of Science</option>

--- a/editions/test/tiddlers/tests/data/widgets/ElementWidgetEventAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/ElementWidgetEventAttributes.tid
@@ -1,0 +1,15 @@
+title: Widgets/ElementWidgetEventAttributes
+description: Element widget should not support event attributes starting with "on"
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<div class="hello" onclick="clicked">
+TiddlyWiki
+</div>
++
+title: ExpectedResult
+
+<p><div class="hello">TiddlyWiki</div></p>

--- a/editions/test/tiddlers/tests/data/widgets/ElementWidgetStyleAttributes.tid
+++ b/editions/test/tiddlers/tests/data/widgets/ElementWidgetStyleAttributes.tid
@@ -1,0 +1,15 @@
+title: Widgets/ElementWidgetStyleAttributes
+description: Element widget should support style.* attributes
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+<div class="hello" onclick="clicked" style.color="blue" style.color="red" style.background="yellow">
+TiddlyWiki
+</div>
++
+title: ExpectedResult
+
+<p><div class="hello" style="color:red;background:yellow;">TiddlyWiki</div></p>


### PR DESCRIPTION

Fixes:
* ensures that event attributes are excluded
* add tests for event attribute exclusion
* ensures that style. attributes are supported when no sourcePrefix is specified
* adds tests for style. attributes for the element widget
* extends fakedom to accurately assign style property of fake DOM node.
* ensures that attribute order is respected and adds a test for this