### PR TITLE
Make $scrollable less jumpy

### DIFF
--- a/core/modules/widgets/scrollable.js
+++ b/core/modules/widgets/scrollable.js
@@ -255,7 +255,7 @@ ScrollableWidget.prototype.refresh = function(changedTiddlers) {
 	}
 	// If a new scroll position was written into the tiddler, update scroll position
 	if(changedTiddlers[this.getAttribute("bind")]) {
-		setTimeout(this.updateScrollPositionFromBoundTiddler.bind(this),50);
+		this.updateScrollPositionFromBoundTiddler.bind(this);
 	}
 	return this.refreshChildren(changedTiddlers);
 };


### PR DESCRIPTION
The setTimeout in the code for the position update could lead to jumpy behavior when doing multiple short scroll actions, because a delayed update could interfere with the next manual scroll action.
