### PR TITLE
deprecate Macro call railroad syntax

### DIFF
--- a/editions/tw5.com/tiddlers/macros/syntax/Macro Call Syntax.tid
+++ b/editions/tw5.com/tiddlers/macros/syntax/Macro Call Syntax.tid
@@ -1,8 +1,12 @@
 created: 20150221105732000
 modified: 20150221222352000
-tags: [[Macro Syntax]]
+tags: [[Macro Syntax]] $:/deprecated
 title: Macro Call Syntax
 type: text/vnd.tiddlywiki
+
+<<.deprecated-since "5.3.0" "Procedure Call Syntax">>
+
+----------
 
 <<.preamble """What follows is a formal presentation of the syntax of the WikiText syntax for macro calls, using [[railroad diagrams|Railroad Diagrams]]. A [[simpler overview|Macro Calls in WikiText]] is also available.""">>
 

--- a/editions/tw5.com/tiddlers/macros/syntax/Macro Definition Syntax.tid
+++ b/editions/tw5.com/tiddlers/macros/syntax/Macro Definition Syntax.tid
@@ -1,8 +1,12 @@
 created: 20150220200255000
 modified: 20150221222349000
-tags: [[Macro Syntax]]
+tags: [[Macro Syntax]] $:/deprecated
 title: Macro Definition Syntax
 type: text/vnd.tiddlywiki
+
+<<.deprecated-since "5.3.0" "Procedure Definition Syntax">>
+
+----------
 
 <<.preamble """What follows is a formal presentation of the syntax of the `\define` pragma, using [[railroad diagrams|Railroad Diagrams]]. A [[simpler overview|Macro Definitions in WikiText]] is also available.""">>
 


### PR DESCRIPTION
This PR adds the $:/deprecated tag to the Macro call syntax description