### PR TITLE
Fix 8166 html tag validation

### DIFF
--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -49,9 +49,6 @@ function FramedEngine(options) {
 	this.widget.domNodes.push(this.iframeNode);
 	// Construct the textarea or input node
 	var tag = $tw.utils.makeTagNameSafe(this.widget.editTag, "input");
-	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-	// 	tag = "input";
-	// }
 	this.domNode = this.iframeDoc.createElement(tag);
 	// Set the text
 	if(this.widget.editTag === "textarea") {

--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -48,7 +48,7 @@ function FramedEngine(options) {
 	this.iframeDoc.body.style.padding = "0";
 	this.widget.domNodes.push(this.iframeNode);
 	// Construct the textarea or input node
-	var tag = $tw.utils.isTagNameSafe(this.widget.editTag, "input");
+	var tag = $tw.utils.makeTagNameSafe(this.widget.editTag, "input");
 	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
 	// 	tag = "input";
 	// }

--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -48,10 +48,10 @@ function FramedEngine(options) {
 	this.iframeDoc.body.style.padding = "0";
 	this.widget.domNodes.push(this.iframeNode);
 	// Construct the textarea or input node
-	var tag = this.widget.editTag;
-	if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-		tag = "input";
-	}
+	var tag = $tw.utils.isTagNameSafe(this.widget.editTag, "input");
+	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
+	// 	tag = "input";
+	// }
 	this.domNode = this.iframeDoc.createElement(tag);
 	// Set the text
 	if(this.widget.editTag === "textarea") {
@@ -200,7 +200,7 @@ FramedEngine.prototype.handleFocusEvent = function(event) {
 Handle a keydown event
  */
 FramedEngine.prototype.handleKeydownEvent = function(event) {
-	if ($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
+	if($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
 		return true;
 	}
 

--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -22,7 +22,7 @@ function SimpleEngine(options) {
 	this.parentNode = options.parentNode;
 	this.nextSibling = options.nextSibling;
 	// Construct the textarea or input node
-	var tag = $tw.utils.isTagNameSafe(this.widget.editTag,"input");
+	var tag = $tw.utils.makeTagNameSafe(this.widget.editTag,"input");
 	// var tag = this.widget.editTag;
 	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
 	// 	tag = "input";

--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -23,10 +23,6 @@ function SimpleEngine(options) {
 	this.nextSibling = options.nextSibling;
 	// Construct the textarea or input node
 	var tag = $tw.utils.makeTagNameSafe(this.widget.editTag,"input");
-	// var tag = this.widget.editTag;
-	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-	// 	tag = "input";
-	// }
 	this.domNode = this.widget.document.createElement(tag);
 	// Set the text
 	if(this.widget.editTag === "textarea") {

--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -22,10 +22,11 @@ function SimpleEngine(options) {
 	this.parentNode = options.parentNode;
 	this.nextSibling = options.nextSibling;
 	// Construct the textarea or input node
-	var tag = this.widget.editTag;
-	if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-		tag = "input";
-	}
+	var tag = $tw.utils.isTagNameSafe(this.widget.editTag,"input");
+	// var tag = this.widget.editTag;
+	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
+	// 	tag = "input";
+	// }
 	this.domNode = this.widget.document.createElement(tag);
 	// Set the text
 	if(this.widget.editTag === "textarea") {

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -389,10 +389,10 @@ exports.querySelectorAllSafe = function(selector,baseElement) {
 /*
 Make sure HTML tag names are valid
 */
-exports.isTagNameSafe = function(tag,defaultTag) {
+exports.makeTagNameSafe = function(tag,defaultTag) {
 	defaultTag = defaultTag || "SPAN";
-	// This implements standard DOM elements: https://html.spec.whatwg.org/#syntax-tag-name
-	// It does _not_ implement Custom Elements: https://html.spec.whatwg.org/#valid-custom-element-name
+	// This implements a check for standard DOM elements: https://html.spec.whatwg.org/#syntax-tag-name
+	// It does _not_ deal with Custom Elements: https://html.spec.whatwg.org/#valid-custom-element-name
 	var regexp = /[a-zA-Z0-9]/g;
 	if(tag && tag.match(regexp) && $tw.config.htmlUnsafeElements.indexOf(tag) === -1) {
 		return tag;

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -289,7 +289,7 @@ exports.copyToClipboard = function(text,options) {
 	var succeeded = false;
 	try {
 		succeeded = document.execCommand("copy");
-	} catch (err) {
+	} catch(err) {
 	}
 	if(!options.doNotNotify) {
 		$tw.notifier.display(succeeded ? "$:/language/Notifications/CopiedToClipboard/Succeeded" : "$:/language/Notifications/CopiedToClipboard/Failed");
@@ -306,8 +306,8 @@ Collect DOM variables
 */
 exports.collectDOMVariables = function(selectedNode,domNode,event) {
 	var variables = {},
-	    selectedNodeRect,
-	    domNodeRect;
+		selectedNodeRect,
+		domNodeRect;
 	if(selectedNode) {
 		$tw.utils.each(selectedNode.attributes,function(attribute) {
 			variables["dom-" + attribute.name] = attribute.value.toString();
@@ -324,7 +324,7 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 			variables["tv-popup-coords"] = Popup.buildCoordinates(Popup.coordinatePrefix.csOffsetParent,nodeRect);
 
 			var absRect = $tw.utils.extend({}, nodeRect);
-			for (var currentNode = selectedNode.offsetParent; currentNode; currentNode = currentNode.offsetParent) {
+			for(var currentNode = selectedNode.offsetParent; currentNode; currentNode = currentNode.offsetParent) {
 				absRect.left += currentNode.offsetLeft;
 				absRect.top += currentNode.offsetTop;
 			}
@@ -366,7 +366,7 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 };
 
 /*
-Make sure the CSS selector is not invalid
+Make sure the CSS selector is valid
 */
 exports.querySelectorSafe = function(selector,baseElement) {
 	baseElement = baseElement || document;
@@ -385,5 +385,20 @@ exports.querySelectorAllSafe = function(selector,baseElement) {
 		console.log("Invalid selector: ",selector);
 	}
 };
+
+/*
+Make sure HTML tag names are valid
+*/
+exports.isTagNameSafe = function(tag,defaultTag) {
+	defaultTag = defaultTag || "SPAN";
+	// This implements standard DOM elements: https://html.spec.whatwg.org/#syntax-tag-name
+	// It does _not_ implement Custom Elements: https://html.spec.whatwg.org/#valid-custom-element-name
+	var regexp = /[a-zA-Z0-9]/g;
+	if(tag && tag.match(regexp) && $tw.config.htmlUnsafeElements.indexOf(tag) === -1) {
+		return tag;
+	}
+	return defaultTag;
+};
+
 
 })();

--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -38,9 +38,6 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 	// Create element
-	// if(this.buttonTag && $tw.config.htmlUnsafeElements.indexOf(this.buttonTag) === -1) {
-	// 	tag = this.buttonTag;
-	// }
 	tag = $tw.utils.makeTagNameSafe(this.buttonTag,tag)
 	domNode = this.document.createElement(tag);
 	this.domNode = domNode;

--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -38,9 +38,10 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 	// Create element
-	if(this.buttonTag && $tw.config.htmlUnsafeElements.indexOf(this.buttonTag) === -1) {
-		tag = this.buttonTag;
-	}
+	// if(this.buttonTag && $tw.config.htmlUnsafeElements.indexOf(this.buttonTag) === -1) {
+	// 	tag = this.buttonTag;
+	// }
+	tag = $tw.utils.isTagNameSafe(this.buttonTag,tag)
 	domNode = this.document.createElement(tag);
 	this.domNode = domNode;
 	// Assign classes
@@ -74,7 +75,7 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 	if(this["aria-label"]) {
 		domNode.setAttribute("aria-label",this["aria-label"]);
 	}
-	if (this.role) {
+	if(this.role) {
 		domNode.setAttribute("role", this.role);
 	}
 	if(this.popup || this.popupTitle) {

--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -41,7 +41,7 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 	// if(this.buttonTag && $tw.config.htmlUnsafeElements.indexOf(this.buttonTag) === -1) {
 	// 	tag = this.buttonTag;
 	// }
-	tag = $tw.utils.isTagNameSafe(this.buttonTag,tag)
+	tag = $tw.utils.makeTagNameSafe(this.buttonTag,tag)
 	domNode = this.document.createElement(tag);
 	this.domNode = domNode;
 	// Assign classes

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -39,9 +39,6 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	// Sanitise the specified tag
 	tag = $tw.utils.makeTagNameSafe(this.draggableTag,"div");
-	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-	// 	tag = "div";
-	// }
 	// Create our element
 	domNode = this.document.createElement(tag);
 	// Assign classes

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -38,7 +38,7 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 	// Execute our logic
 	this.execute();
 	// Sanitise the specified tag
-	tag = $tw.utils.isTagNameSafe(this.draggableTag,"div");
+	tag = $tw.utils.makeTagNameSafe(this.draggableTag,"div");
 	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
 	// 	tag = "div";
 	// }

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -38,10 +38,10 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 	// Execute our logic
 	this.execute();
 	// Sanitise the specified tag
-	tag = this.draggableTag;
-	if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-		tag = "div";
-	}
+	tag = $tw.utils.isTagNameSafe(this.draggableTag,"div");
+	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
+	// 	tag = "div";
+	// }
 	// Create our element
 	domNode = this.document.createElement(tag);
 	// Assign classes

--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -35,9 +35,10 @@ DroppableWidget.prototype.render = function(parent,nextSibling) {
 	// Compute attributes and execute state
 	this.computeAttributes();
 	this.execute();
-	if(this.droppableTag && $tw.config.htmlUnsafeElements.indexOf(this.droppableTag) === -1) {
-		tag = this.droppableTag;
-	}
+	tag = $tw.utils.isTagNameSafe(this.droppableTag,tag);
+	// if(this.droppableTag && $tw.config.htmlUnsafeElements.indexOf(this.droppableTag) === -1) {
+	// 	tag = this.droppableTag;
+	// }
 	// Create element and assign classes
 	domNode = this.document.createElement(tag);
 	this.domNode = domNode;

--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -36,9 +36,6 @@ DroppableWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 	tag = $tw.utils.makeTagNameSafe(this.droppableTag,tag);
-	// if(this.droppableTag && $tw.config.htmlUnsafeElements.indexOf(this.droppableTag) === -1) {
-	// 	tag = this.droppableTag;
-	// }
 	// Create element and assign classes
 	domNode = this.document.createElement(tag);
 	this.domNode = domNode;

--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -35,7 +35,7 @@ DroppableWidget.prototype.render = function(parent,nextSibling) {
 	// Compute attributes and execute state
 	this.computeAttributes();
 	this.execute();
-	tag = $tw.utils.isTagNameSafe(this.droppableTag,tag);
+	tag = $tw.utils.makeTagNameSafe(this.droppableTag,tag);
 	// if(this.droppableTag && $tw.config.htmlUnsafeElements.indexOf(this.droppableTag) === -1) {
 	// 	tag = this.droppableTag;
 	// }

--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -31,9 +31,10 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	// Neuter blacklisted elements
 	this.tag = this.parseTreeNode.tag;
-	if($tw.config.htmlUnsafeElements.indexOf(this.tag) !== -1) {
-		this.tag = "safe-" + this.tag;
-	}
+	this.tag = $tw.utils.isTagNameSafe(this.tag, "safe" + this.tag);
+	// if($tw.config.htmlUnsafeElements.indexOf(this.tag) !== -1) {
+	// 	this.tag = "safe-" + this.tag;
+	// }
 	// Restrict tag name to digits, letts and dashes
 	this.tag = this.tag.replace(/[^0-9a-zA-Z\-]/mg,"");
 	// Default to a span

--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -32,9 +32,6 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	// Neuter blacklisted elements
 	this.tag = this.parseTreeNode.tag;
 	this.tag = $tw.utils.makeTagNameSafe(this.tag, "safe" + this.tag);
-	// if($tw.config.htmlUnsafeElements.indexOf(this.tag) !== -1) {
-	// 	this.tag = "safe-" + this.tag;
-	// }
 	// Restrict tag name to digits, letts and dashes
 	this.tag = this.tag.replace(/[^0-9a-zA-Z\-]/mg,"");
 	// Default to a span

--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -31,7 +31,7 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	// Neuter blacklisted elements
 	this.tag = this.parseTreeNode.tag;
-	this.tag = $tw.utils.isTagNameSafe(this.tag, "safe" + this.tag);
+	this.tag = $tw.utils.makeTagNameSafe(this.tag, "safe" + this.tag);
 	// if($tw.config.htmlUnsafeElements.indexOf(this.tag) !== -1) {
 	// 	this.tag = "safe-" + this.tag;
 	// }

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -35,9 +35,10 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	// Create element
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
-	if(this.elementTag && $tw.config.htmlUnsafeElements.indexOf(this.elementTag) === -1) {
-		tag = this.elementTag;
-	}
+	tag = $tw.utils.isTagNameSafe(this.elementTag,tag)
+	// if(this.elementTag && $tw.config.htmlUnsafeElements.indexOf(this.elementTag) === -1) {
+	// 	tag = this.elementTag;
+	// }
 	var domNode = this.document.createElement(tag);
 	this.domNode = domNode;
 	// Assign classes

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -35,7 +35,7 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	// Create element
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
-	tag = $tw.utils.isTagNameSafe(this.elementTag,tag)
+	tag = $tw.utils.makeTagNameSafe(this.elementTag,tag)
 	// if(this.elementTag && $tw.config.htmlUnsafeElements.indexOf(this.elementTag) === -1) {
 	// 	tag = this.elementTag;
 	// }

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -36,9 +36,6 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 	// Create element
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
 	tag = $tw.utils.makeTagNameSafe(this.elementTag,tag)
-	// if(this.elementTag && $tw.config.htmlUnsafeElements.indexOf(this.elementTag) === -1) {
-	// 	tag = this.elementTag;
-	// }
 	var domNode = this.document.createElement(tag);
 	this.domNode = domNode;
 	// Assign classes

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -34,7 +34,7 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
-	tag = $tw.utils.isTagNameSafe(this.tag,tag);
+	tag = $tw.utils.makeTagNameSafe(this.tag,tag);
 	// if(this.tag && $tw.config.htmlUnsafeElements.indexOf(this.tag) === -1) {
 	// 	tag = this.tag;
 	// }

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -34,9 +34,10 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
-	if(this.tag && $tw.config.htmlUnsafeElements.indexOf(this.tag) === -1) {
-		tag = this.tag;
-	}
+	tag = $tw.utils.isTagNameSafe(this.tag,tag);
+	// if(this.tag && $tw.config.htmlUnsafeElements.indexOf(this.tag) === -1) {
+	// 	tag = this.tag;
+	// }
 	// Create element
 	var domNode = this.document.createElement(tag);
 	// Assign classes
@@ -53,7 +54,7 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 };
 
 KeyboardWidget.prototype.handleChangeEvent = function(event) {
-	if ($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
+	if($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
 		return true;
 	}
 

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -35,9 +35,6 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
 	tag = $tw.utils.makeTagNameSafe(this.tag,tag);
-	// if(this.tag && $tw.config.htmlUnsafeElements.indexOf(this.tag) === -1) {
-	// 	tag = this.tag;
-	// }
 	// Create element
 	var domNode = this.document.createElement(tag);
 	// Assign classes

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -61,7 +61,7 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	var self = this;
 	// Sanitise the specified tag
 	var tag = this.linkTag;
-	tag = $tw.utils.isTagNameSafe(tag,"a");
+	tag = $tw.utils.makeTagNameSafe(tag,"a");
 	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
 	// 	tag = "a";
 	// }

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -62,9 +62,6 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	// Sanitise the specified tag
 	var tag = this.linkTag;
 	tag = $tw.utils.makeTagNameSafe(tag,"a");
-	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-	// 	tag = "a";
-	// }
 	// Create our element
 	var namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"}),
 		domNode = this.document.createElementNS(namespace,tag);

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -61,9 +61,10 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	var self = this;
 	// Sanitise the specified tag
 	var tag = this.linkTag;
-	if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
-		tag = "a";
-	}
+	tag = $tw.utils.isTagNameSafe(tag,"a");
+	// if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
+	// 	tag = "a";
+	// }
 	// Create our element
 	var namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"}),
 		domNode = this.document.createElementNS(namespace,tag);

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -33,7 +33,7 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
-	tag = $tw.utils.isTagNameSafe(this.revealTag,tag);
+	tag = $tw.utils.makeTagNameSafe(this.revealTag,tag);
 	// if(this.revealTag && $tw.config.htmlUnsafeElements.indexOf(this.revealTag) === -1) {
 	// 	tag = this.revealTag;
 	// }

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -33,9 +33,10 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
-	if(this.revealTag && $tw.config.htmlUnsafeElements.indexOf(this.revealTag) === -1) {
-		tag = this.revealTag;
-	}
+	tag = $tw.utils.isTagNameSafe(this.revealTag,tag);
+	// if(this.revealTag && $tw.config.htmlUnsafeElements.indexOf(this.revealTag) === -1) {
+	// 	tag = this.revealTag;
+	// }
 	var domNode = this.document.createElement(tag);
 	this.domNode = domNode;
 	this.assignDomNodeClasses();
@@ -96,9 +97,9 @@ RevealWidget.prototype.positionPopup = function(domNode) {
 		left = Math.max(0,left);
 		top = Math.max(0,top);
 	}
-	if (this.popup.absolute) {
+	if(this.popup.absolute) {
 		// Traverse the offsetParent chain and correct the offset to make it relative to the parent node.
-		for (var offsetParentDomNode = domNode.offsetParent; offsetParentDomNode; offsetParentDomNode = offsetParentDomNode.offsetParent) {
+		for(var offsetParentDomNode = domNode.offsetParent; offsetParentDomNode; offsetParentDomNode = offsetParentDomNode.offsetParent) {
 			left -= offsetParentDomNode.offsetLeft;
 			top -= offsetParentDomNode.offsetTop;
 		}

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -34,9 +34,6 @@ RevealWidget.prototype.render = function(parent,nextSibling) {
 	this.execute();
 	var tag = this.parseTreeNode.isBlock ? "div" : "span";
 	tag = $tw.utils.makeTagNameSafe(this.revealTag,tag);
-	// if(this.revealTag && $tw.config.htmlUnsafeElements.indexOf(this.revealTag) === -1) {
-	// 	tag = this.revealTag;
-	// }
 	var domNode = this.document.createElement(tag);
 	this.domNode = domNode;
 	this.assignDomNodeClasses();


### PR DESCRIPTION
This PR fixes #8166

- #8166

It adds a new function to `$tw.utils.makeTagNameSafe(tag, defaultTag)`

- It checks for the existence of the tag and if it is a safe tag. 
- If defaultTag is undefined it uses SPAN as default

It replaces all the hardcoded checks using `if(complex logi)` with a simple to read function call 
