### PR TITLE
Sidebar-Tools tab new syntax and fix vertical spacing in story river

### DIFF
--- a/core/ui/SideBar/Tools.tid
+++ b/core/ui/SideBar/Tools.tid
@@ -2,31 +2,26 @@ title: $:/core/ui/SideBar/Tools
 tags: $:/tags/SideBar
 caption: {{$:/language/SideBar/Tools/Caption}}
 
-\define lingo-base() $:/language/ControlPanel/
-\define config-title()
-$:/config/PageControlButtons/Visibility/$(listItem)$
-\end
+\whitespace trim
+
+\procedure lingo-base() $:/language/ControlPanel/
+\function config-title() [[$:/config/PageControlButtons/Visibility/$(listItem)$]substitute[]]
 
 <<lingo Basics/Version/Prompt>> <<version>>
 
-<$set name="tv-config-toolbar-icons" value="yes">
-
-<$set name="tv-config-toolbar-text" value="yes">
-
-<$set name="tv-config-toolbar-class" value="">
-
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
-
-<div style="position:relative;" class={{{ [<listItem>encodeuricomponent[]addprefix[tc-btn-]] }}}>
-
-<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show"/> <$transclude tiddler=<<listItem>>/> <i class="tc-muted"><$transclude tiddler=<<listItem>> field="description"/></i>
-
-</div>
-
-</$list>
-
-</$set>
-
-</$set>
-
-</$set>
+<$let tv-config-toolbar-icons="yes"
+	tv-config-toolbar-text="yes"
+	tv-config-toolbar-class=""
+>
+	<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
+		<div class={{{ [<listItem>encodeuricomponent[]addprefix[tc-btn-]] tc-sidebar-tools-item +[join[ ]] }}}
+			data-title=<<listItem>>
+		>
+			<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show" class="tc-tiny-gap-right"/>
+				<$transclude tiddler=<<listItem>>/>
+				<i class="tc-tiny-gap-left tc-muted">
+					<$transclude tiddler=<<listItem>> field="description"/>
+				</i>
+		</div>
+	</$list>
+</$let>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -910,7 +910,8 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	font-weight: normal;
 }
 
-.tc-sidebar-header .tc-sidebar-lists p {
+.tc-sidebar-header .tc-sidebar-lists p,
+.tc-sidebar-tools-item {
 	margin-top: 3px;
 	margin-bottom: 3px;
 }


### PR DESCRIPTION
This PR

- fixes #8076 
- adds `tc-sidebar-tools-item` class to the list-items
- adds  `data-title=<<listItem>>` to every list-item
   - This will improve UX for users who want to "hide" toolbar elements for "read only" modes, since they can use plain tiddler titles for styling
   - This will allow us to simplify the core "read only" theme some day in the future

After: with PR active

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/ca315308-9ab2-4d13-bb2f-121d7c04b1f8)

Before: 

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/f3ca89fc-542e-4607-8bc5-398b47f5d6b8)