### PR TITLE
doc-macros, styles and documentation overview tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/styleguide/Documentation Macros.tid
+++ b/editions/tw5.com/tiddlers/styleguide/Documentation Macros.tid
@@ -1,174 +1,199 @@
 created: 20150110182600000
-modified: 20230325161424684
+modified: 20240224170607731
 tags: [[Improving TiddlyWiki Documentation]]
 title: Documentation Macros
 type: text/vnd.tiddlywiki
 
 The following macros are used throughout ~TiddlyWiki's documentation. Their names start with a dot to keep them out of the way of names that a user might try experimenting with.
 
-!General
+! General
 
-|!Macro |!Used for |!Example |
-|.def |the defining instance of a term |<<.def widget>> |
-|.em |minor emphasis within a sentence |<<.em not>> |
-|.place |a placeholder for the user to fill in |<<.place tagname>> |
-|.strong |major emphasis within a tiddler |<<.strong Important!>> |
-|.word |a mention of an ordinary word or phrase |<<.word "hello world">> |
-|.icon |an icon, sized to match the surrounding text |<<.icon "$:/core/images/globe">> |
+|Macro |Used for |Example |Rendered|h
+|.def |the defining instance of a term |`<<.def widget>>` |<<.def widget>> |
+|.em |minor emphasis within a sentence |`<<.em not>>` |<<.em not>> |
+|.place |a placeholder for the user to fill in |`<<.place tagname>>` |<<.place tagname>> |
+|.strong |major emphasis within a tiddler |`<<.strong Important!>>` |<<.strong Important!>> |
+|.word |a mention of an ordinary word or phrase |`<<.word "hello world">>` |<<.word "hello world">> |
+|.icon |an icon, sized to match the surrounding text |`<<.icon "$:/core/images/globe">>` |<<.icon "$:/core/images/globe">> |
 
-!Advice
+! Textboxes
 
-|!Macro |!Used for |!Example |
-|^.tip |^hints and tips |<<.tip "Turn your screen on, otherwise<br>you won't be able to see much.">> |
-|^.warning |^warning advice |<<.warning "Make a backup of your file<br>before you upgrade.">> |
+!! Textbox Parameters
 
-!Blocks
-|!Macro |!Used for |
-|.preamble |an introductory sentence that stands apart from the rest of the tiddler |
+; text
+: Text to be shown in the box
 
-!Tiddlers and fields
+; title
+: A title shown as an HTML STRONG element
 
-|!Macro |!Used for |!Example |
-|.tid |a tiddler title |<<.tid Example>> |
-|.tag |a tag |<<.tag Example>> |
-|.field |a field name |<<.field example>> |
-|.value |a field value |<<.value "example value">> |
-|.op |a filter operator |<<.op backlinks>> |
-|.var |a variable or macro name |<<.var currentTiddler>> |
-|.wid |a widget name |<<.wid list>> |
-|.attr |an attribute name |<<.attr filter>> |
-|.param |a macro parameter name |<<.param text>> |
-|.tiddler-fields |a list of tiddler fields |<<.tiddler-fields "Monday">> |
+; icon
+: Core icons can be found at [[Icon Gallery]]
+
+; class
+: An optional custom class can be added to the text block. It will overwrite the defaults. To keep the defaults, ''add them'' to the custom class settings. 
+: ''.note''-macro defaults to `doc-note`
+: ''.tip''-macro defaults to `doc-tip`
+: ''.warning''-macro defaults to `doc-warning`
+
+!! Textbox Examples
+
+|Macro |Used for |Example |Renderd |h
+|^.infoBox |^Text-box with an icon |`<<.infoBox text:"A generic ...">>` |<<.infoBox "A generic text box, with an optional title and a custom icon">> |
+|^.note|^Infos with a title |`<<.note text:"Some text ...">>` |<<.note "Some text in a box with a title by default">> |
+|^.tip |^hints and tips |`<<.tip text:"Eg: Turn ...">>` |<<.tip "Eg: Turn your screen on, otherwise<br>you won't be able to see much.">> |
+|^.warning |^warning advice |`<<.warning text:"Eg: Make a backup ...">>` |<<.warning "Eg: Make a backup of your file<br>before you upgrade.">> |
 
 
-!Links
 
-|!Macro |!Used for |!Example |
-|.link |a link containing WikiText |<<.link "^^an^^ ~~example~~" Example>> |
-|.clink |a code link |<<.clink `<$list>` ListWidget>> |
-|.dlink |a link on a defining instance of a term |<<.dlink widget Widgets>> |
-|.dlink-ex |an external link on a defining instance of a term |<<.dlink-ex Example "http://example.com/">> |
-|.flink |a link to a field |<<.flink ListField>> |
-|.mlink |a link to a macro |<<.mlink qualify>> |
-|.mlink2 |a link to a macro, with specified target |<<.mlink2 foo "Examples of Macros">> |
-|.olink |a link to an operator |<<.olink prefix>> |
-|.olink2 |a link to an operator, with specified target |<<.olink2 foo prefix>> |
-|.vlink |a link to a variable |<<.vlink currentTiddler>> |
-|.vlink2 |a link to a variable, with specified target |<<.vlink2 foo "Examples of Variables">> |
-|.wlink |a link to a widget |<<.wlink ButtonWidget>> |
-|.wlink2 |a link to a widget, with specified text |<<.wlink2 foo ButtonWidget>> |
+! Blocks
 
