### PR TITLE
Let caption be displayed as main title

### DIFF
--- a/core/ui/ViewTemplate/title/default.tid
+++ b/core/ui/ViewTemplate/title/default.tid
@@ -2,5 +2,7 @@ title: $:/core/ui/ViewTemplate/title/default
 
 \whitespace trim
 <h2 class="tc-title">
-<$view field="title"/>
+  <$transclude field="caption">
+    <$view field="title"/>
+  </$transclude>
 </h2>


### PR DESCRIPTION
Isn't this already the de facto standard? Many plugins in distributions patch this, and users using vanilla HTML ask how to do this.

Code is copy from https://talk.tiddlywiki.org/t/should-caption-be-displayed-as-main-title/4399/8?u=linonetwo