### PR TITLE
Add the tc-btn-mini class to the tc-remove-tag-button

### DIFF
--- a/editions/tw5.com/tiddlers/$:/core/ui/EditTemplate/tags.tid
+++ b/editions/tw5.com/tiddlers/$:/core/ui/EditTemplate/tags.tid
@@ -1,0 +1,43 @@
+created: 20240302121159409
+modified: 20240302121221748
+tags: $:/tags/EditTemplate
+title: $:/core/ui/EditTemplate/tags
+
+\whitespace trim
+
+\define lingo-base() $:/language/EditTemplate/
+
+\define tag-styles()
+background-color:$(backgroundColor)$;
+fill:$(foregroundColor)$;
+color:$(foregroundColor)$;
+\end
+
+\define tag-body-inner(colour,fallbackTarget,colourA,colourB,icon,tagField:"tags")
+\whitespace trim
+<$vars foregroundColor=<<contrastcolour target:"""$colour$""" fallbackTarget:"""$fallbackTarget$""" colourA:"""$colourA$""" colourB:"""$colourB$""">> backgroundColor="""$colour$""">
+<span style=<<tag-styles>> class="tc-tag-label tc-tag-list-item tc-small-gap-right" data-tag-title=<<currentTiddler>>>
+<$transclude tiddler="""$icon$"""/><$view field="title" format="text"/>
+<$button class="tc-btn-invisible tc-remove-tag-button tc-btn-mini" style=<<tag-styles>>><$action-listops $tiddler=<<saveTiddler>> $field=<<__tagField__>> $subfilter="-[{!!title}]"/>{{$:/core/images/close-button}}</$button>
+</span>
+</$vars>
+\end
+
+\define tag-body(colour,palette,icon,tagField:"tags")
+<$macrocall $name="tag-body-inner" colour="""$colour$""" fallbackTarget={{$palette$##tag-background}} colourA={{$palette$##foreground}} colourB={{$palette$##background}} icon="""$icon$""" tagField=<<__tagField__>>/>
+\end
+
+\define edit-tags-template(tagField:"tags")
+\whitespace trim
+<div class="tc-edit-tags">
+<$list filter="[list[!!$tagField$]sort[title]]" storyview="pop">
+<$macrocall $name="tag-body" colour={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}} palette={{$:/palette}} icon={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] }}} tagField=<<__tagField__>>/>
+</$list>
+<$vars tabIndex={{$:/config/EditTabIndex}} cancelPopups="yes">
+<$macrocall $name="tag-picker" tagField=<<__tagField__>>/>
+</$vars>
+</div>
+\end
+<$set name="saveTiddler" value=<<currentTiddler>>>
+<$macrocall $name="edit-tags-template" tagField=<<tagField>>/>
+</$set>


### PR DESCRIPTION
In edit mode, tag pills display a small remove button. For consistency (and for future optimisations of the css stylesheet), it should have the class "tc-btn-mini", as seen in the sidebar, in the "open" tab. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>