### PR TITLE
Fix transparent draft list when using Solarized palette

### DIFF
--- a/core/palettes/SolarizedDark.tid
+++ b/core/palettes/SolarizedDark.tid
@@ -18,7 +18,7 @@ button-foreground: #93a1a1
 code-background: #073642
 code-border: #586e75
 code-foreground: #93a1a1
-dirty-indicator: inherit
+dirty-indicator: #dc322f
 download-background: #859900
 download-foreground: #073642
 dragger-background: #073642

--- a/core/palettes/SolarizedLight.tid
+++ b/core/palettes/SolarizedLight.tid
@@ -18,7 +18,7 @@ button-foreground: #586e75
 code-background: #eee8d5
 code-border: #93a1a1
 code-foreground: #586e75
-dirty-indicator: inherit
+dirty-indicator: #dc322f
 download-background: #859900
 download-foreground: #eee8d5
 dragger-background: #eee8d5


### PR DESCRIPTION
Tiddlywiki uses the palette's `dirty-indicator` color as the background color of the draft list. Since the Solarized palette set `dirty-indicator` to `inherit`, the background of the draft list becomes transparent when using the palette.

![图片](https://github.com/Jermolene/TiddlyWiki5/assets/70204468/8584311b-2ed0-496c-af10-b32a5e771c18)

This PR fixes that by setting the value of `dirty-indicator` to `#dc322f`.
