### PR TITLE
Refreshes edit widget when the editor type has changed

### DIFF
--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -90,7 +90,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 EditWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	// Refresh if an attribute has changed, or the type associated with the target tiddler has changed
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tabindex || changedAttributes.cancelPopups || changedAttributes.inputActions || changedAttributes.refreshTitle || changedAttributes.autocomplete || (changedTiddlers[this.editTitle] && this.getEditorType() !== this.editorType)) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.tabindex || changedAttributes.cancelPopups || changedAttributes.inputActions || changedAttributes.refreshTitle || changedAttributes.autocomplete || (this.getEditorType() !== this.editorType)) {
 		this.refreshSelf();
 		return true;
 	} else {


### PR DESCRIPTION
This PR improves the refresh handling of the edit widget so that changes in the corresponding `$:/config/EditorTypeMappings` tiddler redraws the editor. This allows for example creating an editor button that can toggle between the default text editor and codemirror.