### PR TITLE
View widget updates - update if wikified content changes

### DIFF
--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -18,10 +18,68 @@ var ViewWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
+var ViewHandler = function(parseTreeNode,options) {
+	this.initialise(parseTreeNode,options);
+};
+
 /*
 Inherit from the base widget class
 */
 ViewWidget.prototype = new Widget();
+
+/*
+Inherit from the base ViewWidget
+*/
+ViewHandler.prototype = new Widget();
+
+/*
+Render this widget into the DOM
+*/
+ViewHandler.prototype.render = function(parent,nextSibling,options) {
+	this.parentDomNode = parent;
+	this.fakeWidget = this.wiki.makeTranscludeWidget(options.title,{
+		document: $tw.fakeDocument,
+		field: options.field,
+		index: options.index,
+		parseAsInline: options.mode !== "block",
+		parentWidget: this,
+		subTiddler: options.subTiddler
+	});
+	this.text = options.text || "";
+	this.viewFormat = options.format;
+	this.fakeNode = $tw.fakeDocument.createElement("div");
+	this.fakeWidget.makeChildWidgets();
+	this.fakeWidget.renderChildren(this.fakeNode,null);
+	var textNode = this.document.createTextNode(this.text);
+	parent.insertBefore(textNode,nextSibling);
+	this.domNodes.push(textNode);
+};
+
+/*
+Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
+*/
+ViewHandler.prototype.refresh = function(changedTiddlers) {
+	var refreshed = this.fakeWidget.refresh(changedTiddlers);
+	if(refreshed) {
+		var newText;
+		switch(this.viewFormat) {
+			case "htmlwikified":
+				newText = this.fakeNode.innerHTML;
+				break;
+			case "plainwikified":
+				newText = this.fakeNode.textContent;
+				break;
+			case "htmlencodedplainwikified":
+				newText = $tw.utils.htmlEncode(this.fakeNode.textContent);
+				break;
+		}
+		if(newText !== this.text) {
+			this.domNodes[0].textContent = newText;
+			this.text = newText;
+		}
+	}
+	return refreshed;
+};
 
 /*
 Render this widget into the DOM
@@ -30,23 +88,26 @@ ViewWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
-	var textNode;
-	if(this.viewUpdate && this.viewWikified) {
-		this.fakeWidget = this.wiki.makeTranscludeWidget(this.viewTitle,{
-			document: $tw.fakeDocument,
+	if(this.viewWikified) {
+		var options = {
+			text: this.text,
+			title: this.viewTitle,
+			subTiddler: this.viewSubtiddler,
 			field: this.viewField,
-			parseAsInline: this.viewMode !== "block",
+			index: this.viewIndex,
+			format: this.viewFormat,
+			template: this.viewTemplate,
+			mode: this.viewMode
+		}
+		this.viewHandler = new ViewHandler(this.parseTreeNode,{
+			wiki: this.wiki,
 			parentWidget: this,
-			subTiddler: this.viewSubtiddler
+			document: this.document
 		});
-		this.fakeNode = $tw.fakeDocument.createElement("div");
-		this.fakeWidget.makeChildWidgets();
-		this.fakeWidget.renderChildren(this.fakeNode,null);
-		textNode = this.document.createTextNode(this.text || "");
-		parent.insertBefore(textNode,nextSibling);
-		this.domNodes.push(textNode);
+		this.viewHandler.render(parent,nextSibling,options);
+		//this.viewHandler.render(parent,nextSibling,options);
 	} else if(this.text) {
-		textNode = this.document.createTextNode(this.text);
+		var textNode = this.document.createTextNode(this.text);
 		parent.insertBefore(textNode,nextSibling);
 		this.domNodes.push(textNode);
 	} else {
@@ -67,8 +128,6 @@ ViewWidget.prototype.execute = function() {
 	this.viewFormat = this.getAttribute("format","text");
 	this.viewTemplate = this.getAttribute("template","");
 	this.viewMode = this.getAttribute("mode","block");
-	this.viewStripComments = this.getAttribute("stripcomments","no") === "yes";
-	this.viewUpdate = this.getAttribute("update","no") === "yes";
 	this.viewWikified = false;
 	switch(this.viewFormat) {
 		case "htmlwikified":
@@ -156,9 +215,7 @@ ViewWidget.prototype.getValue = function(options) {
 };
 
 ViewWidget.prototype.getValueAsText = function() {
-	var value = this.getValue({asString: true}),
-		textValue = this.viewStripComments ? this.stripComments(value) : value;
-	return textValue;
+	return this.getValue({asString: true});
 };
 
 ViewWidget.prototype.getValueAsHtmlWikified = function(mode) {
@@ -233,41 +290,18 @@ ViewWidget.prototype.getValueAsJsEncoded = function() {
 	return $tw.utils.stringify(this.getValueAsText());
 };
 
-ViewWidget.prototype.stripComments = function(text) {
-	// https://stackoverflow.com/questions/37051797/remove-comments-from-string-with-javascript-using-javascript
-	return text.replace(/\/\*[\s\S]*?\*\/|(?<=[^:])\/\/.*|^\/\/.*/g,'').trim();
-};
-
 /*
 Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
 */
 ViewWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.template || changedAttributes.format || changedAttributes.update || changedAttributes.stripcomments || changedTiddlers[this.viewTitle]) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.template || changedAttributes.format || changedTiddlers[this.viewTitle]) {
 		this.refreshSelf();
 		return true;
-	} else if(this.viewUpdate && this.viewWikified) {
-		var refreshed = this.fakeWidget.refresh(changedTiddlers);
-		if(refreshed) {
-			var newText;
-			switch(this.viewFormat) {
-				case "htmlwikified":
-					newText = this.fakeNode.innerHTML;
-					break;
-				case "plainwikified":
-					newText = this.fakeNode.textContent;
-					break;
-				case "htmlencodedplainwikified":
-					newText = $tw.utils.htmlEncode(this.fakeNode.textContent);
-					break;
-			}
-			if(newText !== this.text) {
-				this.domNodes[0].textContent = newText;
-				this.text = newText;
-			}
-		}
-		return refreshed;
 	} else {
+		if(this.viewHandler) {
+			return this.viewHandler.refresh(changedTiddlers);
+		}
 		return false;
 	}
 };

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -243,7 +243,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 ViewWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.template || changedAttributes.format || changedAttributes.update || changedTiddlers[this.viewTitle]) {
+	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.template || changedAttributes.format || changedAttributes.update || changedAttributes.stripcomments || changedTiddlers[this.viewTitle]) {
 		this.refreshSelf();
 		return true;
 	} else if(this.viewUpdate && this.viewWikified) {

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -194,7 +194,7 @@ ViewWidget.prototype.getValueAsRelativeDate = function(format) {
 	}
 };
 
