### PR TITLE
fix: boot.css missing

### DIFF
--- a/boot/boot.css
+++ b/boot/boot.css
@@ -1,6 +1,3 @@
-title: $:/boot/boot.css
-type: text/css
-
 /*
 Basic styles used before we boot up the parsing engine
 */

--- a/boot/tiddlywiki.files
+++ b/boot/tiddlywiki.files
@@ -25,7 +25,7 @@
 			}
 		},
 		{
-			"file": "boot.css.tid",
+			"file": "boot.css",
 			"fields": {
 				"title": "$:/boot/boot.css",
 				"type": "text/css"


### PR DESCRIPTION
#8099 's tiddlywiki.files ignore the css, and was not noticed by me because I don't know I should test it with

```tid
\define re() (color)|(colour)ed

\define str() Something coloured

{{{ [<str>splitregexp<re>] }}}
```

Thanks for @pmario to point it out.

Seems this css file don't need a style system tag, so I correct the config to find it.

I also tried let it still have `.tid` suffix, but failed to load it. And with `.tid` suffix, a drawback is that VSCode can't apply css highlighting to it.

<img width="1050" alt="截屏2024-05-27 18 26 23" src="https://github.com/Jermolene/TiddlyWiki5/assets/3746270/65fed610-92cd-4c0b-a986-b9bc79326088">
