### PR TITLE
Fixes nested functions to resolve filter run variables

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -317,7 +317,8 @@ Widget.prototype.getStateQualifier = function(name) {
 Make a fake widget with specified variables, suitable for variable lookup in filters
 */
 Widget.prototype.makeFakeWidgetWithVariables = function(variables) {
-	var self = this;
+	var self = this,
+		variables = variables || {};
 	return {
 		getVariable: function(name,opts) {
 			if($tw.utils.hop(variables,name)) {
@@ -335,7 +336,7 @@ Widget.prototype.makeFakeWidgetWithVariables = function(variables) {
 				};
 			} else {
 				opts = opts || {};
-				opts.variables = variables;
+				opts.variables = $tw.utils.extend(variables,opts.variables);
 				return self.getVariableInfo(name,opts);
 			};
 		},

--- a/editions/test/tiddlers/tests/data/functions/FunctionFilterrunVariables3.tid
+++ b/editions/test/tiddlers/tests/data/functions/FunctionFilterrunVariables3.tid
@@ -1,0 +1,21 @@
+title: Functions/FunctionFilterrunVariables3
+description: Nested functions in filter runs that set variables
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\whitespace trim
+\define currentTiddler() old-current
+
+\function .inner() [<currentTiddler>]
+\function .outer() [<currentTiddler>match[intermediate2]then[new-current]] :map[function[.inner]]
+\function .wrappertwo() [<currentTiddler>match[intermediate]addsuffix[2]] :map[function[.outer]]
+\function .wrapper() intermediate :map[.wrappertwo[]]
+
+<$text text={{{ [.wrapper[]] }}}/>
+
++
+title: ExpectedResult
+
+new-current


### PR DESCRIPTION
Fixes #8178 

The `getVariable` method in `makeFakeWidgetWithVariables` needs to accommodate being called with variables in the opts argument, which happens with nested fake widget objects.