-ViewWidget.prototype.getValueAsStrippedComments = function() {
+ViewWidget.prototype.getValueAsStrippedComments = function(srcText) {
 	var lines = this.getValueAsText().split("\n"),
 		out = [];
 	for(var line=0; line<lines.length; line++) {
@@ -208,6 +208,10 @@ ViewWidget.prototype.getValueAsStrippedComments = function() {
 
 ViewWidget.prototype.getValueAsJsEncoded = function() {
 	return $tw.utils.stringify(this.getValueAsText());
+};
+
+ViewWidget.prototype.stripComments = function(text) {
+	return text.replace(/\/\*[\s\S]*?\*\/|(?<=[^:])\/\/.*|^\/\/.*/g,'').trim();
 };
 
 /*

--- a/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
@@ -21,6 +21,8 @@ The content of the `<$view>` widget is displayed if the field or property is mis
 |template |Optional template string used when the `format` attribute is set to "date" |
 |subtiddler |Optional SubTiddler title when the target tiddler is a [[plugin|Plugins]] (see below) |
 |mode |<<.from-version "5.1.15">> Optional transclusion parsing mode for wikified formats. May be "inline" or "block" (the default) |
+|update |<<.from-version "5.3.4">> Optional. If set to "yes", the ''wikified'' text updates if its value changes |
+|stripcomments |<<.from-version "5.3.4">> Optional. If set to "yes", comments like `// ...`, `/* ... */` are stripped |
 
 !! Formats
 

--- a/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/ViewWidget.tid
@@ -21,8 +21,6 @@ The content of the `<$view>` widget is displayed if the field or property is mis
 |template |Optional template string used when the `format` attribute is set to "date" |
 |subtiddler |Optional SubTiddler title when the target tiddler is a [[plugin|Plugins]] (see below) |
 |mode |<<.from-version "5.1.15">> Optional transclusion parsing mode for wikified formats. May be "inline" or "block" (the default) |
-|update |<<.from-version "5.3.4">> Optional. If set to "yes", the ''wikified'' text updates if its value changes |
-|stripcomments |<<.from-version "5.3.4">> Optional. If set to "yes", comments like `// ...`, `/* ... */` are stripped |
 
 !! Formats
 


### PR DESCRIPTION
This PR adds two new attributes to the `view` widget:

- update
- stripcomments

The `update` attribute only works for the formats `htmlwikified`, `plainwikified` and `htmlencodedplainwikified`.
It creates a fake widget that gets refreshed in the `refresh` method and if it refreshed, the text Content of the text node gets updated and the refresh method returns true.

The `stripcomments` attribute works for those formats that use `getValueAsText()` which are all but `date` and `relativedate`.
It strips comments like `// This is a comment` , `/* This is a comment */` and also multiline comments.

This PR arises from #8118 where I've added the `update` attribute.
The `stripcomments` attribute is useful to get the wikified text of stylesheet tiddlers without comments into the style tags for example.