### PR TITLE
Update forum link in update wizard

### DIFF
--- a/editions/de-AT/tiddlers/HelloThere.tid
+++ b/editions/de-AT/tiddlers/HelloThere.tid
@@ -21,8 +21,8 @@ Willkommen bei ''~TiddlyWiki'', dem einzigartigen [[nicht-linearen|Philosophy vo
 Anders, als bei herkömmlichen Online-Diensten, lässt Ihnen ~TiddlyWiki die Freiheit, wo sie ihre Daten speichern. Da ~TiddlyWiki alle Daten als simplen Text speichert, sind Notizen, die Sie heute machen, garantiert in Jahrzehnten noch einfach lesbar. 
 
 <div style="font-size:0.7em;text-align:center;margin-top:3em;margin-bottom:3em;">
-<a href="http://groups.google.com/group/TiddlyWiki" class="tc-btn-big-green" style="background-color:#FF8C19;" target="_blank">
-{{$:/core/images/mail}} ~TiddlyWiki Mailing List
+<a href="https://talk.tiddlywiki.org/" class="tc-btn-big-green" style="background-color:#FF8C19;" target="_blank">
+{{$:/core/images/help}} ~TiddlyWiki Forum
 </a>
 <a href="https://twitter.com/TiddlyWiki" class="tc-btn-big-green" style="background-color:#5E9FCA;" target="_blank">
 {{$:/core/images/twitter}} @~TiddlyWiki on Twitter

--- a/editions/de-AT/tiddlers/community/Fur_Entwickler.tid
+++ b/editions/de-AT/tiddlers/community/Fur_Entwickler.tid
@@ -7,5 +7,5 @@ type: text/vnd.tiddlywiki
 Es gibt mehrere Ressourcen für Entwickler, um mehr über das TiddlyWiki Projekt zu erfahren, zu diskutieren und vor allem mitzuhelfen. 
 
 * [[tiddlywiki.com/dev|https://tiddlywiki.com/dev]] Offizielle Entwickler Doku.
-* [[TiddlyWikiDev group|http://groups.google.com/group/TiddlyWikiDev]] Google Diskussionsforum für Entwickler.
+* [[TiddlyWikiDev group|https://talk.tiddlywiki.org/c/devs/]] Diskussionsforum für Entwickler.
 * https://github.com/Jermolene/TiddlyWiki5 .. Github Repository. 

--- a/editions/es-ES/tiddlers/Forums.tid
+++ b/editions/es-ES/tiddlers/Forums.tid
@@ -12,7 +12,9 @@ Son listas de correo en las que hablamos de ~TiddlyWiki: pedimos ayuda, anunciam
 
 Puedes participar a través de la página web asociada, o suscribirte via mail.
 
-!!Usuarios
+!! Usuarios
+
+[[Foro oficial de TiddlyWiki| https://talk.tiddlywiki.org/]]
 
 [[Grupo principal de TiddlyWiki| http://groups.google.com/group/TiddlyWiki]]
 
@@ -25,10 +27,7 @@ o síguenos [[en Twitter|http://twitter.com/TiddlyWiki]] si quieres recibir las 
 
 !! Desarrolladores
 
-[[Grupo de desarrollo de TiddlyWiki|http://groups.google.com/group/TiddlyWikiDev]]
-
->No necesitas tener cuenta en Google para acceder al grupo. Suscríbete igualmente enviando un mail a:
-*mailto:tiddlywikidev+subscribe@googlegroups.com.
+[[Foro de desarrollo de TiddlyWiki|https://talk.tiddlywiki.org/c/devs]]
 
 Accede a nuestra [[página de desarrollo|https://github.com/Jermolene/TiddlyWiki5]] en GitHub y haz tu contribución.
 

--- a/editions/es-ES/tiddlers/HelloThere.tid
+++ b/editions/es-ES/tiddlers/HelloThere.tid
@@ -20,8 +20,8 @@ BIenvenido a TiddlyWiki, un bloc de notas [[no lineal|Philosophy of Tiddlers]] �
 Al revés que los servicios online convencionales, TiddlyWiki te deja escoger dónde quieres guardar tus datos, garantizándote que, por más que pase el tiempo, podrás seguir usando en el futuro las notas que tomes hoy.
 
 <div style="font-size:0.7em;text-align:center;margin-top:3em;margin-bottom:3em;">
-<a href="http://groups.google.com/group/TiddlyWiki" class="tc-btn-big-green" style="background-color:#FF8C19;" target="_blank" rel="noopener noreferrer">
-{{$:/core/images/mail}} ~TiddlyWiki en Google Groups
+<a href="https://talk.tiddlywiki.org/" class="tc-btn-big-green" style="background-color:#FF8C19;" target="_blank" rel="noopener noreferrer">
+{{$:/core/images/mail}} Foro oficial de ~TiddlyWiki
 </a>
 <a href="https://www.youtube.com/c/JeremyRuston" class="tc-btn-big-green" style="background-color:#e52d27;" target="_blank" rel="noopener noreferrer">
 {{$:/core/images/video}} ~TiddlyWiki en ~YouTube

--- a/editions/es-ES/tiddlers/Typography.tid
+++ b/editions/es-ES/tiddlers/Typography.tid
@@ -8,7 +8,7 @@ type: text/vnd.tiddlywiki
 
 Se recomienda el uso de las [[macros de documentación|Documentation Macros]] para facilitar las futuras tareas de mantenimiento del texto frente a nuevos cambios y actualizaciones. 
 
-Se recomienda precaución en el uso arbitrario de estilos directos de formato (''negrita'', //cursiva// ...etc). Si se puede usar una macro, conviene usarla. Si no existe la macro adecuada, se puede crear o, si no se sabe cómo, pedir su creación en el [[Grupo de Google|http://groups.google.com/group/TiddlyWiki]].
+Se recomienda precaución en el uso arbitrario de estilos directos de formato (''negrita'', //cursiva// ...etc). Si se puede usar una macro, conviene usarla. Si no existe la macro adecuada, se puede crear o, si no se sabe cómo, pedir su creación en el [[Foro de TiddlyWiki|https://talk.tiddlywiki.org/]].
 
 Por el mismo motivo, se aconseja el uso de acentos graves <code>&#96;...&#96;</code> para transcribir fragmentos de código y ~WikiText, pero no para nombres de cosas tales como campos, operadores, variables o widgets. Estas tienen su macro correspondiente.
 

--- a/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
+++ b/plugins/tiddlywiki/upgrade/UpgradeWizard.tid
@@ -44,7 +44,7 @@ Make sure that you keep a safe copy of your previous ~TiddlyWiki file.
 
 Close this browser window to prevent others from being able to access your data.
 
-For help and support, visit [[the TiddlyWiki discussion forum|http://groups.google.com/group/TiddlyWiki]].
+For help and support, visit [[the TiddlyWiki discussion forum|https://talk.tiddlywiki.org]].
 
 </$reveal>
 


### PR DESCRIPTION
The update wizard linked to the old Google Groups forum after performing the upgrade.

This PR changes the link to talk.tiddlywiki.org

I also went ahead and updated the references to the forum in the few places I have found them in the es-ES and de-AT editions. Not sure if it's worth much, as these editions seem to be very out of date and rudimentary.