### PR TITLE
Fix tiddlers should not be interactive after being closed

### DIFF
--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -82,6 +82,10 @@ ClassicStoryView.prototype.remove = function(widget) {
 			removeElement = function() {
 				widget.removeChildDomNodes();
 			};
+		// Blur the focus if it is within the descendents of the node we are removing
+		if($tw.utils.domContains(targetElement,targetElement.ownerDocument.activeElement)) {
+			targetElement.ownerDocument.activeElement.blur();
+		}
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
 		if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 			removeElement();

--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -84,33 +84,26 @@ ClassicStoryView.prototype.remove = function(widget) {
 			};
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
 		if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
-			widget.removeChildDomNodes();
+			removeElement();
 			return;
 		}
-		// Clone the target element
-		var cloneElement = targetElement.cloneNode(true);
-		targetElement.parentNode.insertBefore(cloneElement,targetElement);
-		// Remove the original element
-		widget.removeChildDomNodes();
 		// Get the current height of the tiddler
-		var currWidth = cloneElement.offsetWidth,
-			computedStyle = window.getComputedStyle(cloneElement),
+		var currWidth = targetElement.offsetWidth,
+			computedStyle = window.getComputedStyle(targetElement),
 			currMarginBottom = parseInt(computedStyle.marginBottom,10),
 			currMarginTop = parseInt(computedStyle.marginTop,10),
-			currHeight = cloneElement.offsetHeight + currMarginTop;
+			currHeight = targetElement.offsetHeight + currMarginTop;
 		// Remove the dom nodes of the widget at the end of the transition
-		setTimeout(function() {
-			cloneElement.parentNode.removeChild(cloneElement);
-		},duration);
+		setTimeout(removeElement,duration);
 		// Animate the closure
-		$tw.utils.setStyle(cloneElement,[
+		$tw.utils.setStyle(targetElement,[
 			{transition: "none"},
 			{transform: "translateX(0px)"},
 			{marginBottom:  currMarginBottom + "px"},
 			{opacity: "1.0"}
 		]);
-		$tw.utils.forceLayout(cloneElement);
-		$tw.utils.setStyle(cloneElement,[
+		$tw.utils.forceLayout(targetElement);
+		$tw.utils.setStyle(targetElement,[
 			{transition: $tw.utils.roundTripPropertyName("transform") + " " + duration + "ms " + easing + ", " +
 						"opacity " + duration + "ms " + easing + ", " +
 						"margin-bottom " + duration + "ms " + easing},

--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -84,26 +84,33 @@ ClassicStoryView.prototype.remove = function(widget) {
 			};
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
 		if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
-			removeElement();
+			widget.removeChildDomNodes();
 			return;
 		}
+		// Clone the target element
+		var cloneElement = targetElement.cloneNode(true);
+		targetElement.parentNode.insertBefore(cloneElement,targetElement);
+		// Remove the original element
+		widget.removeChildDomNodes();
 		// Get the current height of the tiddler
-		var currWidth = targetElement.offsetWidth,
-			computedStyle = window.getComputedStyle(targetElement),
+		var currWidth = cloneElement.offsetWidth,
+			computedStyle = window.getComputedStyle(cloneElement),
 			currMarginBottom = parseInt(computedStyle.marginBottom,10),
 			currMarginTop = parseInt(computedStyle.marginTop,10),
-			currHeight = targetElement.offsetHeight + currMarginTop;
+			currHeight = cloneElement.offsetHeight + currMarginTop;
 		// Remove the dom nodes of the widget at the end of the transition
-		setTimeout(removeElement,duration);
+		setTimeout(function() {
+			cloneElement.parentNode.removeChild(cloneElement);
+		},duration);
 		// Animate the closure
-		$tw.utils.setStyle(targetElement,[
+		$tw.utils.setStyle(cloneElement,[
 			{transition: "none"},
 			{transform: "translateX(0px)"},
 			{marginBottom:  currMarginBottom + "px"},
 			{opacity: "1.0"}
 		]);
-		$tw.utils.forceLayout(targetElement);
-		$tw.utils.setStyle(targetElement,[
+		$tw.utils.forceLayout(cloneElement);
+		$tw.utils.setStyle(cloneElement,[
 			{transition: $tw.utils.roundTripPropertyName("transform") + " " + duration + "ms " + easing + ", " +
 						"opacity " + duration + "ms " + easing + ", " +
 						"margin-bottom " + duration + "ms " + easing},


### PR DESCRIPTION
The problem identified in #8341 is that in the classic story view it is possible to interact with a tiddler while the "close tiddler" animation is running. In particular, typing into the tiddler after closing it will create a new draft.

This PR fixes the problem by cloning the DOM node that is being removed, and animating the clone, allowing the original DOM node to be deleted immediately.

The only problem I have found is that when editing an image tiddler the image will briefly appear blank while the tiddler is closing. This is because the underlying DOM "cloneNode()" method doesn't replicate the content of canvases. I think we could fix that by manually copying canvas content, but I am not sure that it is worth the investment.