### PR TITLE
fix doubled list in: Deprecated - What does it mean

### DIFF
--- a/editions/tw5.com/tiddlers/system/Deprecated.tid
+++ b/editions/tw5.com/tiddlers/system/Deprecated.tid
@@ -7,6 +7,6 @@ Deprecated features of TiddlyWiki are those that have been superseded by newer, 
 
 Deprecated features will still work, but are not recommended for new content.
 
-Tiddlers tagged $:/deprecated:
+''Tiddlers tagged'' $:/deprecated:
 
 <<list-links filter:"[tag[$:/deprecated]]">>

--- a/editions/tw5.com/tiddlers/system/Deprecated_-_What_does_it_mean.tid
+++ b/editions/tw5.com/tiddlers/system/Deprecated_-_What_does_it_mean.tid
@@ -7,6 +7,3 @@ type: text/vnd.tiddlywiki
 
 Deprecated features are marked with a special warning button. See: [[How to apply custom styles by tag]] for an example.
 
-''Tiddlers tagged `$:/deprecated`''
-
-><<list-links "[tag[$:/deprecated]]">>


### PR DESCRIPTION
Since we added a "tagged" list to: https://tiddlywiki.com/#%24%3A%2Fdeprecated it is now shown 2 times at: https://tiddlywiki.com/#Deprecated%20-%20What%20does%20it%20mean

This PR fixes that. 