### PR TITLE
Improve ControlPanel Settings style-ability

### DIFF
--- a/core/ui/ControlPanel/TiddlyWiki.tid
+++ b/core/ui/ControlPanel/TiddlyWiki.tid
@@ -9,7 +9,7 @@ list-before:
 
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ControlPanel/Settings]]">
 
-<div class="tc-control-panel-setting" data-setting-title=<<currentTiddler>> style="border-top:1px solid #eee;">
+<div class="tc-control-panel-setting" data-setting-title=<<currentTiddler>> >
 
 !!.tc-control-panel-accent <$link><$transclude field="caption"/></$link>
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2513,6 +2513,10 @@ html body.tc-body.tc-single-tiddler-window {
 	width: 100%;
 }
 
+.tc-control-panel-setting {
+	border-top: 1px solid <<colour blockquote-bar>>;
+}
+
 .tc-plugin-info {
 	display: flex;
 	text-shadow: none;


### PR DESCRIPTION
This PR improves the ControlPanel Settings style-ability as requested by @twMat at https://github.com/Jermolene/TiddlyWiki5/pull/8000#issuecomment-2178307290

>Quote from Mat,
>
>I do note that each setting still has the inline `style="border-top:1px solid #eee;"` (which makes it impossible to override with a custom stylesheet) so I'm wondering if this should perhaps be moved into the introduced `class="tc-control-panel-setting"` ?

- The hardcoded style is removed, because there is no real reason for it
- `tc-control-panel-setting` got `border-top: 1px solid <<colour blockquote-bar>>;` as a **setting separator**

I did use the palette colour for `blockquote-bar`, because it is a good fit **with all existing palettes**.

Blockquote bars are usually placed into the tiddler content area and they have a contrast, that is not "intrusive". That's exactly the behaviour we need for a **setting separator**

This PR is related to the PR

- #8000