### PR TITLE
Simplify permalinks

### DIFF
--- a/core/modules/startup/story.js
+++ b/core/modules/startup/story.js
@@ -122,10 +122,10 @@ function openStartupTiddlers(options) {
 		var hash = $tw.locationHash.substr(1),
 			split = hash.indexOf(":");
 		if(split === -1) {
-			target = $tw.utils.decodeURIComponentSafe(hash.trim());
+			target = $tw.utils.decodeTWURITarget(hash.trim());
 		} else {
-			target = $tw.utils.decodeURIComponentSafe(hash.substr(0,split).trim());
-			storyFilter = $tw.utils.decodeURIComponentSafe(hash.substr(split + 1).trim());
+			target = $tw.utils.decodeTWURITarget(hash.substr(0,split).trim());
+			storyFilter = $tw.utils.decodeTWURITarget(hash.substr(split + 1).trim());
 		}
 	}
 	// If the story wasn't specified use the current tiddlers or a blank story
@@ -183,7 +183,234 @@ function updateLocationHash(options) {
 	var storyList = $tw.wiki.getTiddlerList(DEFAULT_STORY_TITLE),
 		historyList = $tw.wiki.getTiddlerData(DEFAULT_HISTORY_TITLE,[]),
 		targetTiddler = "";
-	if(options.targetTiddler) {
+	if(options.targetTiddler) {/*\
+	title: $:/core/modules/startup/story.js
+	type: application/javascript
+	module-type: startup
+	
+	Load core modules
+	
+	\*/
+	(function(){
+	
+	/*jslint node: true, browser: true */
+	/*global $tw: false */
+	"use strict";
+	
+	// Export name and synchronous status
+	exports.name = "story";
+	exports.after = ["startup"];
+	exports.synchronous = true;
+	
+	// Default story and history lists
+	var DEFAULT_STORY_TITLE = "$:/StoryList";
+	var DEFAULT_HISTORY_TITLE = "$:/HistoryList";
+	
+	// Default tiddlers
+	var DEFAULT_TIDDLERS_TITLE = "$:/DefaultTiddlers";
+	
+	// Config
+	var CONFIG_UPDATE_ADDRESS_BAR = "$:/config/Navigation/UpdateAddressBar"; // Can be "no", "permalink", "permaview"
+	var CONFIG_UPDATE_HISTORY = "$:/config/Navigation/UpdateHistory"; // Can be "yes" or "no"
+	var CONFIG_PERMALINKVIEW_COPY_TO_CLIPBOARD = "$:/config/Navigation/Permalinkview/CopyToClipboard"; // Can be "yes" (default) or "no"
+	var CONFIG_PERMALINKVIEW_UPDATE_ADDRESS_BAR = "$:/config/Navigation/Permalinkview/UpdateAddressBar"; // Can be "yes" (default) or "no"
+	
+	
+	// Links to help, if there is no param
+	var HELP_OPEN_EXTERNAL_WINDOW = "http://tiddlywiki.com/#WidgetMessage%3A%20tm-open-external-window";
+	
+	exports.startup = function() {
+		// Open startup tiddlers
+		openStartupTiddlers({
+			disableHistory: $tw.boot.disableStartupNavigation
+		});
+		if($tw.browser) {
+			// Set up location hash update
+			$tw.wiki.addEventListener("change",function(changes) {
+				if($tw.utils.hop(changes,DEFAULT_STORY_TITLE) || $tw.utils.hop(changes,DEFAULT_HISTORY_TITLE)) {
+					updateLocationHash({
+						updateAddressBar: $tw.wiki.getTiddlerText(CONFIG_UPDATE_ADDRESS_BAR,"permaview").trim(),
+						updateHistory: $tw.wiki.getTiddlerText(CONFIG_UPDATE_HISTORY,"no").trim()
+					});
+				}
+			});
+			// Listen for changes to the browser location hash
+			window.addEventListener("hashchange",function() {
+				var hash = $tw.utils.getLocationHash();
+				if(hash !== $tw.locationHash) {
+					$tw.locationHash = hash;
+					if(hash !== "#") {
+						openStartupTiddlers({defaultToCurrentStory: true});
+					}
+				}
+			},false);
+			// Listen for the tm-browser-refresh message
+			$tw.rootWidget.addEventListener("tm-browser-refresh",function(event) {
+				window.location.reload(true);
+			});
+			// Listen for tm-open-external-window message
+			$tw.rootWidget.addEventListener("tm-open-external-window",function(event) {
+				var paramObject = event.paramObject || {},
+					strUrl = event.param || HELP_OPEN_EXTERNAL_WINDOW,
+					strWindowName = paramObject.windowName,
+					strWindowFeatures = paramObject.windowFeatures;
+				window.open(strUrl, strWindowName, strWindowFeatures);
+			});
+			// Listen for the tm-print message
+			$tw.rootWidget.addEventListener("tm-print",function(event) {
+				(event.event.view || window).print();
+			});
+			// Listen for the tm-home message
+			$tw.rootWidget.addEventListener("tm-home",function(event) {
+				window.location.hash = "";
+				var storyFilter = $tw.wiki.getTiddlerText(DEFAULT_TIDDLERS_TITLE),
+					storyList = $tw.wiki.filterTiddlers(storyFilter);
+				//invoke any hooks that might change the default story list
+				storyList = $tw.hooks.invokeHook("th-opening-default-tiddlers-list",storyList);
+				$tw.wiki.addTiddler({title: DEFAULT_STORY_TITLE, text: "", list: storyList},$tw.wiki.getModificationFields());
+				if(storyList[0]) {
+					$tw.wiki.addToHistory(storyList[0]);
+				}
+			});
+			// Listen for the tm-permalink message
+			$tw.rootWidget.addEventListener("tm-permalink",function(event) {
+				updateLocationHash({
+					updateAddressBar: $tw.wiki.getTiddlerText(CONFIG_PERMALINKVIEW_UPDATE_ADDRESS_BAR,"yes").trim() === "yes" ? "permalink" : "none",
+					updateHistory: $tw.wiki.getTiddlerText(CONFIG_UPDATE_HISTORY,"no").trim(),
+					targetTiddler: event.param || event.tiddlerTitle,
+					copyToClipboard: $tw.wiki.getTiddlerText(CONFIG_PERMALINKVIEW_COPY_TO_CLIPBOARD,"yes").trim() === "yes" ? "permalink" : "none"
+				});
+			});
+			// Listen for the tm-permaview message
+			$tw.rootWidget.addEventListener("tm-permaview",function(event) {
+				updateLocationHash({
+					updateAddressBar: $tw.wiki.getTiddlerText(CONFIG_PERMALINKVIEW_UPDATE_ADDRESS_BAR,"yes").trim() === "yes" ? "permaview" : "none",
+					updateHistory: $tw.wiki.getTiddlerText(CONFIG_UPDATE_HISTORY,"no").trim(),
+					targetTiddler: event.param || event.tiddlerTitle,
+					copyToClipboard: $tw.wiki.getTiddlerText(CONFIG_PERMALINKVIEW_COPY_TO_CLIPBOARD,"yes").trim() === "yes" ? "permaview" : "none"
+				});
+			});
+		}
+	};
+	
+	/*
+	Process the location hash to open the specified tiddlers. Options:
+	disableHistory: if true $:/History is NOT updated
+	defaultToCurrentStory: If true, the current story is retained as the default, instead of opening the default tiddlers
+	*/
+	function openStartupTiddlers(options) {
+		options = options || {};
+		// Work out the target tiddler and the story filter. "null" means "unspecified"
+		var target = null,
+			storyFilter = null;
+		if($tw.locationHash.length > 1) {
+			var hash = $tw.locationHash.substr(1),
+				split = hash.indexOf(":");
+			if(split === -1) {
+				target = $tw.utils.decodeTWURITarget(hash.trim());
+			} else {
+				target = $tw.utils.decodeTWURITarget(hash.substr(0,split).trim());
+				storyFilter = $tw.utils.decodeTWURIList(hash.substr(split + 1).trim());
+			}
+		}
+		// If the story wasn't specified use the current tiddlers or a blank story
+		if(storyFilter === null) {
+			if(options.defaultToCurrentStory) {
+				var currStoryList = $tw.wiki.getTiddlerList(DEFAULT_STORY_TITLE);
+				storyFilter = $tw.utils.stringifyList(currStoryList);
+			} else {
+				if(target && target !== "") {
+					storyFilter = "";
+				} else {
+					storyFilter = $tw.wiki.getTiddlerText(DEFAULT_TIDDLERS_TITLE);
+				}
+			}
+		}
+		// Process the story filter to get the story list
+		var storyList = $tw.wiki.filterTiddlers(storyFilter);
+		// Invoke any hooks that want to change the default story list
+		storyList = $tw.hooks.invokeHook("th-opening-default-tiddlers-list",storyList);
+		// If the target tiddler isn't included then splice it in at the top
+		if(target && storyList.indexOf(target) === -1) {
+			storyList.unshift(target);
+		}
+		// Save the story list
+		$tw.wiki.addTiddler({title: DEFAULT_STORY_TITLE, text: "", list: storyList},$tw.wiki.getModificationFields());
+		// Update history
+		var story = new $tw.Story({
+			wiki: $tw.wiki,
+			storyTitle: DEFAULT_STORY_TITLE,
+			historyTitle: DEFAULT_HISTORY_TITLE
+		});
+		if(!options.disableHistory) {
+			// If a target tiddler was specified add it to the history stack
+			if(target && target !== "") {
+				// The target tiddler doesn't need double square brackets, but we'll silently remove them if they're present
+				if(target.indexOf("[[") === 0 && target.substr(-2) === "]]") {
+					target = target.substr(2,target.length - 4);
+				}
+				story.addToHistory(target);
+			} else if(storyList.length > 0) {
+				story.addToHistory(storyList[0]);
+			}
+		}
+	}
+	
+	/*
+	options: See below
+	options.updateAddressBar: "permalink", "permaview" or "no" (defaults to "permaview")
+	options.updateHistory: "yes" or "no" (defaults to "no")
+	options.copyToClipboard: "permalink", "permaview" or "no" (defaults to "no")
+	options.targetTiddler: optional title of target tiddler for permalink
+	*/
+	function updateLocationHash(options) {
+		// Get the story and the history stack
+		var storyList = $tw.wiki.getTiddlerList(DEFAULT_STORY_TITLE),
+			historyList = $tw.wiki.getTiddlerData(DEFAULT_HISTORY_TITLE,[]),
+			targetTiddler = "";
+		if(options.targetTiddler) {
+			targetTiddler = options.targetTiddler;
+		} else {
+			// The target tiddler is the one at the top of the stack
+			if(historyList.length > 0) {
+				targetTiddler = historyList[historyList.length-1].title;
+			}
+			// Blank the target tiddler if it isn't present in the story
+			if(storyList.indexOf(targetTiddler) === -1) {
+				targetTiddler = "";
+			}
+		}
+		// Assemble the location hash
+		switch(options.updateAddressBar) {
+			case "permalink":
+				$tw.locationHash = "#" + $tw.utils.encodeTiddlerTitle(targetTiddler);
+				break;
+			case "permaview":
+				$tw.locationHash = "#" + $tw.utils.encodeTiddlerTitle(targetTiddler) + ":" + $tw.utils.encodeTiddlerTitle($tw.utils.stringifyList(storyList));
+				break;
+		}
+		// Copy URL to the clipboard
+		switch(options.copyToClipboard) {
+			case "permalink":
+				$tw.utils.copyToClipboard($tw.utils.getLocationPath() + "#" + $tw.utils.encodeTiddlerTitle(targetTiddler));
+				break;
+			case "permaview":
+				$tw.utils.copyToClipboard($tw.utils.getLocationPath() + "#" + $tw.utils.encodeTiddlerTitle(targetTiddler) + ":" + $tw.utils.encodeTiddlerTitle($tw.utils.stringifyList(storyList)));
+				break;
+		}
+		// Only change the location hash if we must, thus avoiding unnecessary onhashchange events
+		if($tw.utils.getLocationHash() !== $tw.locationHash) {
+			if(options.updateHistory === "yes") {
+				// Assign the location hash so that history is updated
+				window.location.hash = $tw.locationHash;
+			} else {
+				// We use replace so that browser history isn't affected
+				window.location.replace(window.location.toString().split("#")[0] + $tw.locationHash);
+			}
+		}
+	}
+	
+	})();
 		targetTiddler = options.targetTiddler;
 	} else {
 		// The target tiddler is the one at the top of the stack
@@ -198,19 +425,19 @@ function updateLocationHash(options) {
 	// Assemble the location hash
 	switch(options.updateAddressBar) {
 		case "permalink":
-			$tw.locationHash = "#" + encodeURIComponent(targetTiddler);
+			$tw.locationHash = "#" + $tw.utils.encodeTiddlerTitle(targetTiddler);
 			break;
 		case "permaview":
-			$tw.locationHash = "#" + encodeURIComponent(targetTiddler) + ":" + encodeURIComponent($tw.utils.stringifyList(storyList));
+			$tw.locationHash = "#" + $tw.utils.encodeTiddlerTitle(targetTiddler) + ":" + $tw.utils.encodeFilterPath($tw.utils.stringifyList(storyList));
 			break;
 	}
 	// Copy URL to the clipboard
 	switch(options.copyToClipboard) {
 		case "permalink":
-			$tw.utils.copyToClipboard($tw.utils.getLocationPath() + "#" + encodeURIComponent(targetTiddler));
+			$tw.utils.copyToClipboard($tw.utils.getLocationPath() + "#" + $tw.utils.encodeTiddlerTitle(targetTiddler));
 			break;
 		case "permaview":
-			$tw.utils.copyToClipboard($tw.utils.getLocationPath() + "#" + encodeURIComponent(targetTiddler) + ":" + encodeURIComponent($tw.utils.stringifyList(storyList)));
+			$tw.utils.copyToClipboard($tw.utils.getLocationPath() + "#" + $tw.utils.encodeTiddlerTitle(targetTiddler) + ":" + $tw.utils.encodeFilterPath($tw.utils.stringifyList(storyList)));
 			break;
 	}
 	// Only change the location hash if we must, thus avoiding unnecessary onhashchange events

--- a/core/modules/utils/twuri-encoding.js
+++ b/core/modules/utils/twuri-encoding.js
@@ -1,0 +1,131 @@
+/*\
+title: $:/core/modules/utils/twuri-encoding.js
+type: application/javascript
+module-type: utils
+Utility functions related to permalink/permaview encoding/decoding.
+\*/
+(function(){
+
+	// The character that will substitute for a space in the URL
+	var SPACE_SUBSTITUTE = "+";
+
+	// The character added to the end to avoid ending with `.`, `?`, `!` or the like
+	var TRAILER = "+";
+
+	// The character that will separate out the list elements in the URL
+	var CONJUNCTION = ";";
+
+	// The encoded version of the space substitute as a regex
+	var ENCODED_SPACE_SUBSTITUTE = new RegExp(encodeURIComponent(SPACE_SUBSTITUTE).replace("%", "\\%"), "g");
+
+	// The encoded version of the trailer as a regex
+	var ENCODED_TRAILER = new RegExp(encodeURIComponent(TRAILER).replace("%", "\\%") + "$", "g");
+
+	// Those of the allowed url characters claimed by TW
+	var CLAIMED = [SPACE_SUBSTITUTE, ":", CONJUNCTION];
+
+	// Non-alphanumeric characters allowed in a URL fragment
+	// More information at https://www.rfc-editor.org/rfc/rfc3986#appendix-A
+	var VALID_IN_URL_FRAGMENT = "-._~!$&'()*+,;=:@/?".split("");
+
+	// The subset of the pchars we will not percent-encode in permalinks/permaviews
+	var SUBSTITUTES = []
+	$tw.utils.each(VALID_IN_URL_FRAGMENT, function(c) {
+		if (CLAIMED.indexOf(c) === -1) {
+			SUBSTITUTES.push(c)
+		}
+	});
+
+	// A regex to match the percent-encoded characters we will want to replace.
+	// Something similar to the following, depending on SPACE and CONJUNCTION
+	//     /(%2D|%2E|%7E|%21|%24|%26|%27|%28|%29|%2A|%2B|%3B|%3D|%40|%2F|%3F)/g
+
+	var CHAR_MATCH_STR = []
+	$tw.utils.each(SUBSTITUTES, function(c) {
+		CHAR_MATCH_STR.push("%" + c.charCodeAt(0).toString(16).toUpperCase())
+	})
+	var CHAR_MATCH = new RegExp("(" + CHAR_MATCH_STR.join("|") + ")", "g");
+
+	// A regex to match the SPACE_SUBSTITUTE character
+	var SPACE_MATCH = new RegExp("(\\" + SPACE_SUBSTITUTE + ")", "g");
+
+	// A regex to match URLs ending with sentence-ending punctuation
+	var SENTENCE_ENDING = new RegExp("(\\.|\\!|\\?|\\" + TRAILER + ")$", "g");
+
+	// A regex to match URLs ending with sentence-ending punctuation plus the TRAILER
+	var SENTENCE_TRAILING = new RegExp("(\\.|\\!|\\?|\\" + TRAILER + ")\\" + TRAILER + "$", "g");
+
+	// An object mapping the percent encodings back to their source characters
+	var PCT_CHAR_MAP = []
+    SUBSTITUTES.forEach(function (c) {
+		PCT_CHAR_MAP["%" + c.charCodeAt(0).toString(16).toUpperCase()] = c
+	});
+
+	// Convert a URI List Component encoded string (with the `SPACE_SUBSTITUTE`
+	// value as an allowed replacement for the space character) to a string
+	exports.decodeTWURIList = function(s) {
+		var parts = s.replace(SENTENCE_TRAILING, "$1").split(CONJUNCTION);
+		var withSpaces = []
+		$tw.utils.each(parts, function(s) {
+			withSpaces.push(s.replace(SPACE_MATCH, " "))
+		});
+		var withBrackets  = []
+		$tw.utils.each(withSpaces, function(s) {
+			withBrackets .push(s.indexOf(" ") >= 0 ? "[[" + s + "]]" : s)
+		});
+		return $tw.utils.decodeURIComponentSafe(withBrackets.join(" "));
+	};
+
+	// Convert a URI Target Component encoded string (with the `SPACE_SUBSTITUTE` 
+	// value as an allowed replacement for the space character) to a string
+	exports.decodeTWURITarget = function(s) {
+		return $tw.utils.decodeURIComponentSafe(
+			s.replace(SENTENCE_TRAILING, "$1").replace(SPACE_MATCH, " ")
+		)
+	};
+
+	// Convert a URIComponent encoded title string (with the `SPACE_SUBSTITUTE`
+	// value as an allowed replacement for the space character) to a string
+	exports.encodeTiddlerTitle = function(s) {
+		var extended = s.replace(SENTENCE_ENDING, "$1" + TRAILER)
+		var encoded = encodeURIComponent(extended);
+		var substituted = encoded.replace(/\%20/g, SPACE_SUBSTITUTE).replace(ENCODED_TRAILER, TRAILER)
+		return substituted.replace(CHAR_MATCH, function(_, c) {
+			return PCT_CHAR_MAP[c];
+		});
+	};
+
+	// Convert a URIComponent encoded filter string (with the `SPACE_SUBSTITUTE`
+	// value as an allowed replacement for the space character) to a string
+	exports.encodeFilterPath = function(s) {
+		var parts = s.replace(SENTENCE_ENDING, "$1" + TRAILER)
+			.replace(/\[\[(.+?)\]\]/g, function (_, t) {return t.replace(/ /g, SPACE_SUBSTITUTE )})
+			.split(" ");
+		var nonEmptyParts = []
+		$tw.utils.each(parts, function(p) {
+			if (p) {
+				nonEmptyParts.push (p)
+			}
+		});
+		var trimmed = [];
+		$tw.utils.each(nonEmptyParts, function(s) {
+			trimmed.push(s.trim())
+		});
+		var encoded = [];
+		$tw.utils.each(trimmed, function(s) {
+			encoded.push(encodeURIComponent(s))
+		});
+		var substituted = [];
+		$tw.utils.each(encoded, function(s) {
+			substituted.push(s.replace(/\%20/g, SPACE_SUBSTITUTE).replace(ENCODED_SPACE_SUBSTITUTE, SPACE_SUBSTITUTE))
+		});
+		var replaced = []
+		$tw.utils.each(substituted, function(s) {
+			replaced.push(s.replace(CHAR_MATCH, function(_, c) {
+				return PCT_CHAR_MAP[c];
+			}))
+		});
+		return replaced.join(CONJUNCTION);
+	};
+
+})();

--- a/editions/test/tiddlers/tests/test-utils.js
+++ b/editions/test/tiddlers/tests/test-utils.js
@@ -209,6 +209,58 @@ describe("Utility tests", function() {
 		expect($tw.utils.insertSortedArray(["b","c","d"],"ccc").join(",")).toEqual("b,c,ccc,d");
 	});
 
+	describe("contains the function `encodeTiddlerTitle`, which", function() {
+    it("should convert spaces to plus signs", function() {
+			expect($tw.utils.encodeTiddlerTitle("Foo Bar")).toEqual("Foo+Bar");
+		});
+    it("should handle multiple spaces", function() {
+			expect($tw.utils.encodeTiddlerTitle("Foo Bar Baz Qux")).toEqual("Foo+Bar+Baz+Qux");
+		});
+    it("should handle many special characters", function() {
+			expect($tw.utils.encodeTiddlerTitle("A (...surprising?) tiddler with various *special/unusual* characters, & more")).toEqual("A+(...surprising?)+tiddler+with+various+*special/unusual*+characters,+&+more");
+		});
+    it("should add an extra `+` after trailing end-of-sentence punctuation", function() {
+			expect($tw.utils.encodeTiddlerTitle("Foo Bar Baz.")).toEqual("Foo+Bar+Baz.+");
+			expect($tw.utils.encodeTiddlerTitle("Foo Bar Baz!")).toEqual("Foo+Bar+Baz!+");
+			expect($tw.utils.encodeTiddlerTitle("Foo Bar Baz?")).toEqual("Foo+Bar+Baz?+");
+		});
+	});
+
+	describe("contains the function `decodeTWURITarget`, which", function() {
+    it("should convert plus signs to spaces", function() {
+			expect($tw.utils.decodeTWURITarget("Foo+Bar")).toEqual("Foo Bar");
+		});
+    it("should handle multiple spaces", function() {
+			expect($tw.utils.decodeTWURITarget("Foo+Bar+Baz+Qux")).toEqual("Foo Bar Baz Qux");
+		});
+    it("should handle many special characters", function() {
+			expect($tw.utils.decodeTWURITarget("A+(...surprising?)+tiddler+with+various+*special/unusual*+characters,+&+more")).toEqual("A (...surprising?) tiddler with various *special/unusual* characters, & more");
+		});
+    it("should remove an extra `+` after trailing end-of-sentence punctuation", function() {
+			expect($tw.utils.decodeTWURITarget("Foo+Bar+Baz.+")).toEqual("Foo Bar Baz.");
+			expect($tw.utils.decodeTWURITarget("Foo+Bar+Baz!+")).toEqual("Foo Bar Baz!");
+			expect($tw.utils.decodeTWURITarget("Foo+Bar+Baz?+")).toEqual("Foo Bar Baz?");
+		});
+	});
+
+	describe("contains the function `encodeFilterPath`, which", function() {
+		it("should convert a filter list format string to a plus-sign-encoded url list format", function() {
+			expect($tw.utils.encodeFilterPath("[[Alternative page layouts]] [[Using Stylesheets]] [[Customising search results]]")).toEqual("Alternative+page+layouts;Using+Stylesheets;Customising+search+results");
+			expect($tw.utils.encodeFilterPath("HelloThere [[Using Stylesheets]] [[Hidden Settings]]")).toEqual("HelloThere;Using+Stylesheets;Hidden+Settings");
+		});
+	});
+
+	describe("contains the function `decodeTWURIList`, which", function() {
+		it("should convert the plus-sign-encoded url list format to a filter list format", function() {
+			expect($tw.utils.decodeTWURIList("Alternative+page+layouts;Using+Stylesheets;Customising+search+results")).toEqual("[[Alternative page layouts]] [[Using Stylesheets]] [[Customising search results]]");
+			expect($tw.utils.decodeTWURIList("HelloThere;Using+Stylesheets;Hidden+Settings")).toEqual("HelloThere [[Using Stylesheets]] [[Hidden Settings]]");
+		});
+		it("should convert old percent-encoded filters to a filter list format", function() {
+			expect($tw.utils.decodeTWURIList("[tag[Features]]%20%2B[limit[5]]")).toEqual("[tag[Features]] +[limit[5]]");
+		});
+	});
+
 });
+
 
 })();

