### PR TITLE
Fix bug 7878: Save command

### DIFF
--- a/core/modules/commands/save.js
+++ b/core/modules/commands/save.js
@@ -43,7 +43,9 @@ Saves individual tiddlers in their raw text or binary format to the specified fi
 						directory: path.resolve(self.commander.outputPath),
 						pathFilters: [filenameFilter],
 						wiki: wiki,
-						fileInfo: {}
+						fileInfo: {
+							overwrite: true
+						}
 					});
 					if(self.commander.verbose) {
 						console.log("Saving \"" + title + "\" to \"" + fileInfo.filepath + "\"");

--- a/core/modules/commands/save.js
+++ b/core/modules/commands/save.js
@@ -38,7 +38,7 @@ Saves individual tiddlers in their raw text or binary format to the specified fi
 		$tw.utils.each(tiddlers,function(title) {
 			if(!result) {
 				var tiddler = self.commander.wiki.getTiddler(title);
-				if(tiddler) {
+				if(tiddler) { debugger;
 					var fileInfo = $tw.utils.generateTiddlerFileInfo(tiddler,{
 						directory: path.resolve(self.commander.outputPath),
 						pathFilters: [filenameFilter],

--- a/core/modules/commands/save.js
+++ b/core/modules/commands/save.js
@@ -38,7 +38,7 @@ Saves individual tiddlers in their raw text or binary format to the specified fi
 		$tw.utils.each(tiddlers,function(title) {
 			if(!result) {
 				var tiddler = self.commander.wiki.getTiddler(title);
-				if(tiddler) { debugger;
+				if(tiddler) {
 					var fileInfo = $tw.utils.generateTiddlerFileInfo(tiddler,{
 						directory: path.resolve(self.commander.outputPath),
 						pathFilters: [filenameFilter],

--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -321,6 +321,7 @@ exports.generateTiddlerFilepath = function(title,options) {
 	var directory = options.directory || "",
 		extension = options.extension || "",
 		originalpath = (options.fileInfo && options.fileInfo.originalpath) ? options.fileInfo.originalpath : "",
+		overwrite = options.overwrite || false,
 		filepath;
 	// Check if any of the pathFilters applies
 	if(options.pathFilters && options.wiki) {
@@ -382,18 +383,19 @@ exports.generateTiddlerFilepath = function(title,options) {
 		});
 	}
 	// Add a uniquifier if the file already exists
-	var fullPath, oldPath = (options.fileInfo) ? options.fileInfo.filepath : undefined,
+	var fullPath = path.resolve(directory, filepath + extension);
+	if (!overwrite) {
+		var oldPath = (options.fileInfo) ? options.fileInfo.filepath : undefined,
 		count = 0;
-	do {
-		fullPath = path.resolve(directory,filepath + (count ? "_" + count : "") + extension);
-		if(oldPath && oldPath == fullPath) {
-			break;
-		}
-		count++;
-	} while(fs.existsSync(fullPath));
+		do {
+			fullPath = path.resolve(directory,filepath + (count ? "_" + count : "") + extension);
+			if(oldPath && oldPath == fullPath) break;
+			count++;
+		} while(fs.existsSync(fullPath));
+	}
 	// If the last write failed with an error, or if path does not start with:
 	//	the resolved options.directory, the resolved wikiPath directory, the wikiTiddlersPath directory, 
-	//	or the 'originalpath' directory, then $tw.utils.encodeURIComponentExtended() and resolve to tiddler directory.
+	//	or the 'originalpath' directory, then $tw.utils.encodeURIComponentExtended() and resolve to options.directory.
 	var writePath = $tw.hooks.invokeHook("th-make-tiddler-path",fullPath,fullPath),
 		encode = (options.fileInfo || {writeError: false}).writeError == true;
 	if(!encode) {

--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -382,7 +382,7 @@ exports.generateTiddlerFilepath = function(title,options) {
 			filepath += char.charCodeAt(0).toString();
 		});
 	}
-	// Add a uniquifier if the file already exists
+	// Add a uniquifier if the file already exists (default)
 	var fullPath = path.resolve(directory, filepath + extension);
 	if (!overwrite) {
 		var oldPath = (options.fileInfo) ? options.fileInfo.filepath : undefined,

--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -316,12 +316,13 @@ Options include:
 	pathFilters: optional array of filters to be used to generate the base path
 	wiki: optional wiki for evaluating the pathFilters
 	fileInfo: an existing fileInfo object to check against
+	fileInfo.overwrite: if true, turns off filename clash numbers (defaults to false)
 */
 exports.generateTiddlerFilepath = function(title,options) {
 	var directory = options.directory || "",
 		extension = options.extension || "",
 		originalpath = (options.fileInfo && options.fileInfo.originalpath) ? options.fileInfo.originalpath : "",
-		overwrite = options.overwrite || false,
+		overwrite = options.fileInfo && options.fileInfo.overwrite || false,
 		filepath;
 	// Check if any of the pathFilters applies
 	if(options.pathFilters && options.wiki) {


### PR DESCRIPTION
This restores the previous behavior of the `save` command, as noted in bug https://github.com/Jermolene/TiddlyWiki5/issues/7878.

Should this be configurable with command arguments?