### PR TITLE
Make it easier to see which filter Operators are selection constructors

### DIFF
--- a/editions/tw5.com/tiddlers/Selection Constructors: Conditional.tid
+++ b/editions/tw5.com/tiddlers/Selection Constructors: Conditional.tid
@@ -1,0 +1,9 @@
+created: 20240708174435694
+modified: 20240708175546166
+title: Selection Constructors: Conditional
+
+Most [[filter Operators|filter Operator]] are either ''selection modifiers'' or [[Selection Constructors]].
+
+Within the exceptional category <<tag>> are a tiny minority that //usually// act as ''selection modifiers'', but which can construct a fresh selection under special conditions — namely, whenever their [[parameter|Filter Parameter]] is specified with a selection constructor.
+
+<<list-links "[tag<currentTiddler>]">>

--- a/editions/tw5.com/tiddlers/concepts/Selection Constructors.tid
+++ b/editions/tw5.com/tiddlers/concepts/Selection Constructors.tid
@@ -1,5 +1,5 @@
 created: 20150117204109000
-modified: 20150917193713204
+modified: 20240708201746542
 tags: Filters
 title: Selection Constructors
 type: text/vnd.tiddlywiki
@@ -11,3 +11,7 @@ The output of a [[Filter Step]] depends on its [[operator|Filter Operators]]:
 * A few operators ignore their input and generate an independent output instead. These are called <<.def "selection constructors">>: they construct an entirely new [[selection|Title Selection]].
 
 A good example of a constructor is <<.olink title>>. The output of `[title[A]title[B]]` is just <<.tid B>>. But the <<.olink field>> operator is a modifier, so `[title[A]field:title[B]` outputs nothing at all.
+
+The following [[filter Operators|filter Operator]] are tagged <<tag>>:
+
+<<list-links "[tag<currentTiddler>]" class:"multi-columns">>


### PR DESCRIPTION
This tiddler title ([[Selection Constructors]]) is the home-node for a tag, but there's no easy way to get to the tag-child tiddlers from here. 

The text "A few operators ..." is frustrating to read, if someone wants to know, "OK, but which ones, exactly?"

A tag pill, followed by list-links at bottom, helps to fill this gap.

A brief explanatory tiddler at the tag-node for [[Selection Constructors: Conditional]] — which has been an empty node until now — rounds out the documentation further. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small> 