### PR TITLE
Update draggable.js - fix the call to updateDomNodeClasses

### DIFF
--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -93,7 +93,7 @@ DraggableWidget.prototype.execute = function() {
 };
 
 
-DraggableWidget.prototype.updateDomNodeClasses = function() {
+DraggableWidget.prototype.assignDomNodeClasses = function() {
 	var domNodeClasses = this.domNodes[0].className.split(" "),
 		oldClasses = this.draggableClasses.split(" ");
 	this.draggableClasses = this.getAttribute("class");

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -93,7 +93,7 @@ DraggableWidget.prototype.execute = function() {
 };
 
 
-DraggableWidget.prototype.assignDomNodeClasses = function() {
+DraggableWidget.prototype.updateDomNodeClasses = function() {
 	var domNodeClasses = this.domNodes[0].className.split(" "),
 		oldClasses = this.draggableClasses.split(" ");
 	this.draggableClasses = this.getAttribute("class");
@@ -119,7 +119,7 @@ DraggableWidget.prototype.refresh = function(changedTiddlers) {
 		return true;
 	} else {
 		if(changedAttributes["class"]) {
-			this.assignDomNodeClasses();
+			this.updateDomNodeClasses();
 		}
 		this.assignAttributes(this.domNodes[0],{
 			changedAttributes: changedAttributes,


### PR DESCRIPTION
…sses

If I'm not wrong then the "updateDomNodeClasses" is unused and the "assignDomNodeClasses" is missing

This renames "updateDomNodeClasses" to "assignDomNodeClasses"