### PR TITLE
Updates help text for CommandsCommand to avoid deduplication of commands

### DIFF
--- a/core/language/en-GB/Help/commands.tid
+++ b/core/language/en-GB/Help/commands.tid
@@ -10,7 +10,7 @@ Sequentially run the command tokens returned from a filter
 Examples
 
 ```
---commands "[enlist{$:/build-commands-as-text}]"
+--commands "[enlist:raw{$:/build-commands-as-text}]"
 ```
 
 ```


### PR DESCRIPTION
Fixes #7857 where the given example of using `enlist[] `on commands retrieved from a text reference leads to deduplication of the commands.