### PR TITLE
Add a copy to clipboard button for copying testcase Output tiddler contents

### DIFF
--- a/core/ui/TestCases/DefaultTemplate.tid
+++ b/core/ui/TestCases/DefaultTemplate.tid
@@ -13,7 +13,7 @@ title: $:/core/ui/testcases/DefaultTemplate
 	state={{{ [<qualify "$:/state/testcase">] }}}
 >
 	<div class="tc-test-case-wrapper">
-		<$transclude $variable="copy-to-clipboard-above-right" src={{{[<payloadTiddlers>jsonindexes[]] :filter[<payloadTiddlers>jsonget<currentTiddler>,[title]match[Output]] :map[<payloadTiddlers>jsonget<currentTiddler>,[text]]}}}/>
+		<$transclude $variable="copy-to-clipboard-above-right" src={{Output}}/>
 		<div class="tc-test-case-header">
 			<h2>
 				<$genesis $type={{{ [<linkTarget>!match[]then[$link]else[div]] }}} to=<<testcaseTiddler>>>

--- a/core/ui/TestCases/DefaultTemplate.tid
+++ b/core/ui/TestCases/DefaultTemplate.tid
@@ -13,6 +13,7 @@ title: $:/core/ui/testcases/DefaultTemplate
 	state={{{ [<qualify "$:/state/testcase">] }}}
 >
 	<div class="tc-test-case-wrapper">
+		<$transclude $variable="copy-to-clipboard-above-right" src={{{[<payloadTiddlers>jsonindexes[]] :filter[<payloadTiddlers>jsonget<currentTiddler>,[title]match[Output]] :map[<payloadTiddlers>jsonget<currentTiddler>,[text]]}}}/>
 		<div class="tc-test-case-header">
 			<h2>
 				<$genesis $type={{{ [<linkTarget>!match[]then[$link]else[div]] }}} to=<<testcaseTiddler>>>


### PR DESCRIPTION
The examples in the tiddlywiki documentation currently have a copy-to-clipboard button to copy the text of the example. In order to not lose that feature when converting these examples to use the testcase widget, add a copy to clipboard button to the testcase default template.