### PR TITLE
Remove whitespace immediately after pragmas

### DIFF
--- a/core/modules/parsers/wikiparser/wikiparser.js
+++ b/core/modules/parsers/wikiparser/wikiparser.js
@@ -216,6 +216,8 @@ WikiParser.prototype.parsePragmas = function() {
 			subTree[0].children = [];
 			currentTreeBranch = subTree[0].children;
 		}
+		// Skip whitespace after the pragma
+		this.skipWhitespace();
 	}
 	return currentTreeBranch;
 };

--- a/editions/test/tiddlers/tests/data/pragmas/WhitespaceAfterPragma.tid
+++ b/editions/test/tiddlers/tests/data/pragmas/WhitespaceAfterPragma.tid
@@ -1,0 +1,64 @@
+title: Pragmas/WhitespaceAfterPragma
+description: parsermode pragma
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<$wikify name="parsetree" text={{Text}} mode="inline" output="parsetree">
+<$text text=<<parsetree>>/>
+</$wikify>
++
+title: Text
+
+\procedure this-is-a-definition() Something
+
+
+
+
+Now!
+
++
+title: ExpectedResult
+
+<p>
+[
+    {
+        "type": "set",
+        "attributes": {
+            "name": {
+                "name": "name",
+                "type": "string",
+                "value": "this-is-a-definition"
+            },
+            "value": {
+                "name": "value",
+                "type": "string",
+                "value": "Something"
+            }
+        },
+        "children": [
+            {
+                "type": "text",
+                "text": "Now!\n",
+                "start": 48,
+                "end": 53
+            }
+        ],
+        "params": [],
+        "orderedAttributes": [
+            {
+                "name": "name",
+                "type": "string",
+                "value": "this-is-a-definition"
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "value": "Something"
+            }
+        ],
+        "isProcedureDefinition": true
+    }
+]
+</p>

--- a/editions/test/tiddlers/tests/data/pragmas/WhitespaceNoPragma.tid
+++ b/editions/test/tiddlers/tests/data/pragmas/WhitespaceNoPragma.tid
@@ -1,0 +1,32 @@
+title: Pragmas/WhitespaceNoPragma
+description: parsermode pragma
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<$wikify name="parsetree" text={{Text}} mode="inline" output="parsetree">
+<$text text=<<parsetree>>/>
+</$wikify>
++
+title: Text
+
+
+
+
+
+Now!
+
++
+title: ExpectedResult
+
+<p>
+[
+    {
+        "type": "text",
+        "text": "\n\n\n\nNow!\n",
+        "start": 0,
+        "end": 9
+    }
+]
+</p>


### PR DESCRIPTION
A change to the parser behaviour in #7835 caused a problem with excess whitespace appearing in the output

This PR reverts some of  the behaviour introduced in #7835:

* Whitespace immediately after a pragma is now ignored
* Whitespace at the start of a tiddler is preserved, as implemented by #7835

See the discussion here: https://github.com/Jermolene/TiddlyWiki5/pull/7888#issuecomment-1856184592