### PR TITLE
MWS: Query recently updated tiddlers in a bag

### DIFF
--- a/core/ui/ViewTemplate/title.tid
+++ b/core/ui/ViewTemplate/title.tid
@@ -31,7 +31,7 @@ tags: $:/tags/ViewTemplate
 			</$link>
 		</$set>
 	</div>
-	<$reveal type="nomatch" text="" default="" state=<<tiddlerInfoState>> class="tc-tiddler-info tc-popup-handle" animate="yes" retain="yes">
+	<$reveal tag="div" type="nomatch" text="" default="" state=<<tiddlerInfoState>> class="tc-tiddler-info tc-popup-handle" animate="yes" retain="yes">
 		<$list filter="[all[shadows+tiddlers]tag[$:/tags/TiddlerInfoSegment]!has[draft.of]] [[$:/core/ui/TiddlerInfo]]" variable="listItem">
 			<$transclude tiddler=<<listItem>> mode="block"/>
 		</$list>

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/sql-tiddler-database.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/sql-tiddler-database.js
@@ -110,7 +110,7 @@ SqlTiddlerDatabase.prototype.createBag = function(bag_name,description,accesscon
 	const updateBags = this.engine.runStatement(`
 		UPDATE bags
 		SET accesscontrol = $accesscontrol,
-		description = $description
+		description = $description 
 		WHERE bag_name = $bag_name
 	`,{
 		$bag_name: bag_name,
@@ -337,7 +337,7 @@ SqlTiddlerDatabase.prototype.getBagTiddler = function(title,bag_name) {
 Returns {bag_name:, tiddler: {fields}, tiddler_id:, attachment_blob:}
 */
 SqlTiddlerDatabase.prototype.getRecipeTiddler = function(title,recipe_name) {
-	const rowTiddlerId = this.engine.runStatementGet(`
+	const rowTiddlerId = this.engine.runStatementGet(`	
 		SELECT t.tiddler_id, t.attachment_blob, b.bag_name
 		FROM bags AS b
 		INNER JOIN recipe_bags AS rb ON b.bag_id = rb.bag_id
@@ -395,34 +395,103 @@ SqlTiddlerDatabase.prototype.getBagTiddlers = function(bag_name) {
 };
 
 /*
-Get the titles of the tiddlers in a recipe as {title:,tiddler_id:,bag_name:}. Returns null for recipes that do not exist
+Get the tiddler_id of the newest tiddler in a bag. Returns null for bags that do not exist
 */
-SqlTiddlerDatabase.prototype.getRecipeTiddlers = function(recipe_name) {
-	const rowsCheckRecipe = this.engine.runStatementGetAll(`
-		SELECT * FROM recipes WHERE recipes.recipe_name = $recipe_name
+SqlTiddlerDatabase.prototype.getBagLastTiddlerId = function(bag_name) {
+	const row = this.engine.runStatementGet(`
+		SELECT tiddler_id
+		FROM tiddlers
+		WHERE bag_id IN (
+			SELECT bag_id
+			FROM bags
+			WHERE bag_name = $bag_name
+		)
+		ORDER BY tiddler_id DESC
+		LIMIT 1
 	`,{
-		$recipe_name: recipe_name
+		$bag_name: bag_name
 	});
-	if(rowsCheckRecipe.length === 0) {
+	if(row) {
+		return row.tiddler_id;
+	} else {
 		return null;
 	}
-	const rows = this.engine.runStatementGetAll(`
-		SELECT title, tiddler_id, bag_name
-		FROM (
-			SELECT t.title, t.tiddler_id, b.bag_name, MAX(rb.position) AS position
-			FROM bags AS b
-			INNER JOIN recipe_bags AS rb ON b.bag_id = rb.bag_id
-			INNER JOIN recipes AS r ON rb.recipe_id = r.recipe_id
-			INNER JOIN tiddlers AS t ON b.bag_id = t.bag_id
-			WHERE r.recipe_name = $recipe_name
-			AND t.is_deleted = FALSE
-			GROUP BY t.title
-			ORDER BY t.title
-		)
+};
+
+/*
+Get the metadata of the tiddlers in a recipe as an array [{title:,tiddler_id:,bag_name:,is_deleted:}],
+sorted in ascending order of tiddler_id.
+
+Options include:
+
+limit: optional maximum number of results to return
+last_known_tiddler_id: tiddler_id of the last known update. Only returns tiddlers that have been created, modified or deleted since
+include_deleted: boolean, defaults to false
+
+Returns null for recipes that do not exist
+*/
+SqlTiddlerDatabase.prototype.getRecipeTiddlers = function(recipe_name,options) {
+	options = options || {};
+	// Get the recipe ID
+	const rowsCheckRecipe = this.engine.runStatementGet(`
+		SELECT recipe_id FROM recipes WHERE recipes.recipe_name = $recipe_name
 	`,{
 		$recipe_name: recipe_name
 	});
+	if(!rowsCheckRecipe) {
+		return null;
+	}
+	const recipe_id = rowsCheckRecipe.recipe_id;
+	// Compose the query to get the tiddlers
+	const params = {
+		$recipe_id: recipe_id
+	}
+	if(options.limit) {
+		params.$limit = options.limit.toString();
+	}
+	if(options.last_known_tiddler_id) {
+		params.$last_known_tiddler_id = options.last_known_tiddler_id;
+	}
+	const rows = this.engine.runStatementGetAll(`
+		SELECT title, tiddler_id, is_deleted, bag_name
+		FROM (
+			SELECT t.title, t.tiddler_id, t.is_deleted, b.bag_name, MAX(rb.position) AS position
+			FROM bags AS b
+			INNER JOIN recipe_bags AS rb ON b.bag_id = rb.bag_id
+			INNER JOIN tiddlers AS t ON b.bag_id = t.bag_id
+			WHERE rb.recipe_id = $recipe_id
+			${options.include_deleted ? "" : "AND t.is_deleted = FALSE"}
+			${options.last_known_tiddler_id ? "AND tiddler_id > $last_known_tiddler_id" : ""}
+			GROUP BY t.title
+			ORDER BY t.title, tiddler_id DESC
+			${options.limit ? "LIMIT $limit" : ""}
+		)
+	`,params);
 	return rows;
+};
+
+/*
+Get the tiddler_id of the newest tiddler in a recipe. Returns null for recipes that do not exist
+*/
+SqlTiddlerDatabase.prototype.getRecipeLastTiddlerId = function(recipe_name) {
+	const row = this.engine.runStatementGet(`
+		SELECT t.title, t.tiddler_id, b.bag_name, MAX(rb.position) AS position
+		FROM bags AS b
+		INNER JOIN recipe_bags AS rb ON b.bag_id = rb.bag_id
+		INNER JOIN recipes AS r ON rb.recipe_id = r.recipe_id
+		INNER JOIN tiddlers AS t ON b.bag_id = t.bag_id
+		WHERE r.recipe_name = $recipe_name
+		GROUP BY t.title
+		ORDER BY t.tiddler_id DESC
+		LIMIT 1
+	`,{
+		$recipe_name: recipe_name
+	});
+	if(row) {
+		return row.tiddler_id;
+	} else {
+		return null;
+	}
 };
 
 SqlTiddlerDatabase.prototype.deleteAllTiddlersInBag = function(bag_name) {
@@ -468,49 +537,6 @@ SqlTiddlerDatabase.prototype.getRecipeBags = function(recipe_name) {
 		$recipe_name: recipe_name
 	});
 	return rows.map(value => value.bag_name);
-};
-
-/*
-Get most recently Inserted/Replaced tiddlers from a bag - returns object with array of tiddlers
-Given bag, tiddler_id returned from a prior call, limit number of tiddlers to return
-*/
-SqlTiddlerDatabase.prototype.getBagRecentTiddlers = function(bag_name,last_known_tiddler_id,limit) {
-	last_known_tiddler_id = (last_known_tiddler_id && last_known_tiddler_id > 0) ? last_known_tiddler_id : 0;
-	limit = (limit && limit > 0) ? limit : 20;
-	var rows = this.engine.runStatementGetAll(`
-		SELECT title, is_deleted, tiddler_id
-		FROM tiddlers
-		WHERE bag_id IN (
-			SELECT bag_id
-			FROM bags
-			WHERE bag_name = $bag_name
-		)
-		AND tiddler_id >= $last_known_tiddler_id
-		ORDER BY tiddler_id DESC
-		LIMIT $limit
-	`,{
-		$bag_name: bag_name,
-		$last_known_tiddler_id: last_known_tiddler_id,
-		$limit: limit && limit > 0 ? limit : 20
-	});
-	// First tiddler_id is the max tiddler_id for this bag
-	var bag_max_tiddler_id = rows.length ? rows[0].tiddler_id : 0;
-	// Remove the last known tiddler_id
-	if ( rows.length && rows[rows.length-1].tiddler_id === last_known_tiddler_id ) {
-		rows.pop();
-	}
-	// Get the tiddlers fields
-	for (let idx=0; idx < rows.length; idx++) {
-		let bag_tiddler = this.getBagTiddler(rows[idx].title,bag_name);
-		rows[idx].fields = bag_tiddler ? bag_tiddler.tiddler : null;
-	}
-	return {
-		bag_name,
-		count: rows.length,
-		bag_max_tiddler_id,
-		last_known_tiddler_id,
-		tiddlers: rows
-	};
 };
 
 exports.SqlTiddlerDatabase = SqlTiddlerDatabase;

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/sql-tiddler-store.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/sql-tiddler-store.js
@@ -236,7 +236,7 @@ SqlTiddlerStore.prototype.getBagTiddler = function(title,bag_name) {
 			tiddlerInfo,
 			{
 				tiddler: this.processOutgoingTiddler(tiddlerInfo.tiddler,tiddlerInfo.tiddler_id,bag_name,tiddlerInfo.attachment_blob)
-			});	
+			});
 	} else {
 		return null;
 	}
@@ -325,6 +325,14 @@ Get the names of the bags in a recipe. Returns an empty array for recipes that d
 */
 SqlTiddlerStore.prototype.getRecipeBags = function(recipe_name) {
 	return this.sqlTiddlerDatabase.getRecipeBags(recipe_name);
+};
+
+/*
+Get most recently Inserted/Replaced tiddlers from a bag - returns object with array of tiddlers
+Given bag, tiddler_id returned from a prior call, limit number of tiddlers to return
+*/
+SqlTiddlerStore.prototype.getBagRecentTiddlers = function(bag_name,last_known_tiddler_id,limit) {
+	return this.sqlTiddlerDatabase.getBagRecentTiddlers(bag_name,last_known_tiddler_id,limit);
 };
 
 exports.SqlTiddlerStore = SqlTiddlerStore;

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-database.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-database.js
@@ -74,12 +74,12 @@ function runSqlDatabaseTests(engine) {
 		});
 		// Verify what we've got
 		expect(sqlTiddlerDatabase.getRecipeTiddlers("recipe-rho")).toEqual([ 
-			{ title: 'Another Tiddler', tiddler_id: 1, bag_name: 'bag-alpha' },
-			{ title: 'Hello There', tiddler_id: 3, bag_name: 'bag-beta' }
+			{ title: 'Another Tiddler', tiddler_id: 1, bag_name: 'bag-alpha', is_deleted: 0 },
+			{ title: 'Hello There', tiddler_id: 3, bag_name: 'bag-beta', is_deleted: 0 }
 		]);
 		expect(sqlTiddlerDatabase.getRecipeTiddlers("recipe-sigma")).toEqual([
-			{ title: 'Another Tiddler', tiddler_id: 1, bag_name: 'bag-alpha' },
-    		{ title: 'Hello There', tiddler_id: 4, bag_name: 'bag-gamma' }
+			{ title: 'Another Tiddler', tiddler_id: 1, bag_name: 'bag-alpha', is_deleted: 0 },
+    		{ title: 'Hello There', tiddler_id: 4, bag_name: 'bag-gamma', is_deleted: 0 }
 		]);
 		expect(sqlTiddlerDatabase.getRecipeTiddler("Hello There","recipe-rho").tiddler).toEqual({ title: "Hello There", text: "I'm in beta", tags: "four five six" });
 		expect(sqlTiddlerDatabase.getRecipeTiddler("Missing Tiddler","recipe-rho")).toEqual(null);
@@ -90,17 +90,17 @@ function runSqlDatabaseTests(engine) {
 		// Delete a tiddlers to ensure the underlying tiddler in the recipe shows through
 		sqlTiddlerDatabase.deleteTiddler("Hello There","bag-beta");
 		expect(sqlTiddlerDatabase.getRecipeTiddlers("recipe-rho")).toEqual([
-			{ title: 'Another Tiddler', tiddler_id: 1, bag_name: 'bag-alpha' },
-    		{ title: 'Hello There', tiddler_id: 2, bag_name: 'bag-alpha' }
+			{ title: 'Another Tiddler', tiddler_id: 1, bag_name: 'bag-alpha', is_deleted: 0 },
+    		{ title: 'Hello There', tiddler_id: 2, bag_name: 'bag-alpha', is_deleted: 0 }
 		]);
 		expect(sqlTiddlerDatabase.getRecipeTiddlers("recipe-sigma")).toEqual([ 
-			{ title: 'Another Tiddler', tiddler_id: 1, bag_name: 'bag-alpha' },
-			{ title: 'Hello There', tiddler_id: 4, bag_name: 'bag-gamma' }
+			{ title: 'Another Tiddler', tiddler_id: 1, bag_name: 'bag-alpha', is_deleted: 0 },
+			{ title: 'Hello There', tiddler_id: 4, bag_name: 'bag-gamma', is_deleted: 0 }
 		]);
 		expect(sqlTiddlerDatabase.getRecipeTiddler("Hello There","recipe-beta")).toEqual(null);
 		sqlTiddlerDatabase.deleteTiddler("Another Tiddler","bag-alpha");
-		expect(sqlTiddlerDatabase.getRecipeTiddlers("recipe-rho")).toEqual([ { title: 'Hello There', tiddler_id: 2, bag_name: 'bag-alpha' } ]);
-		expect(sqlTiddlerDatabase.getRecipeTiddlers("recipe-sigma")).toEqual([ { title: 'Hello There', tiddler_id: 4, bag_name: 'bag-gamma' } ]);
+		expect(sqlTiddlerDatabase.getRecipeTiddlers("recipe-rho")).toEqual([ { title: 'Hello There', tiddler_id: 2, bag_name: 'bag-alpha', is_deleted: 0 } ]);
+		expect(sqlTiddlerDatabase.getRecipeTiddlers("recipe-sigma")).toEqual([ { title: 'Hello There', tiddler_id: 4, bag_name: 'bag-gamma', is_deleted: 0 } ]);
 		// Save a recipe tiddler
 		expect(sqlTiddlerDatabase.saveRecipeTiddler({title: "More", text: "None"},"recipe-rho")).toEqual({tiddler_id: 7, bag_name: 'bag-beta'});
 		expect(sqlTiddlerDatabase.getRecipeTiddler("More","recipe-rho").tiddler).toEqual({title: "More", text: "None"});

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-store.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-store.js
@@ -85,22 +85,9 @@ function runSqlStoreTests(engine) {
 
 		expect(store.getBagTiddlers("bag-alpha")).toEqual([{title: "Another Tiddler", tiddler_id: 1}]);
 
-		expect(store.getBagRecentTiddlers("bag-alpha")).toEqual({
-			bag_name: "bag-alpha", count: 1, bag_max_tiddler_id: 1, last_known_tiddler_id: 0,
-			tiddlers: [{
-				title: 'Another Tiddler', is_deleted: 0, tiddler_id: 1,
-				fields: { title: 'Another Tiddler', tags: 'one two three', text: "I'm in alpha" }
-			}]
-		});
-
 		var getBagTiddlerResult = store.getBagTiddler("Another Tiddler","bag-alpha");
 		expect(typeof(getBagTiddlerResult.tiddler_id)).toBe("number");
 		delete getBagTiddlerResult.tiddler_id;
-
-		// these fields may eventually be removed, so don't depend on their presence
-		delete getBagTiddlerResult.tiddler.revision;
-		delete getBagTiddlerResult.tiddler.bag;
-
 		expect(getBagTiddlerResult).toEqual({ attachment_blob: null, tiddler: {title: "Another Tiddler", text: "I'm in alpha", tags: "one two three"} });
 	});
 
@@ -136,16 +123,11 @@ function runSqlStoreTests(engine) {
 		expect(typeof(saveRecipeResult.tiddler_id)).toBe("number");
 		expect(saveRecipeResult.bag_name).toBe("bag-beta");
 
-		expect(store.getRecipeTiddlers("recipe-rho")).toEqual([{title: "Another Tiddler", tiddler_id: 1, bag_name: "bag-beta"}]);
+		expect(store.getRecipeTiddlers("recipe-rho")).toEqual([{title: "Another Tiddler", tiddler_id: 1, bag_name: "bag-beta", is_deleted: 0 }]);
 
 		var getRecipeTiddlerResult = store.getRecipeTiddler("Another Tiddler","recipe-rho");
 		expect(typeof(getRecipeTiddlerResult.tiddler_id)).toBe("number");
 		delete getRecipeTiddlerResult.tiddler_id;
-
-		// these fields may eventually be removed, so don't depend on their presence
-		delete getRecipeTiddlerResult.tiddler.revision;
-		delete getRecipeTiddlerResult.tiddler.bag;
-
 		expect(getRecipeTiddlerResult).toEqual({ attachment_blob: null, bag_name: "bag-beta", tiddler: {title: "Another Tiddler", text: "I'm in rho"} });
 	});
 

--- a/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-store.js
+++ b/plugins/tiddlywiki/multiwikiserver/modules/store/tests-sql-tiddler-store.js
@@ -85,6 +85,14 @@ function runSqlStoreTests(engine) {
 
 		expect(store.getBagTiddlers("bag-alpha")).toEqual([{title: "Another Tiddler", tiddler_id: 1}]);
 
+		expect(store.getBagRecentTiddlers("bag-alpha")).toEqual({
+			bag_name: "bag-alpha", count: 1, bag_max_tiddler_id: 1, last_known_tiddler_id: 0,
+			tiddlers: [{
+				title: 'Another Tiddler', is_deleted: 0, tiddler_id: 1,
+				fields: { title: 'Another Tiddler', tags: 'one two three', text: "I'm in alpha" }
+			}]
+		});
+
 		var getBagTiddlerResult = store.getBagTiddler("Another Tiddler","bag-alpha");
 		expect(typeof(getBagTiddlerResult.tiddler_id)).toBe("number");
 		delete getBagTiddlerResult.tiddler_id;


### PR DESCRIPTION
#  getBagRecentTiddlers

## Objective

The purpose of `$tw.mws.store.getBagRecentTiddlers(bag_name, last_known_ _tiddler_id, limit)` is to be able to poll (server-side) the MWS tiddler database for latest new, updated, deleted tiddlers by bag.

## Why?
The getBagRecentTiddlers function will allow a companion server-side application to process incoming tiddlers and possibly store results back on the database for distribution to MWS web users.

> The *currently in progress*  MWS synchronization mechanism [mwsadaptor](https://github.com/Jermolene/TiddlyWiki5/pull/7915#issuecomment-2009187719) will perform the distribution to web clients.

# Implementation
The connection between MWS and the companion application would be established by creating an *edition* with a plugin profile including both MWS and the application.

```
"plugins": [
    "tiddlywiki/tiddlyweb",
    "tiddlywiki/filesystem",
    "tiddlywiki/multiwikiserver",
    "independent/application"
],
``` 

## Fundamental Tasks
- [x] Create prototype of function
- [x] Build server-side REPL for interactive testing [mws-repl](https://github.com/PotOfCoffee2Go/mws-repl)
- [ ] Discuss bug and feature requests
- [ ] Create and implement tests into MWS test suite
- [ ] Documentation
- [ ] Peer review
- [ ] Finalize code for release
