### PR TITLE
Fix indentation for tiddlers that set tv-config-toolbar-class

### DIFF
--- a/core/ui/EditTemplate/controls.tid
+++ b/core/ui/EditTemplate/controls.tid
@@ -1,12 +1,18 @@
 title: $:/core/ui/EditTemplate/controls
 tags: $:/tags/EditTemplate
 
-\define config-title()
-$:/config/EditToolbarButtons/Visibility/$(listItem)$
-\end
+\define config-title() $:/config/EditToolbarButtons/Visibility/$(listItem)$
 \whitespace trim
 <div class="tc-tiddler-title tc-tiddler-edit-title">
-<$view field="title"/>
-<span class="tc-tiddler-controls tc-titlebar"><$list filter="[all[shadows+tiddlers]tag[$:/tags/EditToolbar]!has[draft.of]]" variable="listItem"><$let tv-config-toolbar-class={{{ [enlist<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]] +[join[ ]]}}}><$reveal type="nomatch" state=<<config-title>> text="hide"><$transclude tiddler=<<listItem>>/></$reveal></$let></$list></span>
-<div style="clear: both;"></div>
+	<$view field="title"/>
+	<span class="tc-tiddler-controls tc-titlebar">
+		<$list filter="[all[shadows+tiddlers]tag[$:/tags/EditToolbar]!has[draft.of]]" variable="listItem">
+			<$let tv-config-toolbar-class={{{ [enlist<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]] +[join[ ]] }}}>
+				<$reveal type="nomatch" state=<<config-title>> text="hide">
+					<$transclude $tiddler=<<listItem>>/>
+				</$reveal>
+			</$let>
+		</$list>
+	</span>
+	<div style="clear: both;"></div>
 </div>

--- a/core/ui/PageControls.tid
+++ b/core/ui/PageControls.tid
@@ -1,17 +1,16 @@
 title: $:/core/ui/PageTemplate/pagecontrols
 
 \whitespace trim
-\define config-title()
-$:/config/PageControlButtons/Visibility/$(listItem)$
-\end
+\define config-title() $:/config/PageControlButtons/Visibility/$(listItem)$
+
 <div class="tc-page-controls">
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
-<$set name="hidden" value=<<config-title>>>
-<$list filter="[<hidden>!text[hide]]" storyview="pop" variable="ignore">
-<$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
-<$transclude tiddler=<<listItem>> mode="inline"/>
-</$set>
-</$list>
-</$set>
-</$list>
+	<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
+		<$set name="hidden" value=<<config-title>>>
+			<$list filter="[<hidden>!text[hide]]" storyview="pop" variable="ignore">
+				<$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
+					<$transclude tiddler=<<listItem>> mode="inline"/>
+				</$set>
+			</$list>
+		</$set>
+	</$list>
 </div>

--- a/core/ui/PageControls/more-page-actions.tid
+++ b/core/ui/PageControls/more-page-actions.tid
@@ -4,48 +4,41 @@ caption: {{$:/core/images/down-arrow}} {{$:/language/Buttons/More/Caption}}
 description: {{$:/language/Buttons/More/Hint}}
 
 \whitespace trim
-\define config-title()
-$:/config/PageControlButtons/Visibility/$(listItem)$
-\end
-<$button popup=<<qualify "$:/state/popup/more">> tooltip={{$:/language/Buttons/More/Hint}} aria-label={{$:/language/Buttons/More/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
-{{$:/core/images/down-arrow}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
-<span class="tc-btn-text">
-<$text text={{$:/language/Buttons/More/Caption}}/>
-</span>
-</$list>
-</$button><$reveal state=<<qualify "$:/state/popup/more">> type="popup" position="below" animate="yes">
+\define config-title() $:/config/PageControlButtons/Visibility/$(listItem)$
 
-<div class="tc-drop-down">
-
-<$set name="tv-config-toolbar-icons" value="yes">
-
-<$set name="tv-config-toolbar-text" value="yes">
-
-<$set name="tv-config-toolbar-class" value="tc-btn-invisible">
-
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]] -[[$:/core/ui/Buttons/more-page-actions]]" variable="listItem">
-
-<$reveal type="match" state=<<config-title>> text="hide">
-
-<$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
-
-<$transclude tiddler=<<listItem>> mode="inline"/>
-
-</$set>
-
-</$reveal>
-
-</$list>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</div>
-
+<$button popup=<<qualify "$:/state/popup/more">>
+	tooltip={{$:/language/Buttons/More/Hint}}
+	aria-label={{$:/language/Buttons/More/Caption}}
+	class=<<tv-config-toolbar-class>>
+	selectedClass="tc-selected"
+>
+	<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+		{{$:/core/images/down-arrow}}
+	</$list>
+	<$list filter="[<tv-config-toolbar-text>match[yes]]">
+		<span class="tc-btn-text">
+			<$text text={{$:/language/Buttons/More/Caption}}/>
+		</span>
+	</$list>
+</$button>
+<$reveal state=<<qualify "$:/state/popup/more">> type="popup" position="below" animate="yes">
+	<div class="tc-drop-down">
+		<$set name="tv-config-toolbar-icons" value="yes">
+			<$set name="tv-config-toolbar-text" value="yes">
+				<$set name="tv-config-toolbar-class" value="tc-btn-invisible">
+					<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]] -[[$:/core/ui/Buttons/more-page-actions]]"
+						variable="listItem"
+					>
+						<$reveal type="match" state=<<config-title>> text="hide">
+							<$set name="tv-config-toolbar-class"
+								filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]"
+							>
+								<$transclude tiddler=<<listItem>> mode="inline"/>
+							</$set>
+						</$reveal>
+					</$list>
+				</$set>
+			</$set>
+		</$set>
+	</div>
 </$reveal>

