### PR TITLE
fix edit toolbar button whitespace

### DIFF
--- a/core/ui/EditTemplate/body-editor.tid
+++ b/core/ui/EditTemplate/body-editor.tid
@@ -3,42 +3,29 @@ title: $:/core/ui/EditTemplate/body/editor
 \whitespace trim
 
 <$edit
-
-  field="text"
-  class="tc-edit-texteditor tc-edit-texteditor-body"
-  placeholder={{$:/language/EditTemplate/Body/Placeholder}}
-  tabindex={{$:/config/EditTabIndex}}
-  focus={{{ [{$:/config/AutoFocus}match[text]then[true]] ~[[false]] }}}
-  cancelPopups="yes"
-  fileDrop={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}}
-
-><$set
-
-  name="targetTiddler"
-  value=<<currentTiddler>>
-
-><$list
-
-  filter="[all[shadows+tiddlers]tag[$:/tags/EditorToolbar]!has[draft.of]]"
-
-><$reveal
-
-  type="nomatch"
-  state=<<config-visibility-title>>
-  text="hide"
-  class="tc-text-editor-toolbar-item-wrapper"
-
-><$transclude
-
-  tiddler="$:/core/ui/EditTemplate/body/toolbar/button"
-  mode="inline"
-
-/></$reveal></$list><$list
-
-  filter="[all[shadows+tiddlers]tag[$:/tags/EditorTools]!has[draft.of]]"
-
-><$list
-	filter={{!!condition}}
-	variable="list-condition"
-><$transclude/>
-</$list></$list></$set></$edit>
+	field="text"
+	class="tc-edit-texteditor tc-edit-texteditor-body"
+	placeholder={{$:/language/EditTemplate/Body/Placeholder}}
+	tabindex={{$:/config/EditTabIndex}}
+	focus={{{ [{$:/config/AutoFocus}match[text]then[true]] ~[[false]] }}}
+	cancelPopups="yes"
+	fileDrop={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}}
+>
+	<$set name="targetTiddler" value=<<currentTiddler>> >
+		<$list filter="[all[shadows+tiddlers]tag[$:/tags/EditorToolbar]!has[draft.of]]">
+			<$reveal
+				type="nomatch"
+				state=<<config-visibility-title>>
+				text="hide"
+				class="tc-text-editor-toolbar-item-wrapper"
+			>
+				<$transclude tiddler="$:/core/ui/EditTemplate/body/toolbar/button" mode="inline"/>
+			</$reveal>
+		</$list>
+		<$list filter="[all[shadows+tiddlers]tag[$:/tags/EditorTools]!has[draft.of]]">
+			<$list filter={{!!condition}} variable="list-condition">
+				<$transclude/>
+			</$list>
+		</$list>
+	</$set>
+</$edit>

--- a/core/ui/EditTemplate/body-toolbar-button.tid
+++ b/core/ui/EditTemplate/body-toolbar-button.tid
@@ -27,7 +27,7 @@ title: $:/core/ui/EditTemplate/body/toolbar/button
 				>
 					<span data-tw-keyboard-shortcut={{{ [<disabled>match[yes]then[]else{!!shortcuts}] }}}/>
 					<<toolbar-button-icon>>
-					<$transclude tiddler=<<currentTiddler>> field="text"/>
+					<$transclude/>
 				</$button>
 			</$set>
 		</$list>
@@ -44,7 +44,7 @@ title: $:/core/ui/EditTemplate/body/toolbar/button
 					>
 						<span data-tw-keyboard-shortcut={{{ [<disabled>match[yes]then[]else{!!shortcuts}] }}}/>
 						<<toolbar-button-icon>>
-						<$transclude tiddler=<<currentTiddler>> field="text"/>
+						<$transclude/>
 					</$button>
 				</$set>
 				<$reveal

--- a/core/ui/EditTemplate/body-toolbar-button.tid
+++ b/core/ui/EditTemplate/body-toolbar-button.tid
@@ -1,5 +1,7 @@
 title: $:/core/ui/EditTemplate/body/toolbar/button
 
+\whitespace trim
+
 \define toolbar-button-icon()
 <$list
 

--- a/core/ui/EditTemplate/body-toolbar-button.tid
+++ b/core/ui/EditTemplate/body-toolbar-button.tid
@@ -3,16 +3,10 @@ title: $:/core/ui/EditTemplate/body/toolbar/button
 \whitespace trim
 
 \define toolbar-button-icon()
-<$list
-
-  filter="[all[current]!has[custom-icon]]"
-  variable="no-custom-icon"
-
-><$transclude
-
-  tiddler={{!!icon}}
-
-/></$list>
+\whitespace trim
+<$list filter="[all[current]!has[custom-icon]]" variable="no-custom-icon">
+	<$transclude tiddler={{!!icon}}/>
+</$list>
 \end
 
 \define toolbar-button-tooltip()
@@ -20,94 +14,61 @@ title: $:/core/ui/EditTemplate/body/toolbar/button
 \end
 
 \define toolbar-button()
