### PR TITLE
Fix: Set a proper doctype for the open window template (chromium bug fix) 

### DIFF
--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -56,7 +56,7 @@ exports.startup = function() {
 			return;
 		}
 		// Initialise the document
-		srcDocument.write("<html><head></head><body class='tc-body tc-single-tiddler-window'></body></html>");
+		srcDocument.write("<!DOCTYPE html><head></head><body class='tc-body tc-single-tiddler-window'></body></html>");
 		srcDocument.close();
 		srcDocument.title = windowTitle;
 		srcWindow.addEventListener("beforeunload",function(event) {


### PR DESCRIPTION
When DOCTYPE is not set, on chromium based browsers, css operator like :has() behave unexpectedly:

![](https://talk.tiddlywiki.org/uploads/default/original/2X/0/0583148d5c004970c915719c877eaf6a75f526f1.gif)

See https://talk.tiddlywiki.org/t/bug-has-hover-not-working-in-single-tindler-window/9379

Snippet to reproduce the bug (solved by this PR):

```
<article>
<span>if this text is green when hovered, :has work</span>
</article>

<pre><style contenteditable style.display="block">article{
color: red;
&:has(:hover){
color: green;
}
}</style></pre>
```