### PR TITLE
fix wikitext-macros example block mode

### DIFF
--- a/editions/tw5.com/tiddlers/system/wikitext-macros.tid
+++ b/editions/tw5.com/tiddlers/system/wikitext-macros.tid
@@ -1,6 +1,6 @@
 code-body: yes
 created: 20150117184156000
-modified: 20240229155641000
+modified: 20240315144208842
 tags: $:/tags/Macro
 title: $:/editions/tw5.com/wikitext-macros
 type: text/vnd.tiddlywiki
@@ -65,7 +65,7 @@ type: text/vnd.tiddlywiki
 	<p>
 		That renders as:
 	</p>
-	<$macrocall $name="src"/>
+	<$transclude $variable="src" $mode="block"/>
 </div>
 \end
 


### PR DESCRIPTION
This PR fixes a problem with the macro: `\procedure wikitext-example-without-html(src)`, which does not use block-mode anymore.

 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>