### PR TITLE
Modifies action-log to return text of functions

### DIFF
--- a/core/modules/widgets/action-log.js
+++ b/core/modules/widgets/action-log.js
@@ -66,7 +66,12 @@ LogWidget.prototype.log = function() {
 	});
 
 	for(var v in this.variables) {
-		allVars[v] = this.getVariable(v,{defaultValue:""});
+		var variable = this.parentWidget && this.parentWidget.variables[v];
+		if(variable && variable.isFunctionDefinition) {
+			allVars[v] = variable.value;
+		} else {
+			allVars[v]  = this.getVariable(v,{defaultValue:""});
+		}
 	}
 	if(this.filter) {
 		filteredVars = this.wiki.compileFilter(this.filter).call(this.wiki,this.wiki.makeTiddlerIterator(allVars));


### PR DESCRIPTION
This PR modifies the action-log widget to return the raw text of functions instead of evaluating them, which can at times be exceedingly slow depending on how the function was written.

Fixes #8189 