### PR TITLE
Fix crash with empty transclusions

### DIFF
--- a/core/modules/parsers/wikiparser/rules/transcludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeblock.js
@@ -26,6 +26,27 @@ exports.init = function(parser) {
 	this.matchRegExp = /\{\{([^\{\}\|]*)(?:\|\|([^\|\{\}]+))?(?:\|([^\{\}]+))?\}\}(?:\r?\n|$)/mg;
 };
 
+/*
+Reject the match if we don't have a template or text reference
+*/
+exports.findNextMatch = function(startPos) {
+	this.matchRegExp.lastIndex = startPos;
+	this.match = this.matchRegExp.exec(this.parser.source);
+	if(this.match) {
+		var template = $tw.utils.trim(this.match[2]),
+			textRef = $tw.utils.trim(this.match[1]);
+		// Bail if we don't have a template or text reference
+		if(!template && !textRef) {
+			return undefined;
+		} else {
+			return this.match.index;
+		}
+	} else {
+		return undefined;
+	}
+	return this.match ? this.match.index : undefined;
+};
+
 exports.parse = function() {
 	// Move past the match
 	this.parser.pos = this.matchRegExp.lastIndex;

--- a/core/modules/parsers/wikiparser/rules/transcludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeinline.js
@@ -26,6 +26,27 @@ exports.init = function(parser) {
 	this.matchRegExp = /\{\{([^\{\}\|]*)(?:\|\|([^\|\{\}]+))?(?:\|([^\{\}]+))?\}\}/mg;
 };
 
+/*
+Reject the match if we don't have a template or text reference
+*/
+exports.findNextMatch = function(startPos) {
+	this.matchRegExp.lastIndex = startPos;
+	this.match = this.matchRegExp.exec(this.parser.source);
+	if(this.match) {
+		var template = $tw.utils.trim(this.match[2]),
+			textRef = $tw.utils.trim(this.match[1]);
+		// Bail if we don't have a template or text reference
+		if(!template && !textRef) {
+			return undefined;
+		} else {
+			return this.match.index;
+		}
+	} else {
+		return undefined;
+	}
+	return this.match ? this.match.index : undefined;
+};
+
 exports.parse = function() {
 	// Move past the match
 	this.parser.pos = this.matchRegExp.lastIndex;

--- a/editions/prerelease/tiddlers/system/TiddlyWiki Pre-release.tid
+++ b/editions/prerelease/tiddlers/system/TiddlyWiki Pre-release.tid
@@ -1,6 +1,12 @@
 title: TiddlyWiki Pre-release
 modified: 20230731122156493
 
+<$let currentTiddler="HelloThere">
+
+<$button>{{}}</$button>
+
+</$let>
+
 This is a pre-release build of TiddlyWiki provided for testing and review purposes. ''Please don't try to depend on the pre-release for anything important'' -- you should use the latest official release from https://tiddlywiki.com.
 
 All of the changes in this pre-release are provisional until it is released and they become frozen by our backwards compatibility policies. This is the perfect time to raise questions or make suggestions. Please [[open a ticket at GitHub|https://github.com/Jermolene/TiddlyWiki5/issues/new/choose]] or make a post at https://talk.tiddlywiki.org/.
@@ -13,4 +19,5 @@ The pre-release is also available as an [[empty wiki|https://tiddlywiki.com/prer
 </div>
 <div class="tc-subtitle">Updated: <$view field="modified" format="date" template={{$:/language/Tiddler/DateFormat}}/></div>
 <$transclude mode="block"/>
+
 </$list>


### PR DESCRIPTION
This PR addresses infinite loops that can occur when `{{}}` is typed in the editor with the preview displayed. See #8144 for an example, but this is a long standing problem. See #7768 for an earlier attempt to fix this problem

The approach taken here is to modify the parse rules for both inline and block transclusions so that the transclusion is not recognised unless there is a non-blank target and/or template.
