### PR TITLE
Adding CLA signature

### DIFF
--- a/licenses/cla-individual.md
+++ b/licenses/cla-individual.md
@@ -579,3 +579,5 @@ Andrei Rybak, @rybak, 2024/06/09
 @springerspandrel, 2024/06/27
 
 @andrewgoz, 2024/07/10
+
+Michael McDermott, @michaeljmcd, 2024-07-09


### PR DESCRIPTION
Adds my signature to `licenses/cla-individual.md`, as discussed in PR #8350.