### PR TITLE
Block Quotes - fix parsing error with spaces before reEndString

### DIFF
--- a/core/modules/parsers/wikiparser/rules/quoteblock.js
+++ b/core/modules/parsers/wikiparser/rules/quoteblock.js
@@ -27,7 +27,6 @@ exports.parse = function() {
 	var reEndString = "^\\s*" + this.match[1] + "(?!<)";
 	// Move past the <s
 	this.parser.pos = this.matchRegExp.lastIndex;
-	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 	// Parse any classes, whitespace and then the optional cite itself
 	classes.push.apply(classes, this.parser.parseClasses());
 	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});

--- a/core/modules/parsers/wikiparser/rules/quoteblock.js
+++ b/core/modules/parsers/wikiparser/rules/quoteblock.js
@@ -8,60 +8,60 @@ Wiki text rule for quote blocks.
 \*/
 (function(){
 
-	/*jslint node: true, browser: true */
-	/*global $tw: false */
-	"use strict";
-	
-	exports.name = "quoteblock";
-	exports.types = {block: true};
-	
-	exports.init = function(parser) {
-		this.parser = parser;
-		// Regexp to match
-		this.matchRegExp = /(<<<+)/mg;
-	};
-	
-	exports.parse = function() {
-		var classes = ["tc-quote"];
-		// Get all the details of the match
-		var reEndString = "^\\s*" + this.match[1] + "(?!<)";   
-		// Move past the <s
-		this.parser.pos = this.matchRegExp.lastIndex;
-		this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
-	// Parse any classes, whitespace and then the optional cite itself
-		classes.push.apply(classes, this.parser.parseClasses());
-		this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
-		var cite = this.parser.parseInlineRun(/(\r?\n)/mg);
-		// before handling the cite, parse the body of the quote
-		var tree = this.parser.parseBlocks(reEndString);       
-		// If we got a cite, put it before the text
-		if(cite.length > 0) {
-			tree.unshift({
-				type: "element",
-				tag: "cite",
-				children: cite
-			});
-		}
-		// Parse any optional cite
-		this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
-		cite = this.parser.parseInlineRun(/(\r?\n)/mg);
-	// If we got a cite, push it
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+exports.name = "quoteblock";
+exports.types = {block: true};
+
+exports.init = function(parser) {
+	this.parser = parser;
+	// Regexp to match
+	this.matchRegExp = /(<<<+)/mg;
+};
+
+exports.parse = function() {
+	var classes = ["tc-quote"];
+	// Get all the details of the match
+	var reEndString = "^\\s*" + this.match[1] + "(?!<)";   
+	// Move past the <s
+	this.parser.pos = this.matchRegExp.lastIndex;
+	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
+// Parse any classes, whitespace and then the optional cite itself
+	classes.push.apply(classes, this.parser.parseClasses());
+	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
+	var cite = this.parser.parseInlineRun(/(\r?\n)/mg);
+	// before handling the cite, parse the body of the quote
+	var tree = this.parser.parseBlocks(reEndString);       
+	// If we got a cite, put it before the text
 	if(cite.length > 0) {
-			tree.push({
-				type: "element",
-				tag: "cite",
-				children: cite
-			});
-		}
-		// Return the blockquote element
-		return [{
+		tree.unshift({
 			type: "element",
-			tag: "blockquote",
-			attributes: {
-				class: { type: "string", value: classes.join(" ") },
-			},
-			children: tree
-		}];
-	};
+			tag: "cite",
+			children: cite
+		});
+	}
+	// Parse any optional cite
+	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
+	cite = this.parser.parseInlineRun(/(\r?\n)/mg);
+// If we got a cite, push it
+if(cite.length > 0) {
+		tree.push({
+			type: "element",
+			tag: "cite",
+			children: cite
+		});
+	}
+	// Return the blockquote element
+	return [{
+		type: "element",
+		tag: "blockquote",
+		attributes: {
+			class: { type: "string", value: classes.join(" ") },
+		},
+		children: tree
+	}];
+};
 	
 })();

