### PR TITLE
Return responseText for all 2XX response codes during handling of `tm-http-request` messages.

### DIFF
--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -283,7 +283,7 @@ exports.httpRequest = function(options) {
 	// Set up the state change handler
 	request.onreadystatechange = function() {
 		if(this.readyState === 4) {
-			if(this.status === 200 || this.status === 201 || this.status === 204) {
+			if(this.status >= 200 && this.status < 300) {
 				// Success!
 				options.callback(null,this[returnProp],this);
 				return;


### PR DESCRIPTION
APIs especially use 2XX response codes outside of 200, 201, 204 for responding to responses.  Treat all "Successful" response codes (i.e. anything between 200-299) as successes, and pass the responseText.