### PR TITLE
fix: wasm can't be loaded properly

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2438,6 +2438,7 @@ $tw.boot.initStartup = function(options) {
 	$tw.utils.registerFileType("image/svg+xml","utf8",".svg",{flags:["image"]});
 	$tw.utils.registerFileType("image/vnd.microsoft.icon","base64",".ico",{flags:["image"]});
 	$tw.utils.registerFileType("image/x-icon","base64",".ico",{flags:["image"]});
+	$tw.utils.registerFileType("application/wasm","base64",".wasm");
 	$tw.utils.registerFileType("application/font-woff","base64",".woff");
 	$tw.utils.registerFileType("application/x-font-ttf","base64",".woff");
 	$tw.utils.registerFileType("application/font-woff2","base64",".woff2");


### PR DESCRIPTION
Copy from https://github.com/Jermolene/TiddlyWiki5/pull/7329

But I can't wait this for too long, use of wasm has come to my plugins, and this line blocks it. I'm currently using `pnpm patch` for this.