### PR TITLE
Add simple examples for EditWidget

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/EditWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditWidget.tid
@@ -1,6 +1,6 @@
 caption: edit
 created: 20131024141900000
-modified: 20211009121634055
+modified: 20240627220419761
 tags: Widgets TriggeringWidgets
 title: EditWidget
 type: text/vnd.tiddlywiki
@@ -24,3 +24,16 @@ The content of the `<$edit>` widget is ignored.
 |inputActions |<<.from-version 5.1.23>> Optional actions that are triggered every time an input event occurs within the input field or textarea |
 |refreshTitle |<<.from-version 5.1.23>> An optional tiddler title that makes the input field update whenever the specified tiddler changes |
 
+! Examples
+
+!! Edit the contents (text field) of a tiddler titled <%if [<now YYYY-0MM-0DD>is[tiddler]] %> <$tiddler tiddler=<<now YYYY-0MM-0DD>> > <$link/></$tiddler> <%else %> with today’s date <% endif %>
+
+<$macrocall $name=".example" n="1"
+eg="""<$edit tiddler=<<now YYYY-0MM-0DD>> class="tc-edit-texteditor"/>
+"""/>
+
+!! Edit $:/status/UserName with single-line input box, have browser offer autocomplete for email
+
+<$macrocall $name=".example" n="2"
+eg="""<$edit-text tiddler="$:/status/UserName" tag="input" size=40 autocomplete="email"/>
+"""/>


### PR DESCRIPTION
Add two examples for EditWidget, which currently has none. 

These examples also add practice for the <<now>> macro, class attribute, plus use of tag="input" and size attribute for specifying input box size (despite editing text field of a tiddler). Second example also illustrates autocomplete (mentioned as attribute but with no examples yet in documentation).

Update: first example now interacts better, showing a link to the newly-created dated tiddler in place of the text "titled with today's date", so that it's obvious to user exactly when a tiddler has been created to hold the editwidget input (even if user is not looking at Recent tab). Easter egg: if user is curious how this works, they can edit source to see implementation of conditional shortcut syntax.

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small> 