### PR TITLE
Docs: Improve `.from-version` macro

### DIFF
--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -1,5 +1,5 @@
 created: 20150117152612000
-modified: 20230325101137075
+modified: 20240223123123497
 tags: $:/tags/Stylesheet
 title: $:/editions/tw5.com/doc-styles
 type: text/vnd.tiddlywiki
@@ -181,18 +181,18 @@ tr.doc-table-subheading {
 	fill: <<colour alert-highlight>>;
 }
 
-a.doc-from-version.tc-tiddlylink {
-    display: inline-block;
-    border-radius: 1em;
-	background: <<colour muted-foreground>>;
-	color: <<colour background>>;
-	fill: <<colour background>>;
-    padding: 0 0.4em;
-    font-size: 0.7em;
-    text-transform: uppercase;
+a.doc-from-version {
+    background-color: <<colour muted-foreground>>;
+    color: <$wikify name="background" text="<<colour muted-foreground>>" mode="inline"><$transclude $variable="contrastcolour" target=<<background>> colourA="#000000" colourB="#ffffff" /></$wikify>;
+    padding: 3px;
+    border-radius: 4px;
     font-weight: bold;
-    line-height: 1.5;
-    vertical-align: text-bottom;
+    font-size: 0.75em;
+}
+
+a.doc-from-version.doc-from-version-new {
+    background-color: <<colour highlight-background>>;
+    color: <<colour highlight-foreground>>;
 }
 
 a.doc-deprecated-version.tc-tiddlylink {

--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -195,6 +195,11 @@ a.doc-from-version.doc-from-version-new {
     color: <<colour highlight-foreground>>;
 }
 
+a.doc-from-version svg {
+    fill: currentColor;
+    vertical-align: sub;
+}
+
 a.doc-deprecated-version.tc-tiddlylink {
     display: inline-block;
     border-radius: 1em;

--- a/editions/tw5.com/tiddlers/system/version-macros.tid
+++ b/editions/tw5.com/tiddlers/system/version-macros.tid
@@ -1,12 +1,19 @@
 code-body: yes
 created: 20161008085627406
-modified: 20221007122259593
+modified: 20231206135257498
 tags: $:/tags/Macro
 title: $:/editions/tw5.com/version-macros
 type: text/vnd.tiddlywiki
 
-\define .from-version(version)
-<$link to={{{ [<__version__>addprefix[Release ]] }}} class="doc-from-version">{{$:/core/images/warning}} New in: <$text text=<<__version__>>/></$link>
+\procedure .from-version-reference() 5.3.0
+
+\procedure .from-version-template(class, text)
+<$link to={{{ [<version>addprefix[Release ]] }}} class=<<class>> ><<text>><<version>></$link>
+\end
+
+\procedure .from-version(version)
+<$list filter="[<version>compare:version:gteq<.from-version-reference>]"><<.from-version-template "doc-from-version doc-from-version-new" "New in v">></$list>
+<$list filter="[<version>compare:version:lt<.from-version-reference>]"><<.from-version-template "doc-from-version" "Introduced in v">></$list>
 \end
 
 \define .deprecated-since(version, superseded:"TODO-Link")

--- a/editions/tw5.com/tiddlers/system/version-macros.tid
+++ b/editions/tw5.com/tiddlers/system/version-macros.tid
@@ -8,7 +8,7 @@ type: text/vnd.tiddlywiki
 \procedure .from-version-reference() 5.3.0
 
 \procedure .from-version-template(class, text)
-<$link to={{{ [<version>addprefix[Release ]] }}} class=<<class>> ><<text>><<version>></$link>
+<$link to={{{ [<version>addprefix[Release ]] }}} class=<<class>> >@@.tc-tiny-gap-right {{$:/core/images/info-button}}@@<<text>><<version>></$link>
 \end
 
 \procedure .from-version(version)


### PR DESCRIPTION
As discussed in this thread: https://talk.tiddlywiki.org/t/are-stringify-and-jsonstringify-operators-duplicates/7760/13, quote from Jeremy:

>In `<<.from-version "5.3.2">>` we could change the annotation text and styling depending on the version number. We could highlight the most recent release with a bright “NEW IN v5.3.2” badge, but mark older versions with less eye catching “introduced in v5.2.3” text.

I have decided to set the threshold of what is considered "new" manually. Highlighting only the last release as new would be more difficult than simply comparing against an arbitrary threshold. It might also not make sense in all situations, e.g. if there is a bugfix release immediately after another release, it makes no sense to mark just the bugfix as new. I have set this threshold to v5.3.0 for now.

The colors of the new badge are the same as in the `.link-badge-added` macro. I imagine it could be dynamically based on primary or highlight colors from current palette, but then it we'd introduce new color combinations for documentation elements. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>  