### PR TITLE
Remove "debugger" statement from code - Make confetti examples more impressive

### DIFF
--- a/plugins/tiddlywiki/confetti/confetti-manager.js
+++ b/plugins/tiddlywiki/confetti/confetti-manager.js
@@ -33,7 +33,7 @@ ConfettiManager.prototype.launch = function (delay,options) {
 				self.outstandingTimers.splice(p,1);
 			} else {
 				console.log("Confetti Manager Error: Cannot find previously stored timer ID");
-				debugger;
+				// debugger;
 			}
 			confetti(options);
 		},delay);

--- a/plugins/tiddlywiki/confetti/examples/staggered.tid
+++ b/plugins/tiddlywiki/confetti/examples/staggered.tid
@@ -3,7 +3,8 @@ tags: $:/tags/ConfettiExample
 
 <$button>
 <$action-sendmessage $message="tm-confetti-launch"/>
-<$action-sendmessage $message="tm-confetti-launch" originY=0.6 spread=70 delay=300/>
-<$action-sendmessage $message="tm-confetti-launch" originY=0.55 spread=30 delay=600/>
-Launch three staggered rounds of confetti
+<$action-sendmessage $message="tm-confetti-launch" delay=300 originY=0.6  spread=100 scalar=1.5/>
+<$action-sendmessage $message="tm-confetti-launch" delay=400 originY=0.55 spread=130/>
+<$action-sendmessage $message="tm-confetti-launch" delay=500 originY=0.55 spread=170 scalar=2/>
+Launch four staggered rounds of confetti
 </$button>

--- a/plugins/tiddlywiki/confetti/examples/typing-trigger.tid
+++ b/plugins/tiddlywiki/confetti/examples/typing-trigger.tid
@@ -6,5 +6,5 @@ Type the word "launch": <$edit-text tiddler="$:/temp/confetti/launchstatus" tag=
 <$list filter="[{$:/temp/confetti/launchstatus}match:caseinsensitive[launch]]" variable="ignore">
 Launched!
 <$confetti particleCount=100/>
-<$confetti particleCount=100 delay=300/>
+<$confetti particleCount=100 spread=170 delay=300/>
 </$list>


### PR DESCRIPTION
@Jermolene 

The current examples are a bit "minimalistic". These changes "pump them up ;)"

While searching the code I also found a "dangling" `debugger` statement
- I did remove "debugger" statement - with it's own commit. 