### PR TITLE
Add explicit docs on temporary tiddlers

### DIFF
--- a/editions/tw5.com/tiddlers/Temporary Tiddlers.tid
+++ b/editions/tw5.com/tiddlers/Temporary Tiddlers.tid
@@ -1,0 +1,8 @@
+created: 20240202112358997
+modified: 20240202120248326
+tags: Concepts
+title: Temporary Tiddlers
+
+Temporary tiddlers are tiddlers that will be discarded when TiddlyWiki is saved. Under default configuration of the SavingMechanism (more specifically, the filter in [[$:/core/save/all]]), these are tiddlers prefixed with `$:/temp/`. This prefix makes them SystemTiddlers as well.
+
+One example usage of temporary tiddlers is storing the search queries. The query typed in the [[$:/AdvancedSearch]] is stored in [[$:/temp/advancedsearch]].

--- a/editions/tw5.com/tiddlers/nodejs/Naming of System Tiddlers.tid
+++ b/editions/tw5.com/tiddlers/nodejs/Naming of System Tiddlers.tid
@@ -1,5 +1,5 @@
 created: 20140112190154121
-modified: 20140912142655205
+modified: 20240202121048363
 tags: SystemTiddlers
 title: Naming of System Tiddlers
 type: text/vnd.tiddlywiki
@@ -17,11 +17,11 @@ The system tiddlers provided as part of the core are named according to the foll
 |`$:/core/wiki/*` |lowercase |Metadata about the entire wiki |
 |`$:/docs/*` |lowercase |Documentation tiddlers |
 |`$:/messages/*` |~CamelCase |System messages |
-|`$:/plugins/*` |lowercase |Plugin tiddlers, and plugin content |
+|`$:/plugins/*` |lowercase |[[Plugin|Plugins]] tiddlers, and plugin content |
 |`$:/snippets/*` |//inconsistent// |Reusable snippets (will be replaced by macros) |
-|`$:/state/*` |lowercase |User interface state tiddlers |
+|`$:/state/*` |lowercase |User interface state tiddlers (see StateMechanism) |
 |`$:/tags/*` |~CamelCase |User interface configuration tags |
-|`$:/temp/*` |lowercase |Temporary tiddlers that shouldn't be saved |
+|`$:/temp/*` |lowercase |[[Temporary tiddlers|Temporary Tiddlers]] that shouldn't be saved |
 |`$:/themes/*` |lowercase |Theme plugins |
 
 In the format column:


### PR DESCRIPTION
How the temporary tiddlers (prefixed with `$:/temp/`) behave could be inferred from docs on saving mechanism, but there was no explicit piece of documentation on them.  

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>