### PR TITLE
Fix bug 8138: cache-control

### DIFF
--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -144,7 +144,7 @@ function sendResponse(request,response,statusCode,headers,data,encoding) {
 		// RFC 7231, 6.1. Overview of Status Codes:
 		// Browser clients may cache 200, 203, 204, 206, 300, 301, 
 		// 404, 405, 410, 414, and 501 unless given explicit cache controls
-		headers["Cache-Control"] = "no-store";
+		headers["Cache-Control"] = headers["Cache-Control"] || "no-store";
 	}
 	/*
 	If the gzip=yes is set, check if the user agent permits compression. If so,

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -144,7 +144,7 @@ function sendResponse(request,response,statusCode,headers,data,encoding) {
 	else
 	{
 		// RFC 7231, 6.1. Overview of Status Codes:
-		// Broswer clients may cache 200, 203, 204, 206, 300, 301, 
+		// Browser clients may cache 200, 203, 204, 206, 300, 301, 
 		// 404, 405, 410, 414, and 501 unless given explicit cache controls
 		headers["Cache-Control"] = "no-store";
 	}

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -140,9 +140,7 @@ function sendResponse(request,response,statusCode,headers,data,encoding) {
 				return;
 			}
 		}
-	}
-	else
-	{
+	} else {
 		// RFC 7231, 6.1. Overview of Status Codes:
 		// Browser clients may cache 200, 203, 204, 206, 300, 301, 
 		// 404, 405, 410, 414, and 501 unless given explicit cache controls

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -143,7 +143,8 @@ function sendResponse(request,response,statusCode,headers,data,encoding) {
 	}
 	else
 	{
-		// broswers will try to cache 200, 203, 204, 206, 300, 301, 
+		// RFC 7231, 6.1. Overview of Status Codes:
+		// Broswer clients may cache 200, 203, 204, 206, 300, 301, 
 		// 404, 405, 410, 414, and 501 unless given explicit cache controls
 		headers["Cache-Control"] = "no-store";
 	}

--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -141,6 +141,12 @@ function sendResponse(request,response,statusCode,headers,data,encoding) {
 			}
 		}
 	}
+	else
+	{
+		// broswers will try to cache 200, 203, 204, 206, 300, 301, 
+		// 404, 405, 410, 414, and 501 unless given explicit cache controls
+		headers["Cache-Control"] = "no-store";
+	}
 	/*
 	If the gzip=yes is set, check if the user agent permits compression. If so,
 	compress our response if the raw data is bigger than 2k. Compressing less


### PR DESCRIPTION
PR addresses:
https://github.com/Jermolene/TiddlyWiki5/issues/8138
https://github.com/Jermolene/TiddlyWiki5/issues/1839

Current behavior: IF the `--use-browser-cache` flag was passed during startup, AND the current response code is 200, a custom ETAG is generated by hashing the contents of the response. Checks this ETag against any passed with the response, and determines the response code/body to send based on that.

Added a DEFAULT to return `Cache-Control: no-store`. This covers all other cases that a browser client may try to cache:
```
	else
	{
		// RFC 7231, 6.1. Overview of Status Codes:
		// Browser clients may cache 200, 203, 204, 206, 300, 301, 
		// 404, 405, 410, 414, and 501 unless given explicit cache controls
		headers["Cache-Control"] = "no-store";
	}
```

Open question. Should we allow the browser to cache the `/files/*` route responses?