### PR TITLE
add code-body field to doc-styles tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/system/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/system/doc-styles.tid
@@ -1,3 +1,4 @@
+code-body: yes
 created: 20150117152612000
 modified: 20240223123123497
 tags: $:/tags/Stylesheet


### PR DESCRIPTION
This PR is docs only and adds the `code-body: yes`  to the doc-styles tiddler for better human readability. It also shows which macros are used, which is important. 