-!Tabs
-|!Macro |!Used for |!Example |
+|Macro |Example |Used for |h
+|.preamble |`<<.preamble "your text comes here">>` |<<.preamble "an introductory sentence that stands apart from the rest of the tiddler">> |
+
+! Tiddlers and Fields
+
+|Macro |Used for |Example |Rendered |h
+|.tid |a tiddler title |`<<.tid Example>>` |<<.tid Example>> |
+|.tag |a tag |`<<.tag Example>>` |<<.tag Example>> |
+|.field |a field name |`<<.field example>>` |<<.field example>> |
+|.value |a field value |`<<.value "example value">>` |<<.value "example value">> |
+|.op |a filter operator |`<<.op backlinks>>` |<<.op backlinks>> |
+|.var |a variable or macro name |`<<.var currentTiddler>>` |<<.var currentTiddler>> |
+|.wid |a widget name |`<<.wid list>>` |<<.wid list>> |
+|.attr |an attribute name |`<<.attr filter>>` |<<.attr filter>> |
+|.param |a macro parameter name |`<<.param text>>` |<<.param text>> |
+|.tiddler-fields |a list of tiddler fields |`<<.tiddler-fields "Monday">>` |<<.tiddler-fields "Monday">> |
+
+! Links
+
+|!Macro |Used for |Example |Renderd |h
+|.link |link containing WikiText |`<<.link "^^an^^ ~~example~~" Example>>` |<<.link "^^an^^ ~~example~~" Example>> |
+|.clink |code link |``<<.clink `<$list>` ListWidget>>`` |<<.clink `<$list>` ListWidget>> |
+|.dlink |definition link for a instance of a term |`<<.dlink widget Widgets>>` |<<.dlink widget Widgets>> |
+|.dlink-ex |external link to a defining instance of a term |`<<.dlink-ex Example "http://example.com/">>` |<<.dlink-ex Example "http://example.com/">> |
+|.flink |field link |`<<.flink ListField>>` |<<.flink ListField>> |
+|.mlink |macro link |`<<.mlink qualify>>` |<<.mlink qualify>> |
+|.mlink2 |macro link with a specified target |`<<.mlink2 foo "Examples of Macros">>` |<<.mlink2 foo "Examples of Macros">> |
+|.olink |operator link |`<<.olink prefix>>` |<<.olink prefix>> |
+|.olink2 |operator link with specified target |`<<.olink2 foo prefix>>` |<<.olink2 foo prefix>> |
+|.vlink |variable link |`<<.vlink currentTiddler>>` |<<.vlink currentTiddler>> |
+|.vlink2 |variable link with specified target |`<<.vlink2 foo "Examples of Variables">>` |<<.vlink2 foo "Examples of Variables">> |
+|.wlink |widget link |`<<.wlink ButtonWidget>>` |<<.wlink ButtonWidget>> |
+|.wlink2 |widget link with specified text |`<<.wlink2 foo ButtonWidget>>` |<<.wlink2 foo ButtonWidget>> |
+
+! Keyboard Shortcuts
+
+|Macro |Used for |Example |Rendered |h
+|.key |a key on the keyboard |`<<.key Escape>>` |<<.key Escape>> |
+|.keys |a key combination |`<<.keys Ctrl+Enter>>` |<<.keys Ctrl+Enter>> |
+
+! Doc-Tabs
+
+See: [[CheckboxWidget]]
+
+|Macro |Used for |Example |h
 |.doc-tabs |showing a tab set in a documentation tiddler | -- |
 |.doc-tab-link |button to activate a tab | -- |
 |.widget-attr-link |button with a widget attribute name to activate a tab | -- |
 
+! Sidebar Tabs
 
-!User interface
+|Macro |Used for |Example |Rendered |h
+|.sidebar-tab |the name of a sidebar tab |`<<.sidebar-tab More>>` |<<.sidebar-tab More>> |
+|.more-tab |the name of a subtab of the More tab |`<<.more-tab Shadows>>` |<<.more-tab Shadows>> |
+|.info-tab |the name of a tiddler info tab |`<<.info-tab Fields>>` |<<.info-tab Fields>> |
+|.controlpanel-tab |the name of a Control Panel tab |`<<.controlpanel-tab Settings>>` |<<.controlpanel-tab Settings>> |
+|.advancedsearch-tab |the name of an Advanced Search tab |`<<.advancedsearch-tab Filter>>` |<<.advancedsearch-tab Filter>> |
+|.toc-tab |name of the tw5.com TOC tab |`<<.toc-tab>>` |<<.toc-tab>> |
+|.example-tab |an example tab name |`<<.example-tab "Notes">>` |<<.example-tab "Notes">> |
 
-|!Macro |!Used for |!Example |
-|.key |a key on the keyboard |<<.key Escape>> |
-|.keycombo |a key combination |<<.keycombo Ctrl Enter>> |
+!! Parameters for .sidebar-tab
 
-!Tabs
+|Open |`<<.sidebar-tab Open>>` |<<.sidebar-tab Open>> |
+|Recent |`<<.sidebar-tab Recent>>` |<<.sidebar-tab Recent>> |
+|Tools |`<<.sidebar-tab Tools>>` |<<.sidebar-tab Tools>> |
+|More |`<<.sidebar-tab More>>` |<<.sidebar-tab More>> |
 
-|!Macro |!Used for |!Example |
-|.sidebar-tab |the name of a sidebar tab |<<.sidebar-tab More>> |
-|.more-tab |the name of a subtab of the More tab |<<.more-tab Shadows>> |
-|.info-tab |the name of a tiddler info tab |<<.info-tab Fields>> |
-|.controlpanel-tab |the name of a Control Panel tab |<<.controlpanel-tab Settings>> |
-|.advancedsearch-tab |the name of an Advanced Search tab |<<.advancedsearch-tab Filter>> |
-|.toc-tab |name of the tw5.com TOC tab |<<.toc-tab>> |
-|.example-tab |an example tab name |<<.example-tab "Notes">> |
+!! Parameters for .more-tab
 
