### PR TITLE
Fix/backlink binary

### DIFF
--- a/core/modules/indexers/back-indexer.js
+++ b/core/modules/indexers/back-indexer.js
@@ -70,6 +70,9 @@ BackSubIndexer.prototype.rebuild = function() {
 * Get things that is being referenced in the text, e.g. tiddler names in the link syntax.
 */
 BackSubIndexer.prototype._getTarget = function(tiddler) {
+	if(this.wiki.isBinaryTiddler(tiddler.fields.text)) {
+		return [];
+	}
 	var parser = this.wiki.parseText(tiddler.fields.type, tiddler.fields.text, {});
 	if(parser) {
 		return this.wiki[this.extractor](parser.tree);

--- a/editions/test/tiddlers/tests/test-backlinks.js
+++ b/editions/test/tiddlers/tests/test-backlinks.js
@@ -12,6 +12,24 @@ Tests the backlinks mechanism.
 "use strict";
 
 describe('Backlinks tests', function() {
+	function setupWiki(wikiOptions) {
+		wikiOptions = wikiOptions || {};
+		// Create a wiki
+		var wiki = new $tw.Wiki(wikiOptions);
+		wiki.addIndexersToWiki();
+
+		wiki.addTiddler({
+			title: 'TestIncoming',
+			text: '',
+		});
+		
+		wiki.addTiddler({
+			title: 'TestOutgoing',
+			text: 'A link to [[TestIncoming]]',
+		});
+		return wiki;
+	}
+
 	describe('a tiddler with no links to it', function() {
 		var wiki = new $tw.Wiki();
 
@@ -25,15 +43,7 @@ describe('Backlinks tests', function() {
 	});
 
 	describe('A tiddler added to the wiki with a link to it', function() {
-		var wiki = new $tw.Wiki();
-
-		wiki.addTiddler({
-			title: 'TestIncoming',
-			text: ''});
-
-		wiki.addTiddler({
-			title: 'TestOutgoing',
-			text: 'A link to [[TestIncoming]]'});
+		var wiki = setupWiki();
 
 		it('should have a backlink', function() {
 			expect(wiki.filterTiddlers('TestIncoming +[backlinks[]]').join(',')).toBe('TestOutgoing');
@@ -42,15 +52,7 @@ describe('Backlinks tests', function() {
 
 	describe('A tiddler that has a link added to it later', function() {
 		it('should have an additional backlink', function() {
-			var wiki = new $tw.Wiki();
-
-			wiki.addTiddler({
-				title: 'TestIncoming',
-				text: ''});
-
-			wiki.addTiddler({
-				title: 'TestOutgoing',
-				text: 'A link to [[TestIncoming]]'});
+			var wiki = setupWiki();
 
 			wiki.addTiddler({
 				title: 'TestOutgoing2',
@@ -67,15 +69,7 @@ describe('Backlinks tests', function() {
 	});
 
 	describe('A tiddler that has a link remove from it later', function() {
-		var wiki = new $tw.Wiki();
-
-		wiki.addTiddler({
-			title: 'TestIncoming',
-			text: ''});
-
-		wiki.addTiddler({
-			title: 'TestOutgoing',
-			text: 'A link to [[TestIncoming]]'});
+		var wiki = setupWiki();
 
 		it('should have one fewer backlink', function() {
 			expect(wiki.filterTiddlers('TestIncoming +[backlinks[]]').join(',')).toBe('TestOutgoing');
@@ -89,15 +83,7 @@ describe('Backlinks tests', function() {
 	});
 
 	describe('A tiddler linking to another that gets renamed', function() {
-		var wiki = new $tw.Wiki();
-
-		wiki.addTiddler({
-			title: 'TestIncoming',
-			text: ''});
-
-		wiki.addTiddler({
-			title: 'TestOutgoing',
-			text: 'A link to [[TestIncoming]]'});
+		var wiki = setupWiki();
 
 		it('should have its name changed in the backlinks', function() {
 			expect(wiki.filterTiddlers('TestIncoming +[backlinks[]]').join(',')).toBe('TestOutgoing');
@@ -109,15 +95,7 @@ describe('Backlinks tests', function() {
 	});
 
 	describe('A tiddler linking to another that gets deleted', function() {
-		var wiki = new $tw.Wiki();
-
-		wiki.addTiddler({
-			title: 'TestIncoming',
-			text: ''});
-
-		wiki.addTiddler({
-			title: 'TestOutgoing',
-			text: 'A link to [[TestIncoming]]'});
+		var wiki = setupWiki();
 
 		it('should be removed from backlinks', function() {
 			expect(wiki.filterTiddlers('TestIncoming +[backlinks[]]').join(',')).toBe('TestOutgoing');
@@ -125,6 +103,41 @@ describe('Backlinks tests', function() {
 			wiki.deleteTiddler('TestOutgoing');
 
 			expect(wiki.filterTiddlers('TestIncoming +[backlinks[]]').join(',')).toBe('');
+		});
+	});
+
+	describe('Binary tiddlers should not be parsed', function() {
+		var wiki = setupWiki();
+
+		wiki.addTiddler({
+			title: 'TestDoc.doc',
+			text: 'A link to [[TestOutgoing]]',
+			type: 'application/msword'
+		});
+
+		wiki.addTiddler({
+			title: 'TestExcel.xls',
+			text: 'A link to [[TestOutgoing]]',
+			type: 'application/excel'
+		});
+
+		wiki.addTiddler({
+			title: 'TestOutgoing',
+			text: 'Some links to [[TestDoc.doc]] and [[TestExcel.xls]].'
+		});
+
+		it('should ignore office files', function() {
+			expect(wiki.getIndexer("BackIndexer").subIndexers.link._getTarget(wiki.getTiddler('TestExcel.xls'))).toEqual([]);
+
+			expect(wiki.filterTiddlers('[all[]] +[backlinks[]]').join(',')).toBe('TestOutgoing');
+			
+			// make it tw5 tiddler
+			wiki.addTiddler({
+				title: 'TestExcel.xls',
+				text: 'A link to [[TestOutgoing]]'
+			});
+
+			expect(wiki.filterTiddlers('[all[]] +[backlinks[]]').join(',')).toBe('TestOutgoing,TestExcel.xls');
 		});
 	});
 });


### PR DESCRIPTION
fixes #8091 . And this won't prevent whiteboard to have backlink, as whiteboard's save file is not binary tiddler.

I also refactor the test to reuse some code.

I find that test will pass without this fix, because it was just wasting time go through the binary tiddler, and find no link so return `[]`.