### PR TITLE
Help beginners orient to empty filter parameters

### DIFF
--- a/editions/tw5.com/tiddlers/Operators without parameters.tid
+++ b/editions/tw5.com/tiddlers/Operators without parameters.tid
@@ -1,0 +1,18 @@
+created: 20240708171243370
+modified: 20240708201827711
+tags: 
+title: Operators without parameters
+
+Many [[Filter Operators]] have no [[parameter|Filter Parameter]] available. Still, each operator must be followed by a bracketed parameter expression — even if it is empty — as with the <<.olink backlinks>> operator below:
+
+`[<currentTiddler>backlinks[]]`
+
+(Even though an expression such as `[<currentTiddler>backlinks]` may at first <<.em seem>> well-formed — insofar as closing brackets seem to pair properly with opening brackets — each operator needs its own parameter brackets, even if empty. See [[Filter Syntax]].)
+
+The following [[Filter Operators]] accept no parameters:
+
+<div>
+
+<<list-links filter:"[op-parameter[none]] [tag[Filter Operators]!has[op-parameter]] -[search:op-purpose[same]]" class:"multi-columns">>
+
+</div>

--- a/editions/tw5.com/tiddlers/filters/syntax/Filter Parameter.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Filter Parameter.tid
@@ -1,5 +1,5 @@
 created: 20150220152540000
-modified: 20230710074423650
+modified: 20240708202234843
 tags: [[Filter Step]]
 title: Filter Parameter
 type: text/vnd.tiddlywiki
@@ -28,6 +28,8 @@ The parameter to a [[filter operator|Filter Operators]] can be:
 :: `<like this>`
 :: The parameter is the current value of the [[variable|Variables]] whose name appears between the angle brackets. Macro parameters are <<.em not>> supported up to v5.2.0
 ::<<.from-version "5.2.0">> Literal macro parameters are supported. For example: `[<now [UTC]YYYY0MM0DD0hh0mm0ssXXX>]`.
+
+<<.note """Every [[filter Operator]] must be followed by a parameter expression. In the case of [[Operators without parameters]], that expression is empty, as with the filter Operator <<.olink links>> in `[<currentTiddler>links[]]`.""">>
 
 ---
 


### PR DESCRIPTION
It can be confusing, to beginners, that so many filter Operators need to have an empty set of brackets, even though there is no actual parameter to pass. (They might assume that getting opening and closing bracket count to match would be enough). This bit of documentation helps to confirm that an empty pair of brackets is needed for proper filter syntax, even for operators such as backlinks. 

REVISED: to use existing multi-columns class. Also, updated to use the .note textbox macro for the note about how every filter operator needs a parameter expression (even if empty).

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small> 