### PR TITLE
fix: on Windows, tiddlywiki.files title source shoud use / instead of \

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1970,7 +1970,7 @@ $tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp) {
 							value = path.relative(rootPath, filename).split('/').slice(0, -1);
 							break;
 						case "filepath":
-							value = path.relative(rootPath, filename);
+							value = path.relative(rootPath, filename).split(path.sep).join('/');
 							break;
 						case "filename":
 							value = path.basename(filename);

--- a/boot/boot.js
+++ b/boot/boot.js
@@ -1967,7 +1967,7 @@ $tw.loadTiddlersFromSpecification = function(filepath,excludeRegExp) {
 					var value = tiddler[name];
 					switch(fieldInfo.source) {
 						case "subdirectories":
-							value = path.relative(rootPath, filename).split('/').slice(0, -1);
+							value = path.relative(rootPath, filename).split(path.sep).slice(0, -1);
 							break;
 						case "filepath":
 							value = path.relative(rootPath, filename).split(path.sep).join('/');


### PR DESCRIPTION
On windows, `path.relative(rootPath, filename)` will produce `items\comestibles\raw_fruit.json`.

Add `.split(path.sep).join('/')` fix this to be `items/comestibles/raw_fruit.json`

Before:

![图片](https://github.com/Jermolene/TiddlyWiki5/assets/3746270/7b92855d-9d9f-4c2a-a5c1-ee39c18024e1)

After:

![图片](https://github.com/Jermolene/TiddlyWiki5/assets/3746270/e8f31709-59dc-425c-a01b-8b1bc0b09600)

The `tiddlywiki.files` file I'm using:

https://github.com/tiddly-gittly/tw-gamification/blob/1d9eaf87019a6f4801ef4bdb09b555551d3bcbf8/src/scp-foundation-site-director/game/tiddlywiki.files