### PR TITLE
add list-links to $:/deprecated tag

### DIFF
--- a/editions/tw5.com/tiddlers/system/Deprecated.tid
+++ b/editions/tw5.com/tiddlers/system/Deprecated.tid
@@ -1,8 +1,12 @@
 created: 20170126143833588
-modified: 20220704174221300
+modified: 20240310123352998
 title: $:/deprecated
 type: text/vnd.tiddlywiki
 
 Deprecated features of TiddlyWiki are those that have been superseded by newer, improved ways of doing the same thing.
 
 Deprecated features will still work, but are not recommended for new content.
+
+Tiddlers tagged $:/deprecated:
+
+<<list-links filter:"[tag[$:/deprecated]]">>


### PR DESCRIPTION
This PR adds a list-links list of tiddlers tagged: $:/deprecated to the tag for better overview