### PR TITLE
Remove NEW ribbon from "Saving with Polly" and "TiddlyBucket "

### DIFF
--- a/editions/tw5.com/tiddlers/saving/Saving with Polly.tid
+++ b/editions/tw5.com/tiddlers/saving/Saving with Polly.tid
@@ -9,7 +9,6 @@ modified: 20220223160414274
 tags: Chrome Firefox [[Internet Explorer]] Linux Mac Opera Safari Saving Windows Edge
 title: Saving with Polly
 type: text/vnd.tiddlywiki
-ribbon-text: NEW
 
 [[Polly|https://github.com/Marxsal/polly]] is a batch file system using Windows //~PowerShell// to restore ~TiddlyWiki files from a specified download directory to their original home directory.
 

--- a/editions/tw5.com/tiddlers/saving/TiddlyBucket - Save to AWS or Google Storage.tid
+++ b/editions/tw5.com/tiddlers/saving/TiddlyBucket - Save to AWS or Google Storage.tid
@@ -8,7 +8,6 @@ modified: 20221126192853897
 tags: Chrome Firefox [[Internet Explorer]] Linux Mac Opera Safari Saving Windows iOS Edge
 title: TiddlyBucket - Save to AWS or Google Storage
 type: text/vnd.tiddlywiki
-ribbon-text: NEW
 
 ~TiddlyBucket - Save to AWS or Google Storage using Go
 


### PR DESCRIPTION
This docs only PR, removes the NEW ribbon from "Saving with Polly" and "TiddlyBucket - .. " since they where added 2022, which imo is not new anymore.  

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>