### PR TITLE
fix: import lingo macro when render title

### DIFF
--- a/core/modules/startup/render.js
+++ b/core/modules/startup/render.js
@@ -29,7 +29,11 @@ var THROTTLE_REFRESH_TIMEOUT = 400;
 
 exports.startup = function() {
 	// Set up the title
-	$tw.titleWidgetNode = $tw.wiki.makeTranscludeWidget(PAGE_TITLE_TITLE,{document: $tw.fakeDocument, parseAsInline: true});
+	$tw.titleWidgetNode = $tw.wiki.makeTranscludeWidget(PAGE_TITLE_TITLE, {
+		document: $tw.fakeDocument,
+		parseAsInline: true,
+		importPageMacros: true,
+	});
 	$tw.titleContainer = $tw.fakeDocument.createElement("div");
 	$tw.titleWidgetNode.render($tw.titleContainer,null);
 	document.title = $tw.titleContainer.textContent;


### PR DESCRIPTION
Tested locally

Before:

![图片](https://github.com/Jermolene/TiddlyWiki5/assets/3746270/47dba271-4b14-4955-aa2e-ff0a81fa136f)

After:

![图片](https://github.com/Jermolene/TiddlyWiki5/assets/3746270/abae1be9-dca1-417f-8854-dac7c9110d1f)
