### PR TITLE
Fix ribbon going over sticky tiddler title

### DIFF
--- a/editions/tw5.com/tiddlers/system/wikitext-macros.tid
+++ b/editions/tw5.com/tiddlers/system/wikitext-macros.tid
@@ -1,6 +1,6 @@
 code-body: yes
 created: 20150117184156000
-modified: 20240315144208842
+modified: 20240321021417066
 tags: $:/tags/Macro
 title: $:/editions/tw5.com/wikitext-macros
 type: text/vnd.tiddlywiki
@@ -90,7 +90,7 @@ type: text/vnd.tiddlywiki
 
 \procedure flex-card(class,bordercolor:"",backgroundcolor:"",textcolor:"",imageField:"image",captionField:"caption",subtitle:"",descriptionField:"description",linkField:"link")
 <$link class={{{ [<class>addprefix[tc-card ]] }}} to={{{ [<currentTiddler>get<linkField>else<currentTiddler>] }}}>
-	<div class="tc-card-accent" style.borderTop={{{ [<bordercolor>!is[blank]addprefix[5px solid ]] }}} style.background={{!!background}} style.backgroundColor=<<backgroundcolor>> style.color=<<textcolor>> style.fill=<<textcolor>>>
+	<div class="tc-card-accent" style.borderTop={{{ [<bordercolor>!is[blank]addprefix[5px solid ]] }}} style.background={{!!background}} style.backgroundColor=<<backgroundcolor>> style.color=<<textcolor>> style.fill=<<textcolor>> style.isolation="isolate">
 		<$list filter="[<currentTiddler>has[ribbon-text]]" variable="ignore">
 			<div class="tc-card-ribbon-wrapper">
 				<div class="tc-card-ribbon" style.backgroundColor={{{ [<currentTiddler>get[ribbon-color]else[red]] }}}>


### PR DESCRIPTION
isolation:isolate is added to the style for the card in order to prevent the ribbon from going in front of the tiddler title 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>