### PR TITLE
implement dynamic config and check for max-widget-tree-depth recursion detection

### DIFF
--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -12,12 +12,24 @@ Button widget
 /*global $tw: false */
 "use strict";
 
+/* String: Maximum -relative- permitted depth of the widget tree for recursion detection */
+var MAX_WIDGET_TREE_DEPTH_RELATIVE = "50";
+
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
 var Popup = require("$:/core/modules/utils/dom/popup.js");
 
 var ButtonWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
+
+	// Check if any parent is a button. Custom recursion detection for widgets in buttons
+	if(!this.hasVariable("tv-button","true")) {
+		this.setVariable("tv-button", "true");
+		// set "local" max depth to a relative value, so nesting in higher levels is possible
+		this.setVariable("tv-UNSAFE-max-widget-tree-depth", this.getAncestorCount() + MAX_WIDGET_TREE_DEPTH_RELATIVE);
+		// allow users to debug the info
+		this.setVariable("tv-ancestors", this.getAncestorCount() + "");
+	}
 };
 
 /*
@@ -74,7 +86,7 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 	if(this["aria-label"]) {
 		domNode.setAttribute("aria-label",this["aria-label"]);
 	}
-	if (this.role) {
+	if(this.role) {
 		domNode.setAttribute("role", this.role);
 	}
 	if(this.popup || this.popupTitle) {

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -12,8 +12,8 @@ Widget base class
 /*global $tw: false */
 "use strict";
 
