### PR TITLE
Stylesheets: Use a single `<style>` tag for each

### DIFF
--- a/core/ui/PageStylesheet.tid
+++ b/core/ui/PageStylesheet.tid
@@ -8,9 +8,7 @@ code-body: yes
 
 <$set name="languageTitle" value={{!!name}}>
 
-<$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!has[draft.of]]">
-<$transclude mode="block"/>
-</$list>
+<<stylesheet>>
 
 </$set>
 


### PR DESCRIPTION
This PR is related to the discussion #8105

It makes each stylesheet tiddler become a single `<style>` tag
If a stylesheet tiddler changes or a stylesheet gets added/removed all style tags get removed and readded. This shouldn't be problematic as that won't happen often.