### PR TITLE
Allows whitespace-only macro/procedure to be closed by \end

### DIFF
--- a/core/modules/parsers/wikiparser/rules/fnprocdef.js
+++ b/core/modules/parsers/wikiparser/rules/fnprocdef.js
@@ -49,11 +49,11 @@ exports.parse = function() {
 	if(this.match[3]) {
 		params = $tw.utils.parseParameterDefinition(this.match[4]);
 	}
-	// Is this a multiline definition?
+	// Is the remainder of the line blank after the parameter close paren?
 	var reEnd;
 	if(this.match[5]) {
-		// If so, the end of the body is marked with \end
-		reEnd = new RegExp("(\\r?\\n[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[2]) + ")?(?:$|\\r?\\n))","mg");
+		// If so, it is a multiline definition and the end of the body is marked with \end
+		reEnd = new RegExp("((:?^|\\r?\\n)[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[2]) + ")?(?:$|\\r?\\n))","mg");
 	} else {
 		// Otherwise, the end of the definition is marked by the end of the line
 		reEnd = /($|\r?\n)/mg;

--- a/core/modules/parsers/wikiparser/rules/macrodef.js
+++ b/core/modules/parsers/wikiparser/rules/macrodef.js
@@ -54,11 +54,11 @@ exports.parse = function() {
 			paramMatch = reParam.exec(paramString);
 		}
 	}
-	// Is this a multiline definition?
+	// On the \define line, was there anything other than whitespace after the close paren?
 	var reEnd;
 	if(this.match[3]) {
-		// If so, the end of the body is marked with \end
-		reEnd = new RegExp("(\\r?\\n[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[1]) + ")?(?:$|\\r?\\n))","mg");
+		// If so, it is a multiline definition and the end of the body is marked with \end
+		reEnd = new RegExp("((?:^|\\r?\\n)[^\\S\\n\\r]*\\\\end[^\\S\\n\\r]*(?:" + $tw.utils.escapeRegExp(this.match[1]) + ")?(?:$|\\r?\\n))","mg");
 	} else {
 		// Otherwise, the end of the definition is marked by the end of the line
 		reEnd = /($|\r?\n)/mg;

--- a/core/modules/parsers/wikiparser/rules/macrodef.js
+++ b/core/modules/parsers/wikiparser/rules/macrodef.js
@@ -54,7 +54,7 @@ exports.parse = function() {
 			paramMatch = reParam.exec(paramString);
 		}
 	}