-!!Parameters for .sidebar-tab
+|All |`<<.more-tab All>>` |<<.more-tab All>> |
+|Recent |`<<.more-tab Recent>>` |<<.more-tab Recent>> |
+|Tags |`<<.more-tab Tags>>` |<<.more-tab Tags>> |
+|Missing |`<<.more-tab Missing>>` |<<.more-tab Missing>> |
+|Drafts |`<<.more-tab Drafts>>` |<<.more-tab Drafts>> |
+|Orphans |`<<.more-tab Orphans>>` |<<.more-tab Orphans>> |
+|Types |`<<.more-tab Types>>` |<<.more-tab Types>> |
+|System |`<<.more-tab System>>` |<<.more-tab System>> |
+|Shadows |`<<.more-tab Shadows>>` |<<.more-tab Shadows>> |
 
-|Open |<<.sidebar-tab Open>> |
-|Recent |<<.sidebar-tab Recent>> |
-|Tools |<<.sidebar-tab Tools>> |
-|More |<<.sidebar-tab More>> |
+!! Parameters for .info-tab
 
-!!Parameters for .more-tab
+|Tools |`<<.info-tab Tools>>` |<<.info-tab Tools>> |
+|References |`<<.info-tab References>>` |<<.info-tab References>> |
+|Tagging |`<<.info-tab Tagging>>` |<<.info-tab Tagging>> |
+|List |`<<.info-tab List>>` |<<.info-tab List>> |
+|Listed |`<<.info-tab Listed>>` |<<.info-tab Listed>> |
+|Fields |`<<.info-tab Fields>>` |<<.info-tab Fields>> |
+|Advanced |`<<.info-tab Advanced>>` |<<.info-tab Advanced>> |
 
-|All |<<.more-tab All>> |
-|Recent |<<.more-tab Recent>> |
-|Tags |<<.more-tab Tags>> |
-|Missing |<<.more-tab Missing>> |
-|Drafts |<<.more-tab Drafts>> |
-|Orphans |<<.more-tab Orphans>> |
-|Types |<<.more-tab Types>> |
-|System |<<.more-tab System>> |
-|Shadows |<<.more-tab Shadows>> |
+!! Parameters for .controlpanel-tab
 
-!!Parameters for .info-tab
+|Info |`<<.controlpanel-tab Info>>` |<<.controlpanel-tab Info>> |
+|Appearance |`<<.controlpanel-tab Appearance>>` |<<.controlpanel-tab Appearance>> |
+|Settings |`<<.controlpanel-tab Settings>>` |<<.controlpanel-tab Settings>> |
+|Saving |`<<.controlpanel-tab Saving>>` |<<.controlpanel-tab Saving>> |
+|Plugins |`<<.controlpanel-tab Plugins>>` |<<.controlpanel-tab Plugins>> |
 
-|Tools |<<.info-tab Tools>> |
-|References |<<.info-tab References>> |
-|Tagging |<<.info-tab Tagging>> |
-|List |<<.info-tab List>> |
-|Listed |<<.info-tab Listed>> |
-|Fields |<<.info-tab Fields>> |
-|Advanced |<<.info-tab Advanced>> |
+!! Parameters for .advancedsearch-tab
 
-!!Parameters for .controlpanel-tab
+|Standard |`<<.advancedsearch-tab Standard>>` |<<.advancedsearch-tab Standard>> |
+|System |`<<.advancedsearch-tab System>>` |<<.advancedsearch-tab System>> |
+|Shadows |`<<.advancedsearch-tab Shadows>>` |<<.advancedsearch-tab Shadows>> |
+|Filter |`<<.advancedsearch-tab Filter>>` |<<.advancedsearch-tab Filter>> |
 
-|Info |<<.controlpanel-tab Info>> |
-|Appearance |<<.controlpanel-tab Appearance>> |
-|Settings |<<.controlpanel-tab Settings>> |
-|Saving |<<.controlpanel-tab Saving>> |
-|Plugins |<<.controlpanel-tab Plugins>> |
+! Buttons
 
-!!Parameters for .advancedsearch-tab
+|Macro |Used for |Example |Rendered |h
+|.button |a standard button name and icon |`<<.button "new-tiddler">>` |<<.button "new-tiddler">> |
 
-|Standard |<<.advancedsearch-tab Standard>> |
-|System |<<.advancedsearch-tab System>> |
-|Shadows |<<.advancedsearch-tab Shadows>> |
-|Filter |<<.advancedsearch-tab Filter>> |
+!! Parameters for .button
 
-!Buttons
+!!! Tiddler toolbar
 
-|!Macro |!Used for |!Example |
-|.button |a standard button name and icon |<<.button "new-tiddler">> |
+|clone |`<<.button "clone">>` |<<.button "clone">> |
+|close |`<<.button "close">>` |<<.button "close">> |
+|close-others |`<<.button "close-others">>` |<<.button "close-others">> |
+|edit |`<<.button "edit">>` |<<.button "edit">> |
+|export-tiddler |`<<.button "export-tiddler">>` |<<.button "export-tiddler">> |
+|info |`<<.button "info">>` |<<.button "info">> |
+|more-tiddler-actions |`<<.button "more-tiddler-actions">>` |<<.button "more-tiddler-actions">> |
+|new-here |`<<.button "new-here">>` |<<.button "new-here">> |
+|new-journal-here |`<<.button "new-journal-here">>` |<<.button "new-journal-here">> |
+|permalink |`<<.button "permalink">>` |<<.button "permalink">> |
 
-!!Parameters for .button
+!!! Edit-mode toolbar
 
-!!!Tiddler toolbar
+|cancel |`<<.button "cancel">>` |<<.button "cancel">> |
+|delete |`<<.button "delete">>` |<<.button "delete">> |
+|save |`<<.button "save">>` |<<.button "save">> |
 
-|clone |<<.button "clone">> |
-|close |<<.button "close">> |
-|close-others |<<.button "close-others">> |
-|edit |<<.button "edit">> |
-|export-tiddler |<<.button "export-tiddler">> |
-|info |<<.button "info">> |
-|more-tiddler-actions |<<.button "more-tiddler-actions">> |
-|new-here |<<.button "new-here">> |
-|new-journal-here |<<.button "new-journal-here">> |
-|permalink |<<.button "permalink">> |
+!!! Page toolbar
 
