### PR TITLE
fixes functions to use variables set by filter runs

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -164,6 +164,7 @@ Widget.prototype.getVariableInfo = function(name,options) {
 			$tw.utils.each(params,function(param) {
 				variables[param.name] = param.value;
 			});
+			variables = $tw.utils.extend({},options.variables||{},variables);
 			resultList = this.wiki.filterTiddlers(value,this.makeFakeWidgetWithVariables(variables),options.source);
 			value = resultList[0] || "";
 		}

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -153,7 +153,7 @@ Widget.prototype.getVariableInfo = function(name,options) {
 		} else if(variable.isFunctionDefinition) {
 			// Function evaluations
 			params = self.resolveVariableParameters(variable.params,actualParams);
-			var variables = Object.create(null);
+			var variables = options.variables || Object.create(null);
 			// Apply default parameter values
 			$tw.utils.each(variable.params,function(param,index) {
 				if(param["default"]) {
@@ -164,7 +164,6 @@ Widget.prototype.getVariableInfo = function(name,options) {
 			$tw.utils.each(params,function(param) {
 				variables[param.name] = param.value;
 			});
-			variables = $tw.utils.extend({},options.variables||{},variables);
 			resultList = this.wiki.filterTiddlers(value,this.makeFakeWidgetWithVariables(variables),options.source);
 			value = resultList[0] || "";
 		}

--- a/editions/test/tiddlers/tests/data/functions/FunctionFilterrunVariables.tid
+++ b/editions/test/tiddlers/tests/data/functions/FunctionFilterrunVariables.tid
@@ -1,0 +1,24 @@
+title: Functions/FunctionFilterrunVariables
+description: Functions in filter runs that set variables
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Idiosyncrasy
+caption: Idiosyncrasy Caption Field
+
++
+title: Output
+
+\whitespace trim
+\procedure demo-subfilter() [<currentTiddler>]
+\function .demo-function() [<currentTiddler>]
+
+<$let currentTiddler="Idiosyncrasy">
+<$text text={{{ [<currentTiddler>get[caption]!is[blank]else<currentTiddler>] :map[subfilter<demo-subfilter>] }}}/>,
+<$text text={{{ [<currentTiddler>get[caption]!is[blank]else<currentTiddler>] :map[.demo-function[]] }}}/>
+</$let>
+
++
+title: ExpectedResult
+
+<p>Idiosyncrasy Caption Field,Idiosyncrasy Caption Field</p>

--- a/editions/test/tiddlers/tests/data/functions/FunctionFilterrunVariables2.tid
+++ b/editions/test/tiddlers/tests/data/functions/FunctionFilterrunVariables2.tid
@@ -1,0 +1,20 @@
+title: Functions/FunctionFilterrunVariables2
+description: Functions in filter runs that set variables
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Apple
+cost: 5
+
++
+title: Output
+
+\whitespace trim
+\function .doublecost() [<currentTiddler>get[cost]multiply[2]]
+
+<$text text={{{ [[Apple]] :map[.doublecost[]] }}}/>
+
++
+title: ExpectedResult
+
+10


### PR DESCRIPTION
Currently, functions do not use the variables set by filter run prefixes. This PR fixes that behaviour making the variables set by filter runs available to functions.

Example test that should work but does not without this PR:
```
title: Apple
cost: 5

+
title: Output

\whitespace trim
\function .doublecost() [<currentTiddler>get[cost]multiply[2]]

<$text text={{{ [[Apple]] :map[.doublecost[]] }}}/>

+
title: ExpectedResult

10

```


Fixes #7907 