-	// On the \define line, was there anything other than whitespace after the close paren?
+	// Is the remainder of the \define line blank after the parameter close paren?
 	var reEnd;
 	if(this.match[3]) {
 		// If so, it is a multiline definition and the end of the body is marked with \end

--- a/editions/test/tiddlers/tests/data/macros/EndInBody.tid
+++ b/editions/test/tiddlers/tests/data/macros/EndInBody.tid
@@ -1,0 +1,16 @@
+title: Macros/EndInBody
+description: \end line starting with non-whitespace is part of macro body
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define hello()
+ hello \end
+\end
+
+Out: <<hello>>
++
+title: ExpectedResult
+
+<p>Out:  hello \end</p>

--- a/editions/test/tiddlers/tests/data/macros/IndentedEnd.tid
+++ b/editions/test/tiddlers/tests/data/macros/IndentedEnd.tid
@@ -1,0 +1,16 @@
+title: Macros/IndentedEnd
+description: \end line starting with whitespace ends a macro body
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define hello()
+ hello \end
+  \end
+
+Out: <<hello>>
++
+title: ExpectedResult
+
+<p>Out:  hello \end</p>

--- a/editions/test/tiddlers/tests/data/macros/MismatchedNamedEnd.tid
+++ b/editions/test/tiddlers/tests/data/macros/MismatchedNamedEnd.tid
@@ -1,0 +1,16 @@
+title: Macros/MismatchedNamedEnd
+description: Mismatched named end is part of the body
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define hello()
+ \end goodbye
+\end
+
+Out: <<hello>>
++
+title: ExpectedResult
+
+<p>Out:  \end goodbye</p>

--- a/editions/test/tiddlers/tests/data/macros/WhitespaceOnlyWithEnd.tid
+++ b/editions/test/tiddlers/tests/data/macros/WhitespaceOnlyWithEnd.tid
@@ -1,0 +1,18 @@
+title: Macros/WhitespaceOnlyWithEnd
+description: The /end should be detected when macro definition contains only whitespace
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define max()
+\end
+Nothing
+\end
+
+Out: <<max>>
++
+title: ExpectedResult
+
+<p>Nothing
+\end</p><p>Out: </p>

--- a/editions/test/tiddlers/tests/data/macros/WhitespaceOnlyWithEnd2.tid
+++ b/editions/test/tiddlers/tests/data/macros/WhitespaceOnlyWithEnd2.tid
@@ -1,0 +1,15 @@
+title: Macros/WhitespaceOnlyWithEnd2
+description: Line with \end can start with whitespace
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define empty()
+ \end
+
+Out: <<empty>>
++
+title: ExpectedResult
+
+<p>Out: </p>

--- a/editions/test/tiddlers/tests/data/procedures/EndInBody.tid
+++ b/editions/test/tiddlers/tests/data/procedures/EndInBody.tid
@@ -1,0 +1,16 @@
+title: Procedures/EndInBody
+description: \end line starting with non-whitespace is part of procedure body
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure hello()
+ hello \end
+\end
+
+Out: <<hello>>
++
+title: ExpectedResult
+
+<p>Out:  hello \end</p>

--- a/editions/test/tiddlers/tests/data/procedures/IndentedEnd.tid
+++ b/editions/test/tiddlers/tests/data/procedures/IndentedEnd.tid
@@ -1,0 +1,16 @@
+title: Procedures/IndentedEnd
+description: \end line starting with whitespace ends a procedure body
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure hello()
+ hello \end
+  \end
+
+Out: <<hello>>
++
+title: ExpectedResult
+
+<p>Out:  hello \end</p>

--- a/editions/test/tiddlers/tests/data/procedures/MismatchedNamedEnd.tid
+++ b/editions/test/tiddlers/tests/data/procedures/MismatchedNamedEnd.tid
@@ -1,0 +1,16 @@
+title: Procedures/MismatchedNamedEnd
+description: Mismatched named end is part of the body
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure hello()
+ \end goodbye
+\end
+
+Out: <<hello>>
++
+title: ExpectedResult
+
+<p>Out:  \end goodbye</p>

--- a/editions/test/tiddlers/tests/data/procedures/WhitespaceOnlyWithEnd.tid
+++ b/editions/test/tiddlers/tests/data/procedures/WhitespaceOnlyWithEnd.tid
@@ -1,0 +1,18 @@
+title: Procedures/WhitespaceOnlyWithEnd
+description: The /end should be detected when procedure definition contains only whitespace
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure max()
+\end
+Nothing
+\end
+
+Out: <<max>>
++
+title: ExpectedResult
+
+<p>Nothing
+\end</p><p>Out: </p>

--- a/editions/test/tiddlers/tests/data/procedures/WhitespaceOnlyWithEnd2.tid
+++ b/editions/test/tiddlers/tests/data/procedures/WhitespaceOnlyWithEnd2.tid
@@ -1,0 +1,15 @@
+title: Procedures/WhitespaceOnlyWithEnd2
+description: Line with \end can start with whitespace
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure empty()
+ \end
+
+Out: <<empty>>
++
+title: ExpectedResult
+
+<p>Out: </p>


### PR DESCRIPTION
Change the regular expression used by the parser to find the end of a macro/procedure/widget/function so it can properly terminate by `\end` when the body is empty (contains nothing except whitespace).

Previously, the regular expression required matching a `\n` prior to the `\end`, but the `\n` on the `\define` line (or `\procedure`, etc.) processed by the parser.

The new regular expression makes the `\n` optional by matching either `\n` or beginning of string.

Fixes #3460.