### PR TITLE
Testcase UI enhancements

### DIFF
--- a/core/language/en-GB/Buttons.multids
+++ b/core/language/en-GB/Buttons.multids
@@ -104,6 +104,8 @@ ShowSideBar/Caption: show sidebar
 ShowSideBar/Hint: Show sidebar
 TagManager/Caption: tag manager
 TagManager/Hint: Open tag manager
+TestCaseImport/Caption: import tiddlers
+TestCaseImport/Hint: Import tiddlers
 Timestamp/Caption: timestamps
 Timestamp/Hint: Choose whether modifications update timestamps
 Timestamp/On/Caption: timestamps are on

--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -95,6 +95,7 @@ function SaverHandler(options) {
 	if($tw.browser) {
 		$tw.rootWidget.addEventListener("tm-save-wiki",function(event) {
 			self.saveWiki({
+				wiki: event.widget.wiki,
 				template: event.param,
 				downloadType: "text/plain",
 				variables: event.paramObject
@@ -102,6 +103,7 @@ function SaverHandler(options) {
 		});
 		$tw.rootWidget.addEventListener("tm-download-file",function(event) {
 			self.saveWiki({
+				wiki: event.widget.wiki,
 				method: "download",
 				template: event.param,
 				downloadType: "text/plain",
@@ -147,20 +149,22 @@ Save the wiki contents. Options are:
 	method: "save", "autosave" or "download"
 	template: the tiddler containing the template to save
 	downloadType: the content type for the saved file
+	wiki: optional wiki, overriding the default wiki specified in the constructor
 */
 SaverHandler.prototype.saveWiki = function(options) {
 	options = options || {};
 	var self = this,
+		wiki = options.wiki || this.wiki,
 		method = options.method || "save";
 	// Ignore autosave if disabled
-	if(method === "autosave" && ($tw.config.disableAutoSave || this.wiki.getTiddlerText(this.titleAutoSave,"yes") !== "yes")) {
+	if(method === "autosave" && ($tw.config.disableAutoSave || wiki.getTiddlerText(this.titleAutoSave,"yes") !== "yes")) {
 		return false;
 	}
 	var	variables = options.variables || {},
 		template = (options.template || 
-		           this.wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
+		           wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
 		downloadType = options.downloadType || "text/plain",
-		text = this.wiki.renderTiddler(downloadType,template,options),
+		text = wiki.renderTiddler(downloadType,template,options),
 		callback = function(err) {
 			if(err) {
 				alert($tw.language.getString("Error/WhileSaving") + ":\n\n" + err);

--- a/core/palettes/Vanilla.tid
+++ b/core/palettes/Vanilla.tid
@@ -99,7 +99,7 @@ table-footer-background: #a8a8a8
 table-header-background: #f0f0f0
 tag-background: #ec6
 tag-foreground: #ffffff
-testcase-accent-level-1: #84C5E6
+testcase-accent-level-1: #c1eaff
 testcase-accent-level-2: #E3B740
 testcase-accent-level-3: #5FD564
 tiddler-background: <<colour background>>

--- a/core/ui/TestCases/DefaultTemplate.tid
+++ b/core/ui/TestCases/DefaultTemplate.tid
@@ -46,7 +46,7 @@ title: $:/core/ui/testcases/DefaultTemplate
 		<%endif%>
 		<div class="tc-test-case-panes">
 			<div class="tc-test-case-source">
-				<$macrocall $name="tabs" tabsList="[all[tiddlers]sort[]] -[prefix<state>] -Description -Narrative -ExpectedResult -Output Output +[putfirst[]] -[has[plugin-type]]" state=<<state>> default="Output" template="$:/core/ui/testcases/DefaultTemplate/SourceTabs"/>
+				<$macrocall $name="tabs" tabsList="[all[tiddlers]sort[]] -[prefix<state>] -Description -Narrative -Output Output +[putfirst[]] -[has[plugin-type]]" state=<<state>> default="Output" template="$:/core/ui/testcases/DefaultTemplate/SourceTabs"/>
 			</div>
 			<div class="tc-test-case-divider">
 			</div>

--- a/core/ui/TestCases/DefaultTemplate.tid
+++ b/core/ui/TestCases/DefaultTemplate.tid
@@ -27,6 +27,31 @@ title: $:/core/ui/testcases/DefaultTemplate
 					<%endif%>
 					<$view tiddler="Description" mode="inline"/>
 				</$genesis>
+				<span class="tc-test-case-toolbar">
+					<$button popup=`$(state)$-more`
+						tooltip={{$:/language/Buttons/More/Hint}}
+						aria-label={{$:/language/Buttons/More/Caption}}
+						class="tc-btn-invisible"
+						selectedClass="tc-selected"
+					>
+						{{$:/core/images/down-arrow}}
+					</$button>
+					<$let 
+						tv-config-toolbar-icons="yes"
+						tv-config-toolbar-text="yes"
+						tv-config-toolbar-class="tc-btn-invisible"
+					>
+						<$reveal state=`$(state)$-more` type="popup" position="belowleft" animate="yes">
+							<div class="tc-drop-down">
+								<$list filter="[all[shadows+tiddlers]tag[$:/tags/TestCase/Actions]!has[draft.of]]"
+									variable="listItem"
+								>
+									<$transclude tiddler=<<listItem>> mode="inline"/>
+								</$list>
+							</div>
+						</$reveal>
+					</$let>
+				</span>
 			</h2>
 		</div>
 		<%if [[Narrative]is[tiddler]] %>

--- a/core/ui/TestCases/DefaultTemplateSourceTabs.tid
+++ b/core/ui/TestCases/DefaultTemplateSourceTabs.tid
@@ -19,7 +19,9 @@ title: $:/core/ui/testcases/DefaultTemplate/SourceTabs
 	</table>
 </$list>
 <$edit class="tc-edit-texteditor" tiddler=<<currentTab>>/>
+<div class="tc-test-case-footer-toolbar">
 <$macrocall $name="copy-to-clipboard" src={{{ [<currentTab>get[text]] }}}/>
+</div>
 \end
 
 <$transclude $variable="body" $mode="inline"/>

--- a/core/ui/TestCases/DefaultTemplateSourceTabs.tid
+++ b/core/ui/TestCases/DefaultTemplateSourceTabs.tid
@@ -19,6 +19,7 @@ title: $:/core/ui/testcases/DefaultTemplate/SourceTabs
 	</table>
 </$list>
 <$edit class="tc-edit-texteditor" tiddler=<<currentTab>>/>
+<$macrocall $name="copy-to-clipboard" src={{{ [<currentTab>get[text]] }}}/>
 \end
 
 <$transclude $variable="body" $mode="inline"/>

--- a/core/ui/TestCases/actions/Export.tid
+++ b/core/ui/TestCases/actions/Export.tid
@@ -1,0 +1,4 @@
+title: $:/core/ui/testcases/actions/Export
+tags: $:/tags/TestCase/Actions
+
+<$macrocall $name="exportButton" exportFilter="[all[tiddlers]sort[]] -[prefix[$:/state/]] -Description -Narrative -ExpectedResult -Output Output +[putfirst[]] -[has[plugin-type]]" lingoBase="$:/language/Buttons/ExportTiddlers/"/>

--- a/core/ui/TestCases/actions/Import.tid
+++ b/core/ui/TestCases/actions/Import.tid
@@ -1,0 +1,11 @@
+title: $:/core/ui/testcases/actions/Import
+tags: $:/tags/TestCase/Actions
+
+\whitespace trim
+<$button tooltip={{$:/language/Buttons/TestCaseImport/Hint}} aria-label={{$:/language/Buttons/TestCaseImport/Caption}} class=<<tv-config-toolbar-class>>>
+<$action-sendmessage $message="tm-import-tiddlers" $param=<<payloadTiddlers>>/>
+{{$:/core/images/permalink-button}}
+<span class="tc-btn-text">
+<$text text={{$:/language/Buttons/TestCaseImport/Caption}}/>
+</span>
+</$button>

--- a/core/wiki/tags/TestCaseActions.tid
+++ b/core/wiki/tags/TestCaseActions.tid
@@ -1,0 +1,2 @@
+title: $:/tags/TestCase/Actions
+list:

--- a/editions/tw5.com/tiddlers/testcases/TestCaseWidget/FailingTest.tid
+++ b/editions/tw5.com/tiddlers/testcases/TestCaseWidget/FailingTest.tid
@@ -5,7 +5,7 @@ description: An example of a failing test
 
 title: Narrative
 
-This test case intentionally fails (in order to show how failures are displayed)
+This test case intentionally fails (in order to show how failures are displayed). The expected result is set to <code><$text text={{ExpectedResult}}/></code>, but the result computes to <code><$wikify name="html" text={{Output}} mode="block" output="html"><$text text=<<html>>/></$wikify></code>
 +
 title: Output
 

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -3337,6 +3337,10 @@ span.tc-translink > a:first-child {
 	fill: <<colour tiddler-controls-foreground>>;
 }
 
+.tc-test-case-toolbar .tc-drop-down {
+	font-size: 0.8em;
+}
+
 .tc-test-case-result-fail {
 	border: 1px solid <<colour foreground>>;
 	background-color: <<colour background>>;
@@ -3380,8 +3384,12 @@ span.tc-translink > a:first-child {
 }
 
 .tc-test-case-source .tc-tab-content {
-	background: <<colour background>>;
+	background: inherit;
 	margin: 0;
+}
+
+.tc-test-case-source .tc-tab-content .tc-field-table {
+	background: <<colour background>>;
 }
 
 .tc-test-case-source .tc-field-table {
@@ -3402,6 +3410,11 @@ span.tc-translink > a:first-child {
 
 .tc-test-case-source .tc-tab-buttons {
 	padding-top: 0;
+}
+
+.tc-test-case-footer-toolbar {
+	display: flex;
+	justify-content: flex-end;
 }
 
 .tc-test-case-output {

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -3297,7 +3297,7 @@ span.tc-translink > a:first-child {
 	display: inline-block;
 	line-height: 0;
 	border-radius: 1em;
-	vertical-align: bottom;
+	vertical-align: text-bottom;
 	margin-right: 0.25em;
 }
 
@@ -3314,6 +3314,12 @@ span.tc-translink > a:first-child {
 	height: 0.5em;
 }
 
+.tc-test-case-header > h2 {
+	background: <<colour background>>;
+	border-radius: 4px;
+	padding: 0.25em;
+}
+
 .tc-test-case-header > h2,
 .tc-test-case-source > pre {
 	margin: 0;
@@ -3321,6 +3327,14 @@ span.tc-translink > a:first-child {
 
 .tc-test-case-header > h2 a.tc-tiddlylink-missing {
 	font-style: normal;
+}
+
+.tc-test-case-toolbar {
+	float: right;
+}
+
+.tc-test-case-toolbar svg {
+	fill: <<colour tiddler-controls-foreground>>;
 }
 
 .tc-test-case-result-fail {
@@ -3394,7 +3408,7 @@ span.tc-translink > a:first-child {
 	box-shadow: inset 2px 2px 10px 0px <<colour muted-foreground>>;
 	background: <<colour background>>;
 	border-radius: 4px;
-	border: 1px solid <<colour foreground>>;
+	border: 1px solid <<colour muted-foreground>>;
 	flex: 1 0 49%;
 	min-width: 250px;
 	padding: 0.25em 1em;


### PR DESCRIPTION
Building on #8290, this PR improves the UI of the testcase widget:

* Button to copy the text of any of the payload tiddlers
* Adds dropdown menu to testcase toolbar
* Option to export payload tiddlers as a file
* Option to import payload tiddlers into the main wiki (giving the user a chance to rename them)
* Lightens the background colour

<img width="686" alt="image" src="https://github.com/Jermolene/TiddlyWiki5/assets/174761/5a350452-f666-488b-880e-0eebb8686079">

<img width="752" alt="image" src="https://github.com/Jermolene/TiddlyWiki5/assets/174761/ed323847-4149-4439-a952-801b5e2b720f">
