### PR TITLE
fix archive output paths

### DIFF
--- a/editions/tw5.com/tiddlywiki.info
+++ b/editions/tw5.com/tiddlywiki.info
@@ -56,8 +56,8 @@
 			"--render","$:/core/save/offline-external-js","[[external-]addsuffix<version>addsuffix[.html]]","text/plain",
 			"--render","$:/core/templates/tiddlywiki5.js","[[tiddlywikicore-]addsuffix<version>addsuffix[.js]]","text/plain"],
 		"archive":[
-			"--render","$:/core/save/all","[[archive/TiddlyWiki-]addsuffix<version>addsuffix[.html]]","text/plain",
-			"--render","$:/editions/tw5.com/download-empty","[[archive/Empty-TiddlyWiki-]addsuffix<version>addsuffix[.html]]","text/plain",
+			"--render","$:/core/save/all","[[archive/full/TiddlyWiki-]addsuffix<version>addsuffix[.html]]","text/plain",
+			"--render","$:/editions/tw5.com/download-empty","[[archive/empty/Empty-TiddlyWiki-]addsuffix<version>addsuffix[.html]]","text/plain",
 			"--render","[[TiddlyWiki Archive]]","archive/index.html","text/plain","$:/core/templates/static.tiddler.html",
 			"--render","$:/core/templates/static.template.css","archive/static.css","text/plain"]
 	},


### PR DESCRIPTION
This PR should fix the archive output paths mentioned at: https://github.com/Jermolene/TiddlyWiki5/pull/7776#issuecomment-1879271524

Please double-check. 

@Jermolene ... It should be easy to move the existing files from https://github.com/Jermolene/jermolene.github.io/tree/master/archive to "/full and /empty" by hand. 

I did test them in the archive/ dir and they seem to work as intended -- only in the wrong dir.  

