### PR TITLE
[DOCS] Improve TiddlyWiki Archive

### DIFF
--- a/editions/tw5.com/tiddlers/about/Archive.tid
+++ b/editions/tw5.com/tiddlers/about/Archive.tid
@@ -1,14 +1,14 @@
-title: TiddlyWiki Archive
 created: 20231005205623086
-modified: 20231005210538879
+modified: 20240628132622052
 tags: About
+title: TiddlyWiki Archive
 
 \procedure versions()
 5.1.0 5.1.1 5.1.2 5.1.3 5.1.4 5.1.5 5.1.6 5.1.7 5.1.8 5.1.9
 5.1.10 5.1.11 5.1.12 5.1.13 5.1.14 5.1.15 5.1.16 5.1.17 5.1.18 5.1.19
 5.1.20 5.1.21 5.1.22 5.1.23
 5.2.0 5.2.1 5.2.2 5.2.3 5.2.4 5.2.5 5.2.6 5.2.7
-5.3.0 5.3.1 5.3.2 5.3.3
+5.3.0 5.3.1 5.3.2 5.3.3 5.3.4
 \end
 
 Older versions of TiddlyWiki are available in the [[archive|https://github.com/Jermolene/jermolene.github.io/tree/master/archive]]:

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.3.4.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.3.4.tid
@@ -1,11 +1,11 @@
 caption: 5.3.4
 created: 20240627165458407
-modified: 20240627165458407
+description: Testcase Widget, Tour Plugin, Geospatial Plugin, transcludes- backtranscludes operators, ... 
+modified: 20240628132840367
 released: 20240627165458407
 tags: ReleaseNotes
 title: Release 5.3.4
 type: text/vnd.tiddlywiki
-description: Under development
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.3.3...v5.3.4]]//
 


### PR DESCRIPTION
This PR adds TW v5.3.4 to the archive

- The Lifetime "current" is now shown for v5.3.4
- v5.3.4 shows the right summary
- The lifetime for v5.3.3 is calculated 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>