### PR TITLE
Use Levenshtein distance to order search results

### DIFF
--- a/core/ui/DefaultSearchResultList.tid
+++ b/core/ui/DefaultSearchResultList.tid
@@ -1,7 +1,7 @@
 title: $:/core/ui/DefaultSearchResultList
 tags: $:/tags/SearchResults
 caption: {{$:/language/Search/DefaultResults/Caption}}
-first-search-filter: [!is[system]search:title<userInput>sort[title]limit[250]]
+first-search-filter: [!is[system]search:title<userInput>] :sort:integer[levenshtein<userInput>] :and[limit[250]]
 second-search-filter: [!is[system]search<userInput>sort[title]limit[250]]
 
 \define searchResultList()


### PR DESCRIPTION
This PR fixes: **#7917 [BUG] The core search result list should return relevant info for basic search terms - early** 

It replaces the default filter string in `$:/core/ui/DefaultSearchResultList`

- replace: `[!is[system]search:title<userInput>sort[title]limit[250]]`
- with: `[!is[system]search:title<userInput>] :sort:integer[levenshtein<userInput>] :and[limit[250]]`

It may not be optimal, but I think it's a huge improvement. 

**All Example Screenshots** can be seen at: #7917 -- I'll only add one here for **tiddler**

![01-tiddler](https://github.com/Jermolene/TiddlyWiki5/assets/374655/9b2f4db8-3eb8-450c-a55b-5206946f5678)