### PR TITLE
feat: allow render tiddler above root

### DIFF
--- a/core/ui/RootTemplate.tid
+++ b/core/ui/RootTemplate.tid
@@ -1,5 +1,12 @@
 title: $:/core/ui/RootTemplate
 code-body: yes
 
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/AboveRoot]!has[draft.of]]">
+<$transclude/>
+</$list>
+
 <$transclude tiddler={{{ [{$:/layout}has[text]] ~[[$:/core/ui/PageTemplate]] }}} mode="inline"/>
 
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/BelowRoot]!has[draft.of]]">
+<$transclude/>
+</$list>

--- a/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_AboveRoot.tid
+++ b/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_AboveRoot.tid
@@ -1,0 +1,9 @@
+caption: $:/tags/AboveRoot
+created: 20180926170345251
+description: marks elements to be placed at the top of the root
+modified: 20180926171456529
+tags: SystemTags
+title: SystemTag: $:/tags/AboveRoot
+type: text/vnd.tiddlywiki
+
+The [[system tag|SystemTags]] `$:/tags/AboveRoot` marks elements to be placed at the top of the root, on every layout.

--- a/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_BelowRoot.tid
+++ b/editions/tw5.com/tiddlers/systemtags/SystemTag_ $__tags_BelowRoot.tid
@@ -1,0 +1,9 @@
+caption: $:/tags/BelowRoot
+created: 20180926170345251
+description: marks elements to be placed at the bottom of the root
+modified: 20180926171456521
+tags: SystemTags
+title: SystemTag: $:/tags/BelowRoot
+type: text/vnd.tiddlywiki
+
+The [[system tag|SystemTags]] `$:/tags/BelowRoot` marks elements to be placed at the bottom of the root, on every layout.


### PR DESCRIPTION
![图片](https://github.com/Jermolene/TiddlyWiki5/assets/3746270/4fa9da1e-ba43-431a-bdd6-daaffd0908f8)

To show command palette on every possible layout, I need a place that is transcend of the layout mechanism to mount it, where it is the `$:/core/ui/RootTemplate`.