### PR TITLE
[DOCS] Empty river show home button

### DIFF
--- a/editions/tw5.com/tiddlers/system/$__config_EmptyStoryMessage.tid
+++ b/editions/tw5.com/tiddlers/system/$__config_EmptyStoryMessage.tid
@@ -1,0 +1,20 @@
+title: $:/config/EmptyStoryMessage
+
+\whitespace trim
+<style>
+.tc-story-empty {
+	text-align: center;
+	padding-top: 5em;
+}
+.tc-story-empty button svg.tc-image-button {
+	height: 30em;
+	width: 30em;
+}
+</style>
+<$wikify name="fill-colour" text="<<color muted-foreground>>">
+	<div class="tc-story-empty">
+		<$button class=" tc-btn-invisible" style=`fill: $(fill-colour)$;` message="tm-home">
+			{{$:/core/images/home-button}}
+		</$button>
+	</div>
+</$wikify>


### PR DESCRIPTION
@Jermolene This PR is docs only

- It shows a big home-button, if the story river is empty. 
- The top of the icon is just below the baseline of the page title

![image](https://github.com/Jermolene/TiddlyWiki5/assets/374655/06853a08-52fb-4fb2-a31f-05edfa46e122)