-<$list
-
-  filter={{!!condition}}
-  variable="list-condition"
-
-><$wikify
-
-  name="tooltip-text"
-  text=<<toolbar-button-tooltip>>
-  mode="inline"
-  output="text"
-
-><$list
-
-  filter="[all[current]!has[dropdown]]"
-  variable="no-dropdown"
-
-><$set name=disabled filter={{!!condition-disabled}}><$button
-
-  class="tc-btn-invisible $(buttonClasses)$"
-  tooltip=<<tooltip-text>>
-  actions={{!!actions}}
-  disabled=<<disabled>>
-
-><span
-
-  data-tw-keyboard-shortcut={{{ [<disabled>match[yes]then[]else{!!shortcuts}] }}}
-
-/><<toolbar-button-icon>><$transclude
-
-  tiddler=<<currentTiddler>>
-  field="text"
-
-/></$button></$set></$list><$list
-
-  filter="[all[current]has[dropdown]]"
-  variable="dropdown"
-
-><$set
-
-  name="dropdown-state"
-  value=<<qualify "$:/state/EditorToolbarDropdown">>
-
-><$set name=disabled filter={{!!condition-disabled}}><$button
-
-  popup=<<dropdown-state>>
-  class="tc-popup-keep tc-btn-invisible $(buttonClasses)$"
-  selectedClass="tc-selected"
-  tooltip=<<tooltip-text>>
-  actions={{!!actions}}
-  disabled=<<disabled>>
-
-><span
-
-  data-tw-keyboard-shortcut={{{ [<disabled>match[yes]then[]else{!!shortcuts}] }}}
-
-/><<toolbar-button-icon>><$transclude
-
-  tiddler=<<currentTiddler>>
-  field="text"
-
-/></$button></$set><$reveal
-
-  state=<<dropdown-state>>
-  type="popup"
-  position="below"
-  animate="yes"
-  tag="span"
-
-><div
-
-  class="tc-drop-down tc-popup-keep"
-
-><$transclude
-
-  tiddler={{!!dropdown}}
-  mode="block"
-
-/></div></$reveal></$set></$list></$wikify></$list>
+\whitespace trim
+<$list filter={{!!condition}} variable="list-condition">
+	<$wikify name="tooltip-text" text=<<toolbar-button-tooltip>> mode="inline" output="text">
+		<$list filter="[all[current]!has[dropdown]]" variable="no-dropdown">
+			<$set name=disabled filter={{!!condition-disabled}}>
+				<$button
+					class="tc-btn-invisible $(buttonClasses)$"
+					tooltip=<<tooltip-text>>
+					actions={{!!actions}}
+					disabled=<<disabled>>
+				>
+					<span data-tw-keyboard-shortcut={{{ [<disabled>match[yes]then[]else{!!shortcuts}] }}}/>
+					<<toolbar-button-icon>>
+					<$transclude tiddler=<<currentTiddler>> field="text"/>
+				</$button>
+			</$set>
+		</$list>
+		<$list filter="[all[current]has[dropdown]]" variable="dropdown">
+			<$set name="dropdown-state" value=<<qualify "$:/state/EditorToolbarDropdown">> >
+				<$set name=disabled filter={{!!condition-disabled}}>
+					<$button
+						popup=<<dropdown-state>>
+						class="tc-popup-keep tc-btn-invisible $(buttonClasses)$"
+						selectedClass="tc-selected"
+						tooltip=<<tooltip-text>>
+						actions={{!!actions}}
+						disabled=<<disabled>>
+					>
+						<span data-tw-keyboard-shortcut={{{ [<disabled>match[yes]then[]else{!!shortcuts}] }}}/>
+						<<toolbar-button-icon>>
+						<$transclude tiddler=<<currentTiddler>> field="text"/>
+					</$button>
+				</$set>
+				<$reveal
+					state=<<dropdown-state>>
+					type="popup"
+					position="below"
+					animate="yes"
+					tag="span"
+				>
+					<div class="tc-drop-down tc-popup-keep">
+						<$transclude tiddler={{!!dropdown}} mode="block"/>
+					</div>
+				</$reveal>
+			</$set>
+		</$list>
+	</$wikify>
+</$list>
 \end
 
 \define toolbar-button-outer()
-<$set
-
-  name="buttonClasses"
-  value={{!!button-classes}}
-
-><<toolbar-button>></$set>
+\whitespace trim
+<$set name="buttonClasses" value={{!!button-classes}}>
+	<<toolbar-button>>
+</$set>
 \end
 
 <<toolbar-button-outer>>


### PR DESCRIPTION
@Jermolene It's not really clear, where the new problem comes from. 

----

This PR fixes: fix edit toolbar button whitespace

Image from: https://talk.tiddlywiki.org/t/announcing-the-release-of-tiddlywiki-v5-3-2/8661/4?u=pmario

![9de7de28f56a130d1dc52f17fa148a5650ee1796_2_1035x237](https://github.com/Jermolene/TiddlyWiki5/assets/374655/9b241500-0bf9-48bd-817b-dd08e0b8cb9b)

Problem as shown at: https://talk.tiddlywiki.org/t/announcing-the-release-of-tiddlywiki-v5-3-2/8661/5?u=pmario

![d4e841b88c52eee528ba6600a98aa005458781fa](https://github.com/Jermolene/TiddlyWiki5/assets/374655/629e60e9-4de9-4ad0-8d8a-937c81e962cc)

-------

**fixed**

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/8f5c1dbb-21b4-4211-9834-28946b6eafaa)
