### PR TITLE
Fix link in AutoSave.tid from SaverModule to SavingMechanism

### DIFF
--- a/editions/tw5.com/tiddlers/features/AutoSave.tid
+++ b/editions/tw5.com/tiddlers/features/AutoSave.tid
@@ -4,7 +4,7 @@ tags: Features
 title: AutoSave
 type: text/vnd.tiddlywiki
 
-If there is a SaverModule available that supports it, TiddlyWiki will automatically trigger a save of the current document on clicking <<.icon $:/core/images/done-button>> ''ok'' or <<.icon $:/core/images/delete-button>> ''delete'' when editing a tiddler.
+If there is a SavingMechanism available that supports it, TiddlyWiki will automatically trigger a save of the current document on clicking <<.icon $:/core/images/done-button>> ''ok'' or <<.icon $:/core/images/delete-button>> ''delete'' when editing a tiddler.
 
 You should see a yellow notification at the top right of the window to confirm that an automatic save has taken place.
 


### PR DESCRIPTION
AutoSave tiddler's first sentence currently points to SaverModule, which is a missing tiddler. SavingMechanism seems to be the retitled tiddler that wasn't relinked. (Perhaps more changes are warranted, but this minimal change avoids the embarrassment of a dead link at a place newbies might actually be depending on info.)