--- a/core/ui/ViewTemplate/title.tid
+++ b/core/ui/ViewTemplate/title.tid
@@ -2,31 +2,38 @@ title: $:/core/ui/ViewTemplate/title
 tags: $:/tags/ViewTemplate
 
 \whitespace trim
-\define title-styles()
-fill:$(foregroundColor)$;
-\end
+\define title-styles() fill:$(foregroundColor)$;
+
 <div class="tc-tiddler-title">
-<div class="tc-titlebar">
-<span class="tc-tiddler-controls">
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]] :filter[lookup[$:/config/ViewToolbarButtons/Visibility/]!match[hide]]" storyview="pop" variable="listItem"><$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]"><$transclude tiddler=<<listItem>>/></$set></$list>
-</span>
-<$set name="tv-wikilinks" value={{$:/config/Tiddlers/TitleLinks}}>
-<$link>
-<$list filter="[<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] +[!is[blank]]" variable="ignore">
-<$let foregroundColor={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}}>
-<span class="tc-tiddler-title-icon" style=<<title-styles>>>
-{{||$:/core/ui/TiddlerIcon}}
-</span>
-</$let>
-</$list>
-<$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/ViewTemplateTitleFilter]!is[draft]get[text]] :and[!is[blank]else[$:/core/ui/ViewTemplate/title/default]] }}} />
-</$link>
-</$set>
-</div>
-
-<$reveal type="nomatch" text="" default="" state=<<tiddlerInfoState>> class="tc-tiddler-info tc-popup-handle" animate="yes" retain="yes">
-
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfoSegment]!has[draft.of]] [[$:/core/ui/TiddlerInfo]]" variable="listItem"><$transclude tiddler=<<listItem>> mode="block"/></$list>
-
-</$reveal>
+	<div class="tc-titlebar">
+		<span class="tc-tiddler-controls">
+			<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]] :filter[lookup[$:/config/ViewToolbarButtons/Visibility/]!match[hide]]"
+				storyview="pop"
+				variable="listItem"
+			>
+				<$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
+					<$transclude tiddler=<<listItem>>/>
+				</$set>
+			</$list>
+		</span>
+		<$set name="tv-wikilinks" value={{$:/config/Tiddlers/TitleLinks}}>
+			<$link>
+				<$list filter="[<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerIconFilter]!is[draft]get[text]] +[!is[blank]]"
+					variable="ignore"
+				>
+					<$let foregroundColor={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/TiddlerColourFilter]!is[draft]get[text]] }}}>
+						<span class="tc-tiddler-title-icon" style=<<title-styles>>>
+							{{||$:/core/ui/TiddlerIcon}}
+						</span>
+					</$let>
+				</$list>
+				<$transclude tiddler={{{ [<currentTiddler>] :cascade[all[shadows+tiddlers]tag[$:/tags/ViewTemplateTitleFilter]!is[draft]get[text]] :and[!is[blank]else[$:/core/ui/ViewTemplate/title/default]] }}} />
+			</$link>
+		</$set>
+	</div>
+	<$reveal type="nomatch" text="" default="" state=<<tiddlerInfoState>> class="tc-tiddler-info tc-popup-handle" animate="yes" retain="yes">
+		<$list filter="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfoSegment]!has[draft.of]] [[$:/core/ui/TiddlerInfo]]" variable="listItem">
+			<$transclude tiddler=<<listItem>> mode="block"/>
+		</$list>
+	</$reveal>
 </div>

--- a/core/ui/ViewToolbar/more-tiddler-actions.tid
+++ b/core/ui/ViewToolbar/more-tiddler-actions.tid
@@ -4,49 +4,41 @@ caption: {{$:/core/images/down-arrow}} {{$:/language/Buttons/More/Caption}}
 description: {{$:/language/Buttons/More/Hint}}
 
 \whitespace trim
