### PR TITLE
Remove the `x-requested-with` header from the tm-http-request message

### DIFF
--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -245,20 +245,6 @@ exports.httpRequest = function(options) {
 		getHeader = function(targetHeader) {
 			return headers[targetHeader] || headers[targetHeader.toLowerCase()];
 		},
-		isSimpleRequest = function(type,headers) {
-			if(["GET","HEAD","POST"].indexOf(type) === -1) {
-				return false;
-			}
-			for(var header in headers) {
-				if(["accept","accept-language","content-language","content-type"].indexOf(header.toLowerCase()) === -1) {
-					return false;
-				}
-			}
-			if(hasHeader("Content-Type") && ["application/x-www-form-urlencoded","multipart/form-data","text/plain"].indexOf(getHeader["Content-Type"]) === -1) {
-				return false;
-			}
-			return true;	
-		},
 		returnProp = options.returnProp || "responseText",
 		request = new XMLHttpRequest(),
 		data = "",
@@ -309,9 +295,6 @@ exports.httpRequest = function(options) {
 	}
 	if(data && !hasHeader("Content-Type")) {
 		request.setRequestHeader("Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
-	}
-	if(!hasHeader("X-Requested-With") && !isSimpleRequest(type,headers)) {
-		request.setRequestHeader("X-Requested-With","TiddlyWiki");
 	}
 	// Send data
 	try {


### PR DESCRIPTION
Extraneous headers can interfere with CORS validation when hitting external APIs, due to tightly configured `Access-Control-Allow-Headers` headers.  Until there's a way to disable these headers, it's probably better (i.e. most flexible) to expect users to set them deliberately.  

In this case, I ran into an API that uses CORS and the above header, and was unable to make a request to it without making the changes in this PR.  I'm also open to modifying the message to allow disabling these headers, but this was the simplest solution I could come up with.