-!!!Edit-mode toolbar
-
-|cancel |<<.button "cancel">> |
-|delete |<<.button "delete">> |
-|save |<<.button "save">> |
-
-!!!Page toolbar
-
-|advanced-search |<<.button "advanced-search">> |
-|close-all |<<.button "close-all">> |
-|control-panel |<<.button "control-panel">> |
-|encryption |<<.button "encryption">> |
-|export-page |<<.button "export-page">> |
-|full-screen |<<.button "full-screen">> |
-|home |<<.button "home">> |
-|import |<<.button "import">> |
-|language |<<.button "language">> |
-|more-page-actions |<<.button "more-page-actions">> |
-|new-journal |<<.button "new-journal">> |
-|new-tiddler |<<.button "new-tiddler">> |
-|permaview |<<.button "permaview">> |
-|refresh |<<.button "refresh">> |
-|save-wiki |<<.button "save-wiki">> |
-|storyview |<<.button "storyview">> |
-|tag-manager |<<.button "tag-manager">> |
-|theme |<<.button "theme">> |
+|advanced-search |`<<.button "advanced-search">>` |<<.button "advanced-search">> |
+|close-all |`<<.button "close-all">>` |<<.button "close-all">> |
+|control-panel |`<<.button "control-panel">>` |<<.button "control-panel">> |
+|encryption |`<<.button "encryption">>` |<<.button "encryption">> |
+|export-page |`<<.button "export-page">>` |<<.button "export-page">> |
+|full-screen |`<<.button "full-screen">>` |<<.button "full-screen">> |
+|home |`<<.button "home">>` |<<.button "home">> |
+|import |`<<.button "import">>` |<<.button "import">> |
+|language |`<<.button "language">>` |<<.button "language">> |
+|more-page-actions |`<<.button "more-page-actions">>` |<<.button "more-page-actions">> |
+|new-journal |`<<.button "new-journal">>` |<<.button "new-journal">> |
+|new-tiddler |`<<.button "new-tiddler">>` |<<.button "new-tiddler">> |
+|permaview |`<<.button "permaview">>` |<<.button "permaview">> |
+|refresh |`<<.button "refresh">>` |<<.button "refresh">> |
+|save-wiki |`<<.button "save-wiki">>` |<<.button "save-wiki">> |
+|storyview |`<<.button "storyview">>` |<<.button "storyview">> |
+|tag-manager |`<<.button "tag-manager">>` |<<.button "tag-manager">> |
+|theme |`<<.button "theme">>` |<<.button "theme">> |

--- a/editions/tw5.com/tiddlers/system/doc-macros.tid
+++ b/editions/tw5.com/tiddlers/system/doc-macros.tid
@@ -1,81 +1,100 @@
 created: 20150117152607000
-modified: 20230325141733992
+modified: 20240229155550000
 tags: $:/tags/Macro
 title: $:/editions/tw5.com/doc-macros
+code-body: yes
 type: text/vnd.tiddlywiki
 
-\define .concat(1,2,3,4,5) $1$$2$$3$$4$$5$
+\whitespace trim
 
-\define .def(_) <dfn class="doc-def">$_$</dfn>
-\define .em(_) <em class="doc-em">$_$</em>
-\define .strong(_) <strong class="doc-strong">$_$</strong>
-\define .place(_) <code class="doc-place">$_$</code>
-\define .word(_) "$_$"
+\function .concat(1,2,3,4,5) [[$(1)$$(2)$$(3)$$(4)$$(5)$]substitute[]]
+\function .word(_) [["]] [<_>] =[["]] +[join[]]
 
-\define .preamble(_) :.doc-preamble $_$
-\define .note(_)
-@@.doc-note
-;Note
-: $_$
-@@
+\procedure .def(_) <dfn class="doc-def"><<_>></dfn>
+\procedure .em(_) <em class="doc-em"><<_>></em>
+\procedure .strong(_) <strong class="doc-strong"><<_>></strong>
+\procedure .place(_) <code class="doc-place"><<_>></code>
+\procedure .preamble(_) <dl><dd class="doc-preamble"><<_>></dd></dl>
+
+\procedure .tid(_) <code class="doc-tiddler"><<_>></code>
+\procedure .tag(_) <code class="doc-tag"><<_>></code>
+\procedure .field(_) <code class="doc-field"><<_>></code>
+\procedure .value(_) <code class="doc-value"><<_>></code>
+\procedure .op(_) <code class="doc-operator"><<_>></code>
+\procedure .var(_) <code class="doc-var"><<_>></code>
+\procedure .wid(_) <code class="doc-widget"><$macrocall $name=".concat" 1="$" 2=<<_>>/></code>
+\procedure .attr(_) <code class="doc-attr"><<_>></code>
+\procedure .param(_) <code class="doc-param"><<_>></code>
+
+\procedure .tiddler-fields(tiddler)
+<$tiddler tiddler=<<tiddler>>>
+	<div class="doc-tiddler-fields">
+		<h2>
+		<$link>
+			<span class="tc-tiddler-title-icon">{{||$:/core/ui/TiddlerIcon}}</span><$text text=<<currentTiddler>>/>
+		</$link>
+		</h2>
+		<table class="tc-view-field-table">
+			<tbody>
+				<$list filter="[all[current]fields[]sort[title]] -title" template="$:/core/ui/TiddlerFieldTemplate" variable="listItem"/>
+			</tbody>
+		</table>
+	</div>
+</$tiddler>
 \end
 
-\define .tid(_) <code class="doc-tiddler">$_$</code>
-\define .tag(_) <code class="doc-tag">$_$</code>
-\define .field(_) <code class="doc-field">$_$</code>
-\define .value(_) <code class="doc-value">$_$</code>
-\define .op(_) <code class="doc-operator">$_$</code>
-\define .var(_) <code class="doc-var">$_$</code>
-\define .wid(_) <code class="doc-widget">$$_$</code>
-\define .attr(_) <code class="doc-attr">$_$</code>
-\define .param(_) <code class="doc-param">$_$</code>
+\function .mtitle(_) [<_>] Macro +[join[ ]]
+\function .otitle(_) [<_>] Operator +[join[ ]]
+\function .vtitle(_) [<_>] Variable +[join[ ]]
 
