### PR TITLE
Use caption instead of title in the TOC, Sidebar All and Sidebar Recent

### DIFF
--- a/core/wiki/macros/timeline.tid
+++ b/core/wiki/macros/timeline.tid
@@ -6,7 +6,7 @@ title: $:/core/macros/timeline
 <!-- Override one or both of the following two macros with a global or local macro of the same name 
 if you need to change how titles are displayed on a timeline -->
 
-\define timeline-title() <$view field="title"/>
+\define timeline-title() <$transclude field="caption"><$view field="title"/></$transclude>
 \define timeline-link() <$link to={{!!title}}><<timeline-title>></$link>
 \define timeline(limit:"100",format:"DDth MMM YYYY",subfilter:"",dateField:"modified")
 \whitespace trim


### PR DESCRIPTION
Another PR to make `caption` field a standard field for display. So community plugins won't be diverse in the field name.

code is copy from https://talk.tiddlywiki.org/t/how-to-use-caption-instead-of-title-in-the-toc-sidebar-all-and-sidebar-recent/6072/7?u=linonetwo