### PR TITLE
Update backtranscludes.tid

### DIFF
--- a/editions/tw5.com/tiddlers/filters/backtranscludes.tid
+++ b/editions/tw5.com/tiddlers/filters/backtranscludes.tid
@@ -1,0 +1,13 @@
+created: 20211002204500000
+tags: [[Filter Operators]]
+title: backtranscludes Operator
+type: text/vnd.tiddlywiki
+caption: backtranscludes
+op-purpose: find the titles that transcludes to each input title
+op-input: a [[selection of titles|Title Selection]]
+op-parameter: none
+op-output: any non-[[system|SystemTiddlers]] titles that contain [[transclusion|Transclusion]] to the input titles
+
+<<.from-version 5.3.3>> Similar to [[backlinks|backlinks Operator]]. Each input title is processed in turn. The corresponding tiddler's list of backtranscludes is generated, sorted alphabetically by title, and then [[dominantly appended|Dominant Append]] to the operator's overall output.
+
+<<.operator-examples "backtranscludes">>

--- a/editions/tw5.com/tiddlers/filters/backtranscludes.tid
+++ b/editions/tw5.com/tiddlers/filters/backtranscludes.tid
@@ -8,6 +8,6 @@ op-input: a [[selection of titles|Title Selection]]
 op-parameter: none
 op-output: any non-[[system|SystemTiddlers]] titles that contain [[transclusion|Transclusion]] to the input titles
 
-<<.from-version 5.3.3>> Similar to [[backlinks|backlinks Operator]]. Each input title is processed in turn. The corresponding tiddler's list of backtranscludes is generated, sorted alphabetically by title, and then [[dominantly appended|Dominant Append]] to the operator's overall output.
+<<.from-version 5.3.4>> Similar to [[backlinks|backlinks Operator]]. Each input title is processed in turn. The corresponding tiddler's list of backtranscludes is generated, sorted alphabetically by title, and then [[dominantly appended|Dominant Append]] to the operator's overall output.
 
 <<.operator-examples "backtranscludes">>


### PR DESCRIPTION
> Shouldn't indicate <<.from-version 5.3.3>> in the doc? @kookma 

https://github.com/Jermolene/TiddlyWiki5/pull/6081#issuecomment-1964082038