### PR TITLE
Fix per-tiddler previews

### DIFF
--- a/core/ui/EditTemplate/body/default.tid
+++ b/core/ui/EditTemplate/body/default.tid
@@ -1,9 +1,5 @@
 title: $:/core/ui/EditTemplate/body/default
 
-\function edit-preview-state()
-[{$:/config/ShowEditPreview/PerTiddler}!match[yes]then[$:/state/showeditpreview]] :else[<qualify "$:/state/showeditpreview">] +[get[text]] :else[[no]]
-\end
-
 \define config-visibility-title()
 $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 \end
@@ -14,11 +10,12 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 
 \whitespace trim
 <$let
+	editPreviewState={{{ [{$:/config/ShowEditPreview/PerTiddler}!match[yes]then[$:/state/showeditpreview]] :else[<qualify "$:/state/showeditpreview">] +[get[text]] :else[[no]] }}}
 	importTitle=<<qualify $:/ImportImage>>
 	importState=<<qualify $:/state/ImportImage>> >
 <$dropzone importTitle=<<importTitle>> autoOpenOnImport="no" contentTypesFilter={{$:/config/Editor/ImportContentTypesFilter}} class="tc-dropzone-editor" enable={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}} filesOnly="yes" actions=<<importFileActions>> >
 <div>
-<div class={{{ [function[edit-preview-state]match[yes]then[tc-tiddler-preview]else[tc-tiddler-preview-hidden]] [[tc-tiddler-editor]] +[join[ ]] }}}>
+<div class={{{ [function[editPreviewState]match[yes]then[tc-tiddler-preview]else[tc-tiddler-preview-hidden]] [[tc-tiddler-editor]] +[join[ ]] }}}>
 
 <$transclude tiddler="$:/core/ui/EditTemplate/body/editor" mode="inline"/>
 

--- a/core/ui/EditTemplate/body/default.tid
+++ b/core/ui/EditTemplate/body/default.tid
@@ -10,16 +10,16 @@ $:/config/EditorToolbarButtons/Visibility/$(currentTiddler)$
 
 \whitespace trim
 <$let
-	editPreviewState={{{ [{$:/config/ShowEditPreview/PerTiddler}!match[yes]then[$:/state/showeditpreview]] :else[<qualify "$:/state/showeditpreview">] +[get[text]] :else[[no]] }}}
+	editPreviewStateTiddler={{{ [{$:/config/ShowEditPreview/PerTiddler}!match[yes]then[$:/state/showeditpreview]] :else[<qualify "$:/state/showeditpreview">] }}}
 	importTitle=<<qualify $:/ImportImage>>
 	importState=<<qualify $:/state/ImportImage>> >
 <$dropzone importTitle=<<importTitle>> autoOpenOnImport="no" contentTypesFilter={{$:/config/Editor/ImportContentTypesFilter}} class="tc-dropzone-editor" enable={{{ [{$:/config/DragAndDrop/Enable}match[no]] :else[subfilter{$:/config/Editor/EnableImportFilter}then[yes]else[no]] }}} filesOnly="yes" actions=<<importFileActions>> >
 <div>
-<div class={{{ [function[editPreviewState]match[yes]then[tc-tiddler-preview]else[tc-tiddler-preview-hidden]] [[tc-tiddler-editor]] +[join[ ]] }}}>
+<div class={{{ [<editPreviewStateTiddler>get[text]match[yes]then[tc-tiddler-preview]else[tc-tiddler-preview-hidden]] [[tc-tiddler-editor]] +[join[ ]] }}}>
 
 <$transclude tiddler="$:/core/ui/EditTemplate/body/editor" mode="inline"/>
 
-<$list filter="[function[edit-preview-state]match[yes]]" variable="ignore">
+<$list filter="[<editPreviewStateTiddler>get[text]match[yes]]" variable="ignore">
 
 <div class="tc-tiddler-preview-preview" data-tiddler-title={{!!draft.title}} data-tags={{!!tags}}>
 