--- a/core/modules/parsers/wikiparser/rules/quoteblock.js
+++ b/core/modules/parsers/wikiparser/rules/quoteblock.js
@@ -28,7 +28,7 @@ exports.parse = function() {
 	// Move past the <s
 	this.parser.pos = this.matchRegExp.lastIndex;
 	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
-// Parse any classes, whitespace and then the optional cite itself
+	// Parse any classes, whitespace and then the optional cite itself
 	classes.push.apply(classes, this.parser.parseClasses());
 	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 	var cite = this.parser.parseInlineRun(/(\r?\n)/mg);
@@ -45,8 +45,8 @@ exports.parse = function() {
 	// Parse any optional cite
 	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 	cite = this.parser.parseInlineRun(/(\r?\n)/mg);
-// If we got a cite, push it
-if(cite.length > 0) {
+	// If we got a cite, push it
+	if(cite.length > 0) {
 		tree.push({
 			type: "element",
 			tag: "cite",

--- a/core/modules/parsers/wikiparser/rules/quoteblock.js
+++ b/core/modules/parsers/wikiparser/rules/quoteblock.js
@@ -8,60 +8,60 @@ Wiki text rule for quote blocks.
 \*/
 (function(){
 
-    /*jslint node: true, browser: true */
-    /*global $tw: false */
-    "use strict";
-    
-    exports.name = "quoteblock";
-    exports.types = {block: true};
-    
-    exports.init = function(parser) {
-        this.parser = parser;
-        // Regexp to match
-        this.matchRegExp = /(<<<+)/mg;
-    };
-    
-    exports.parse = function() {
-        var classes = ["tc-quote"];
-        // Get all the details of the match
-        var reEndString = "^\\s*" + this.match[1] + "(?!<)";   
-        // Move past the <s
-        this.parser.pos = this.matchRegExp.lastIndex;
+	/*jslint node: true, browser: true */
+	/*global $tw: false */
+	"use strict";
+	
+	exports.name = "quoteblock";
+	exports.types = {block: true};
+	
+	exports.init = function(parser) {
+		this.parser = parser;
+		// Regexp to match
+		this.matchRegExp = /(<<<+)/mg;
+	};
+	
+	exports.parse = function() {
+		var classes = ["tc-quote"];
+		// Get all the details of the match
+		var reEndString = "^\\s*" + this.match[1] + "(?!<)";   
+		// Move past the <s
+		this.parser.pos = this.matchRegExp.lastIndex;
 		this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 	// Parse any classes, whitespace and then the optional cite itself
-        classes.push.apply(classes, this.parser.parseClasses());
-        this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
-        var cite = this.parser.parseInlineRun(/(\r?\n)/mg);
-        // before handling the cite, parse the body of the quote
-        var tree = this.parser.parseBlocks(reEndString);       
-        // If we got a cite, put it before the text
-        if(cite.length > 0) {
-            tree.unshift({
-                type: "element",
-                tag: "cite",
-                children: cite
-            });
-        }
+		classes.push.apply(classes, this.parser.parseClasses());
+		this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
+		var cite = this.parser.parseInlineRun(/(\r?\n)/mg);
+		// before handling the cite, parse the body of the quote
+		var tree = this.parser.parseBlocks(reEndString);       
+		// If we got a cite, put it before the text
+		if(cite.length > 0) {
+			tree.unshift({
+				type: "element",
+				tag: "cite",
+				children: cite
+			});
+		}
 		// Parse any optional cite
 		this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 		cite = this.parser.parseInlineRun(/(\r?\n)/mg);
 	// If we got a cite, push it
 	if(cite.length > 0) {
-            tree.push({
-                type: "element",
-                tag: "cite",
-                children: cite
-            });
-        }
-        // Return the blockquote element
-        return [{
-            type: "element",
-            tag: "blockquote",
-            attributes: {
-                class: { type: "string", value: classes.join(" ") },
-            },
-            children: tree
-        }];
-    };
-    
+			tree.push({
+				type: "element",
+				tag: "cite",
+				children: cite
+			});
+		}
+		// Return the blockquote element
+		return [{
+			type: "element",
+			tag: "blockquote",
+			attributes: {
+				class: { type: "string", value: classes.join(" ") },
+			},
+			children: tree
+		}];
+	};
+	
 })();

--- a/core/modules/parsers/wikiparser/rules/quoteblock.js
+++ b/core/modules/parsers/wikiparser/rules/quoteblock.js
@@ -3,88 +3,65 @@ title: $:/core/modules/parsers/wikiparser/rules/quoteblock.js
 type: application/javascript
 module-type: wikirule
 
-Wiki text rule for quote blocks. For example:
-
-```
-	<<<.optionalClass(es) optional cited from
-	a quote
-	<<<
-	
-	<<<.optionalClass(es)
-	a quote
-	<<< optional cited from
-```
-
-Quotes can be quoted by putting more <s
-
-```
-	<<<
-	Quote Level 1
-	
-	<<<<
-	QuoteLevel 2
-	<<<<
-	
-	<<<
-```
+Wiki text rule for quote blocks.
 
 \*/
 (function(){
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
-"use strict";
-
-exports.name = "quoteblock";
-exports.types = {block: true};
-
-exports.init = function(parser) {
-	this.parser = parser;
-	// Regexp to match
-	this.matchRegExp = /(<<<+)/mg;
-};
-
-exports.parse = function() {
-	var classes = ["tc-quote"];
-	// Get all the details of the match
-	var reEndString = "^" + this.match[1] + "(?!<)";
-	// Move past the <s
-	this.parser.pos = this.matchRegExp.lastIndex;
-	
+    /*jslint node: true, browser: true */
+    /*global $tw: false */
+    "use strict";
+    
+    exports.name = "quoteblock";
+    exports.types = {block: true};
+    
+    exports.init = function(parser) {
+        this.parser = parser;
+        // Regexp to match
+        this.matchRegExp = /(<<<+)/mg;
+    };
+    
+    exports.parse = function() {
+        var classes = ["tc-quote"];
+        // Get all the details of the match
+        var reEndString = "^\\s*" + this.match[1] + "(?!<)";   
+        // Move past the <s
+        this.parser.pos = this.matchRegExp.lastIndex;
+		this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 	// Parse any classes, whitespace and then the optional cite itself
-	classes.push.apply(classes, this.parser.parseClasses());
-	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
-	var cite = this.parser.parseInlineRun(/(\r?\n)/mg);
-	// before handling the cite, parse the body of the quote
-	var tree= this.parser.parseBlocks(reEndString);
-	// If we got a cite, put it before the text
-	if(cite.length > 0) {
-		tree.unshift({
-			type: "element",
-			tag: "cite",
-			children: cite
-		});
-	}
-	// Parse any optional cite
-	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
-	cite = this.parser.parseInlineRun(/(\r?\n)/mg);
+        classes.push.apply(classes, this.parser.parseClasses());
+        this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
+        var cite = this.parser.parseInlineRun(/(\r?\n)/mg);
+        // before handling the cite, parse the body of the quote
+        var tree = this.parser.parseBlocks(reEndString);       
+        // If we got a cite, put it before the text
+        if(cite.length > 0) {
+            tree.unshift({
+                type: "element",
+                tag: "cite",
+                children: cite
+            });
+        }
+		// Parse any optional cite
+		this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
+		cite = this.parser.parseInlineRun(/(\r?\n)/mg);
 	// If we got a cite, push it
 	if(cite.length > 0) {
-		tree.push({
-			type: "element",
-			tag: "cite",
-			children: cite
-		});
-	}
-	// Return the blockquote element
-	return [{
-		type: "element",
-		tag: "blockquote",
-		attributes: {
-			class: { type: "string", value: classes.join(" ") },
-		},
-		children: tree
-	}];
-};
-
+            tree.push({
+                type: "element",
+                tag: "cite",
+                children: cite
+            });
+        }
+        // Return the blockquote element
+        return [{
+            type: "element",
+            tag: "blockquote",
+            attributes: {
+                class: { type: "string", value: classes.join(" ") },
+            },
+            children: tree
+        }];
+    };
+    
 })();

--- a/core/modules/parsers/wikiparser/rules/quoteblock.js
+++ b/core/modules/parsers/wikiparser/rules/quoteblock.js
@@ -24,7 +24,7 @@ exports.init = function(parser) {
 exports.parse = function() {
 	var classes = ["tc-quote"];
 	// Get all the details of the match
-	var reEndString = "^\\s*" + this.match[1] + "(?!<)";   
+	var reEndString = "^\\s*" + this.match[1] + "(?!<)";
 	// Move past the <s
 	this.parser.pos = this.matchRegExp.lastIndex;
 	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
@@ -33,7 +33,7 @@ exports.parse = function() {
 	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 	var cite = this.parser.parseInlineRun(/(\r?\n)/mg);
 	// before handling the cite, parse the body of the quote
-	var tree = this.parser.parseBlocks(reEndString);       
+	var tree = this.parser.parseBlocks(reEndString);
 	// If we got a cite, put it before the text
 	if(cite.length > 0) {
 		tree.unshift({
@@ -63,5 +63,5 @@ exports.parse = function() {
 		children: tree
 	}];
 };
-	
+
 })();

--- a/editions/tw5.com/tiddlers/wikitext/Block Quotes in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Block Quotes in WikiText.tid
@@ -76,14 +76,24 @@ You can also mix block quotes with other list items. For example:
 ! Advanced Wikitext and Block Quotes
 You can also mix block quotes with paragraphs and other block wikitext. Be mindful of block mode - if other quoted content follows a paragraph, end it with a blank line. The final paragraph in the quote does not need to end with a blank line. If using indentation, make sure __not to indent the blank lines__. The parser will interpret this as additional inline content and not return to block mode. For example:
 
-<<wikitext-example src:"<<< Mixing Block Quotes with Inline Wikitext
-A paragraph appears before other ''wikitext'', which needs to end with a blank line.
+<<wikitext-example src:'<<< Mixing Block Quotes with Inline Wikitext
+A paragraph appears before other //wikitext//, which needs to end with a blank line.
 
     * List One
     ** List Two
     **> A quote
+"""
+A poem
+with line beaks
+needs to have
+a blank line after
+the final quotes
+if followed
+by other content
+"""
+
     <<<< Deep Block Quote
-        A paragraph before other ''wikitext'', which ends with a blank line.
+        A paragraph before other //wikitext//, which ends with a blank line.
 
         ! A Header
         Another paragraph, which needs to end with a blank line.
@@ -92,4 +102,4 @@ A paragraph appears before other ''wikitext'', which needs to end with a blank l
             A final paragraph, which __does not__ need to end with a blank line as the Block Quote ends.
     <<<<
 <<<
-">>
+'>>

--- a/editions/tw5.com/tiddlers/wikitext/Block Quotes in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Block Quotes in WikiText.tid
@@ -1,6 +1,6 @@
 caption: Block Quotes
 created: 20131206154636572
-modified: 20170417165145317
+modified: 20240512000910702
 tags: WikiText
 title: Block Quotes in WikiText
 type: text/vnd.tiddlywiki
@@ -71,4 +71,25 @@ You can also mix block quotes with other list items. For example:
 **> A quote
 **> Another quote
 * List Three
+">>
+
+! Advanced Wikitext and Block Quotes
+You can also mix block quotes with paragraphs and other block wikitext. Be mindful of block mode - if other quoted content follows a paragraph, end it with a blank line. The final paragraph in the quote does not need to end with a blank line. If using indentation, make sure __not to indent the blank lines__. The parser will interpret this as additional inline content and not return to block mode. For example:
+
+<<wikitext-example src:"<<< Mixing Block Quotes with Inline Wikitext
+A paragraph appears before other ''wikitext'', which needs to end with a blank line.
+
+    * List One
+    ** List Two
+    **> A quote
+    <<<< Deep Block Quote
+        A paragraph before other ''wikitext'', which ends with a blank line.
+
+        ! A Header
+        Another paragraph, which needs to end with a blank line.
+
+            !! Sub Header
+            A final paragraph, which __does not__ need to end with a blank line as the Block Quote ends.
+    <<<<
+<<<
 ">>

--- a/editions/tw5.com/tiddlers/wikitext/Hard Linebreaks in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Hard Linebreaks in WikiText.tid
@@ -1,9 +1,9 @@
+caption: Hard Linebreaks
 created: 20131214165710101
-modified: 20131214170106553
+modified: 20240512001649319
 tags: WikiText
 title: Hard Linebreaks in WikiText
 type: text/vnd.tiddlywiki
-caption: Hard Linebreaks
 
 The usual handling of [[paragraphs in wikitext|Paragraphs in WikiText]] causes single line breaks to be ignored, and double linebreaks to be interpreted as the end of a paragraph.
 
@@ -15,4 +15,8 @@ and this is a new line
 while this is yet another line
 and this is the final one
 apart from this one
-"""'>>
+"""
+
+'>>
+
+<<.tip 'Note: <strong>Hard Linebreaks in ~WikiText</strong> require an extra blank line after the trailing `"""` before the parser will return to [[block mode|Block Mode WikiText]].'>>.

--- a/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/parser/Block Mode WikiText.tid
@@ -1,6 +1,6 @@
 caption: block parser mode
 created: 20220110234234616
-modified: 20220122182842032
+modified: 20240512001555383
 tags: [[WikiText Parser Modes]]
 title: Block Mode WikiText
 type: text/vnd.tiddlywiki
@@ -28,7 +28,7 @@ Common characteristics of such block mode WikiText:
 The above WikiText types are only recognised in ''block mode''. However, the text <<.em enclosed>> by most of them will be parsed in ''inline mode'' ([[Block Quotes in WikiText]] and [[Styles and Classes in WikiText]] are the two exceptions in which the parser will continue in ''block mode''). While in ''inline mode'' the parser may encounter something which moves it to ''block mode'' (see [[WikiText parser mode transitions]]).
 
 At the end of the terminating line, the parser will return to ''block mode''. 
-<<.tip 'Note: [[Hard Linebreaks in WikiText]] require an extra blank line after the trailing `"""` before the parser will return to <b>block mode</b>'>>.
+<<.tip 'Note: [[Hard Linebreaks in WikiText]] require an extra blank line after the trailing `"""` before the parser will return to <strong>block mode</strong>.'>>
 
 If the punctuation for the above types of WikiText is encountered while the parser is in ''inline mode'', it will be //ignored// and output as-is.
 


### PR DESCRIPTION
- Fixes parsing error when spaces/tabs appear before the end `<<<+`
- Clarifies docs as to what to do to "return to block parsing mode" after paragraphs inside block quotes.
- Clarifies similar docs in the "Hard Line Breaks" (tested inside of a block quote).
- Additional "Advanced Wikitest and Block Quotes" examples.

Fixes bug: https://github.com/Jermolene/TiddlyWiki5/issues/8183