### PR TITLE
Use the testcase widget to add some simple tm-http-request examples

### DIFF
--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request Examples.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request Examples.tid
@@ -1,0 +1,117 @@
+created: 20240609152203076
+modified: 20240614210714914
+tags: 
+title: WidgetMessage: tm-http-request Examples
+type: text/vnd.tiddlywiki
+
+<$let store-fetched-output="""\procedure store-fetched-output()
+<$action-setfield $tiddler=Output status=<<status>> error=<<error>> data=<<data>> headers=<<headers>>/>
+\end
+""">
+<$testcase>
+<$data title=Description text="Simple tm-http-request GET"/>
+<$data title=Narrative text="""Use the oncompletion attribute to store the results of a method="GET" request"""/>
+<$data title=Output text=`$(store-fetched-output)$
+\procedure http-get()
+	<$action-sendmessage
+		$message="tm-http-request"
+		url="https://httpbin.org/get"
+		method="GET"
+		oncompletion=<<store-fetched-output>>
+	/>
+\end
+
+<$button actions=<<http-get>>>send HTTP GET</$button>`/>
+</$testcase>
+
+<$testcase>
+<$data title=Description text="Simple tm-http-request POST"/>
+<$data title=Narrative text="""Use the oncompletion attribute to store the results of a method="POST" request. Use the body attribute to send data"""/>
+<$data title=Output text=`$(store-fetched-output)$
+\procedure http-post()
+	<$action-sendmessage
+		$message="tm-http-request"
+		url="https://httpbin.org/post"
+		method="POST"
+		body='{"foo": "bar"}'
+		oncompletion=<<store-fetched-output>>
+	/>
+\end
+
+<$button actions=<<http-post>>>send HTTP POST</$button>`/>
+</$testcase>
+
+<$testcase>
+<$data title=Description text="tm-http-request with delayed response"/>
+<$data title=Narrative text="""Use the bind-status and bind-progress attributes to watch the intermediate state of a slow response"""/>
+<$data title=Output text=`$(store-fetched-output)$
+\procedure http-get()
+	<$action-sendmessage
+		$message="tm-http-request"
+		url="https://httpbin.org/delay/2"
+		bind-status=status
+		bind-progress=progress
+		method="GET"
+		oncompletion=<<store-fetched-output>>
+	/>
+\end
+
+<$button actions=<<http-get>>>send HTTP GET</$button>
+
+|!status |{{status}}|
+|!progress %|{{progress}}|`/>
+</$testcase>
+
+<$testcase>
+<$data title=Description text="tm-http-request with dripped response"/>
+<$data title=Narrative text="""Use the bind-status and bind-progress attributes to watch progress of data which arrives a little at a time"""/>
+<$data title=Output text=`$(store-fetched-output)$
+\procedure http-get()
+	<$action-sendmessage
+		$message="tm-http-request"
+		url="https://httpbin.org/drip?duration=2&numbytes=10&code=200&delay=2"
+		bind-status=status
+		bind-progress=progress
+		method="GET"
+		oncompletion=<<store-fetched-output>>
+	/>
+\end
+
+<$button actions=<<http-get>>>send HTTP GET</$button>
+
+|!status |{{status}}|
+|!progress %|{{progress}}|`/>
+</$testcase>
+
+<$testcase>
+<$data title=Description text="tm-http-request 504 Bad Gateway error response"/>
+<$data title=Narrative text="""Send a request to a url which simulates a 504 HTTP response in order to illustrate what an error response looks like"""/>
+<$data title=Output text=`$(store-fetched-output)$
+\procedure http-get()
+	<$action-sendmessage
+		$message="tm-http-request"
+		url="https://httpbin.org/status/504"
+		method="GET"
+		oncompletion=<<store-fetched-output>>
+	/>
+\end
+
+<$button actions=<<http-get>>>send HTTP GET</$button>`/>
+</$testcase>
+
+<$testcase>
+<$data title=Description text="tm-http-request 405 Method Not Allowed error response"/>
+<$data title=Narrative text="""Another error response example. This one sends a GET to a URL which only allows POST"""/>
+<$data title=Output text=`$(store-fetched-output)$
+\procedure http-get()
+	<$action-sendmessage
+		$message="tm-http-request"
+		url="https://httpbin.org/post"
+		method="GET"
+		oncompletion=<<store-fetched-output>>
+	/>
+\end
+
+<$button actions=<<http-get>>>send HTTP GET</$button>`/>
+</$testcase>
+</$let>

--- a/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
+++ b/editions/tw5.com/tiddlers/messages/WidgetMessage_ tm-http-request.tid
@@ -1,6 +1,6 @@
 caption: tm-http-request
 created: 20230429161453032
-modified: 20230723215344887
+modified: 20240614204704401
 tags: Messages
 title: WidgetMessage: tm-http-request
 type: text/vnd.tiddlywiki
@@ -54,6 +54,7 @@ Note that the state tiddler $:/state/http-requests contains a number representin
 
 !! Examples
 
+* Several simple examples using https://httpbin.org: [[WidgetMessage: tm-http-request Examples]]
 * [[Zotero's|https://www.zotero.org/]] API for retrieving reference items: [[WidgetMessage: tm-http-request Example - Zotero]]
 * [[Random Dog's|https://random.dog/]] API for retrieving random pictures of dogs showing how to retrieve binary data: [[WidgetMessage: tm-http-request Example - Random Dog]]
 * Example of using HTTP Basic Authentication: [[WidgetMessage: tm-http-request Example - Basic Authentication]]


### PR DESCRIPTION
Add some tm-http-request examples which are simpler than the more comprehensive Zotero and Random dog examples. The examples use the useful https://httpbin.org website.