--- a/core/ui/EditorToolbar/preview.tid
+++ b/core/ui/EditorToolbar/preview.tid
@@ -10,7 +10,7 @@ shortcuts: ((preview))
 
 \whitespace trim
 <span>
-	<$transclude $tiddler={{{ [<editPreviewState>get[text]match[yes]then[$:/core/images/preview-open]else[$:/core/images/preview-closed]] }}} />
+	<$transclude $tiddler={{{ [<editPreviewStateTiddler>get[text]match[yes]then[$:/core/images/preview-open]else[$:/core/images/preview-closed]] }}} />
 </span>
-<$action-setfield $tiddler=<<editPreviewState>> $value={{{ [<editPreviewState>get[text]toggle[yes],[no]] }}} />
+<$action-setfield $tiddler=<<editPreviewStateTiddler>> $value={{{ [<editPreviewStateTiddler>get[text]toggle[yes],[no]] }}} />
 <$action-sendmessage $message="tm-edit-text-operation" $param="focus-editor"/>

--- a/core/ui/EditorToolbar/preview.tid
+++ b/core/ui/EditorToolbar/preview.tid
@@ -9,6 +9,8 @@ button-classes: tc-text-editor-toolbar-item-start-group
 shortcuts: ((preview))
 
 \whitespace trim
-<$transclude $tiddler={{{ [<editPreviewState>get[text]match[yes]then[$:/core/images/preview-open]else[$:/core/images/preview-closed]] }}} />
+<span>
+	<$transclude $tiddler={{{ [<editPreviewState>get[text]match[yes]then[$:/core/images/preview-open]else[$:/core/images/preview-closed]] }}} />
+</span>
 <$action-setfield $tiddler=<<editPreviewState>> $value={{{ [<editPreviewState>get[text]toggle[yes],[no]] }}} />
 <$action-sendmessage $message="tm-edit-text-operation" $param="focus-editor"/>

--- a/core/ui/EditorToolbar/preview.tid
+++ b/core/ui/EditorToolbar/preview.tid
@@ -9,17 +9,6 @@ button-classes: tc-text-editor-toolbar-item-start-group
 shortcuts: ((preview))
 
 \whitespace trim
-<$let
-	edit-preview-state={{{ [{$:/config/ShowEditPreview/PerTiddler}!match[yes]then[$:/state/showeditpreview]] :else[<qualify "$:/state/showeditpreview">] }}}
->
-<$reveal state=<<edit-preview-state>> type="match" text="yes" tag="span">
-{{$:/core/images/preview-open}}
-<$action-setfield $tiddler=<<edit-preview-state>> $value="no"/>
+<$transclude $tiddler={{{ [<editPreviewState>get[text]match[yes]then[$:/core/images/preview-open]else[$:/core/images/preview-closed]] }}} />
+<$action-setfield $tiddler=<<editPreviewState>> $value={{{ [<editPreviewState>get[text]toggle[yes],[no]] }}} />
 <$action-sendmessage $message="tm-edit-text-operation" $param="focus-editor"/>
-</$reveal>
-<$reveal state=<<edit-preview-state>> type="nomatch" text="yes" tag="span">
-{{$:/core/images/preview-closed}}
-<$action-setfield $tiddler=<<edit-preview-state>> $value="yes"/>
-<$action-sendmessage $message="tm-edit-text-operation" $param="focus-editor"/>
-</$reveal>
-</$let>


### PR DESCRIPTION
This is a fix for #7893.

Basically, it reverts the parts of #7747 that use a function in the EditTemplate in favor of setting the variable `editPreviewStateTiddler` which is also referred to in the preview button code. Otherwise, the qualify macro yields different state tiddlers and previews cannot be activated.

In one fell swoop, I also streamlined the preview button code to make use of inline filters instead of multiple RevealWidgets. This reduces it to three lines. It could be rolled back, of course, if we want to be conservative there.