### PR TITLE
docs - download empty button new syntax - v5.3.x 

### DIFF
--- a/editions/tw5.com/tiddlers/system/download-empty.tid
+++ b/editions/tw5.com/tiddlers/system/download-empty.tid
@@ -4,7 +4,7 @@ code-body: yes
 \define saveTiddlerFilter()
 [[$:/core]] [[$:/isEncrypted]] [[$:/themes/tiddlywiki/snowwhite]] [[$:/themes/tiddlywiki/vanilla]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]]
 \end
-\define savingEmpty()
-yes
-\end
+
+\define savingEmpty() yes
+
 {{$:/core/templates/tiddlywiki5.html}}

--- a/editions/tw5.com/tiddlers/system/download-empty.tid
+++ b/editions/tw5.com/tiddlers/system/download-empty.tid
@@ -1,10 +1,10 @@
 title: $:/editions/tw5.com/download-empty
 code-body: yes
 
-\define saveTiddlerFilter()
+\procedure saveTiddlerFilter()
 [[$:/core]] [[$:/isEncrypted]] [[$:/themes/tiddlywiki/snowwhite]] [[$:/themes/tiddlywiki/vanilla]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]]
 \end
 
-\define savingEmpty() yes
+\procedure savingEmpty() yes
 
 {{$:/core/templates/tiddlywiki5.html}}


### PR DESCRIPTION
@Jermolene, @saqimtiaz 

**This is a PR intended to discuss some things.** 

I want to keep stuff like this using the old syntax for the time being.

Since the `\define`s are direct preparations for core templates, I cannot predict any side effects at the moment. 

Also for "text-like" building blocks it still feels much better to use `\define savingEmpty() yes` instead of `\procedure savingEmpty() yes` ... `\procedure xx() something` just feels wrong. 