### PR TITLE
Link to correct plugin instructions for Node.js

### DIFF
--- a/plugins/tiddlywiki/tiddlyweb/language/en-GB/Translations.multids
+++ b/plugins/tiddlywiki/tiddlyweb/language/en-GB/Translations.multids
@@ -1,6 +1,6 @@
 title: $:/plugins/tiddlywiki/tiddlyweb/language/en-GB/
 
-ConfigOfficialPluginLibrary: The official plugin library is disabled when using the client-server configuration. Instead, plugins should be installed via the `tiddlywiki.info` file, as described [[here|https://tiddlywiki.com/#Installing%20a%20plugin%20from%20the%20plugin%20library]].
+ConfigOfficialPluginLibrary: The official plugin library is disabled when using the client-server configuration. Instead, plugins should be installed via the `tiddlywiki.info` file, as described [[here|https://tiddlywiki.com/#Installing%20official%20plugins%20on%20Node.js]].
 GettingStartedStep1: Step 1<br>Syncing
 CopySyncerLogs: Copy syncer logs to clipboard
 LoginAs: You are logged in<$reveal state="$:/status/UserName" type="nomatch" text="" default=""> as <strong><$text text={{$:/status/UserName}}/></strong></$reveal>


### PR DESCRIPTION
If a user of a Node.js (aka "client-server") installation of TiddlyWiki5
goes through instructions of "Installing a plugin from the plugin
library" [1], they will encounter a dead end, quote:

	The official plugin library is disabled when using the
	client-server configuration. Instead, plugins should be
	installed via the `tiddlywiki.info` file, as described here.

The word "here" links to the same tiddler [1], sending the user into a
endless loop.

Instead, link to "Installing official plugins on Node.js" [2], which
actually contains the instructions for editing `tiddlywiki.info` file.

[1] https://tiddlywiki.com/#Installing%20a%20plugin%20from%20the%20plugin%20library
[2] https://tiddlywiki.com/#Installing%20official%20plugins%20on%20Node.js