### PR TITLE
Fix: Edge-Browser - Opening HelloThere with debugger "Pause on caught exceptions" causes a break

### DIFF
--- a/editions/tw5.com/tiddlers/images/Open Collective Logo.tid
+++ b/editions/tw5.com/tiddlers/images/Open Collective Logo.tid
@@ -1,4 +1,6 @@
-title: Open Collective Logo
+created: 20240621075644739
+modified: 20240621075647009
 tags: picture
+title: Open Collective Logo
 
-<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2" viewBox="0 0 28 28"><path d="M25.509 6.026A13.934 13.934 0 0 1 28 14c0 2.963-.92 5.71-2.491 7.974l-3.626-3.627A8.96 8.96 0 0 0 23 14a8.964 8.964 0 0 0-1.117-4.347l3.626-3.627Z"/><path d="m21.974 2.49-3.627 3.628a9 9 0 1 0 0 15.765l3.627 3.626A13.934 13.934 0 0 1 14 27.999C6.268 28 0 21.733 0 14 0 6.269 6.268 0 14 0c2.963 0 5.711.922 7.974 2.492Z"/></svg>
+<svg style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2" viewBox="0 0 28 28"><path d="M25.509 6.026A13.934 13.934 0 0 1 28 14c0 2.963-.92 5.71-2.491 7.974l-3.626-3.627A8.96 8.96 0 0 0 23 14a8.964 8.964 0 0 0-1.117-4.347l3.626-3.627Z"/><path d="m21.974 2.49-3.627 3.628a9 9 0 1 0 0 15.765l3.627 3.626A13.934 13.934 0 0 1 14 27.999C6.268 28 0 21.733 0 14 0 6.269 6.268 0 14 0c2.963 0 5.711.922 7.974 2.492Z"/></svg>


### PR DESCRIPTION
Windows 11, **Edge**-Browser: Opening HelloThere with "Pause on caught exceptions" causes the debugger to break.

- As seen in the screenshot in the next post, the A element is created
- The Open Collective logo causes the problem.

This PR fixes that problem 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>