### PR TITLE
Enhance RSOE error screen with emergency download tiddlers button

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -177,6 +177,7 @@ document: defaults to current document
 eventListeners: array of event listeners (this option won't work until $tw.utils.addEventListeners() has been loaded)
 */
 $tw.utils.domMaker = function(tag,options) {
+	var options = options || {};
 	var doc = options.document || document;
 	var element = doc.createElementNS(options.namespace || "http://www.w3.org/1999/xhtml",tag);
 	if(options["class"]) {
@@ -218,9 +219,34 @@ $tw.utils.error = function(err) {
 			heading = dm("h1",{text: errHeading}),
 			prompt = dm("div",{text: promptMsg, "class": "tc-error-prompt"}),
 			message = dm("div",{text: err, "class":"tc-error-message"}),
-			button = dm("div",{children: [dm("button",{text: ( $tw.language == undefined ? "close" : $tw.language.getString("Buttons/Close/Caption") )})], "class": "tc-error-prompt"}),
-			form = dm("form",{children: [heading,prompt,message,button], "class": "tc-error-form"});
+			closeButton = dm("div",{children: [dm("button",{text: ( $tw.language == undefined ? "close" : $tw.language.getString("Buttons/Close/Caption") )})], "class": "tc-error-prompt"}),
+			downloadButton = dm("div",{children: [dm("button",{text: ( $tw.language == undefined ? "download tiddlers" : $tw.language.getString("Buttons/EmergencyDownload/Caption") )})], "class": "tc-error-prompt"}),
+			form = dm("form",{children: [heading,prompt,downloadButton,message,closeButton], "class": "tc-error-form"});
 		document.body.insertBefore(form,document.body.firstChild);
+		downloadButton.addEventListener("click",function(event) {
+			if($tw && $tw.wiki) {
+				var tiddlers = [];
+				$tw.wiki.each(function(tiddler,title) {
+					tiddlers.push(tiddler.fields);
+				});
+				var link = dm("a"),
+					text = JSON.stringify(tiddlers);
+				if(Blob !== undefined) {
+					var blob = new Blob([text], {type: "text/html"});
+					link.setAttribute("href", URL.createObjectURL(blob));
+				} else {
+					link.setAttribute("href","data:text/html," + encodeURIComponent(text));
+				}
+				link.setAttribute("download","emergency-tiddlers-" + (new Date()) + ".json");
+				document.body.appendChild(link);
+				link.click();
+				document.body.removeChild(link);
+			} else {
+				alert("Emergency tiddler download is not available");
+			}
+			event.preventDefault();
+			return false;
+		},true);
 		form.addEventListener("submit",function(event) {
 			document.body.removeChild(form);
 			event.preventDefault();

--- a/core/language/en-GB/Buttons.multids
+++ b/core/language/en-GB/Buttons.multids
@@ -28,6 +28,7 @@ Encryption/ClearPassword/Caption: clear password
 Encryption/ClearPassword/Hint: Clear the password and save this wiki without encryption
 Encryption/SetPassword/Caption: set password
 Encryption/SetPassword/Hint: Set a password for saving this wiki with encryption
+EmergencyDownload/Caption: download tiddlers as json
 ExportPage/Caption: export all
 ExportPage/Hint: Export all tiddlers
 ExportTiddler/Caption: export tiddler

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -155,6 +155,8 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 };
 
 LinkWidget.prototype.handleClickEvent = function(event) {
+	// Force an error to try out the Red Screen Of Embarrassment
+	var something = Everything;
 	// Send the click on its way as a navigate event
 	var bounds = this.domNodes[0].getBoundingClientRect();
 	this.dispatchEvent({


### PR DESCRIPTION
This PR adds a button to the "red screen of embarrassment" error dialogue to allow the contents of the tiddler store to be downloaded as a JSON file.

It currently looks like this, but I am intending to improve the styling:

<img width="468" alt="image" src="https://github.com/Jermolene/TiddlyWiki5/assets/174761/50327fea-a547-4f4a-ae0e-5445958265a1">

# Trying it out

The [preview](https://tiddlywiki5-git-rsoe-emergency-download-jermolene.vercel.app/) has been rigged so that clicking on any tiddler link will initiate an error.

1. Visit the [preview](https://tiddlywiki5-git-rsoe-emergency-download-jermolene.vercel.app/)
2. Click a tiddler link
3. See the RSOE and click the emergency download button

# Progress

* [x] Basic functionality
* [ ] Styling
