### PR TITLE
datawidget: Add check if tiddler exists for $filter attribute to avoide rsod

### DIFF
--- a/core/modules/widgets/data.js
+++ b/core/modules/widgets/data.js
@@ -91,7 +91,9 @@ DataWidget.prototype.computeDataTiddlerValues = function() {
 			var titles = this.wiki.filterTiddlers(filter);
 			$tw.utils.each(titles,function(title) {
 				var tiddler = self.wiki.getTiddler(title);
-				tiddlers.push(tiddler);
+				if(tiddler) {
+					tiddlers.push(tiddler);
+				}
 			});
 		}
 	}


### PR DESCRIPTION
This PR fixes 

- #8330

It adds the same `if (tiddler)` check, that is used for the `$tiddler` attribute. 

@btheado please check the preview, once it is built