### PR TITLE
dev-edition. change layout to fluid-fixed to use screen-space

### DIFF
--- a/editions/dev/tiddlers/system/$__themes_tiddlywiki_vanilla_options_sidebarlayout.tid
+++ b/editions/dev/tiddlers/system/$__themes_tiddlywiki_vanilla_options_sidebarlayout.tid
@@ -1,0 +1,6 @@
+created: 20240311150859344
+modified: 20240311150859344
+title: $:/themes/tiddlywiki/vanilla/options/sidebarlayout
+type: text/vnd.tiddlywiki
+
+fluid-fixed


### PR DESCRIPTION
@jermolene -- I do not know if that's the right branch for dev-docs PRs?

This PR changes the default layout for the dev-edtion to **fluid-fixed** so it uses more available screen width.

