### PR TITLE
Fix wikitext-example-table-row to render output in block mode

### DIFF
--- a/editions/tw5.com/tiddlers/system/wikitext-macros.tid
+++ b/editions/tw5.com/tiddlers/system/wikitext-macros.tid
@@ -75,10 +75,7 @@ type: text/vnd.tiddlywiki
 <tr>
 	<th><<id>></th>
 	<td><$codeblock code=<<code>>/></td>
-	<td>
-
-		<<code>>
-	</td>
+	<td><$transclude $variable="code" $mode="block"/></td>
 </tr>
 \end
 

--- a/editions/tw5.com/tiddlers/system/wikitext-macros.tid
+++ b/editions/tw5.com/tiddlers/system/wikitext-macros.tid
@@ -75,7 +75,10 @@ type: text/vnd.tiddlywiki
 <tr>
 	<th><<id>></th>
 	<td><$codeblock code=<<code>>/></td>
-	<td><<code>></td>
+	<td>
+
+		<<code>>
+	</td>
 </tr>
 \end
 


### PR DESCRIPTION
Prior to #8059, the wikitext-example-table-row macro output table cell used extra blank line after the open html tag to render the output in block mode. All of the uses of that macro either depend on this behavior or are not broken by it. Add the blank line back.