### PR TITLE
add $:/StoryList to gitignore for tiddlywiki-com branche

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 /test-results/
 /playwright-report/
 /playwright/.cache/
+$__StoryList.tid


### PR DESCRIPTION
This PR adds $__StoryList.tid to .gitignore, so it does not interfere with "untracked" files 