### PR TITLE
Make sure split(regex) returns an array of strings

### DIFF
--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -127,7 +127,7 @@ function diffPartsToChars(text1,text2,mode) {
             if(lineHash.hasOwnProperty ? lineHash.hasOwnProperty(line) : (lineHash[line] !== undefined)) {
 				chars += String.fromCharCode(lineHash[line]);
             } else {
-                if (lineArrayLength == maxLines) {
+                if(lineArrayLength == maxLines) {
                   line = text.substring(lineStart);
                   lineEnd = text.length;
                 }
@@ -218,7 +218,7 @@ exports.splitregexp = function(source,operator,options) {
 	}
 	source(function(tiddler,title) {
 		var parts = title.split(regExp).map(function(part){
-			return part+"";	// make sure it's a string
+			return part || "";	// make sure it's a string
 		});
 		Array.prototype.push.apply(result,parts);
 	});
@@ -267,7 +267,7 @@ exports.pad = function(source,operator,options) {
 			} else {
 				var padString = "",
 					padStringLength = targetLength - title.length;
-				while (padStringLength > padString.length) {
+				while(padStringLength > padString.length) {
 					padString += fill;
 				}
 				//make sure we do not exceed the specified length

--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -217,7 +217,10 @@ exports.splitregexp = function(source,operator,options) {
 		return ["RegExp error: " + ex];
 	}
 	source(function(tiddler,title) {
-		Array.prototype.push.apply(result,title.split(regExp));
+		var parts = title.split(regExp).map(function(part){
+			return part+"";	// make sure it's a string
+		});
+		Array.prototype.push.apply(result,parts);
 	});
 	return result;
 };

--- a/editions/tw5.com/tiddlers/filters/splitregexp Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/splitregexp Operator.tid
@@ -1,6 +1,6 @@
 caption: splitregexp
 created: 20190613154722705
-modified: 20190613154924724
+modified: 20240606113433618
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input titles split into separate items according to the specified regular expression <<.place R>>
 op-parameter: The regular expression at which to split each title
@@ -13,7 +13,7 @@ type: text/vnd.tiddlywiki
 
 <<.from-version "5.1.20">>
 
-Note that in some circumstances the <<.op splitregexp>> operator will include blank items in the list of results. For example, 
+<<.note """... that in some circumstances the <<.op splitregexp>> operator will include blank items in the list of results. For example, """>>
 
 ```
 [[the band thethe are the best the]splitregexp[the]]
@@ -42,3 +42,21 @@ Syntax errors in the regular expression will cause the filter to return an error
 <<.operator-example 2 "[[the cat sat on the mat]splitregexp[\]]">>
 
 <<.operator-examples "splitregexp">>
+
+----
+
+The <<.op splitregexp>> operator is intended to be used as described above. If the `regexp` contains //capture groups// those groups will be included into the output.
+
+<<.bad-example """```
+\procedure re() (color)|(colour)ed
+\procedure str() Some coloured text
+{{{ [<str>splitregexp<re>join[, ]] }}}
+```""">>
+
+Somewhat more useful may be this code. 
+
+```
+\procedure re() (colou?red)
+\procedure str() Some coloured text
+{{{ [<str>splitregexp<re>join[, ]] }}}
+```


### PR DESCRIPTION
This PR makes sure split(regex) used by the `splitregexp` operator returns an array of strings. It fixes: #8216 and #8213

Code to test with

```
\define re() (color)|(colour)ed
\define str() Something coloured
{{{ [<str>splitregexp<re>join[, ]] }}}

---

{{{ [<str>splitregexp<re>] }}}
```

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/c65c2e6b-0f9c-4084-8e9a-2d1c1dbd448c)