-\define .mtitle(_) $_$ Macro
-\define .otitle(_) $_$ Operator
-\define .vtitle(_) $_$ Variable
+\procedure .link(_,to) <$link to=<<to>> ><<_>></$link>
+\procedure .clink(_,to) <span class="doc-clink"><$link to=<<to>>><<_>></$link></span>
 
-\define .link(_,to) <$link to="$to$">$_$</$link>
-\define .clink(_,to) <span class="doc-clink"><<.link """$_$""" "$to$">></span>
-\define .dlink(_,to) <$macrocall $name=".link" _=<<.def "$_$">> to="$to$">/>
-\define .dlink-ex(_,to) <a href="$to$" class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><<.def "$_$">></a>
-\define .flink(to) <$macrocall $name=".link" _=<<.field {{$to$!!caption}}>> to="$to$"/>
-\define .mlink(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to=<<.mtitle "$_$">>/>
-\define .mlink2(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to="$to$"/>
-\define .olink(_) <$macrocall $name=".link" _=<<.op "$_$">> to=<<.otitle "$_$">>/>
-\define .olink2(_,to) <$macrocall $name=".link" _=<<.op "$_$">> to=<<.otitle "$to$">>/>
-\define .vlink(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to=<<.vtitle "$_$">>/>
-\define .vlink2(_,to) <$macrocall $name=".link" _=<<.var "$_$">> to="$to$"/>
-\define .wlink(to) <$macrocall $name=".link" _=<<.wid {{$to$!!caption}}>> to="$to$"/>
-\define .wlink2(_,to) <$macrocall $name=".link" _="$_$" to="$to$"/>
+\procedure .dlink(_,to) <$link to=<<to>>><$macrocall $name=".def" _=<<_>>/></$link>
 
-\define .key(_) <span class="doc-key">$_$</span>
-\define .combokey(_) <$macrocall $name=".if" cond="$_$" then=<<.key '$_$'>>/>
-\define .keycombo(1,2,3,4) <<.combokey "$1$">><<.if "$2$" +>><<.combokey "$2$">><<.if "$3$" +>><<.combokey "$3$">><<.if "$4$" +>><<.combokey "$4$">>
+\procedure .dlink-ex(_,to) <a href=<<to>> class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><$macrocall $name=".def" _=<<_>>/></a>
+\procedure .flink(to) <$macrocall $name=".link" _=`<<.field {{$(to)$!!caption}}>>` to=<<to>>/>
 
-\define .tab(_) <span class="doc-tab">{{$_$!!caption}}</span>
-\define .sidebar-tab(_) <<.tab "$:/core/ui/SideBar/$_$">>
-\define .more-tab(_) <<.tab "$:/core/ui/MoreSideBar/$_$">>
-\define .info-tab(_) <<.tab "$:/core/ui/TiddlerInfo/$_$">>
-\define .controlpanel-tab(_) <<.tab "$:/core/ui/ControlPanel/$_$">>
-\define .advancedsearch-tab(_) <<.tab "$:/core/ui/AdvancedSearch/$_$">>
-\define .toc-tab() <<.tab "TableOfContents">>
-\define .example-tab(_) <span class="doc-tab">$_$</span>
+\procedure .mlink(_) <$link to={{{ [.mtitle<_>] }}}><$macrocall $name=".var" _=<<_>>/> </$link>
+\procedure .mlink2(_,to) <$link to=<<to>>><$macrocall $name=".var" _=<<_>>/> </$link>
 
-\define .doc-tabs()
+\procedure .olink(_) <$link to={{{ [.otitle<_>] }}}><$macrocall $name=".op" _=<<_>>/> </$link>
+\procedure .olink2(_,to) <$link to={{{ [.otitle<to>] }}}><$macrocall $name=".op" _=<<_>>/> </$link>
+
+\procedure .vlink(_) <$link to={{{ [.vtitle<_>] }}}><$macrocall $name=".var" _=<<_>>/> </$link>
+\procedure .vlink2(_,to) <$link to=<<to>>><$macrocall $name=".var" _=<<_>>/></$link>
+
+\procedure .wlink(to) <$link to=<<to>> > <$macrocall $name=".wid" _={{{ [<to>get[caption]] }}}> </$link>
+\procedure .wlink2(_,to) <$link to=<<to>> ><<_>></$link>
+
+\procedure .key(_) <span class="doc-key"><<_>></span>
+\procedure .keys(_) <span class="doc-key"><<_>></span>
+
+\procedure .tab(_) <span class="doc-tab"><$transclude $tiddler=<<_>> $field=caption ><<_>></$transclude></span>
+\procedure .sidebar-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/SideBar/$(_)$`/>
+\procedure .more-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/MoreSideBar/$(_)$`/>
+\procedure .info-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/TiddlerInfo/$(_)$`/>
+\procedure .controlpanel-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/ControlPanel/$(_)$`/>
+\procedure .advancedsearch-tab(_) <$macrocall $name=".tab" _=`$:/core/ui/AdvancedSearch/$(_)$`/>
+\procedure .toc-tab() <$macrocall $name=".tab" _="TableOfContents"/>
+\procedure .example-tab(_) <span class="doc-tab"><<_>></span>
+
+\procedure .doc-tabs()
 <$macrocall $name="tabs"
-      tabsList="[tag<currentTiddler>description[tab]]"
-      default={{{ [tag<currentTiddler>first[]] }}}
-      explicitState={{{ [<currentTiddler>addprefix[$:/state/tab/]] }}}
-      class={{{ [[doc-tabs]] [<currentTiddler>encodeuricomponent[]escapecss[]addprefix[doc-tabs-]] +[join[ ]] }}} />
+    tabsList="[tag<currentTiddler>description[tab]]"
+    default={{{ [tag<currentTiddler>first[]] }}}
+    explicitState={{{ [<currentTiddler>addprefix[$:/state/tab/]] }}}
+    class={{{ [[doc-tabs]] [<currentTiddler>encodeuricomponent[]escapecss[]addprefix[doc-tabs-]] +[join[ ]] }}} />
 \end
-\define .doc-tab-link(text, target, tooltip:"", class:"")
+
+\procedure .doc-tab-link(text, target, tooltip:"", class:"")
 <!-- figure out where the addressed doc-tabs are -->
 <$tiddler tiddler={{{ [<currentTiddler>search:text[.doc-tabs]] :else[<currentTiddler>tags[]search:text[.doc-tabs]first[]] :else[<currentTiddler>] }}} >
-<$button class={{{ [[tc-btn-invisible tc-tiddlylink]] [<__class__>] +[join[ ]] }}}
-      set={{{ [<currentTiddler>addprefix[$:/state/tab/]] }}}
-      setTo=<<__target__>>
-      tooltip=<<__tooltip__>>>
-    <<__text__>>
+<$button class={{{ [[tc-btn-invisible tc-tiddlylink]] [<class>] +[join[ ]] }}}
+    set={{{ [<currentTiddler>addprefix[$:/state/tab/]] }}}
+    setTo=<<target>>
+    tooltip=<<tooltip>>>
+    <<text>>
     <!-- if tiddler with tabs is open, scroll to tabs, otherwise open that tiddler (relevant from within tab subtiddlers) -->
     <$list filter="[[$:/StoryList]contains<currentTiddler>]" variable="ignore" emptyMessage="<$action-navigate />">
         <$action-sendmessage $message="tm-scroll" selector={{{ [<currentTiddler>encodeuricomponent[]addprefix[.doc-tabs-]] }}} />
@@ -84,136 +103,128 @@ type: text/vnd.tiddlywiki
 </$button>
 </$tiddler>
 \end
-\define .widget-attr-link(text, target)
+
+\procedure .widget-attr-link(text, target)
 <$macrocall $name=".doc-tab-link" 
-      text={{{ [[<code class="doc-attr">]] [<__text__>] [[</code>]] +[join[]] }}}
-      class="doc-tab-link"
-      target=<<__target__>>
-      tooltip={{{ [[Show more information about the ']] [<__text__>] [[' attribute]] +[join[]] }}} />
+    text={{{ [[<code class="doc-attr">]] [<text>] [[</code>]] +[join[]] }}}
+    class="doc-tab-link"
+    target=<<target>>
+    tooltip={{{ [[Show more information about the ']] [<text>] [[' attribute]] +[join[]] }}} />
 \end
 
-\define .button(_) <span class="doc-button">{{$:/core/ui/Buttons/$_$!!caption}}</span>
+\procedure .button(_) <span class="doc-button"><$transclude $tiddler=`$:/core/ui/Buttons/$(_)$` $field="caption" ><<_>></$transclude></span>
 
-\define .icon(_) <span class="doc-icon">{{$_$}}</span>
+\procedure .icon(_) <span class="doc-icon"><$transclude $tiddler=<<_>>/></span>
 
-\define .tip(_) <div class="doc-icon-block"><div class="doc-block-icon">{{$:/core/images/tip}}</div> $_$</div>
-\define .warning(_) <div class="doc-icon-block"><div class="doc-block-icon">{{$:/core/images/warning}}</div> $_$</div>
+\procedure .infoBox(text:"", title, icon:"$:/core/images/info-button", class, iconSize:"1.4rem")
+\function _f.tipClass() [[doc-icon-block]] [<class>!is[blank]then<class>] +[join[ ]]
+<div class=<<_f.tipClass>>>
+	<%if [<title>!is[blank]] %><div>''<<title>>''</div><% endif %>
+	<div class="doc-block-icon"><$transclude $tiddler=<<icon>> size=<<iconSize>>/></div>
+	<<text>>
+</div>
+\end
 
-\define .state-prefix() $:/state/editions/tw5.com/
+\procedure .note(_:"", title:"Note", icon:"$:/core/images/info-button", class:"doc-note", iconSize:"22pt")
+<$macrocall $name=".infoBox" text=<<_>> title=<<title>> icon=<<icon>> class=<<class>> iconSize=<<iconSize>>/>
+\end
 
-\define .lorem()
+\procedure .tip(_:"", title:"Tip" , icon:"$:/core/images/tip", class:"doc-tip", iconSize:"22pt")
+<$macrocall $name=".infoBox" text=<<_>> title=<<title>> icon=<<icon>> class=<<class>> iconSize=<<iconSize>>/>
+\end
+
+\procedure .warning(_:"", title:"Warning", icon:"$:/core/images/warning", class:"doc-warning", iconSize:"22pt")
+<$macrocall $name=".infoBox" text=<<_>> title=<<title>> icon=<<icon>> class=<<class>> iconSize=<<iconSize>>/>
+\end
+
+\procedure .state-prefix() $:/state/editions/tw5.com/
+
+\procedure .lorem()
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 \end
 
-\define .toc-lorem()
+\procedure .toc-lorem()
 This is an example tiddler. See [[Table-of-Contents Macros (Examples)]].
 
 <<.lorem>>
 \end
 
-\define .example(n,eg,egvar:NO-SUCH-VAR)
+\procedure .example(n,eg,egvar)
+<$let eg={{{ [<egvar>!is[blank]getvariable[]] :else[<eg>] }}}>
 <div class="doc-example">
-<$reveal default="$egvar$" type="match" text="NO-SUCH-VAR">
-	<$macrocall $name="copy-to-clipboard-above-right" src="""$eg$"""/>
-	<$codeblock code="""$eg$"""/>
-</$reveal>
-<$reveal default="$egvar$" type="nomatch" text="NO-SUCH-VAR">
-	<!-- allow an example to contain """ -->
-	<$macrocall $name="copy-to-clipboard-above-right" src=<<$egvar$>>/>
-	<$codeblock code=<<$egvar$>>/>
-</$reveal>
-<$list filter="[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix[$n$]]" variable=".state">
-<$reveal state=<<.state>> type="nomatch" text="show">
-	<dl>
-	<dd><$button set=<<.state>> setTo="show">Try it</$button></dd>
-	</dl>
-</$reveal>
-<$reveal state=<<.state>> type="match" text="show">
-	<dl>
-	<dd><$button set=<<.state>> setTo="">Hide</$button></dd>
-	</dl>
-	<blockquote class="doc-example-result">
-	<$reveal default="$egvar$" type="match" text="NO-SUCH-VAR">
-
-$$$text/vnd.tiddlywiki
-$eg$
-$$$
-
-	</$reveal>
-	<$reveal default="$egvar$" type="nomatch" text="NO-SUCH-VAR">
-		<<$egvar$>>
-	</$reveal>
-	</blockquote>
-</$reveal>
-</$list>
+	<$macrocall $name="copy-to-clipboard-above-right" src=<<eg>>/>
+	<$codeblock code=<<eg>>/>
+	<$list filter=`[title<.state-prefix>addsuffix{!!title}addsuffix[/]addsuffix[$(n)$]]` variable=".state">
+		<$reveal state=<<.state>> type="nomatch" text="show">
+			<dl>
+				<dd><$button set=<<.state>> setTo="show">Try it</$button></dd>
+			</dl>
+		</$reveal>
+		<$reveal state=<<.state>> type="match" text="show">
+			<dl>
+				<dd><$button set=<<.state>> setTo="">Hide</$button></dd>
+			</dl>
+			<blockquote class="doc-example-result">
+				<<eg>>
+			</blockquote>
+		</$reveal>
+	</$list>
+</div>
+</$let>
 \end
 
-\define .bad-example(eg)
+\procedure .bad-example(eg)
 <table class="doc-bad-example">
-<tbody>
-<tr class="evenRow">
-<td><span style="font-size:1.5em;">&#9888;</span> Warning:<br> Don't do it this way!</td>
-<td>
-
-$eg$
-</td>
-</tr>
-</tbody>
+	<tbody>
+		<tr class="evenRow">
+			<td>
+				<span class="tc-small-gap-right" style="font-size:1.5em;">&#9888;</span>
+				Warning:<br> Don't do it this way!
+			</td>
+			<td>
+				<$transclude $variable="eg" $mode="block"/>
+			</td>
+		</tr>
+	</tbody>
 </table>
 \end
 
-\define .link-badge(text,link,colour)
-<a href=<<__link__>> class="doc-link-badge" style="background-color:$colour$;" target="_blank" rel="noopener noreferrer"><$text text=<<__text__>>/></a>
+\procedure .link-badge(text,link,colour)
+<a href=<<link>> class="doc-link-badge" style.background-color=<<colour>> target="_blank" rel="noopener noreferrer">
+	<$text text=<<text>>/>
+</a>
 \end
 
+<!-- TODO use $:/palette colour settings -->
+\procedure .link-badge-added(link,colour:#ffe246)    <$macrocall $name=".link-badge" text="added"    link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-addendum(link,colour:#fcc84a) <$macrocall $name=".link-badge" text="addendum" link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-extended(link,colour:#f9a344) <$macrocall $name=".link-badge" text="extended" link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-fixed(link,colour:#ffa86d)    <$macrocall $name=".link-badge" text="fixed"    link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-here(link,colour:#d88e63)     <$macrocall $name=".link-badge" text="here"     link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-hide(link,colour:#9d959f)     <$macrocall $name=".link-badge" text="hide"     link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-improved(link,colour:#7593c7) <$macrocall $name=".link-badge" text="improved" link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-modified(link,colour:#7f99c9) <$macrocall $name=".link-badge" text="modified" link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-removed(link,colour:#a9aabc)  <$macrocall $name=".link-badge" text="removed"  link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-renamed(link,colour:#b4b995)  <$macrocall $name=".link-badge" text="renamed"  link=<<link>> colour=<<colour>>/>
+\procedure .link-badge-updated(link,colour:#91ba66)  <$macrocall $name=".link-badge" text="updated"  link=<<link>> colour=<<colour>>/>
 
-\define .link-badge-added(link,colour:#ffe246) <<.link-badge "added" """$link$""" """$colour$""">>
-\define .link-badge-addendum(link,colour:#fcc84a) <<.link-badge "addendum" """$link$""" """$colour$""">>
-\define .link-badge-extended(link,colour:#f9a344) <<.link-badge "extended" """$link$""" """$colour$""">>
-\define .link-badge-fixed(link,colour:#ffa86d) <<.link-badge "fixed" """$link$""" """$colour$""">>
-\define .link-badge-here(link,colour:#d88e63) <<.link-badge "here" """$link$""" """$colour$""">>
-\define .link-badge-hide(link,colour:#9d959f) <<.link-badge "hide" """$link$""" """$colour$""">>
-\define .link-badge-improved(link,colour:#7593c7) <<.link-badge "improved" """$link$""" """$colour$""">>
-\define .link-badge-modified(link,colour:#7f99c9) <<.link-badge "modified" """$link$""" """$colour$""">>
-\define .link-badge-removed(link,colour:#a9aabc) <<.link-badge "removed" """$link$""" """$colour$""">>
-\define .link-badge-renamed(link,colour:#b4b995) <<.link-badge "renamed" """$link$""" """$colour$""">>
-\define .link-badge-updated(link,colour:#91ba66) <<.link-badge "updated" """$link$""" """$colour$""">>
-
-\define .tiddler-fields(tiddler)
-<$tiddler tiddler=<<__tiddler__>>>
-<div class="doc-tiddler-fields">
-<h2>
-<$link>
-<span class="tc-tiddler-title-icon">{{||$:/core/ui/TiddlerIcon}}</span><$text text=<<currentTiddler>>/>
-</$link>
-</h2>
-<table class="tc-view-field-table">
-<tbody>
-<$list filter="[all[current]fields[]sort[title]] -title" template="$:/core/ui/TiddlerFieldTemplate" variable="listItem"/>
-</tbody>
-</table>
-</div>
-</$tiddler>
+\procedure .banner-credits(credit,url)
+<img src=<<url>> width="140" style="float:left;margin-right:0.5em;"/>
+<<credit>>
+<div style="clear:both;"/>
 \end
 
-\define .banner-credits(credit,url)
-<img src=<<__url__>> width="140" style="float:left;margin-right:0.5em;"/>
-
-$credit$
-
-<div style="clear:both;">
-
-</div>
-\end
-
-\define .contributors(usernames)
+\procedure .contributors(usernames)
 <ol class="doc-github-contributors">
-<$list filter="[enlist<__usernames__>sort[]]" variable="username">
-<li>
-<a href={{{ [[https://github.com/]addsuffix<username>] }}} class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer"><img src={{{ [[https://github.com/]addsuffix<username>addsuffix[.png?size=64]] }}} width="64" height="64"/><span class="doc-github-contributor-username">@<$text text=<<username>>/></span></a>
-</li>
-</$list>
+	<$list filter="[enlist<usernames>sort[]]" variable="username">
+		<li>
+			<a href={{{ [[https://github.com/]addsuffix<username>] }}} class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer">
+				<img src={{{ [[https://github.com/]addsuffix<username>addsuffix[.png?size=64]] }}} width="64" height="64"/>
+				<span class="doc-github-contributor-username">
+					@<$text text=<<username>>/>
+				</span>
+			</a>
+		</li>
+	</$list>
 </ol>
 \end
-
-<pre><$view field="text"/></pre>

--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -31,6 +31,7 @@ type: text/vnd.tiddlywiki
 	color: <<color very-muted-foreground>>;
 	font-style: normal;
 	font-weight: bold;
+	padding: 0;
 }
 
 .doc-button,
@@ -85,7 +86,6 @@ td svg {
 .doc-preamble {
 	border: 2px solid <<colour code-border>>;
 	color: <<colour very-muted-foreground>>;
-	font-size: 90%;
 	margin-left: 0;
 	padding: 0.5em 0.7em;
 }
@@ -112,7 +112,7 @@ td svg {
 }
 
 .doc-example input[type=search] { 
-  width: 95%;
+	width: 95%;
 }
 .doc-example pre:first-child {
 	margin-top: 0;
@@ -138,7 +138,7 @@ td svg {
 }
 
 .doc-bad-example code, .doc-bad-example pre, table.doc-bad-example {
-  background-color:#ffff80;
+	background-color:#ffff80;
 }
 
 .doc-table th, .doc-table tr {
@@ -164,19 +164,37 @@ tr.doc-table-subheading {
 }
 
 .doc-icon-block {
-	border-left: 2px solid <<colour code-border>>;
-	margin-left: 3em;
+	border-left: 4px solid <<colour blockquote-bar>>;
+	margin: 15px 0 15px 3em;
 	padding-left: 0.6em;
 	position: relative;
 }
+
 .doc-block-icon {
 	position: absolute;
 	left: -3em;
 	top: 0.2em;
 }
+
+.doc-icon-block.doc-note {
+	border-left: 4px solid <<colour blockquote-bar>>;
+	background: <<colour blockquote-bar>>11;
+}
+
+.doc-icon-block.doc-tip {
+	border-left: 4px solid <<colour primary>>;
+	background: <<colour primary>>11;
+}
+
+.doc-icon-block.doc-warning {
+	border-left: 4px solid <<colour alert-highlight>>;
+	background: <<colour alert-highlight>>11;
+}
+
 .doc-block-icon .tc-image-tip {
 	fill: <<colour primary>>;
 }
+
 .doc-block-icon .tc-image-warning {
 	fill: <<colour alert-highlight>>;
 }
@@ -246,7 +264,6 @@ a.doc-deprecated-version.tc-tiddlylink {
 	height: 1em;
 }
 
-
 .doc-tiddler-fields table, 
 .doc-tiddler-fields h2 {
 	margin: 0.5em 0;
@@ -299,13 +316,13 @@ ol.doc-github-contributors li {
 	color: #666;
 }
 .doc-tabs.tc-tab-buttons button {
-  font-size: 1rem;
-  padding: 0.5em;
+	font-size: 1rem;
+	padding: 0.5em;
 }
 .doc-tabs button .doc-attr {
-  background-color: unset;
-  color: #666;
+	background-color: unset;
+	color: #666;
 }
 .doc-tab-link .doc-attr {
-  color: unset;
+	color: unset;
 }


### PR DESCRIPTION
This PR does convert the doc-macros into the new v5.3.x syntax. It may be possible to make some code look prettier, but I think they all still work in a backwards compatible way. 

This PR also fixes the issues

- #8003 and
- #8004

There are new "info boxes" now, which all use $:/palette colour variables to allow palette switching.

**Note boxes** look like this now

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/13db7689-7c60-4eb3-93b0-3eb8203c9614)

**Tips** look like this now

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/023e31f7-0334-43f9-a272-4c5c3446e740)

**Warnings** look like this now

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/6bfef51c-7104-44f4-be32-d5decc5e3cbe)

**Note together with a Warning" looks like this now

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/d4052cc7-2d38-4b26-934c-da2529f81a70)

**Documentation Macro** docs is improved

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/4efd8ffd-f613-4fd6-9a4a-513b1e54336f)

-----

This PR replaces: **Doc macros new syntax #8009**, since it was splint into several smaller PRs. 