### PR TITLE
remove overflow: auto from tiddler preview

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1577,10 +1577,6 @@ html body.tc-body.tc-single-tiddler-window {
 	padding-left: 4px;
 }
 
-.tc-tiddler-preview {
-	overflow: auto;
-}
-
 .tc-tiddler-editor {
 	display: grid;
 }


### PR DESCRIPTION
This removes `overflow: auto` from the tiddler preview. I'm not sure anymore why it was added.
It causes some problems in the preview with popups for example, see screenshots

![2024-02-14 13_31_54_389](https://github.com/Jermolene/TiddlyWiki5/assets/9407182/435804a3-d9e2-4481-a89d-252c665a9875)
![2024-02-14 13_31_29_908](https://github.com/Jermolene/TiddlyWiki5/assets/9407182/41fab7d8-b49f-44bc-98c5-532e72228509)
