### PR TITLE
New v5.3.x syntax for page template sidebar

### DIFF
--- a/core/ui/PageTemplate/sidebar.tid
+++ b/core/ui/PageTemplate/sidebar.tid
@@ -2,16 +2,18 @@ title: $:/core/ui/PageTemplate/sidebar
 tags: $:/tags/PageTemplate
 
 \whitespace trim
-\define config-title() $:/config/SideBarSegments/Visibility/$(listItem)$
+\function config-title() [[$:/config/SideBarSegments/Visibility/$(listItem)$]substitute[]]
 
 <$scrollable fallthrough="no" class="tc-sidebar-scrollable">
-	<div class="tc-sidebar-header">
-		<$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes" animate="yes" tag="div">
-			<$list filter="[all[shadows+tiddlers]tag[$:/tags/SideBarSegment]!has[draft.of]]" variable="listItem">
-				<$reveal type="nomatch" state=<<config-title>> text="hide" tag="div">
-					<$transclude tiddler=<<listItem>> mode="block"/>
-				</$reveal>
-			</$list>
-		</$reveal>
-	</div>
+	<$reveal state="$:/state/sidebar"
+		tag="div" class="tc-sidebar-header"
+		type="match" text="yes" default="yes"
+		retain="yes" animate="yes"
+	>
+		<$list filter="[all[shadows+tiddlers]tag[$:/tags/SideBarSegment]!has[draft.of]]" variable="listItem">
+			<$reveal type="nomatch" state=<<config-title>> text="hide" tag="div">
+				<$transclude $tiddler=<<listItem>> $mode="block"/>
+			</$reveal>
+		</$list>
+	</$reveal>
 </$scrollable>

--- a/core/ui/PageTemplate/sidebar.tid
+++ b/core/ui/PageTemplate/sidebar.tid
@@ -2,28 +2,16 @@ title: $:/core/ui/PageTemplate/sidebar
 tags: $:/tags/PageTemplate
 
 \whitespace trim
-\define config-title()
-$:/config/SideBarSegments/Visibility/$(listItem)$
-\end
+\define config-title() $:/config/SideBarSegments/Visibility/$(listItem)$
 
 <$scrollable fallthrough="no" class="tc-sidebar-scrollable">
-
-<div class="tc-sidebar-header">
-
-<$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes" animate="yes">
-
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/SideBarSegment]!has[draft.of]]" variable="listItem">
-
-<$reveal type="nomatch" state=<<config-title>> text="hide"  tag="div">
-
-<$transclude tiddler=<<listItem>> mode="block"/>
-
-</$reveal>
-
-</$list>
-
-</$reveal>
-
-</div>
-
+	<div class="tc-sidebar-header">
+		<$reveal state="$:/state/sidebar" type="match" text="yes" default="yes" retain="yes" animate="yes" tag="div">
+			<$list filter="[all[shadows+tiddlers]tag[$:/tags/SideBarSegment]!has[draft.of]]" variable="listItem">
+				<$reveal type="nomatch" state=<<config-title>> text="hide" tag="div">
+					<$transclude tiddler=<<listItem>> mode="block"/>
+				</$reveal>
+			</$list>
+		</$reveal>
+	</div>
 </$scrollable>


### PR DESCRIPTION
This PR depends on, so the other one should be merged first. (I hope GitHub allows it that way)

- #8086

It changes

- `\define` -> `\function`
- changes transclusion to $params
- removes a redundant DIV since the scrollable-widget adds it's own wrapper DIV. 

