### PR TITLE
Add defaultHeaders flag that controls helpful default heders that can sometimes interfere with apis

### DIFF
--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -39,6 +39,7 @@ exports.startup = function() {
 			method: params.method,
 			body: params.body,
 			binary: params.binary,
+			defaultHeaders: params.defaultHeaders,
 			oncompletion: params.oncompletion,
 			onprogress: params.onprogress,
 			bindStatus: params["bind-status"],

--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -69,7 +69,7 @@ HttpClient.prototype.cancelAllHttpRequests = function() {
 		for(var t=this.requests.length - 1; t--; t>=0) {
 			var requestInfo = this.requests[t];
 			requestInfo.request.cancel();
-		}	
+		}
 	}
 	this.requests = [];
 	this.updateRequestTracker();
@@ -112,6 +112,7 @@ function HttpClientRequest(options) {
 	this.method = options.method || "GET";
 	this.body = options.body || "";
 	this.binary = options.binary || "";
+	this.defaultHeaders = options.defaultHeaders || true,
 	this.variables = options.variables;
 	var url = options.url;
 	$tw.utils.each(options.queryStrings,function(value,name) {
@@ -231,7 +232,7 @@ Make an HTTP request. Options are:
 exports.httpRequest = function(options) {
 	var type = options.type || "GET",
 		url = options.url,
-		headers = options.headers || {accept: "application/json"},
+		headers = options.headers || (options.defaultHeaders ? {accept: "application/json"} : {}),
 		hasHeader = function(targetHeader) {
 			targetHeader = targetHeader.toLowerCase();
 			var result = false;
@@ -257,7 +258,7 @@ exports.httpRequest = function(options) {
 			if(hasHeader("Content-Type") && ["application/x-www-form-urlencoded","multipart/form-data","text/plain"].indexOf(getHeader["Content-Type"]) === -1) {
 				return false;
 			}
-			return true;	
+			return true;
 		},
 		returnProp = options.returnProp || "responseText",
 		request = new XMLHttpRequest(),
@@ -307,10 +308,10 @@ exports.httpRequest = function(options) {
 			request.setRequestHeader(headerTitle,header);
 		});
 	}
-	if(data && !hasHeader("Content-Type")) {
+	if(data && !hasHeader("Content-Type") && options.defaultHeaders) {
 		request.setRequestHeader("Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
 	}
-	if(!hasHeader("X-Requested-With") && !isSimpleRequest(type,headers)) {
+	if(!hasHeader("X-Requested-With") && !isSimpleRequest(type,headers) && options.defaultHeaders) {
 		request.setRequestHeader("X-Requested-With","TiddlyWiki");
 	}
 	// Send data

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
@@ -19,7 +19,7 @@ The following parameters are used:
 |method |HTTP method (eg "GET", "POST") |
 |body |String data to be sent with the request |
 |binary |<<.from-version "5.3.1">> Set to "yes" to cause the response body to be treated as binary data and returned in base64 format |
-|defaultHeaders |<<.from-version "5.3.2">> Defaults to true.  Set to "false" to prevent default headers from being added.  This can be helpful when dealing with apis that restrict header fields. |
+|defaultHeaders |<<.from-version "5.3.4">> Defaults to true.  Set to "false" to prevent default headers from being added.  This can be helpful when dealing with apis that restrict header fields. |
 |query-* |Query string parameters with string values |
 |header-* |Headers with string values |
 |password-header-* |Headers with values taken from the password store |

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
@@ -19,6 +19,7 @@ The following parameters are used:
 |method |HTTP method (eg "GET", "POST") |
 |body |String data to be sent with the request |
 |binary |<<.from-version "5.3.1">> Set to "yes" to cause the response body to be treated as binary data and returned in base64 format |
+|defaultHeaders |<<.from-version "5.3.2">> Defaults to true.  Set to "false" to prevent default headers from being added.  This can be helpful when dealing with apis that restrict header fields. |
 |query-* |Query string parameters with string values |
 |header-* |Headers with string values |
 |password-header-* |Headers with values taken from the password store |


### PR DESCRIPTION
Extraneous headers can interfere with CORS validation when hitting external APIs, due to tightly configured `Access-Control-Allow-Headers` headers. Add a way to disable these headers when they are causing issues.