### PR TITLE
docs: Corrects tag on parsermode pragma documentation

### DIFF
--- a/editions/tw5.com/tiddlers/pragmas/Pragma_ _parsermode.tid
+++ b/editions/tw5.com/tiddlers/pragmas/Pragma_ _parsermode.tid
@@ -1,6 +1,6 @@
 created: 20221123223127425
-modified: 20230117112244779
-tags: Pragma
+modified: 20240604174402875
+tags: Pragmas
 title: Pragma: \parsermode
 type: text/vnd.tiddlywiki
 

--- a/editions/tw5.com/tiddlers/pragmas/Pragma_ _parsermode.tid
+++ b/editions/tw5.com/tiddlers/pragmas/Pragma_ _parsermode.tid
@@ -1,5 +1,5 @@
 created: 20221123223127425
-modified: 20240604174402875
+modified: 20230117112244779
 tags: Pragmas
 title: Pragma: \parsermode
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
Corrects the tag on the `Pragma: \parsermode` tiddler so that it is listed in the Pragmas tiddler. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>