### PR TITLE
Improve filter run prefix docs

### DIFF
--- a/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Map Filter Run Prefix.tid
@@ -1,6 +1,6 @@
 created: 20210618133745003
 from-version: 5.2.0
-modified: 20230710073315595
+modified: 20240312202834547
 rp-input: the filter output of all previous runs so far
 rp-output: the input titles as modified by the result of this filter run
 rp-purpose: modify input titles by the result of evaluating this filter run for each item
@@ -12,7 +12,7 @@ type: text/vnd.tiddlywiki
 <$railroad text="""
 \start none
 \end none
-( ":map" | - )
+( ":map" (: ":flat" | - ) | - )
 [[run|"Filter Run"]]
 """/>
 

--- a/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix.tid
@@ -1,6 +1,6 @@
 created: 20210428083929749
 from-version: 5.2.0
-modified: 20230322140722470
+modified: 20240312203002082
 rp-input: the filter output of all previous runs so far
 rp-output: output titles replace the output of previous filter runs
 rp-purpose: sort the input titles by the result of evaluating this filter run for each item
@@ -12,9 +12,9 @@ type: text/vnd.tiddlywiki
 <$railroad text="""
 \start none
 \end none
-( ":sort" )
+( ( ":sort" ) 
 ( : ":string" | ":alphanumeric" | ":number" | ":integer" | ":version" | ":date" )
-( : ":casesensitive" /"required for string and alphanumeric"/ | ":caseinsensitive" /"required for string and alphanumeric"/  | ":reverse" /"optional"/ | - ) 
+( : ":casesensitive" /"required for string and alphanumeric"/ | ":caseinsensitive" /"required for string and alphanumeric"/  | ":reverse" /"optional"/ | - ) | - )
 [[run|"Filter Run"]]
 """/>
 


### PR DESCRIPTION
* Add missing `:flat` suffix to the railroad diagram of `:map` filter run prefix
* Add missing "empty" side rail (indicating that the entire prefix is optional, as in other prefixes) to `:sort` filter run prefix

This was inspired by this [recent discussion](https://talk.tiddlywiki.org/t/plea-for-a-new-as-filter-run-prefix/9313) and by me myself not being able to easily find about the flat suffix not so long ago. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>