### PR TITLE
Clarify wording on examples for tag-picker Macro

### DIFF
--- a/editions/tw5.com/tiddlers/tag-picker Macro (Examples).tid
+++ b/editions/tw5.com/tiddlers/tag-picker Macro (Examples).tid
@@ -1,13 +1,13 @@
 created: 20230616104546608
-modified: 20240214174032498
+modified: 20240708132312901
 tags: [[tag-picker Macro]] [[Macro Examples]]
 title: tag-picker Macro (Examples)
 type: text/vnd.tiddlywiki
 
-<<.warning """The first example will set the tag of the <<.tid currentTiddler>> so you should copy / paste it to a new tiddler for testing. Otherwise you'll change "this tiddler" """>>
+<<.warning """The first example will add tags to the <<.tid currentTiddler>> so you should copy / paste it to a new tiddler for testing. Otherwise you'll change "this tiddler" """>>
 
-<$macrocall $name=".example" n="1"
-eg="""Use all existing tags and set the ''tags'' field here: <<tag-picker>>
+<$transclude $variable=".example" n="1"
+eg="""Add tags to this tiddler's ''tags'' field (selecting from a list of all tags): <<tag-picker>>
 """/>
 
 ----
@@ -17,41 +17,41 @@ eg="""Use all existing tags and set the ''tags'' field here: <<tag-picker>>
 <<.tip """The following examples use a temporary tiddler: $:/temp/test/tag-picker. So this tiddler will not be changed """>>
 
 
-<$macrocall $name=".example" n="2" 
+<$transclude $variable=".example" n="2" 
 eg="""$:/temp/test/tag-picker ''tags'': <$text text={{{ [[$:/temp/test/tag-picker]get[tags]enlist-input[]join[, ]else[n/a]] }}}/>
 
-Use all existing tags and set the $:/temp/test/tag-picker ''tags'' field: <<tag-picker tiddler:"$:/temp/test/tag-picker">>
+Add tags to the $:/temp/test/tag-picker ''tags'' field (selecting from a list of all tags): <<tag-picker tiddler:"$:/temp/test/tag-picker">>
 """/>
 
 ----
 
 <<.tip """Use the following example to populate the $:/temp/test/tag-picker ''foo''-field, which are needed by some examples below """>>
 
-<$macrocall $name=".example" n="3" 
+<$transclude $variable=".example" n="3" 
 eg="""$:/temp/test/tag-picker ''foo'': <$text text={{{ [[$:/temp/test/tag-picker]get[foo]enlist-input[]join[, ]else[n/a]] }}}/>
 
-Use all existing tags and set the $:/temp/test/tag-picker ''foo'' field: <<tag-picker tagField:"foo"  tiddler:"$:/temp/test/tag-picker">>
+Add tags to the $:/temp/test/tag-picker ''foo'' field (selecting from a list of all tags): <<tag-picker tagField:"foo"  tiddler:"$:/temp/test/tag-picker">>
 """/>
 
 ----
 
 <<.tip """The following example expects some values in the "foo" field of the tiddler $:/temp/test/tag-picker, which can be created by the example above.""">>
 
-<$macrocall $name=".example" n="4" eg="""\procedure listSource() $:/temp/test/tag-picker
+<$transclude $variable=".example" n="4" eg="""\procedure listSource() $:/temp/test/tag-picker
 
 $:/temp/test/tag-picker foo: <$text text={{{ [[$:/temp/test/tag-picker]get[foo]enlist-input[]join[, ]else[n/a]] }}}/><br>
 $:/temp/test/tag-picker bar: <$text text={{{ [[$:/temp/test/tag-picker]get[bar]enlist-input[]join[, ]else[n/a]] }}}/>
 
-Use $:/temp/test/tag-picker ''foo'' field as source and set ''bar'': <<tag-picker tagField:"bar" tagListFilter:"[<listSource>get[foo]enlist-input[]]" tiddler:"$:/temp/test/tag-picker">>
+Add tags to the ''bar'' field, selecting from values in ''foo'' field of $:/temp/test/tag-picker: <<tag-picker tagField:"bar" tagListFilter:"[<listSource>get[foo]enlist-input[]]" tiddler:"$:/temp/test/tag-picker">>
 """/>
 
 ----
 
 <<.tip """The following example expects some values in the "foo" field of the tiddler $:/temp/test/tag-picker, which can be created by the example above.<br>
-It will also add completely new tags to the bar-field and the source tiddlers foo-field. New tags can be entered by typing into the tag-name input
+It will also add completely new tags to the bar-field and the source tiddler‘s foo-field. New tags can be entered by typing into the tag-name input
 """>>
 
-<$macrocall $name=".example" n="5" eg="""
+<$transclude $variable=".example" n="5" eg="""
 \procedure listSource() $:/temp/test/tag-picker
 \procedure listSourceField() foo
 
@@ -62,7 +62,7 @@ It will also add completely new tags to the bar-field and the source tiddlers fo
 $:/temp/test/tag-picker foo: <$text text={{{ [[$:/temp/test/tag-picker]get[foo]enlist-input[]join[, ]else[n/a]] }}}/><br>
 $:/temp/test/tag-picker ''bar'': <$text text={{{ [[$:/temp/test/tag-picker]get[bar]enlist-input[]join[, ]else[n/a]] }}}/>
 
-Use $:/temp/test/tag-picker ''foo'' field as source and set ''bar'': <$macrocall $name="tag-picker" tagField="bar" tagListFilter="[<listSource>get<listSourceField>enlist-input[]]" tiddler="$:/temp/test/tag-picker" actions=<<addNewTagToSource>>/>
+Add tags to ''bar'' field, selecting from values in ''foo'' field of $:/temp/test/tag-picker: <$macrocall $name="tag-picker" tagField="bar" tagListFilter="[<listSource>get<listSourceField>enlist-input[]]" tiddler="$:/temp/test/tag-picker" actions=<<addNewTagToSource>>/>
 
 """/>
 


### PR DESCRIPTION
Prior wording was confusing in two ways: 

"Use all tags" is ambiguous. ("use all" sounds like "choose all"). It's clearer to say, "select from all tags"

"Set tags field" should be "add tags", since the tag field (as a field) is not being completely replaced by the choice (which "set" might imply, when applied to a field). 

(Especially with the warning on the first example, it may seem as though interacting with the example would cauee the tags field of current tiddler to include ("use") all tags. That would indeed be alarming!)

For each example, I've also put the active point of the example ("add tags") at the beginning of the explanation, for more straightforward reading.

In last example, I also supplied the missing apostrophe (typo) in original ("source tiddlers foo-field"). 

UPDATE: Presumably, moving forward, we should invoke `<$transclude $variable= ... >`in our examples rather than macrocall widgets. I've updated accordingly.

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>  