### PR TITLE
add tc-tag-missing or tc-tag-exists to tag pills including docs

### DIFF
--- a/core/wiki/macros/tag.tid
+++ b/core/wiki/macros/tag.tid
@@ -21,7 +21,9 @@ color:$(foregroundColor)$;
 >
 	<<__actions__>>
 	<$transclude tiddler=<<__icon__>>/>
-	<$view tiddler=<<__tag__>> field="title" format="text" />
+	<span class={{{ [<__tag__>is[missing]then[tc-tag-missing]else[tc-tag-exists]] }}}>
+		<$view tiddler=<<__tag__>> field="title" format="text" />
+	</span>
 </$element-tag$>
 </$let>
 \end

--- a/editions/tw5.com/tiddlers/macros/TagMacro.tid
+++ b/editions/tw5.com/tiddlers/macros/TagMacro.tid
@@ -1,9 +1,31 @@
 caption: tag
 created: 20141206130540337
-modified: 20230725201240201
+modified: 20240128142041965
 tags: Macros [[Core Macros]]
 title: tag Macro
 type: text/vnd.tiddlywiki
+
+\procedure resetTagStyleTemplate()
+.tc-tag-missing {
+	font-style: initial;
+}
+\end
+
+\procedure resetTagStylesTitle() reset-tag-missing-styles
+
+\procedure resetTagFormatting()
+<% if [<resetTagStylesTitle>!has[text]] %>
+<$action-createtiddler
+	$basetitle=<<resetTagStylesTitle>>
+	text=<<resetTagStyleTemplate>>
+	code-body= "yes"
+	tags= "$:/tags/Stylesheet"
+/>
+<$action-navigate $to=<<resetTagStylesTitle>>/>
+<% else %>
+<$action-navigate $to=<<resetTagStylesTitle>>/>
+<% endif %>
+\end
 
 The <<.def tag>> [[macro|Macros]] generates a tag pill for a specified tag. Clicking the tag pill opens a dropdown. This can be compared to the [[tag-pill Macro]] which also features other parameters.
 
@@ -11,7 +33,27 @@ The <<.def tag>> [[macro|Macros]] generates a tag pill for a specified tag. Clic
 
 !! Parameters
 
-;tag
+; tag
 : The title of the tag, defaulting to the [[current tiddler|Current Tiddler]]
+
+!! CSS classes
+
+; `tc-tag-missing`
+: This class is defined if a tag does ''not exist'' as a tiddler. By default the format is set to //italic//
+
+; `tc-tag-exists`
+: This class is defined if a tag does exist as a tiddler. This class has ''no'' default definition
+
+
+!! Disabling CSS classes
+
+To reset `tc-tag-missing` a stylesheet tiddler tagged: `$:/tags/Stylesheet` can be created.
+
+See: <<tag "Does not exist">>
+
+<$button actions=<<resetTagFormatting>>>Reset missing tag formatting</$button>
+<$button message="tm-delete-tiddler" param=<<resetTagStylesTitle>> >Delete tiddler: <<resetTagStylesTitle>></$button>
+
+<pre><code><$transclude $variable="resetTagStyleTemplate" $mode=block $output="text/plain" $type="text/plain" /></code></pre>
 
 <<.macro-examples "tag">>

--- a/editions/tw5.com/tiddlers/macros/examples/tag.tid
+++ b/editions/tw5.com/tiddlers/macros/examples/tag.tid
@@ -1,5 +1,5 @@
 created: 20150221211317000
-modified: 20230725203751870
+modified: 20240128134650786
 tags: [[tag Macro]] [[Macro Examples]]
 title: tag Macro (Examples)
 type: text/vnd.tiddlywiki
@@ -7,22 +7,26 @@ type: text/vnd.tiddlywiki
 <$macrocall $name=".example" n="1" eg="""<<tag>>"""/>
 <$macrocall $name=".example" n="2" eg="""<<tag Concepts>>"""/>
 
+The Following tag is shown with a font-style: //italic// since it does not exits. 
+
+<$macrocall $name=".example" n="3" eg="""<<tag "Does not exist">>"""/>
+
 If a [[list widget|ListWidget]] generates multiple tag macros for the same tag, clicking any of them opens dropdowns on all of them, as in the example below. This is usually unwanted.
-<$macrocall $name=".example" n="3" eg="""<$list filter="[tag[HelloThere]]">
+<$macrocall $name=".example" n="4" eg="""<$list filter="[tag[HelloThere]]">
 
 * <$link/> is tagged with: <$list filter="[<currentTiddler>tags[]]"> <<tag>> </$list>
 
 </$list>"""/>
 
 Adding the `counter="transclusion"` attribute to the list widget that generates multiple identical tag macros causes each of them to be identified as a unique one. Clicking on any of them opens only a single dropdown.
-<$macrocall $name=".example" n="4" eg="""<$list filter="[tag[HelloThere]]" counter="transclusion">
+<$macrocall $name=".example" n="5" eg="""<$list filter="[tag[HelloThere]]" counter="transclusion">
 
 * <$link/> is tagged with: <$list filter="[<currentTiddler>tags[]]"> <<tag>> </$list>
 
 </$list>"""/>
 
 A slightly more performant option is to use the `variable="transclusion"` attribute in the list widget. In this case, the variable `<<transclusion>>` has to be used inside the list widget instead of the `<<currentTiddler>>` .
-<$macrocall $name=".example" n="5" eg="""<$list filter="[tag[HelloThere]]" variable="transclusion">
+<$macrocall $name=".example" n="6" eg="""<$list filter="[tag[HelloThere]]" variable="transclusion">
 
 * <$link to=<<transclusion>>/> is tagged with: <$list filter="[<transclusion>tags[]]"> <<tag>> </$list>
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -783,6 +783,10 @@ button svg.tc-image-button, button .tc-image-button img {
 	margin-right: 7px;
 }
 
+.tc-tag-missing {
+	font-style: italic;
+}
+
 .tc-missing-tiddler-label {
 	font-style: italic;
 	font-weight: normal;


### PR DESCRIPTION
This PR fixes #7950

- #7950

- It implements 2 new classes: `tc-tag-missing` and `tc-tag-exists`
- There is a new "example" in the example tiddler
- There is some interactive info in the Tag Macro documentation tiddler to disable the setting, if needed


