### PR TITLE
Update description field for Release v5.3.2 and v5.3.3

### DIFF
--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.3.2.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.3.2.tid
@@ -1,11 +1,11 @@
 caption: 5.3.2
 created: 20231213080637781
+description: Conditional Shortcut Syntax, ListWidget Improvements
 modified: 20231213080637781
 released: 20231213080637781
 tags: ReleaseNotes
 title: Release 5.3.2
 type: text/vnd.tiddlywiki
-description: Under development
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.3.1...v5.3.2]]//
 

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.3.3.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.3.3.tid
@@ -1,11 +1,11 @@
 caption: 5.3.3
 created: 20231223102201587
+description: Bugfix release for v5.3.2
 modified: 20231223102201587
 released: 20231223102201587
 tags: ReleaseNotes
 title: Release 5.3.3
 type: text/vnd.tiddlywiki
-description: Under development
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.3.2...v5.3.3]]//
 


### PR DESCRIPTION
This PR updates the "description" field for Release v5.3.2 and v5.3.3

Old descr: Under development

New: 

v5.3.3 ... Bugfix release for v5.3.2
v5.3.2 ... Conditional Shortcut Syntax, ListWidget Improvements 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>