### PR TITLE
fix broken internal links

### DIFF
--- a/editions/tw5.com/tiddlers/filters/examples/Brownies.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/Brownies.tid
@@ -1,9 +1,9 @@
 created: 20201004145650743
-modified: 20201006181234412
+modified: 20240421085808684
 price: 4.99
 quantity: 1
 tags: shopping
 title: Brownies
 type: text/vnd.tiddlywiki
 
-//This is a sample shopping list item for the [[Shopping List Example]]//
+//This is a sample shopping list item for the [[reduce Operator (Examples)]]//

--- a/editions/tw5.com/tiddlers/filters/examples/Chick Peas.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/Chick Peas.tid
@@ -1,9 +1,9 @@
 created: 20201004145612358
-modified: 20201006181232439
+modified: 20240421085815782
 price: 1.32
 quantity: 5
 tags: shopping
 title: Chick Peas
 type: text/vnd.tiddlywiki
 
-//This is a sample shopping list item for the [[Shopping List Example]]//
+//This is a sample shopping list item for the [[reduce Operator (Examples)]]//

--- a/editions/tw5.com/tiddlers/filters/examples/Milk.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/Milk.tid
@@ -1,9 +1,9 @@
 created: 20201004145636906
-modified: 20201006181233518
+modified: 20240421085820855
 price: 0.46
 quantity: 12
 tags: shopping
 title: Milk
 type: text/vnd.tiddlywiki
 
-//This is a sample shopping list item for the [[Shopping List Example]]//
+//This is a sample shopping list item for the [[reduce Operator (Examples)]]//

--- a/editions/tw5.com/tiddlers/filters/examples/Rice Pudding.tid
+++ b/editions/tw5.com/tiddlers/filters/examples/Rice Pudding.tid
@@ -1,9 +1,9 @@
 created: 20201004145502135
-modified: 20201006181230956
+modified: 20240421085828570
 price: 2.66
 quantity: 4
 tags: shopping
 title: Rice Pudding
 type: text/vnd.tiddlywiki
 
-//This is a sample shopping list item for the [[Shopping List Example]]//
+//This is a sample shopping list item for the [[reduce Operator (Examples)]]//


### PR DESCRIPTION
The "Shopping List Example" tiddler does not exist anymore. It may have been replaced by the new checkbox-widget docs. 
But these tiddlers are used with [reduce Operator (Examples)](https://tiddlywiki.com/#reduce%20Operator%20(Examples)) 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>