### PR TITLE
Add a "Refresh Browser" keyboard shortcut

### DIFF
--- a/core/ui/KeyboardShortcuts/refresh.tid
+++ b/core/ui/KeyboardShortcuts/refresh.tid
@@ -1,0 +1,4 @@
+title: $:/core/ui/KeyboardShortcuts/refresh
+tags: $:/tags/KeyboardShortcut
+key: ((refresh))
+

--- a/core/ui/KeyboardShortcuts/refresh.tid
+++ b/core/ui/KeyboardShortcuts/refresh.tid
@@ -2,3 +2,4 @@ title: $:/core/ui/KeyboardShortcuts/refresh
 tags: $:/tags/KeyboardShortcut
 key: ((refresh))
 
+<$action-sendmessage $message="tm-browser-refresh"/>

--- a/core/wiki/config/ShortcutInfo.multids
+++ b/core/wiki/config/ShortcutInfo.multids
@@ -35,6 +35,7 @@ new-tiddler: {{$:/language/Buttons/NewTiddler/Hint}}
 picture: {{$:/language/Buttons/Picture/Hint}}
 preview: {{$:/language/Buttons/Preview/Hint}}
 quote: {{$:/language/Buttons/Quote/Hint}}
+refresh: {{$:/language/Buttons/Refresh/Hint}}
 save-tiddler: {{$:/language/Buttons/Save/Hint}}
 save-wiki: {{$:/language/Buttons/SaveWiki/Hint}}
 sidebar-search: {{$:/language/Buttons/SidebarSearch/Hint}}

--- a/core/wiki/config/shortcuts/shortcuts-mac.multids
+++ b/core/wiki/config/shortcuts/shortcuts-mac.multids
@@ -6,4 +6,5 @@ underline: meta-U
 new-image: ctrl-I
 new-journal: ctrl-J
 new-tiddler: ctrl-N
+refresh: meta-R
 save-wiki: meta-S

--- a/core/wiki/config/shortcuts/shortcuts-not-mac.multids
+++ b/core/wiki/config/shortcuts/shortcuts-not-mac.multids
@@ -6,3 +6,4 @@ underline: ctrl-U
 new-image: alt-I
 new-journal: alt-J
 new-tiddler: alt-N
+refresh: ctrl-R


### PR DESCRIPTION
In TiddlyDesktop the <kbd>ctrl-R</kbd> shortcut doesn't work and this adds a keyboard shortcut for that purpose.
It's very cumbersome having to open the "Tools" tab every time and going down to the dedicated button.

