### PR TITLE
Add useDefaultHeaders flag to tm-http-request (V2)

### DIFF
--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -39,7 +39,7 @@ exports.startup = function() {
 			method: params.method,
 			body: params.body,
 			binary: params.binary,
-			defaultHeaders: params.defaultHeaders,
+			useDefaultHeaders: params.useDefaultHeaders,
 			oncompletion: params.oncompletion,
 			onprogress: params.onprogress,
 			bindStatus: params["bind-status"],

--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -39,6 +39,7 @@ exports.startup = function() {
 			method: params.method,
 			body: params.body,
 			binary: params.binary,
+			defaultHeaders: params.defaultHeaders,
 			oncompletion: params.oncompletion,
 			onprogress: params.onprogress,
 			bindStatus: params["bind-status"],

--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -112,7 +112,7 @@ function HttpClientRequest(options) {
 	this.method = options.method || "GET";
 	this.body = options.body || "";
 	this.binary = options.binary || "";
-	this.useDefaultHeaders = options.useDefaultHeaders || true,
+	this.useDefaultHeaders = options.useDefaultHeaders !== "false" ? true : false,
 	this.variables = options.variables;
 	var url = options.url;
 	$tw.utils.each(options.queryStrings,function(value,name) {
@@ -157,6 +157,7 @@ HttpClientRequest.prototype.send = function(callback) {
 		this.xhr = $tw.utils.httpRequest({
 			url: this.url,
 			type: this.method,
+			useDefaultHeaders: this.useDefaultHeaders,
 			headers: this.requestHeaders,
 			data: this.body,
 			returnProp: this.binary === "" ? "responseText" : "response",
@@ -232,7 +233,7 @@ Make an HTTP request. Options are:
 exports.httpRequest = function(options) {
 	var type = options.type || "GET",
 		url = options.url,
-		useDefaultHeaders = options.useDefaultHeaders || true,
+		useDefaultHeaders = options.useDefaultHeaders !== false ? true : false,
 		headers = options.headers || (useDefaultHeaders ? {accept: "application/json"} : {}),
 		hasHeader = function(targetHeader) {
 			targetHeader = targetHeader.toLowerCase();

--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -69,7 +69,7 @@ HttpClient.prototype.cancelAllHttpRequests = function() {
 		for(var t=this.requests.length - 1; t--; t>=0) {
 			var requestInfo = this.requests[t];
 			requestInfo.request.cancel();
-		}	
+		}
 	}
 	this.requests = [];
 	this.updateRequestTracker();
@@ -112,6 +112,7 @@ function HttpClientRequest(options) {
 	this.method = options.method || "GET";
 	this.body = options.body || "";
 	this.binary = options.binary || "";
+	this.defaultHeaders = options.defaultHeaders || true,
 	this.variables = options.variables;
 	var url = options.url;
 	$tw.utils.each(options.queryStrings,function(value,name) {
@@ -231,7 +232,7 @@ Make an HTTP request. Options are:
 exports.httpRequest = function(options) {
 	var type = options.type || "GET",
 		url = options.url,
-		headers = options.headers || {accept: "application/json"},
+		headers = options.headers || (options.defaultHeaders ? {accept: "application/json"} : {}),
 		hasHeader = function(targetHeader) {
 			targetHeader = targetHeader.toLowerCase();
 			var result = false;
@@ -257,7 +258,7 @@ exports.httpRequest = function(options) {
 			if(hasHeader("Content-Type") && ["application/x-www-form-urlencoded","multipart/form-data","text/plain"].indexOf(getHeader["Content-Type"]) === -1) {
 				return false;
 			}
-			return true;	
+			return true;
 		},
 		returnProp = options.returnProp || "responseText",
 		request = new XMLHttpRequest(),
@@ -307,10 +308,10 @@ exports.httpRequest = function(options) {
 			request.setRequestHeader(headerTitle,header);
 		});
 	}
-	if(data && !hasHeader("Content-Type")) {
+	if(data && !hasHeader("Content-Type") && options.defaultHeaders) {
 		request.setRequestHeader("Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
 	}
-	if(!hasHeader("X-Requested-With") && !isSimpleRequest(type,headers)) {
+	if(!hasHeader("X-Requested-With") && !isSimpleRequest(type,headers) && options.defaultHeaders) {
 		request.setRequestHeader("X-Requested-With","TiddlyWiki");
 	}
 	// Send data

--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -112,7 +112,7 @@ function HttpClientRequest(options) {
 	this.method = options.method || "GET";
 	this.body = options.body || "";
 	this.binary = options.binary || "";
-	this.defaultHeaders = options.defaultHeaders || true,
+	this.useDefaultHeaders = options.useDefaultHeaders || true,
 	this.variables = options.variables;
 	var url = options.url;
 	$tw.utils.each(options.queryStrings,function(value,name) {
@@ -232,7 +232,8 @@ Make an HTTP request. Options are:
 exports.httpRequest = function(options) {
 	var type = options.type || "GET",
 		url = options.url,
-		headers = options.headers || (options.defaultHeaders ? {accept: "application/json"} : {}),
+		useDefaultHeaders = options.useDefaultHeaders || true,
+		headers = options.headers || (useDefaultHeaders ? {accept: "application/json"} : {}),
 		hasHeader = function(targetHeader) {
 			targetHeader = targetHeader.toLowerCase();
 			var result = false;
@@ -308,10 +309,10 @@ exports.httpRequest = function(options) {
 			request.setRequestHeader(headerTitle,header);
 		});
 	}
-	if(data && !hasHeader("Content-Type") && options.defaultHeaders) {
+	if(data && !hasHeader("Content-Type") && useDefaultHeaders) {
 		request.setRequestHeader("Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
 	}
-	if(!hasHeader("X-Requested-With") && !isSimpleRequest(type,headers) && options.defaultHeaders) {
+	if(!hasHeader("X-Requested-With") && !isSimpleRequest(type,headers) && useDefaultHeaders) {
 		request.setRequestHeader("X-Requested-With","TiddlyWiki");
 	}
 	// Send data

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
@@ -19,7 +19,7 @@ The following parameters are used:
 |method |HTTP method (eg "GET", "POST") |
 |body |String data to be sent with the request |
 |binary |<<.from-version "5.3.1">> Set to "yes" to cause the response body to be treated as binary data and returned in base64 format |
-|defaultHeaders |<<.from-version "5.3.4">> Defaults to true.  Set to "false" to prevent default headers from being added.  This can be helpful when dealing with apis that restrict header fields. |
+|useDefaultHeaders |<<.from-version "5.3.4">> Defaults to true.  Set to "false" to prevent default headers from being added.  This can be helpful when dealing with apis that restrict header fields. |
 |query-* |Query string parameters with string values |
 |header-* |Headers with string values |
 |password-header-* |Headers with values taken from the password store |

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
@@ -19,7 +19,7 @@ The following parameters are used:
 |method |HTTP method (eg "GET", "POST") |
 |body |String data to be sent with the request |
 |binary |<<.from-version "5.3.1">> Set to "yes" to cause the response body to be treated as binary data and returned in base64 format |
-|defaultHeaders |<<.from-version "5.3.2">> Defaults to true.  Set to "false" to prevent default headers from being added.  This can be helpful when dealing with apis that restrict header fields. |
+|defaultHeaders |<<.from-version "5.3.4">> Defaults to true.  Set to "false" to prevent default headers from being added.  This can be helpful when dealing with apis that restrict header fields. |
 |query-* |Query string parameters with string values |
 |header-* |Headers with string values |
 |password-header-* |Headers with values taken from the password store |

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
@@ -19,6 +19,7 @@ The following parameters are used:
 |method |HTTP method (eg "GET", "POST") |
 |body |String data to be sent with the request |
 |binary |<<.from-version "5.3.1">> Set to "yes" to cause the response body to be treated as binary data and returned in base64 format |
+|defaultHeaders |<<.from-version "5.3.2">> Defaults to true.  Set to "false" to prevent default headers from being added.  This can be helpful when dealing with apis that restrict header fields. |
 |query-* |Query string parameters with string values |
 |header-* |Headers with string values |
 |password-header-* |Headers with values taken from the password store |

--- a/editions/tw5.com/tiddlers/workingwithtw/Sharing your tiddlers with others.tid
+++ b/editions/tw5.com/tiddlers/workingwithtw/Sharing your tiddlers with others.tid
@@ -1,5 +1,5 @@
 created: 20140908163900000
-modified: 20240529203107233
+modified: 20201228143412000
 tags: Learning
 title: Sharing your tiddlers with others
 type: text/vnd.tiddlywiki

--- a/editions/tw5.com/tiddlers/workingwithtw/Sharing your tiddlers with others.tid
+++ b/editions/tw5.com/tiddlers/workingwithtw/Sharing your tiddlers with others.tid
@@ -1,5 +1,5 @@
 created: 20140908163900000
-modified: 20201228143412000
+modified: 20240529203107233
 tags: Learning
 title: Sharing your tiddlers with others
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
Reworked the handling of useDefaultHeaders did better testing than last time.  

* Switched to a ternary operator for converting to boolean, as the previous logic didn't correctly parse possible value strings.

Hopefully I got it right this time.  I did try running `nodejs tiddlywiki.js editions/tw5.com-server --listen` and validating that both normal browsing and my new changes appear to work.
