### PR TITLE
docs - operator macros, templates and filter-run template

### DIFF
--- a/editions/tw5.com/tiddlers/system/filter-run-template.tid
+++ b/editions/tw5.com/tiddlers/system/filter-run-template.tid
@@ -1,26 +1,27 @@
 code-body: yes
 created: 20230316112235083
 list-before: $:/core/ui/ViewTemplate/body
-modified: 20230326145802667
+modified: 20240229161432000
 tags: $:/tags/ViewTemplate
 title: $:/editions/tw5.com/filter-run-template
 type: text/vnd.tiddlywiki
 
-\define .op-place()
-<$macrocall $name=".if"
-	cond="""$(op-name)$"""
-	then="<<.place '$(op-name)$'>> = "
-	else=""/>
-\end
-
-\define .op-row()
-<$macrocall $name=".if"
-	cond="""$(op-body)$"""
-	then="""<tr><th align="left">$(op-head)$</th><td><<.op-place>>$(op-body)$</td></tr>"""
-	else=""/>
-\end
-
 \whitespace trim
+
+\procedure .op-place()
+<% if [<op-name>!is[blank]] %>
+	<$macrocall $name=".place" _=<<op-name>> /><span class="tc-tiny-gap">=</span>
+<% endif %>
+\end
+
+\procedure .op-row()
+<% if [<op-body>!is[blank]] %>
+	<tr>
+		<th align="left"><<op-head>></th>
+		<td><<.op-place>><<op-body>></td>
+	</tr>
+<% endif %>
+\end
 
 <$list filter="[all[current]tag[Named Filter Run Prefix]]">
 	<$let op-head="" op-body="" op-name="">

--- a/editions/tw5.com/tiddlers/system/operator-macros.tid
+++ b/editions/tw5.com/tiddlers/system/operator-macros.tid
@@ -1,52 +1,66 @@
 created: 20150117152607000
-modified: 20230617183916622
+modified: 20240229132501000
 tags: $:/tags/Macro
+code-body: yes
 title: $:/editions/tw5.com/operator-macros
 
-\define .operator-examples(op,text:"Examples") <$link to="$op$ Operator (Examples)">$text$</$link>
+
+\whitespace trim
+
+\procedure .operator-examples(op,text:"Examples") <$link to=`$(op)$ Operator (Examples)`><<text>></$link>
 
 \procedure .operator-example-tryit-actions() <$action-setfield $tiddler=<<.state>> text="show" filter=<<eg>>/>
+
 \procedure .operator-example(n,eg,ie)
 <div class="doc-example">
-<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix<n>]" variable=".state">
-<$reveal state=<<.state>> type="nomatch" text="show">
-	<code><$text text=<<eg>>/></code>
-	<$macrocall $name=".if" cond=<<ie>> then={{{[[<dd>&rarr; ]addsuffix<ie>addsuffix[</dd>]]}}}/>
-	<dl>
-	<dd><$button actions=<<.operator-example-tryit-actions>>>Try it</$button></dd>
-	</dl>
-</$reveal>
-<$reveal state=<<.state>> type="match" text="show">
-	<$edit-text tiddler=<<.state>> field="filter" tag="input" type=search focus="true"/>
-	<dl>
-	<dd>
-	<$button set=<<.state>> setTo="">Hide</$button>
-	<$reveal stateTitle=<<.state>> stateField="filter" type="nomatch" text=<<eg>>>
-		<$button actions=<<.operator-example-tryit-actions>>>Reset</$button>
-	</$reveal>
-	</dd>
-	</dl>
-	<blockquote class="doc-example-result">
-	<ul><$list filter={{{[<.state>get[filter]]}}} emptyMessage="(empty)">
-	<li><$link><$view field="title"/></$link></li>
-	</$list></ul>
-	</blockquote>
-</$reveal>
-</$list>
+	<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix<n>]" variable=".state">
+		<$reveal state=<<.state>> type="nomatch" text="show">
+			<code><$text text=<<eg>>/></code>
+			<% if [<ie>!is[blank]] %>
+				<dd>&rarr;&nbsp;<<ie>></dd>
+			<% endif %>
+			<dl>
+				<dd><$button actions=<<.operator-example-tryit-actions>>>Try it</$button></dd>
+			</dl>
+		</$reveal>
+		<$reveal state=<<.state>> type="match" text="show">
+			<$edit-text tiddler=<<.state>> field="filter" tag="input" type=search focus="true"/>
+			<dl>
+				<dd>
+					<$button set=<<.state>> setTo="">Hide</$button>
+					<$reveal stateTitle=<<.state>> stateField="filter" type="nomatch" text=<<eg>>>
+						<$button actions=<<.operator-example-tryit-actions>>>Reset</$button>
+					</$reveal>
+				</dd>
+			</dl>
+			<blockquote class="doc-example-result">
+				<ul>
+					<$list filter={{{[<.state>get[filter]]}}} emptyMessage="(empty)">
+						<li><$link><$view field="title"/></$link></li>
+					</$list>
+				</ul>
+			</blockquote>
+		</$reveal>
+	</$list>
+</div>
 \end
 
