### PR TITLE
Revert to \define colour macro for backwards compatibility

### DIFF
--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -13,25 +13,6 @@ tags: $:/tags/Macro $:/tags/Global
 
 \define color(name) <<colour $name$>>
 
-<!-- New syntax that allows: <div style.background=<<tf.colour sidebar-tab-border>>> -->
-\define colorRegexp() <<colou?r\s.*>>
-\define removeRegex() <<colou?r\s|"|'|>>
-
-\function tf.colour(name)
-	[{$:/palette}getindex<name>]
-	:else[[$:/palettes/Vanilla]getindex<name>]
-	:else[[$:/config/DefaultColourMappings/]addsuffix<name>get[text]trim[]]
-	:map[_tf.recolour<currentTiddler>]
-\end
-
-\function _tf.recolour(name)
-	[<name>regexp<colorRegexp>]
-	:then[<name>search-replace:g:regexp<removeRegex>,[]trim[]] :map[tf.colour<currentTiddler>]
-	:else[<name>]
-\end
-
-\function tf.color(name) [tf.colour<name>]
-
 \function box-shadow(shadow)
 [[ -webkit-box-shadow: $(shadow)$;
 	-moz-box-shadow: $(shadow)$;

--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -1,18 +1,34 @@
 title: $:/core/macros/CSS
 tags: $:/tags/Macro $:/tags/Global
 
-\procedure colour(name)
+<!-- Needs to stay that way for backwards compatibility. See GH issue: #8326 -->
+\define colour(name)
 \whitespace trim
-<$transclude $tiddler={{$:/palette}} $index=`$(name)$`>
-	<$transclude $tiddler="$:/palettes/Vanilla" $index=`$(name)$`>
-		<$transclude $tiddler=`$:/config/DefaultColourMappings/$(name)$`/>
+<$transclude tiddler={{$:/palette}} index="$name$">
+	<$transclude tiddler="$:/palettes/Vanilla" index="$name$">
+		<$transclude tiddler="$:/config/DefaultColourMappings/$name$"/>
 	</$transclude>
 </$transclude>
 \end
 
-\procedure color(name)
-<$macrocall $name=colour name=`$(name)$`/>
+<!-- New syntax that allows: <div style.background=<<tf.colour sidebar-tab-border>>> -->
+\define colorRegexp() <<colou?r\s.*>>
+\define removeRegex() <<colou?r\s|"|'|>>
+
+\function tf.colour(name)
+	[{$:/palette}getindex<name>]
+	:else[[$:/palettes/Vanilla]getindex<name>]
+	:else[[$:/config/DefaultColourMappings/]addsuffix<name>get[text]trim[]]
+	:map[_tf.recolour<currentTiddler>]
 \end
+
+\function _tf.recolour(name)
+	[<name>regexp<colorRegexp>]
+	:then[<name>search-replace:g:regexp<removeRegex>,[]trim[]] :map[tf.colour<currentTiddler>]
+	:else[<name>]
+\end
+
+\function tf.color(name) [tf.colour<name>]
 
 \function box-shadow(shadow)
 [[ -webkit-box-shadow: $(shadow)$;

--- a/core/wiki/macros/CSS.tid
+++ b/core/wiki/macros/CSS.tid
@@ -11,6 +11,8 @@ tags: $:/tags/Macro $:/tags/Global
 </$transclude>
 \end
 
+\define color(name) <<colour $name$>>
+
 <!-- New syntax that allows: <div style.background=<<tf.colour sidebar-tab-border>>> -->
 \define colorRegexp() <<colou?r\s.*>>
 \define removeRegex() <<colou?r\s|"|'|>>


### PR DESCRIPTION
This PR should fix #8326

Please test. 

The new functions @ericshulman suggested are implemented like this: 

- core functions are prefixed `tf.` to allow us to use them like `tf.colour<name>` instead of `function[tf.colour],<name>`
  -  Both versions should be possible
- For convenience there are 2 colou?r functions: `tf.colour(name)` and `tf.color(name)` 
  - They should work with eg: `<div style.background=<<tf.colour alert-background>>>`
- Test: `<<tf.colour sidebar-tab-border>>` lets you test the recursive resolution "since sidebar-tab-border" uses `<<colour tab-border>>` in vanilla
- The regexp should be able to allow unicode whitespace

Sorry for the trouble :(
I'll add some tests and some docs if it gets merged. 