### PR TITLE
use a textarea in advanced-search-filter tab

### DIFF
--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -43,9 +43,11 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 	this.domNode = domNode;
 	this.assignDomNodeClasses();
 	// Add a keyboard event handler
-	$tw.utils.addEventListeners(domNode,[
-		{name: "keydown", handlerObject: this, handlerMethod: "handleChangeEvent"}
-	]);
+	if(this.disabled === "no") {
+		$tw.utils.addEventListeners(domNode,[
+			{name: "keydown", handlerObject: this, handlerMethod: "handleChangeEvent"}
+		]);
+	}
 	// Insert element
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);
@@ -53,10 +55,9 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 };
 
 KeyboardWidget.prototype.handleChangeEvent = function(event) {
-	if ($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
+	if($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
 		return true;
 	}
-
 	var keyInfo = $tw.keyboardManager.getMatchingKeyDescriptor(event,this.keyInfoArray);
 	if(keyInfo) {
 		var handled = this.invokeActions(this,event);
@@ -96,6 +97,7 @@ KeyboardWidget.prototype.execute = function() {
 	this.param = this.getAttribute("param","");
 	this.key = this.getAttribute("key","");
 	this.tag = this.getAttribute("tag","");
+	this.disabled = this.getAttribute("disabled","no");
 	this.keyInfoArray = $tw.keyboardManager.parseKeyDescriptors(this.key);
 	if(this.key.substr(0,2) === "((" && this.key.substr(-2,2) === "))") {
 		this.shortcutTiddlers = [];
@@ -111,6 +113,9 @@ KeyboardWidget.prototype.execute = function() {
 KeyboardWidget.prototype.assignDomNodeClasses = function() {
 	var classes = this.getAttribute("class","").split(" ");
 	classes.push("tc-keyboard");
+	if(this.disabled === "yes") {
+		classes.push("tc-disabled");
+	}
 	this.domNode.className = classes.join(" ");
 };
 
@@ -119,7 +124,7 @@ Selectively refreshes the widget if needed. Returns true if the widget or any of
 */
 KeyboardWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
-	if(changedAttributes.message || changedAttributes.param || changedAttributes.key || changedAttributes.tag) {
+	if(changedAttributes.message || changedAttributes.param || changedAttributes.key || changedAttributes.tag || changedAttributes.disabled) {
 		this.refreshSelf();
 		return true;
 	} else if(changedAttributes["class"]) {

--- a/core/ui/AdvancedSearch/Filter.tid
+++ b/core/ui/AdvancedSearch/Filter.tid
@@ -12,17 +12,7 @@ caption: {{$:/language/Search/Filter/Caption}}
 	actions="<$action-setfield $tiddler='$:/state/advancedsearch/currentTab' text=<<nextTab>>/>"/>
 \end
 
-\define cancel-search-actions()
-\whitespace trim
-<$list
-	filter="[{$:/temp/advancedsearch/input}!match{$:/temp/advancedsearch}]"
-	emptyMessage="<$action-deletetiddler $filter='[[$:/temp/advancedsearch]] [[$:/temp/advancedsearch/input]] [[$:/temp/advancedsearch/selected-item]]' />">
-	<$action-setfield $tiddler="$:/temp/advancedsearch/input" text={{$:/temp/advancedsearch}}/>
-	<$action-setfield $tiddler="$:/temp/advancedsearch/refresh" text="yes"/>
-</$list>
-\end
-
-\define input-accept-actions()
+\define input-accept-variant-actions()
 \whitespace trim
 <$list
 	filter="[{$:/config/Search/NavigateOnEnter/enable}match[yes]]"
@@ -31,33 +21,27 @@ caption: {{$:/language/Search/Filter/Caption}}
 </$list>
 \end
 
-\define input-accept-variant-actions()
-\whitespace trim
-<$list
-	filter="[{$:/config/Search/NavigateOnEnter/enable}match[yes]]"
-	emptyMessage="<$list filter='[<__tiddler__>get[text]!is[missing]] ~[<__tiddler__>get[text]is[shadow]]'><$list filter='[<__tiddler__>get[text]minlength[1]]'><$action-sendmessage $message='tm-edit-tiddler' $param={{{  [<__tiddler__>get[text]] }}}/></$list></$list>">
-	<$list filter="[<__tiddler__>get[text]minlength[1]]">
-		<$action-sendmessage $message="tm-edit-tiddler" $param={{{  [<__tiddler__>get[text]] }}}/>
-</$list></$list>
-\end
 \whitespace trim
 <<lingo Filter/Hint>>
-<div class="tc-search tc-advanced-search">
+<div class="tc-search tc-advanced-search tc-advanced-search-filter">
 <$keyboard key="((input-tab-right))" actions=<<set-next-input-tab>>>
 <$keyboard key="((input-tab-left))" actions=<<set-next-input-tab "before">>>
-<$macrocall $name="keyboard-driven-input"
-	tiddler="$:/temp/advancedsearch/input"
-	storeTitle="$:/temp/advancedsearch"
-	refreshTitle="$:/temp/advancedsearch/refresh"
-	selectionStateTitle="$:/temp/advancedsearch/selected-item"
-	type="search"
-	tag="input"
-	focus={{$:/config/Search/AutoFocus}}
-	configTiddlerFilter="[[$:/temp/advancedsearch]]"
-	firstSearchFilterField="text"
-	inputAcceptActions=<<input-accept-actions>>
-	inputAcceptVariantActions=<<input-accept-variant-actions>>
-	inputCancelActions=<<cancel-search-actions>>/>
+	<$macrocall $name="keyboard-driven-input"
+		tiddler="$:/temp/advancedsearch/input"
+		storeTitle="$:/temp/advancedsearch"
+		refreshTitle="$:/temp/advancedsearch/refresh"
+		selectionStateTitle="$:/temp/advancedsearch/selected-item"
+		type="search"
+		tag="textarea"
+		autoHeight="yes"
+		focus={{$:/config/Search/AutoFocus}}
+		configTiddlerFilter="[[$:/temp/advancedsearch]]"
+		firstSearchFilterField="text"
+		inputAcceptActions=<<input-accept-actions>>
+		inputAcceptVariantActions=<<input-accept-variant-actions>>
+		inputCancelActions=<<cancel-search-actions>>
+		disableUpDownCancel="yes"
+	/>
 </$keyboard>
 </$keyboard>
 &#32;

--- a/core/wiki/macros/keyboard-driven-input.tid
+++ b/core/wiki/macros/keyboard-driven-input.tid
@@ -86,13 +86,13 @@ tags: $:/tags/Macro
 </$list>
 \end
 
-\define keyboard-driven-input(tiddler,storeTitle,field:"text",index:"",tag:"input",type,focus:"",inputAcceptActions,inputAcceptVariantActions,inputCancelActions,placeholder:"",default:"",class,focusPopup,rows,minHeight,tabindex,size,autoHeight,filterMinLength:"0",refreshTitle,selectionStateTitle,cancelPopups:"",configTiddlerFilter,firstSearchFilterField:"first-search-filter",secondSearchFilterField:"second-search-filter")
+\define keyboard-driven-input(tiddler,storeTitle,field:"text",index:"",tag:"input",type,focus:"",inputAcceptActions,inputAcceptVariantActions,inputCancelActions,placeholder:"",default:"",class,focusPopup,rows,minHeight,tabindex,size,autoHeight,filterMinLength:"0",refreshTitle,selectionStateTitle,cancelPopups:"",configTiddlerFilter,firstSearchFilterField:"first-search-filter",secondSearchFilterField:"second-search-filter",disableUpDownCancel:"no")
 \whitespace trim
 <$keyboard key="((input-accept))" actions=<<__inputAcceptActions__>>>
 <$keyboard key="((input-accept-variant))" actions=<<__inputAcceptVariantActions__>>>
-<$keyboard key="((input-up))" actions=<<input-next-actions "before" "reverse[]">>>
-<$keyboard key="((input-down))" actions=<<input-next-actions>>>
-<$keyboard key="((input-cancel))" actions=<<__inputCancelActions__>>>
+<$keyboard key="((input-up))" actions=<<input-next-actions "before" "reverse[]">> disabled={{{ [<__disableUpDownCancel__>match[yes]else[no]] }}}>
+<$keyboard key="((input-down))" actions=<<input-next-actions>> disabled={{{ [<__disableUpDownCancel__>match[yes]else[no]] }}}>
+<$keyboard key="((input-cancel))" actions=<<__inputCancelActions__>> disabled={{{ [<__disableUpDownCancel__>match[yes]else[no]] }}}>
 	<$edit-text
 		tiddler=<<__tiddler__>> field=<<__field__>> index=<<__index__>>
 		inputActions=<<keyboard-input-actions>> tag=<<__tag__>> class=<<__class__>>

--- a/editions/tw5.com/tiddlers/macros/keyboard-driven-input_Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/keyboard-driven-input_Macro.tid
@@ -1,5 +1,5 @@
-title: keyboard-driven-input Macro
 tags: Macros [[Core Macros]]
+title: keyboard-driven-input Macro
 
 The <<.def keyboard-driven-input>> [[macro|Macros]] generates an input field or textarea that lets you cycle through a given list of entries with the <kbd><<displayshortcuts ((input-up))>></kbd> and <kbd><<displayshortcuts ((input-down))>></kbd> keys. Doing so, an entry gets selected and can be processed with further actions
 
@@ -19,7 +19,6 @@ The additional parameters are:
 |firstSearchFilterField |the field of the configTiddler where the first search-filter is stored. Defaults to <<.field first-search-filter>> |
 |secondSearchFilterField |the field of the configTiddler where the second search-filter is stored. Defaults to <<.field second-search-filter>> |
 |filterMinLength |the minimum length of the user input after which items are filtered |
+|disableUpDownCancel|<<.from-version "5.3.4">> Defaults to "no". If set to "yes" the up-, down- and cancel-keys defined by the macro are disabled. This setting is needed to be able to navigate in a textarea as used by the $:/AdvancedSearch -> Filter tab. Also see: [[KeyboardWidget]]|
 
 See [[Demonstration: keyboard-driven-input Macro]] for further guidance on using this macro.
-
-

--- a/editions/tw5.com/tiddlers/widgets/KeyboardWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/KeyboardWidget.tid
@@ -1,6 +1,6 @@
 caption: keyboard
 created: 20140302192136805
-modified: 20211009121239821
+modified: 20240517131307923
 tags: Widgets TriggeringWidgets
 title: KeyboardWidget
 type: text/vnd.tiddlywiki
@@ -19,7 +19,8 @@ The content of the `<$keyboard>` widget is rendered normally. The keyboard short
 |param |The parameter to be passed with the [[WidgetMessage|Messages]] |
 |key |Key string identifying the key(s) to be trapped (see below) |
 |class |A CSS class to be assigned to the generated HTML DIV element |
-|tag|<<.from-version "5.1.14">> The html element the widget creates to capture the keyboard event, defaults to:<br>» `span` when parsed in inline-mode<br>» `div` when parsed in block-mode|
+|tag |<<.from-version "5.1.14">> The html element the widget creates to capture the keyboard event, defaults to:<br>» `span` when parsed in inline-mode<br>» `div` when parsed in block-mode|
+|disabled |<<.from-version "5.3.4">> Optional. If set to "yes" the keyboard actions are not activated. Defaults to "no" |
 
 ! Variables
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -920,7 +920,12 @@ button.tc-btn-invisible.tc-remove-tag-button {
 }
 
 .tc-advanced-search input {
-	width: 60%;
+	width: 80%;
+}
+
+.tc-advanced-search-filter textarea {
+	max-width: 80%;
+	min-width: 80%;
 }
 
 .tc-search a svg {


### PR DESCRIPTION
**Advanced Search Filter Tab** 

- This PR uses a textarea as the AdvancedSearch Filter tab input element, so multiline filter strings can be used. 
- This will especially be convenient once we can have comments in filter strings. 

**Keyboard Widget**

- It adds a new `disable` parameter to the **keyboard-widget**. Default: "no" for backwards compatibility
- It updates the documentation for the keyboard-widget

**keyboard-driven-input** Macro

- It sets the textarea to "autoHeight" and limits max-width and min-width to 80%, so users can only change the height
- It adds a `disableUpDownCancel` parameter to the macro, which allows the default textarea navigation 
- If the keyboard widget is disabled the `class="tc-disabled"` is set to the DOM element for easier debugging and styling if needed
- It updates the macro docs. 

**Default Styles**

- It adds `tc-advanced-search-filter` as a new class
- It sets the default width for all input elements to 80%, to allow longer input strings 


![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/b0e906af-80f3-41fc-9112-ab078afc8360)