### PR TITLE
docs: add contribution graph to readme

### DIFF
--- a/editions/tw5.com/tiddlers/about/Developers.tid
+++ b/editions/tw5.com/tiddlers/about/Developers.tid
@@ -8,6 +8,7 @@ There are several resources for developers to learn more about TiddlyWiki and to
 
 * [[tiddlywiki.com/dev|https://tiddlywiki.com/dev]] is the official developer documentation
 * Get involved in the [[development on GitHub|https://github.com/Jermolene/TiddlyWiki5]]
+** [img[https://repobeats.axiom.co/api/embed/5a3bb51fd1ebe84a2da5548f78d2d74e456cebf3.svg]]
 ** [[Discussions|https://github.com/Jermolene/TiddlyWiki5/discussions]] are for Q&A and open-ended discussion
 ** [[Issues|https://github.com/Jermolene/TiddlyWiki5/issues]] are for raising bug reports and proposing specific, actionable new ideas
 * The older ~TiddlyWikiDev Google Group is now closed in favour of [[GitHub Discussions|https://github.com/Jermolene/TiddlyWiki5/discussions]] but remains a useful archive: https://groups.google.com/group/TiddlyWikiDev


### PR DESCRIPTION
For https://github.com/Jermolene/TiddlyWiki5/discussions/7979. I found this readme widget when browsering repos in github and saw the https://github.com/hcengineering/platform/tree/main?tab=readme-ov-file#activity

This seems to be the only developing-related section.

Looks like this:

![截屏2024-02-11 23 01 04](https://github.com/Jermolene/TiddlyWiki5/assets/3746270/7f7056b4-2a95-488f-b334-e3abd4943d36)

Happy to see I'm in the top 5 contributors this month.

Also, during this PR I found Jeremy is manually

```
# Run `./bin/readme-bld.sh` to build the readme files
```

I think this can be done automatically on GitHub actions after each PR is merged.