-/* Maximum permitted depth of the widget tree for recursion detection */
-var MAX_WIDGET_TREE_DEPTH = 1000;
+/* String: Maximum permitted depth of the widget tree for recursion detection */
+var MAX_WIDGET_TREE_DEPTH = "1000";
 
 /*
 Create a widget object for a parse tree node
@@ -481,6 +481,7 @@ Widget.prototype.getAncestorCount = function() {
 			this.ancestorCount = this.parentWidget.getAncestorCount() + 1;
 		} else {
 			this.ancestorCount = 0;
+			this.setVariable("tv-UNSAFE-max-widget-tree-depth", MAX_WIDGET_TREE_DEPTH);
 		}
 	}
 	return this.ancestorCount;
@@ -492,11 +493,12 @@ Make child widgets correspondng to specified parseTreeNodes
 Widget.prototype.makeChildWidgets = function(parseTreeNodes,options) {
 	options = options || {};
 	this.children = [];
-	var self = this;
+	var self = this,
+		maxWidgetTreeDepth = $tw.utils.getInt(this.variables["tv-UNSAFE-max-widget-tree-depth"].value, MAX_WIDGET_TREE_DEPTH);
 	// Check for too much recursion
-	if(this.getAncestorCount() > MAX_WIDGET_TREE_DEPTH) {
+	if(this.getAncestorCount() > maxWidgetTreeDepth) {
 		this.children.push(this.makeChildWidget({type: "error", attributes: {
-			"$message": {type: "string", value: $tw.language.getString("Error/RecursiveTransclusion")}
+			"$message": {type: "string", value: this.getAncestorCount() + " - " + $tw.language.getString("Error/RecursiveTransclusion")}
 		}}));
 	} else {
 		// Create set variable widgets for each variable
@@ -682,7 +684,7 @@ Refresh all the children of a widget
 Widget.prototype.refreshChildren = function(changedTiddlers) {
 	var children = this.children,
 		refreshed = false;
-	for (var i = 0; i < children.length; i++) {
+	for(var i = 0; i < children.length; i++) {
 		refreshed = children[i].refresh(changedTiddlers) || refreshed;
 	}
 	return refreshed;

--- a/editions/tw5.com/tiddlers/Draft of 'test-collatz'.tid
+++ b/editions/tw5.com/tiddlers/Draft of 'test-collatz'.tid
@@ -1,0 +1,25 @@
+created: 20240415102801809
+draft.of: test-collatz
+draft.title: test-collatz
+modified: 20240416094922377
+tags: 
+title: Draft of 'test-collatz'
+type: text/vnd.tiddlywiki
+
+\procedure collatz(n) 
+<% if [<n>match[1]] %>
+  1
+<% elseif [<n>remainder[2]match[1]] %>
+  <<n>> <$button>→</$button> <$transclude $variable="collatz" n = {{{ [<n>multiply[3]add[1]] }}}/>
+<% else %>
+  <<n>> <$button>→</$button> <$transclude $variable="collatz" n = {{{ [<n>divide[2]] }}}/>
+<% endif %>
+\end
+
+\procedure test(x:10)
+<$let tv-UNSAFE-max-widget-tree-depth="2000">
+<$transclude $variable=collatz n=<<x>>/>
+</$let>
+\end
+
+<<test 77031>>

--- a/editions/tw5.com/tiddlers/Draft of 'test-recursive button'.tid
+++ b/editions/tw5.com/tiddlers/Draft of 'test-recursive button'.tid
@@ -1,0 +1,11 @@
+created: 20240415124530887
+draft.of: test-recursive button
+draft.title: test-recursive button
+modified: 20240416094919710
+tags: 
+title: Draft of 'test-recursive button'
+type: text/vnd.tiddlywiki
+
+<$button>
+<$transclude/>
+</$button>

--- a/editions/tw5.com/tiddlers/system/DefaultTiddlers.tid
+++ b/editions/tw5.com/tiddlers/system/DefaultTiddlers.tid
@@ -1,8 +1,6 @@
 created: 20131127215321439
-modified: 20140912135951542
+modified: 20240416092903807
 title: $:/DefaultTiddlers
 type: text/vnd.tiddlywiki
 
-HelloThere
-GettingStarted
-Community
+[list[$:/StoryList]]

--- a/editions/tw5.com/tiddlers/test-collatz.tid
+++ b/editions/tw5.com/tiddlers/test-collatz.tid
@@ -1,0 +1,23 @@
+created: 20240415102801809
+modified: 20240416092855340
+tags: 
+title: test-collatz
+type: text/vnd.tiddlywiki
+
+\procedure collatz(n) 
+<% if [<n>match[1]] %>
+  1
+<% elseif [<n>remainder[2]match[1]] %>
+  <<n>> <$button>→</$button> <$transclude $variable="collatz" n = {{{ [<n>multiply[3]add[1]] }}}/>
+<% else %>
+  <<n>> <$button>→</$button> <$transclude $variable="collatz" n = {{{ [<n>divide[2]] }}}/>
+<% endif %>
+\end
+
+\procedure test(x:10)
+<$let tv-UNSAFE-max-widget-tree-depth="2000">
+<$transclude $variable=collatz n=<<x>>/>
+</$let>
+\end
+
+<<test 77031>>

--- a/editions/tw5.com/tiddlers/test-recursive button.tid
+++ b/editions/tw5.com/tiddlers/test-recursive button.tid
@@ -1,0 +1,9 @@
+created: 20240415124530887
+modified: 20240416092728701
+tags: 
+title: test-recursive button
+type: text/vnd.tiddlywiki
+
+<$button>
+<$transclude/>
+</$button>


### PR DESCRIPTION
This PR implements a dynamic config and check for max-widget-tree-depth recursion detection

There is a new `tv-` variable in widget.js

- `tv-UNSAFE-max-widget-tree-depth` - which may need a better name

There are new `tv-` variables in button.js

- `tv-button` ... set to "true" if the widget is a button
- `tv-ancestors` ... variable for debugging

`tv-UNSAFE-max-widget-tree-depth` is set to a relative value, which allows us to dynamically limit the number of nested widgets inside the button widget. defaults to "50" atm see: `MAX_WIDGET_TREE_DEPTH_RELATIVE`

The Vercel CI created wiki also contains 2 test tiddlers for easy experiments. 

@Jermolene - What do you think. 