### PR TITLE
change tags operator from object hashmap to ListLinks

### DIFF
--- a/core/modules/filters/tags.js
+++ b/core/modules/filters/tags.js
@@ -14,18 +14,20 @@ Filter operator returning all the tags of the selected tiddlers
 
 /*
 Export our filter function
+LinkedList instead of Object. Should be as performant but allows us to have unsorted arrays.
 */
 exports.tags = function(source,operator,options) {
-	var tags = {};
+	var results = new $tw.utils.LinkedList();
 	source(function(tiddler,title) {
 		var t, length;
 		if(tiddler && tiddler.fields.tags) {
 			for(t=0, length=tiddler.fields.tags.length; t<length; t++) {
-				tags[tiddler.fields.tags[t]] = true;
+				results.pushTop(tiddler.fields.tags[t])
 			}
 		}
 	});
-	return Object.keys(tags);
+	// return results.makeTiddlerIterator(options.wiki);
+	return results.toArray();
 };
 
 })();


### PR DESCRIPTION
This PR fixes 
- #8228

Change tags operator from object hashmap to ListLinks, so we can show tags using the order, which they where created. 