### PR TITLE
Made library boot module requirements consistent

### DIFF
--- a/core/templates/external-js/save-all-external-js.tid
+++ b/core/templates/external-js/save-all-external-js.tid
@@ -3,7 +3,7 @@ title: $:/core/save/all-external-js
 \whitespace trim
 \import [subfilter{$:/core/config/GlobalImportFilter}]
 \define saveTiddlerFilter()
-[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
+[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/boot/boot.css]] -[is[system]type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
 
 <!-- Important: core library is provided by serving URI encoded $:/core/templates/tiddlywiki5.js -->

--- a/core/templates/external-js/save-offline-external-js.tid
+++ b/core/templates/external-js/save-offline-external-js.tid
@@ -3,7 +3,7 @@ title: $:/core/save/offline-external-js
 \whitespace trim
 \import [subfilter{$:/core/config/GlobalImportFilter}]
 \define saveTiddlerFilter()
-[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/plugins/tiddlywiki/filesystem]] -[[$:/plugins/tiddlywiki/tiddlyweb]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
+[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/core]] -[[$:/plugins/tiddlywiki/filesystem]] -[[$:/plugins/tiddlywiki/tiddlyweb]] -[[$:/boot/boot.css]] -[is[system]type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
 \define defaultCoreURL() tiddlywikicore-$(version)$.js
 <$let coreURL={{{ [[coreURL]is[variable]then<coreURL>else<defaultCoreURL>] }}}>

--- a/core/templates/save-all.tid
+++ b/core/templates/save-all.tid
@@ -2,6 +2,6 @@ title: $:/core/save/all
 
 \import [subfilter{$:/core/config/GlobalImportFilter}]
 \define saveTiddlerFilter()
-[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
+[is[tiddler]] -[prefix[$:/state/popup/]] -[prefix[$:/temp/]] -[prefix[$:/HistoryList]] -[status[pending]plugin-type[import]] -[[$:/boot/boot.css]] -[is[system]type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]] $(publishFilter)$
 \end
 {{$:/core/templates/tiddlywiki5.html}}

--- a/core/templates/save-empty.tid
+++ b/core/templates/save-empty.tid
@@ -1,6 +1,6 @@
 title: $:/core/save/empty
 
 \define saveTiddlerFilter()
-[is[system]] -[prefix[$:/state/popup/]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]]
+[is[system]] -[prefix[$:/state/popup/]] -[[$:/boot/boot.css]] -[is[system]type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] +[sort[title]]
 \end
 {{$:/core/templates/tiddlywiki5.html}}

--- a/core/templates/save-lazy-all.tid
+++ b/core/templates/save-lazy-all.tid
@@ -1,7 +1,7 @@
 title: $:/core/save/lazy-all
 
 \define saveTiddlerFilter()
-[is[system]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] [is[tiddler]type[application/javascript]] +[sort[title]]
+[is[system]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[is[system]type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] [is[tiddler]type[application/javascript]] +[sort[title]]
 \end
 \define skinnySaveTiddlerFilter()
 [!is[system]] -[type[application/javascript]]

--- a/core/templates/save-lazy-images.tid
+++ b/core/templates/save-lazy-images.tid
@@ -1,7 +1,7 @@
 title: $:/core/save/lazy-images
 
 \define saveTiddlerFilter()
-[is[tiddler]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] -[!is[system]is[image]] +[sort[title]] 
+[is[tiddler]] -[prefix[$:/state/popup/]] -[[$:/HistoryList]] -[[$:/boot/boot.css]] -[is[system]type[application/javascript]library[yes]] -[[$:/boot/boot.js]] -[[$:/boot/bootprefix.js]] -[!is[system]is[image]] +[sort[title]] 
 \end
 \define skinnySaveTiddlerFilter()
 [!is[system]is[image]]


### PR DESCRIPTION
Here is the minor fix for #8069. Tiddlers with `[library[yes]]` only get treated specially if they're system tiddlers.