### PR TITLE
deprecated the if-macro, since it is not needed anymore. Use <% if %> instead

### DIFF
--- a/editions/tw5.com/tiddlers/system/if-macro.js
+++ b/editions/tw5.com/tiddlers/system/if-macro.js
@@ -1,7 +1,12 @@
 /*\
 title: $:/editions/tw5.com/if-macro.js
 type: application/javascript
+tags: $:/deprecated
 module-type: macro
+
+DEPRECATED -- Since TW v5.3.x this documentation macro is not needed anymore
+Use: https://tiddlywiki.com/#Conditional%20Shortcut%20Syntax instead
+
 \*/
 (function(){
 

--- a/editions/tw5.com/tiddlers/system/if-macro.js.meta
+++ b/editions/tw5.com/tiddlers/system/if-macro.js.meta
@@ -1,0 +1,6 @@
+created: 20240310123422910
+modified: 20240310123427872
+module-type: macro
+tags: $:/deprecated
+title: $:/editions/tw5.com/if-macro.js
+type: application/javascript


### PR DESCRIPTION
This PR is docs only. It add the $:/deprecated tag to the if-macro. In the core docs this macro should already be replaced by `<% if %>`.

But users may still use it in their docs. So it should stay in the docs for a little bit longer.

@jermolene -- Should we completely remove it already?