### PR TITLE
Add links to and instructions about Saq's PR Maker in docs

### DIFF
--- a/editions/tw5.com/tiddlers/TiddlyWiki Docs PR Maker.tid
+++ b/editions/tw5.com/tiddlers/TiddlyWiki Docs PR Maker.tid
@@ -1,0 +1,12 @@
+created: 20240313100515958
+modified: 20240313103959789
+tags: Editions
+title: TiddlyWiki Docs PR Maker
+
+''~TiddlyWiki Docs PR Maker'' is a special edition of tiddlywiki.com designed to help you contribute to and improve the documentation made by [[@saqimtiaz|https://github.com/saqimtiaz/]].
+
+https://saqimtiaz.github.io/tw5-docs-pr-maker/
+
+All changes made to the documentation can be very easily submitted to GitHub -- the pull request will be automatically made, hence the "PR Maker" name of the edition.
+
+You will need to create a free ~GitHub account and sign the [[Contributor License Agreement]] before using the Docs PR Maker. You can find more details about contributing to the documentation [[here|Improving TiddlyWiki Documentation]].

--- a/editions/tw5.com/tiddlers/community/Improving TiddlyWiki Documentation.tid
+++ b/editions/tw5.com/tiddlers/community/Improving TiddlyWiki Documentation.tid
@@ -1,5 +1,5 @@
 created: 20140820151051019
-modified: 20190115165616599
+modified: 20240313114828368
 tags: Community
 title: Improving TiddlyWiki Documentation
 type: text/vnd.tiddlywiki
@@ -8,9 +8,29 @@ Anyone can submit improvements to the TiddlyWiki documentation that appears on h
 
 <<.warning """If you already know GitHub, note that documentation updates must be directed to the `tiddlywiki-com` branch""">>
 
+! Before you start editing
+
 # Read and observe the [[Documentation Style Guide]]
 # Create an account on https://github.com if you don't already have one
 # If you haven't done so already, sign the [[Contributor License Agreement]] as described in [[Signing the Contributor License Agreement]]
+
+! Editing and submitting your edits
+
+You can choose to edit the documentation using the [[TiddlyWiki Docs PR Maker]] or directly in ~GitHub. The first method is especially recommended for users not familiar with ~GitHub.
+
+!! Using [[Docs PR Maker|TiddlyWiki Docs PR Maker]] edition
+
+# Go to https://saqimtiaz.github.io/tw5-docs-pr-maker/ or click the link displayed in the ribbon underneath the title when editing a tiddler on tiddlywiki.com
+# Go through the quick introduction where you will need to provide your ~GitHub username and a ~GitHub access token (you will be guided in creating one)
+# Edit or create tiddlers to update the documentation, the wiki will keep track of all changes
+# Click the "Submit updates" button and check if all the tiddlers that you edited are included in the submission; if not, drag them into the box
+# Provide a concise title and description of your changes (see the rules about titling pull requests in [[contribution guidelines|Contributing]])
+# Submit your changes:
+** "Save as draft" will create a //draft// pull request, this is useful if you don't want the changes to be merged //yet//, because you want to work on it later or discuss it first
+** "Submit documentation update" will create a pull request, which will be immediately available for review and merging 
+
+!! Using ~GitHub
+
 # On https://tiddlywiki.com, click "edit" on the tiddler you want to improve
 # You should see a pink banner with the text: //Can you help us improve this documentation? Find out how to edit this tiddler on ~GitHub//
 # Click on the external link ...''this tiddler on ~GitHub''

--- a/editions/tw5.com/tiddlers/system/ContributionBanner.tid
+++ b/editions/tw5.com/tiddlers/system/ContributionBanner.tid
@@ -1,6 +1,8 @@
-title: $:/ContributionBanner
-tags: $:/tags/EditTemplate
+created: 20240313115309914
 list-after: $:/core/ui/EditTemplate/title
+modified: 20240313115810689
+tags: $:/tags/EditTemplate
+title: $:/ContributionBanner
 
 \define base-github()
 https://github.com/Jermolene/TiddlyWiki5/edit/tiddlywiki-com/editions/tw5.com/tiddlers/
@@ -10,7 +12,9 @@ https://github.com/Jermolene/TiddlyWiki5/edit/tiddlywiki-com/editions/tw5.com/ti
 <$list filter="[[$:/config/OriginalTiddlerPaths]getindex<draft-of>]" variable="target" >
 <div class="tc-improvement-banner">
 {{$:/core/images/star-filled}} Can you help us improve this documentation? [[Find out how|Improving TiddlyWiki Documentation]] to
-<a href={{{ [<target>addprefix<base-github>] }}} class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer">edit this tiddler on ~GitHub</a>
+<a href={{{ [<draft-of>encodeuricomponent[]addprefix[https://saqimtiaz.github.io/tw5-docs-pr-maker/#]] }}} class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer">edit this tiddler in Docs PR Maker</a>
+or
+<a href={{{ [<target>addprefix<base-github>] }}} class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer">edit it directly on ~GitHub</a>
 </div>
 </$list>
 </$set>

--- a/editions/tw5.com/tiddlers/system/Sources.tid
+++ b/editions/tw5.com/tiddlers/system/Sources.tid
@@ -1,7 +1,9 @@
-title: $:/editions/tw5.com/TiddlerInfo/Sources
-tags: $:/tags/TiddlerInfo
 caption: Sources
 code-body: yes
+created: 20240313090915565
+modified: 20240313115026563
+tags: $:/tags/TiddlerInfo
+title: $:/editions/tw5.com/TiddlerInfo/Sources
 
 \function static-link-base() [[https://tiddlywiki.com/static/$(title)$.html]substitute[]]
 
@@ -29,9 +31,17 @@ code-body: yes
 			class="tc-tiddlylink-external"
 			target="_blank"
 			rel="noopener noreferrer"
-		>Direct link to <$text text=<<currentTiddler>>/> on github.com</a>
+		>Link to "<$text text=<<currentTiddler>>/>" on github.com</a>
 	</$set>
 </$set>
+\end
+
+\procedure make-pr-maker-link()
+<a href={{{ [<currentTiddler>encodeuricomponent[]addprefix[https://saqimtiaz.github.io/tw5-docs-pr-maker/#]] }}}
+	class="tc-tiddlylink-external"
+	target="_blank"
+	rel="noopener noreferrer"
+>Link to "<$text text=<<currentTiddler>>/>" in Docs PR Maker edition</a>
 \end
 
 <$list filter="[all[current]!is[system]!is[shadow]]">
@@ -40,8 +50,9 @@ A static HTML representation of this tiddler is available at the URL:
 
 * <<make-static-link>>
 
-Help us to improve the documentation by suggesting changes to this tiddler using the [[TiddlyWiki Docs PR Maker|https://saqimtiaz.github.io/tw5-docs-pr-maker/]]
+Help us to [[improve the documentation|Improving TiddlyWiki Documentation]] by suggesting changes to this tiddler using the [[TiddlyWiki Docs PR Maker]] or directly on ~GitHub.
 
+* <<make-pr-maker-link>>
 * <<make-github-link>>
 
 </$list>


### PR DESCRIPTION
Related Talk TW thread: https://talk.tiddlywiki.org/t/demo-updating-docs-and-creating-a-pr-from-within-tiddlywiki/1285/63 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>