### PR TITLE
Fix 8347 tag-picker macro improve tagListFilter 

### DIFF
--- a/core/wiki/macros/tag-picker.tid
+++ b/core/wiki/macros/tag-picker.tid
@@ -1,9 +1,12 @@
 title: $:/core/macros/tag-picker
 tags: $:/tags/Macro $:/tags/Global
-first-search-filter: [subfilter<tagListFilter>!is[system]search:title<userInput>sort[]]
-second-search-filter: [subfilter<tagListFilter>is[system]search:title<userInput>sort[]]
+first-search-filter: [subfilter<tagListFilter>!is[system]search:title<userInput>]
+second-search-filter: [subfilter<tagListFilter>is[system]search:title<userInput>]
 
-<!-- first-search-filter and second-search-filter fields are not used here in the code, but they are defined as parameters for keyboard-driven-input macro -->
+<!--
+	Fields: "first-search-filter", "second-search-filter" are assigned to the keyboard-driven input macro with parameter: "configTiddlerFilter"
+	They __need to be the same__ as used for variables: "nonSystemTagsFilter" and "systemTagsFilter". See code below!
+-->
 
 \whitespace trim
 
@@ -150,7 +153,7 @@ The second ESC tries to close the "draft tiddler"
 \end
 
 <!-- prepare all variables for tag-picker keyboard handling -->
-\procedure tag-picker(actions, tagField:"tags", tiddler, tagListFilter:"[tags[]]")
+\procedure tag-picker(actions, tagField:"tags", tiddler, tagListFilter:"[tags[]sort[]]")
 
 \function _tf.getUserInput() [<storeTitle>get[text]]
 \function _tf.getTag() [<newTagNameTiddler>get[text]]
@@ -158,6 +161,7 @@ The second ESC tries to close the "draft tiddler"
 \function _tf.makeTagNameTiddler() [[$:/temp/NewTagName]] [<tagField>!match[tags]] +[join[/]] [<qualify>] +[join[]]
 
 <!-- keep those variables because they may "bleed" into macros using old syntax -->
+<!-- "nonSystemTagsFilter", "systemTagsFilter" __need to be the same__ as fields: "first-search-filter", "second-search-filter" -->
 <$let
 	palette={{$:/palette}}
 	colourA={{{ [<palette>getindex[foreground]] }}}
@@ -174,8 +178,8 @@ The second ESC tries to close the "draft tiddler"
 
 	refreshTitle=<<qualify "$:/temp/NewTagName/refresh">>
 
-	nonSystemTagsFilter="[subfilter<tagListFilter>!is[system]search:title<userInput>sort[]]"
-	systemTagsFilter="[subfilter<tagListFilter>is[system]search:title<userInput>sort[]]"
+	nonSystemTagsFilter="[subfilter<tagListFilter>!is[system]search:title<userInput>]"
+	systemTagsFilter="[subfilter<tagListFilter>is[system]search:title<userInput>]"
 
 	cancelPopups="yes"
 >

--- a/editions/tw5.com/tiddlers/macros/tag-picker_Macro.tid
+++ b/editions/tw5.com/tiddlers/macros/tag-picker_Macro.tid
@@ -1,6 +1,6 @@
 caption: tag-picker
 created: 20161128191316701
-modified: 20230616114543787
+modified: 20240708175550512
 tags: Macros [[Core Macros]]
 title: tag-picker Macro
 type: text/vnd.tiddlywiki
@@ -19,7 +19,8 @@ The <<.def tag-picker>> [[macro|Macros]] generates a combination of a text box a
 : <<.from-version 5.3.4>> Defines the target tiddler, which should be manipulated. Defaults to: <<.var currentTiddler>>.
 
 ; tagListFilter
-: <<.from-version 5.3.4>> This parameter defaults to: `[tags[]]` which creates a list of all existing tags. If the tag list should come from a different source the filter should look similar to eg: `[<listSource>get[field-name]enlist-input[]]`. 
+: <<.from-version 5.3.4>> This parameter defaults to: `[tags[]]` which creates a list of all existing tags. If the tag list should come from a different source the filter should look similar to eg: `[<listSource>get[field-name]enlist-input[]]`. See examples.
+: <<.from-version 5.3.6>> This parameter defaults to: `[tags[]sort[]]`. This change allows a custom sort order, since `sort[]` is not hardcoded into the tag-picker macro anymore. 
 
 
 <<.macro-examples "tag-picker">>


### PR DESCRIPTION
Fix #8347 tag-picker macro, change tagListFilter 

- This PR changes `tagListFilter` from `[tags[]]` to `[tags[]sort[]]`
- It removes the hardcoded `sort[]` from the default filters. 
 
So users can provide custom filters now. 

@twMat Please test the preview, once it is built