### PR TITLE
add tag parameter to reveal-widget to fix info-area regression

### DIFF
--- a/core/ui/ViewTemplate/title.tid
+++ b/core/ui/ViewTemplate/title.tid
@@ -31,7 +31,7 @@ tags: $:/tags/ViewTemplate
 			</$link>
 		</$set>
 	</div>
-	<$reveal type="nomatch" text="" default="" state=<<tiddlerInfoState>> class="tc-tiddler-info tc-popup-handle" animate="yes" retain="yes">
+	<$reveal tag="div" type="nomatch" text="" default="" state=<<tiddlerInfoState>> class="tc-tiddler-info tc-popup-handle" animate="yes" retain="yes">
 		<$list filter="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfoSegment]!has[draft.of]] [[$:/core/ui/TiddlerInfo]]" variable="listItem">
 			<$transclude tiddler=<<listItem>> mode="block"/>
 		</$list>


### PR DESCRIPTION
Fix problem introduced with #8079 

PR applied

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/86e9be94-3987-4d4b-8c91-039fb9190086)

Before: 

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/f9d16133-0f48-4779-8ac3-4a9b3ca7be9d)


@BurningTreeC Thx for the "catch"

