### PR TITLE
fix #7899 recursive "release" tabs problem

### DIFF
--- a/editions/tw5.com/tiddlers/releasenotes/BetaReleases.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/BetaReleases.tid
@@ -1,9 +1,9 @@
 created: 20131109105400007
-modified: 20211117230125737
+modified: 20231220113054682
 tags: Releases BetaReleaseNotes
 title: BetaReleases
 type: text/vnd.tiddlywiki
 
 Here are the details of the beta releases of TiddlyWiki5. See [[TiddlyWiki5 Versioning]] for details of how releases are named.
 
-<<tabs "[tag[BetaReleaseNotes]!sort[created]]" "Release 5.0.18-beta" "$:/state/tab2" "tc-vertical" "ReleaseTemplate">>
+<<tabs "[tag[BetaReleaseNotes]!sort[created]] -[<currentTiddler>]" "Release 5.0.18-beta" "$:/state/tab2" "tc-vertical" "ReleaseTemplate">>

--- a/editions/tw5.com/tiddlers/releasenotes/alpha/AlphaReleases.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/alpha/AlphaReleases.tid
@@ -1,9 +1,9 @@
 created: 20131109105400007
-modified: 20211117225858830
+modified: 20231220113044942
 tags: Releases AlphaReleaseNotes
 title: AlphaReleases
 type: text/vnd.tiddlywiki
 
 Here are the details of the alpha releases of TiddlyWiki5. See [[TiddlyWiki5 Versioning]] for details of how releases are named.
 
-<<tabs "[tag[AlphaReleaseNotes]!sort[created]]" "Release 5.0.1-alpha" "$:/state/tab2" "tc-vertical" "ReleaseTemplate">>
+<<tabs "[tag[AlphaReleaseNotes]!sort[created]] -[<currentTiddler>]" "Release 5.0.1-alpha" "$:/state/tab2" "tc-vertical" "ReleaseTemplate">>


### PR DESCRIPTION
This PR should fix #7899 recursive "release" tabs problem for "Alpha" and "Beta" release tabs
 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>