### PR TITLE
Fixed issue with fakedome TW_Node inheritence

### DIFF
--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -42,7 +42,7 @@ var TW_TextNode = function(text) {
 	this.textContent = text + "";
 };
 
-Object.setPrototypeOf(TW_TextNode,TW_Node.prototype);
+Object.setPrototypeOf(TW_TextNode.prototype,TW_Node.prototype);
 
 Object.defineProperty(TW_TextNode.prototype, "nodeType", {
 	get: function() {
@@ -67,7 +67,7 @@ var TW_Element = function(tag,namespace) {
 	this.namespaceURI = namespace || "http://www.w3.org/1999/xhtml";
 };
 
-Object.setPrototypeOf(TW_Element,TW_Node.prototype);
+Object.setPrototypeOf(TW_Element.prototype,TW_Node.prototype);
 
 Object.defineProperty(TW_Element.prototype, "style", {
 	get: function() {

--- a/editions/test/tiddlers/tests/test-fakedom.js
+++ b/editions/test/tiddlers/tests/test-fakedom.js
@@ -1,0 +1,27 @@
+/*\
+title: test-fakedom.js
+type: application/javascript
+tags: [[$:/tags/test-spec]]
+
+Tests the fakedom that Tiddlywiki occasionally uses.
+
+\*/
+(function(){
+
+/*jslint node: true, browser: true */
+/*global $tw: false */
+"use strict";
+
+describe("fakedom tests", function() {
+
+	it("properly assigns nodeType based on DOM standards", function() {
+		// According to MDN, ELEMENT_NODE == 1 && TEXT_NODE == 3
+		// There are others, but currently they're not implemented in fakedom
+		expect($tw.fakeDocument.createElement("div").nodeType).toBe(1);
+		expect($tw.fakeDocument.createElement("div").ELEMENT_NODE).toBe(1);
+		expect($tw.fakeDocument.createTextNode("text").nodeType).toBe(3);
+		expect($tw.fakeDocument.createTextNode("text").TEXT_NODE).toBe(3);
+	});
+});
+
+})();


### PR DESCRIPTION
I discovered this. fakedom TW_Element and TW_TextNode don't inherit from TW_Node correctly, so nodeType couldn't be properly compared.