### PR TITLE
Expand $:/language/Docs/Fields/_canonical_uri to note broader range of _canonical_uri types

### DIFF
--- a/editions/tw5.com/tiddlers/$:/language/Docs/Fields/_canonical_uri.tid
+++ b/editions/tw5.com/tiddlers/$:/language/Docs/Fields/_canonical_uri.tid
@@ -1,0 +1,5 @@
+created: 20240627223618060
+modified: 20240627223637576
+title: $:/language/Docs/Fields/_canonical_uri
+
+The full URI of an external image, audio, or html file


### PR DESCRIPTION
_canonical_uri field description was misleadingly limited to "external image tiddlers". This is misleading both because the location string need not be for an external *tiddler* at all (after all, we do have processes for loading tiddlers from external sites now). Also, it's not just images, but externally available audio, html, etc. that may be rendered with help of this field. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>