### PR TITLE
Fix: some plugin subtiddlers do not have title in savewikifolder command

### DIFF
--- a/core/modules/commands/savewikifolder.js
+++ b/core/modules/commands/savewikifolder.js
@@ -176,7 +176,8 @@ WikiFolderMaker.prototype.saveCustomPlugin = function(pluginTiddler) {
 	this.saveJSONFile(directory + path.sep + "plugin.info",pluginInfo);
 	self.log("Writing " + directory + path.sep + "plugin.info: " + JSON.stringify(pluginInfo,null,$tw.config.preferences.jsonSpaces));
 	var pluginTiddlers = $tw.utils.parseJSONSafe(pluginTiddler.fields.text).tiddlers; // A hashmap of tiddlers in the plugin
-	$tw.utils.each(pluginTiddlers,function(tiddler) {
+	$tw.utils.each(pluginTiddlers,function(tiddler,title) {
+		if(!tiddler.title) tiddler.title = title;
 		self.saveTiddler(directory,new $tw.Tiddler(tiddler));
 	});
 };

--- a/core/modules/commands/savewikifolder.js
+++ b/core/modules/commands/savewikifolder.js
@@ -177,7 +177,9 @@ WikiFolderMaker.prototype.saveCustomPlugin = function(pluginTiddler) {
 	self.log("Writing " + directory + path.sep + "plugin.info: " + JSON.stringify(pluginInfo,null,$tw.config.preferences.jsonSpaces));
 	var pluginTiddlers = $tw.utils.parseJSONSafe(pluginTiddler.fields.text).tiddlers; // A hashmap of tiddlers in the plugin
 	$tw.utils.each(pluginTiddlers,function(tiddler,title) {
-		if(!tiddler.title) tiddler.title = title;
+		if(!tiddler.title) {
+			tiddler.title = title;
+		 }
 		self.saveTiddler(directory,new $tw.Tiddler(tiddler));
 	});
 };


### PR DESCRIPTION
This fix is intended to resolve the errors encountered by some plugins under this command, for example: [Todolist Plugin 1.5.0 — Organize, prioritize, and plan your work](https://kookma.github.io/TW-Todolist/ "Todolist Plugin 1.5.0 — Organize, prioritize, and plan your work")