-\define config-title()
-$:/config/ViewToolbarButtons/Visibility/$(listItem)$
-\end
-<$button popup=<<qualify "$:/state/popup/more">> tooltip={{$:/language/Buttons/More/Hint}} aria-label={{$:/language/Buttons/More/Caption}} class=<<tv-config-toolbar-class>> selectedClass="tc-selected">
-<$list filter="[<tv-config-toolbar-icons>match[yes]]">
-{{$:/core/images/down-arrow}}
-</$list>
-<$list filter="[<tv-config-toolbar-text>match[yes]]">
-<span class="tc-btn-text">
-<$text text={{$:/language/Buttons/More/Caption}}/>
-</span>
-</$list>
+\define config-title() $:/config/ViewToolbarButtons/Visibility/$(listItem)$
+
+<$button popup=<<qualify "$:/state/popup/more">>
+	tooltip={{$:/language/Buttons/More/Hint}}
+	aria-label={{$:/language/Buttons/More/Caption}}
+	class=<<tv-config-toolbar-class>>
+	selectedClass="tc-selected"
+>
+	<$list filter="[<tv-config-toolbar-icons>match[yes]]">
+		{{$:/core/images/down-arrow}}
+	</$list>
+	<$list filter="[<tv-config-toolbar-text>match[yes]]">
+		<span class="tc-btn-text">
+			<$text text={{$:/language/Buttons/More/Caption}}/>
+		</span>
+	</$list>
 </$button>
 <$reveal state=<<qualify "$:/state/popup/more">> type="popup" position="belowleft" animate="yes">
-
-<div class="tc-drop-down">
-
-<$set name="tv-config-toolbar-icons" value="yes">
-
-<$set name="tv-config-toolbar-text" value="yes">
-
-<$set name="tv-config-toolbar-class" value="tc-btn-invisible">
-
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]] -[[$:/core/ui/Buttons/more-tiddler-actions]]" variable="listItem">
-
-<$reveal type="match" state=<<config-title>> text="hide">
-
-<$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
-
-<$transclude tiddler=<<listItem>> mode="inline"/>
-
-</$set>
-
-</$reveal>
-
-</$list>
-
-</$set>
-
-</$set>
-
-</$set>
-
-</div>
-
+	<div class="tc-drop-down">
+		<$set name="tv-config-toolbar-icons" value="yes">
+			<$set name="tv-config-toolbar-text" value="yes">
+				<$set name="tv-config-toolbar-class" value="tc-btn-invisible">
+					<$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewToolbar]!has[draft.of]] -[[$:/core/ui/Buttons/more-tiddler-actions]]"
+						variable="listItem"
+					>
+						<$reveal type="match" state=<<config-title>> text="hide">
+							<$set name="tv-config-toolbar-class"
+								filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]"
+							>
+								<$transclude tiddler=<<listItem>> mode="inline"/>
+							</$set>
+						</$reveal>
+					</$list>
+				</$set>
+			</$set>
+		</$set>
+	</div>
 </$reveal>

--- a/plugins/tiddlywiki/menubar/items/pagecontrols.tid
+++ b/plugins/tiddlywiki/menubar/items/pagecontrols.tid
@@ -5,15 +5,14 @@ caption: Page controls
 custom-menu-content: <$transclude tiddler="$:/plugins/tiddlywiki/menubar/items/pagecontrols" mode="inline"/>
 
 \whitespace trim
-\define config-title()
-$:/config/PageControlButtons/Visibility/$(listItem)$
-\end
+\define config-title() $:/config/PageControlButtons/Visibility/$(listItem)$
+
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
-<$set name="hidden" value=<<config-title>>>
-<$list filter="[<hidden>!text[hide]]" storyview="pop" variable="ignore">
-<$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
-<$transclude tiddler=<<listItem>> mode="inline"/>
-</$set>
-</$list>
-</$set>
+	<$set name="hidden" value=<<config-title>>>
+		<$list filter="[<hidden>!text[hide]]" storyview="pop" variable="ignore">
+			<$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
+				<$transclude tiddler=<<listItem>> mode="inline"/>
+			</$set>
+		</$list>
+	</$set>
 </$list>


### PR DESCRIPTION
This PR makes the code human readable for tiddlers, that do **define the variable ** tv-config-toolbar-class with an uriencoded listItem name. 

This PR is a preparation to add `data-title=<<listItem>>` to buttons for better UX defining a "read only" theme. The `data-title` attribute allows us to use plain text titles instead of uri-encoded classes, which nobody can read. 

-	modified:   core/ui/EditTemplate/controls.tid
-	modified:   core/ui/PageControls.tid
-	modified:   core/ui/PageControls/more-page-actions.tid
-	modified:   core/ui/ViewTemplate/title.tid
-	modified:   core/ui/ViewToolbar/more-tiddler-actions.tid
-	modified:   plugins/tiddlywiki/menubar/items/pagecontrols.tid