### PR TITLE
Docs: fixes typos in conditonal shortcut syntax docs

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/Conditional Shortcut Syntax.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Conditional Shortcut Syntax.tid
@@ -4,7 +4,7 @@ tags: WikiText
 title: Conditional Shortcut Syntax
 type: text/vnd.tiddlywiki
 
-<<.from-version "5.3.2">> The conditional shortcut syntax provides a convenient way to express if-then-else logic within WikiText. It evaluates a filter expression and considers the condition to be true if there is at least one result (regardless of the value of that result).
+<<.from-version "5.3.2">> The conditional shortcut syntax provides a convenient way to express if-then-else logic within WikiText. It evaluates a [[filter expression|Filter Expression]] and considers the condition to be true if there is at least one result (regardless of the value of that result).
 
 Within an "if" or "elseif" clause, the variable `condition` contains the value of the first result of evaluating the filter condition.
 


### PR DESCRIPTION
Fixes typos in the documentation for the conditional shortcut syntax and replaces the use of the word `filter` with `filter expression` for specificity and clarity.