-\define .inline-operator-example(eg)
-<code><$text text=<<__eg__>>/></code> evaluates to <$list filter=<<__eg__>> emptyMessage="(empty)"> <code><$text text=<<currentTiddler>>/></code> </$list>
+\procedure .inline-operator-example(eg)
+<code>
+	<$text text=<<eg>>/>
+</code>
+<span class="tc-tiny-gap">evaluates to</span>
+<$list filter=<<eg>> emptyMessage="(empty)">
+	<code class="tc-tiny-gap-left"><$text text=<<currentTiddler>>/></code>
+</$list>
 \end
 
 \define .this-is-operator-example() This example tiddler is used to illustrate some of the [[Filter Operators]].
 \define .using-days-of-week() These examples make use of the [[Days of the Week]] tiddler.
 \define .s-matching-is-case-sensitive() In looking for matches for <<.place S>>, capital and lowercase letters are treated as different.
 
-\define .node-only-operator()
+\procedure .node-only-operator()
 
 <$macrocall $name=".note" _="This operator is <<.em not>> available when ~TiddlyWiki is running in a web browser."/>
 
 \end
-
-<pre><$view field="text"/></pre>

--- a/editions/tw5.com/tiddlers/system/operator-template.tid
+++ b/editions/tw5.com/tiddlers/system/operator-template.tid
@@ -1,25 +1,25 @@
 created: 20150203173506000
+modified: 20240229155612000
 list-before: $:/core/ui/ViewTemplate/body
-modified: 20230602181119360
 tags: $:/tags/ViewTemplate
 code-body: yes
 title: $:/editions/tw5.com/operator-template
 
-\define .op-place()
-<$macrocall $name=".if"
-	cond="""$(op-name)$"""
-	then="<<.place '$(op-name)$'>> = "
-	else=""/>
-\end
-
-\define .op-row()
-<$macrocall $name=".if"
-	cond="""$(op-body)$"""
-	then="""<tr><th align="left">$(op-head)$</th><td><<.op-place>>$(op-body)$</td></tr>"""
-	else=""/>
-\end
-
 \whitespace trim
+
+\procedure .op-place()
+<% if [<op-name>!is[blank]] %>
+	<$macrocall $name=".place" _=<<op-name>> /><span class="tc-tiny-gap">=</span>
+<% endif %>
+\end
+
+\procedure .op-row()
+<% if [<op-body>!is[blank]] %>
+	<tr>
+		<th align="left"><<op-head>></th><td><<.op-place>><<op-body>></td>
+	</tr>
+<% endif %>
+\end
 
 <$list filter="[all[current]tag[Filter Operators]]">
 	<$let op-head="" op-body="" op-name="">


### PR DESCRIPTION
@Jermolene -- this is a docs only PR - It contains 3 tiddlers, that are highly connected, so they are part of 1 PR. 

This PR converts them to the new v5.3.x syntax.

They are responsible for elements as shown in the screenshot

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/f5fd2ba0-fdca-4288-9cdc-fb8b4c5f1ce3)
