### PR TITLE
Fix RSOE when editing the JSON of a plugin tiddler

### DIFF
--- a/core/modules/startup/plugins.js
+++ b/core/modules/startup/plugins.js
@@ -61,7 +61,7 @@ exports.startup = function() {
 				// Collect the shadow tiddlers of any modified plugins
 				$tw.utils.each(changes.modifiedPlugins,function(pluginTitle) {
 					var pluginInfo = $tw.wiki.getPluginInfo(pluginTitle);
-					if(pluginInfo) {
+					if(pluginInfo && pluginInfo.tiddlers) {
 						$tw.utils.each(Object.keys(pluginInfo.tiddlers),function(title) {
 							changedShadowTiddlers[title] = false;
 						});


### PR DESCRIPTION
Reported by @twMat on https://talk.tiddlywiki.org/t/please-help-final-checks-for-bug-fix-release-v5-3-5/10104/5:

> When editing a plugin and mistakenly removing a comma inside the json structure I get an RSOE. I’m curious why this would happen in edit mode? Is it a bug or to be expected?

 