### PR TITLE
use v5.3.x syntax for $:/core/ui/PageTemplate/pagecontrols

### DIFF
--- a/core/ui/PageControls.tid
+++ b/core/ui/PageControls.tid
@@ -1,16 +1,14 @@
 title: $:/core/ui/PageTemplate/pagecontrols
 
 \whitespace trim
-\define config-title() $:/config/PageControlButtons/Visibility/$(listItem)$
+\function config-title() [[$:/config/PageControlButtons/Visibility/$(listItem)$]substitute[]]
 
 <div class="tc-page-controls">
 	<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
-		<$set name="hidden" value=<<config-title>>>
-			<$list filter="[<hidden>!text[hide]]" storyview="pop" variable="ignore">
-				<$set name="tv-config-toolbar-class" filter="[<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]]">
-					<$transclude tiddler=<<listItem>> mode="inline"/>
-				</$set>
-			</$list>
-		</$set>
+		<$list filter="[<config-title>!text[hide]]" storyview="pop" variable="ignore">
+			<$let tv-config-toolbar-class={{{ [enlist<tv-config-toolbar-class>] [<listItem>encodeuricomponent[]addprefix[tc-btn-]] +[join[ ]] }}}>
+				<$transclude $tiddler=<<listItem>> $mode="inline"/>
+			</$let>
+		</$list>
 	</$list>
 </div>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -931,6 +931,7 @@ button.tc-btn-invisible.tc-remove-tag-button {
 
 .tc-page-controls {
 	margin-top: 14px;
+	margin-bottom: 14px;
 	font-size: 1.5em;
 }
 


### PR DESCRIPTION
This PR 

- changes `\define config-title` to a `\function`
- it removes a redundant set-widget
   - The substitution `\function` works as the screenshot below shows
   - Enabling / disabling element from the sidebar -> Tools tab also works
- transclude uses $params
- Stylesheet
  - The `tc-page-controls` DIV currently is covered by an HTML P-tag, which has `margin-top` and `margin-bottom` set to 14px. 
  - `tc-page-controls` CSS currently **only** has `margin-top`: 14px -> This PR fixes that problem (for the future)

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/5da83109-cdc9-499a-aab6-7aadafad85e2)


