### PR TITLE
Fixed issue where $parameters did nothing with no $transclude

### DIFF
--- a/core/modules/widgets/parameters.js
+++ b/core/modules/widgets/parameters.js
@@ -74,6 +74,18 @@ ParametersWidget.prototype.execute = function() {
 				self.setVariable(variableName,getValue(name));
 			}
 		});
+	} else {
+		// There is no parent transclude. i.e. direct rendering.
+		// We use default values only.
+		$tw.utils.each($tw.utils.getOrderedAttributesFromParseTreeNode(self.parseTreeNode),function(attr,index) {
+			var name = attr.name;
+			// If the attribute name starts with $$ then reduce to a single dollar
+			if(name.substr(0,2) === "$$") {
+				name = name.substr(1);
+			}
+			var value = self.getAttribute(attr.name,"");
+			self.setVariable(name,value);
+		});
 	}
 	// Construct the child widgets
 	this.makeChildWidgets();

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -775,6 +775,16 @@ describe("Widget module", function() {
 		expect(wrapper.innerHTML).toBe("<p>Bval</p>");
 	});
 
+	it("should use default parameters if directly rendered", function() {
+		var wiki = new $tw.Wiki();
+		var text = "<$parameters bee=default $$dollar=bill nothing empty=''>bee=<<bee>>, $dollar=<<$dollar>>, nothing=<<nothing>>, empty=<<empty>></$parameters>";
+		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
+		// Render the widget node to the DOM
+		var wrapper = renderWidgetNode(widgetNode);
+		// nothing = true in this attribute form because valueless attributes always equal true.
+		expect(wrapper.innerHTML).toBe("<p>bee=default, $dollar=bill, nothing=true, empty=</p>");
+	});
+
 	it("can have more than one macroDef variable imported", function() {
 		var wiki = new $tw.Wiki();
 		wiki.addTiddlers([


### PR DESCRIPTION
Discovered this problem when creating a new TiddlyMap release.

If you try to directly render a tiddler (such as by using `$tw.wiki.renderTiddler`) that has `\parameters` or `<$parameters>` in it, the parameters widget will do nothing. It'll look up its parent tree, find no transclude to possibly pull arguments from, and just disable itself.

I'm not sure this should be expected behavior. For instance, TiddlyMap now has to do a weird workaround for this just so it can render the `$:/core/images/tag-button` into a usable form for svg icons. I would think expected behavior for $parameters would be to use its default parameters in such a case. It certainly makes sense for icons.