### PR TITLE
Add basic authentication support for tm-http-request

### DIFF
--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -47,7 +47,11 @@ exports.startup = function() {
 			headers: getPropertiesWithPrefix(params,"header-"),
 			passwordHeaders: getPropertiesWithPrefix(params,"password-header-"),
 			queryStrings: getPropertiesWithPrefix(params,"query-"),
-			passwordQueryStrings: getPropertiesWithPrefix(params,"password-query-")
+			passwordQueryStrings: getPropertiesWithPrefix(params,"password-query-"),
+			basicAuthUsername: params["basic-auth-username"],
+			basicAuthUsernameFromStore: params["basic-auth-username-from-store"],
+			basicAuthPassword: params["basic-auth-password"],
+			basicAuthPasswordFromStore: params["basic-auth-password-from-store"]
 		});
 	});
 	$tw.rootWidget.addEventListener("tm-http-cancel-all-requests",function(event) {

--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -100,6 +100,10 @@ headers: hashmap of header name to header value to be sent with the request
 passwordHeaders: hashmap of header name to password store name to be sent with the request
 queryStrings: hashmap of query string parameter name to parameter value to be sent with the request
 passwordQueryStrings: hashmap of query string parameter name to password store name to be sent with the request
+basicAuthUsername: plain username for basic authentication
+basicAuthUsernameFromStore: name of password store entry containing username
+basicAuthPassword: plain password for basic authentication
+basicAuthPasswordFromStore: name of password store entry containing password
 */
 function HttpClientRequest(options) {
 	var self = this;
@@ -128,6 +132,11 @@ function HttpClientRequest(options) {
 	$tw.utils.each(options.passwordHeaders,function(value,name) {
 		self.requestHeaders[name] = $tw.utils.getPassword(value) || "";
 	});
+	this.basicAuthUsername = options.basicAuthUsername || (options.basicAuthUsernameFromStore && $tw.utils.getPassword(options.basicAuthUsernameFromStore)) || "";
+	this.basicAuthPassword = options.basicAuthPassword || (options.basicAuthPasswordFromStore && $tw.utils.getPassword(options.basicAuthPasswordFromStore)) || "";
+	if(this.basicAuthUsername && this.basicAuthPassword) {
+		this.requestHeaders.Authorization = "Basic " + $tw.utils.base64Encode(this.basicAuthUsername + ":" + this.basicAuthPassword);
+	}
 }
 
 HttpClientRequest.prototype.send = function(callback) {

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
@@ -23,6 +23,10 @@ The following parameters are used:
 |header-* |Headers with string values |
 |password-header-* |Headers with values taken from the password store |
 |password-query-* |Query string parameters with values taken from the password store |
+|basic-auth-username |<<.from-version "5.3.4">> Optional username for HTTP basic authentication |
+|basic-auth-username-from-store |<<.from-version "5.3.4">> Optional username for HTTP basic authentication, specified as the name of the entry in the password store containing the username |
+|basic-auth-password |<<.from-version "5.3.4">> Optional password for HTTP basic authentication |
+|basic-auth-password-from-store |<<.from-version "5.3.4">> Optional password for HTTP basic authentication, specified as the name of the entry in the password store containing the password |
 |var-* |Variables to be passed to the completion and progress handlers (without the "var-" prefix) |
 |bind-status |Title of tiddler to which the status of the request ("pending", "complete", "error") should be bound |
 |bind-progress |Title of tiddler to which the progress of the request (0 to 100) should be bound |


### PR DESCRIPTION
This PR adds support for basic authentication to the tm-http-request.

It was already possible to create an "Authorisation" header of the correct format with code like this:

```
header-Authorization={{{ [<username>addsuffix[:]addsuffix<password>encodebase64[]addprefix[Basic ]] }}}
```

However, that will only work if the password is available to wikitext. It is preferred to store passwords via the `<$password>` widget so that they are not accessible to casual wikitext.

This PR adds four new parameters to the `tm-http-request`message that allow the username and password to be passed as plain text, or taken from named entries in the password store:

* **basic-auth-username** - Optional username for HTTP basic authentication
* **basic-auth-username-from-store** - Optional username for HTTP basic authentication, specified as the name of the entry in the password store containing the username
* **basic-auth-password** - Optional password for HTTP basic authentication
* **basic-auth-password-from-store** - Optional password for HTTP basic authentication, specified as the name of the entry in the password store containing the password

