### PR TITLE
doc-macros - variable-macros new v5.3.x syntax

### DIFF
--- a/editions/tw5.com/tiddlers/system/variable-macros.tid
+++ b/editions/tw5.com/tiddlers/system/variable-macros.tid
@@ -1,5 +1,5 @@
 created: 20150228114241000
-modified: 20240229155624000
+modified: 20220227210136243
 tags: $:/tags/Macro
 code-body: yes
 title: $:/editions/tw5.com/variable-macros

--- a/editions/tw5.com/tiddlers/system/variable-macros.tid
+++ b/editions/tw5.com/tiddlers/system/variable-macros.tid
@@ -1,21 +1,26 @@
 created: 20150228114241000
-modified: 20220227210136243
+modified: 20240229155624000
 tags: $:/tags/Macro
+code-body: yes
 title: $:/editions/tw5.com/variable-macros
 
-\define .variable-examples(v,text:"Examples") <$link to="$v$ Variable (Examples)">$text$</$link>
-\define .macro-examples(m,text:"Examples") <$link to="$m$ Macro (Examples)">$text$</$link>
-\define .widget-examples(w,text:"Examples") <$link to="$w$ Widget (Examples)">$text$</$link>
+\procedure .variable-examples(v,text:"Examples") <$link to=`$(v)$ Variable (Examples)`><<text>></$link>
+\procedure .macro-examples(m,text:"Examples") <$link to=`$(m)$ Macro (Examples)`><<text>></$link>
+\procedure .widget-examples(w,text:"Examples") <$link to=`$(w)$ Widget (Examples)`><<text>></$link>
 
-\define .js-macro-link(_) [[$_$|https://tiddlywiki.com/dev/index.html#JavaScript%20Macros]]
-
-\define .this-is-static-link-variable() <<.tip "This variable has no useful effect when ~TiddlyWiki is running in a browser, as the `href` attribute is ignored there -- links between tiddlers are performed by JavaScript instead. The variable comes into play when one is using the [[Node.js configuration|TiddlyWiki on Node.js]] to [[generate a static version|RenderTiddlersCommand]] of a wiki.">>
-
-\define .this-is-toolbar-config-variable(configTiddler)
-
-It can be set to <<.value yes>> or <<.value no>> prior to transcluding such a button.
-
-The standard page template sets it to the value found in [[$configTiddler$]], with the result that this becomes the default for the whole page. The user can adjust this default by using a tickbox on the <<.controlpanel-tab Settings>> tab of the [[Control Panel|$:/ControlPanel]].
+\procedure .js-macro-link(_)
+<a href="https://tiddlywiki.com/dev/index.html#JavaScript%20Macros"
+	class="tc-tiddlylink-external"
+	target="_blank"
+	rel="noopener noreferrer"
+><$text text=<<_>>/></a>
 \end
 
-<pre><$view field="text"/></pre>
+\procedure .this-is-static-link-variable() <<.note "This variable has no useful effect when ~TiddlyWiki is running in a browser, as the `href` attribute is ignored there -- links between tiddlers are performed by JavaScript instead. The variable comes into play when one is using the [[Node.js configuration|TiddlyWiki on Node.js]] to [[generate a static version|RenderTiddlersCommand]] of a wiki.">>
+
+\procedure .this-is-toolbar-config-variable(configTiddler)
+\whitespace notrim
+It can be set to <<.value yes>> or <<.value no>> prior to transcluding such a button.
+
+The standard page template sets it to the value found in <$link to=<<configTiddler>>><<configTiddler>></$link>, with the result that this becomes the default for the whole page. The user can adjust this default by using a tickbox on the <<.controlpanel-tab Settings>> tab of the [[Control Panel|$:/ControlPanel]].
+\end


### PR DESCRIPTION
@Jermolene This is a docs-only PR. It contains 

- Variable macros syntax change to v5.3.x