### PR TITLE
tiddler-info-source - change sources tab to new syntax and add link to pr-creator

### DIFF
--- a/editions/tw5.com/tiddlers/system/Sources.tid
+++ b/editions/tw5.com/tiddlers/system/Sources.tid
@@ -1,26 +1,39 @@
 title: $:/editions/tw5.com/TiddlerInfo/Sources
 tags: $:/tags/TiddlerInfo
 caption: Sources
+code-body: yes
 
-\define static-link-base()
-https://tiddlywiki.com/static/$(title)$.html
+\function static-link-base() [[https://tiddlywiki.com/static/$(title)$.html]substitute[]]
+
+\function github-link-base()
+[[https://github.com/Jermolene/TiddlyWiki5/blob/tiddlywiki-com/editions/tw5.com/tiddlers/$(title)$]substitute[]]
 \end
 
-\define make-static-link()
+\procedure make-static-link()
+\whitespace trim
 <$set name="title" filter="[<currentTiddler>encodeuricomponent[]encodeuricomponent[]]" select="0">
-<a href=<<static-link-base>> class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><$text text=<<static-link-base>>/></a>
+	<a href=<<static-link-base>>
+		class="tc-tiddlylink-external"
+		target="_blank"
+		rel="noopener noreferrer"
+	>
+		<$text text=<<static-link-base>>/>
+	</a>
 </$set>
 \end
 
-\define github-link-base()
-https://github.com/Jermolene/TiddlyWiki5/blob/tiddlywiki-com/editions/tw5.com/tiddlers/$(title)$
-\end
-
-\define make-github-link()
-<$set name="title" value={{$:/config/OriginalTiddlerPaths##$(currentTiddler)$}}>
-<$set name="title" filter="[<title>encodeuricomponent[]]" select="0">
-<a href=<<github-link-base>> class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><$text text=<<github-link-base>>/></a>
-</$set>
+\procedure make-github-link()
+\whitespace trim
+<$set name="title" value={{{ [[$:/config/OriginalTiddlerPaths]getindex<currentTiddler>] }}}>
+	<$set name="title" filter="[<title>encodeuricomponent[]]" select="0">
+		<a href=<<github-link-base>>
+			class="tc-tiddlylink-external"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			<$text text=<<currentTiddler>>/><span class="tc-tiny-gap-left">at github</span>
+		</a>
+	</$set>
 </$set>
 \end
 
@@ -32,6 +45,7 @@ A static HTML representation of this tiddler is available at the URL:
 
 Help us to improve the documentation by sending a ~GitHub pull request for this tiddler:
 
+* [[Contribute to TW documentation using TiddlyWiki|https://saqimtiaz.github.io/tw5-docs-pr-maker/]]
 * <<make-github-link>>
 
 </$list>

--- a/editions/tw5.com/tiddlers/system/Sources.tid
+++ b/editions/tw5.com/tiddlers/system/Sources.tid
@@ -23,16 +23,13 @@ code-body: yes
 \end
 
 \procedure make-github-link()
-\whitespace trim
 <$set name="title" value={{{ [[$:/config/OriginalTiddlerPaths]getindex<currentTiddler>] }}}>
 	<$set name="title" filter="[<title>encodeuricomponent[]]" select="0">
 		<a href=<<github-link-base>>
 			class="tc-tiddlylink-external"
 			target="_blank"
 			rel="noopener noreferrer"
-		>
-			<$text text=<<currentTiddler>>/><span class="tc-tiny-gap-left">at github</span>
-		</a>
+		>Direct link to <$text text=<<currentTiddler>>/> on github.com</a>
 	</$set>
 </$set>
 \end
@@ -43,9 +40,8 @@ A static HTML representation of this tiddler is available at the URL:
 
 * <<make-static-link>>
 
-Help us to improve the documentation by sending a ~GitHub pull request for this tiddler:
+Help us to improve the documentation by suggesting changes to this tiddler using the [[TiddlyWiki Docs PR Maker|https://saqimtiaz.github.io/tw5-docs-pr-maker/]]
 
-* [[Contribute to TW documentation using TiddlyWiki|https://saqimtiaz.github.io/tw5-docs-pr-maker/]]
 * <<make-github-link>>
 
 </$list>


### PR DESCRIPTION
This PR 

- uses a prettylink to link to the tiddler at the GitHub repository. 
- adds a link to Saq Imitaz's PR-Maker edition for easier community contribution
- changes the code syntax to v5.3.x

**New**

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/e2d46d13-679a-4091-9f66-4df356c134e9)

**Old**

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/24f3c0e4-3006-4d0b-bd46-3eeb08b4c4d5)
