### PR TITLE
Allow fieldmangler to catch unsaved tag changes

### DIFF
--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -157,7 +157,7 @@ The second ESC tries to close the "draft tiddler"
 <!-- Use this function if tag-picker is a stand alone macro. Otherwise use "newTagNameTiddler" defined for fieldmangler in EditTemplate -->
 \function _tf.makeTagNameTiddler() [[$:/temp/NewTagName]] [<tagField>!match[tags]] +[join[/]] [<qualify>] +[join[]]
 
-<!-- keep those variables because they may "blead" into macros using old syntax -->
+<!-- keep those variables because they may "bleed" into macros using old syntax -->
 <$let
 	palette={{$:/palette}}
 	colourA={{{ [<palette>getindex[foreground]] }}}

--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -154,6 +154,8 @@ The second ESC tries to close the "draft tiddler"
 
 \function _tf.getUserInput() [<storeTitle>get[text]]
 \function _tf.getTag() [<newTagNameTiddler>get[text]]
+<!-- Use this function if tag-picker is a stand alone macro. Otherwise use "newTagNameTiddler" defined for fieldmangler in EditTemplate -->
+\function _tf.makeTagNameTiddler() [[$:/temp/NewTagName]] [<tagField>!match[tags]] +[join[/]] [<qualify>] +[join[]]
 
 <!-- keep those variables because they may "blead" into macros using old syntax -->
 <$let
@@ -164,7 +166,7 @@ The second ESC tries to close the "draft tiddler"
 
 	saveTiddler={{{ [<tiddler>is[blank]then<currentTiddler>else<tiddler>] }}}
 
-	newTagNameTiddler={{{ [[$:/temp/NewTagName]] [<tagField>!match[tags]] +[join[/]] [<qualify>] +[join[]] }}}
+	newTagNameTiddler={{{ [[newTagNameTiddler]is[variable]then<newTagNameTiddler>] :else[<_tf.makeTagNameTiddler>] }}}
 	storeTitle={{{ [[$:/temp/NewTagName/input]] [<tagField>!match[tags]] +[join[/]] [<qualify>] +[join[]] }}}
 
 	newTagNameSelectionTiddlerQualified=<<qualify "$:/temp/NewTagName/selected-item">>


### PR DESCRIPTION
This PR should fix

- #8328 

@twMat -- Please check the preview once it's built. 

@Jermolene  -- This one is a regression in v5.3.4 -- introduced by the tag-picker rewrite.  I did see the problem of possible "bleeding" variables, but I did not test that specific usecase. 

I did test the [tag-picker examples](https://tiddlywiki.com/#tag-picker%20Macro%20(Examples)). They still work as expected. 