--- a/editions/tw5.com/tiddlers/concepts/PermaLinks.tid
+++ b/editions/tw5.com/tiddlers/concepts/PermaLinks.tid
@@ -52,7 +52,7 @@ instead looks like
 
 Existing story filter URLs like
 
-> @@font-family:monospace;#:[tag[Features]]%20+[limit[5]]@@
+> @@font-family:monospace;#:[tag[Features]]%20%2B[limit[5]]@@
 
 will continue to work.
 

--- a/editions/tw5.com/tiddlers/concepts/PermaLinks.tid
+++ b/editions/tw5.com/tiddlers/concepts/PermaLinks.tid
@@ -40,6 +40,22 @@ There are technical restrictions on the legal characters in an URL fragment. To 
 
 Both the target tiddler title and the story filter should be URL encoded (but not the separating colon). TiddlyWiki generates properly encoded URLs which can look quite ugly. However, in practice browsers will usually perfectly happily process arbitrary characters in URL fragments. Thus when creating permalinks manually you can choose to ignore URL encoding.
 
+!! Simpler URLS
+
+<<.from-version "5.3.4">> The URLs generated are simplified from the hard-to-read percent encoding when feasible.  Spaces are replaced with plus signs (`+`), many punctuation characters are allowed to remain unencoded, and permaview filters receive a simpler encoding.  For example the tiddler "Hard Linebreaks with CSS - Example", which percent-encoded would look like 
+
+> @@font-family:monospace;#Hard%20Linebreaks%20with%20CSS%20-%20Example@@
+
+instead looks like 
+
+> @@font-family:monospace;#Hard+Linebreaks+with+CSS+-+Example@@
+
+Existing story filter URLs like
+
+> @@font-family:monospace;#:[tag[Features]]%20+[limit[5]]@@
+
+will continue to work.
+
 ! Permalink Behaviour
 
 Two important aspects of TiddlyWiki's behaviour with permalinks can be controlled via options in the [[control panel|$:/ControlPanel]] <<.icon $:/core/images/options-button>> ''Settings'' tab:


### PR DESCRIPTION
This is a reworking of #7729, creating more user-friendly permalinks and permaviews.  There's not much to discuss here; you can see that closed PR for rationale and some interesting discussion.

The largest difference is that the previous version replaced spaces with underscore characters (`_`), whereas this one uses plus signs (`+`).  Although there was an attempt in the previous version to abstract that character into a single variable to allow a quick switch, there was still some need to alter the code because of the difference in how underscores and plus signs are converted in native url-encoding.  These were not huge changes, and the code is substantially the same.

This version includes a number of unit tests.  They are a little different from some of the others in the `$tw.utils` namespace, so I would appreciate it if someone can look them over to make sure they seem all right.  The difference is that I have a second level of suites to focus on each function by name, and then a number of specs under these.  The specs contain either a single assertion or a few very-closely related ones.  I kept with the majority trend in the unit tests by starting my descriptions with "should`", although I personally prefer to skip that.  Is there any other level of testing I should add?  These are used by `core/modules/startup/story`, and I didn't see other tests for that.  Should I be looking elsewhere?