### PR TITLE
Correction to Minlength Operator

### DIFF
--- a/editions/tw5.com/tiddlers/filters/minlength.tid
+++ b/editions/tw5.com/tiddlers/filters/minlength.tid
@@ -1,12 +1,12 @@
 caption: minlength
 created: 20161011074235805
-modified: 20161011074235805
+from-version: 5.1.14
+modified: 20240621073052597
 op-input: a list of items
 op-output: those items at least as long as the specified minimum length
 op-parameter: the minimum length for items
 op-parameter-name: minlength
-op-purpose: filter items shorter than the specified minimum length
-from-version: 5.1.14
+op-purpose: filter items their length is greater than the specified minimum length
 tags: [[Filter Operators]]
 title: minlength Operator
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
In TiddlyWiki, when we say filtered list, it means items passed a criterion. Here for minlength operator, the purpose is filter items their length is greater than the specified minimum length NOT filter items shorter than specified minimum length.

NOTE: This is aligned with the word `filter`. Filter something means passing through. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>