### PR TITLE
Improve view templates to show tag children

### DIFF
--- a/editions/tw5.com/tiddlers/empty-tag-node-template.tid
+++ b/editions/tw5.com/tiddlers/empty-tag-node-template.tid
@@ -1,0 +1,11 @@
+created: 20240710161501472
+list-after: $:/core/ui/ViewTemplate/body
+modified: 20240710165557977
+tags: $:/tags/ViewTemplate
+title: $:/editions/tw5.com/empty-tag-node-template
+type: 
+
+<$list filter='[<storyTiddler>is[missing]] :filter[tagging[]]'>
+The following tiddlers are tagged with <<tag>>:
+</$list>
+<<list-links filter:"[<storyTiddler>is[missing]tagging[]]" class:"multi-columns">>

--- a/editions/tw5.com/tiddlers/system/systemtag-template.tid
+++ b/editions/tw5.com/tiddlers/system/systemtag-template.tid
@@ -1,19 +1,19 @@
 created: 20220719120233104
 list-after: $:/core/ui/ViewTemplate/body
-modified: 20220719120319922
+modified: 20240710163659672
 tags: $:/tags/ViewTemplate
 title: $:/editions/tw5.com/systemtag-template
 
 <$list filter='[all[current]prefix[SystemTag: ]]'>
-<$let tag={{{ [all[current]removeprefix[SystemTag: ]] }}} >
+<$let thisTag={{{ [all[current]removeprefix[SystemTag: ]] }}} >
 
-<$list filter='[all[tiddlers+shadows]tag<tag>limit[1]]' emptyMessage='(No tiddlers are currently tagged with <<tag>> )'>
+<$list filter='[all[tiddlers+shadows]tag<thisTag>limit[1]]' emptyMessage='(No tiddlers are currently tagged with <<tag>> )'>
 
-The following tiddlers are tagged with <<tag>>
+The following tiddlers are tagged with <<tag $(thisTag)$ >>
 
 <table>
 <tr><th></th><th>caption</th></tr>
-<$list filter='[all[tiddlers+shadows]tag<tag>sort[]]'>
+<$list filter='[all[tiddlers+shadows]tag<thisTag>sort[]]'>
 <tr>
 <td><$link/></td>
 <td><$transclude field="caption"><$transclude field="description"><$view field="title"/></$transclude></$transclude></td>


### PR DESCRIPTION
First, I make a minor tweak to $:/editions/tw5.com/systemtag-template ... Because it had used "tag" as a variable name in its list widget, the use of `<<tag>>` (within the list widget) failed to render as a tag, but was showing up only as a link (so dropdown could not be accessed, and visual recognition of tag *as* tag, along with tag-pill interactions, was diminished). 

So, this PR changes the list variable to "thisTag", so that `<<tag>>` properly invokes tag macro. :)

Second, an analogous view template (in same namespace) is added. It shows up for any "missing" tiddler that is also the home-node for a tag, and just offers a list-links macro for tag children. (This is a conservative version of "show tag children" view template, since it applies only to missing tiddlers, and will not clutter the view for existing tiddlers which are also tag-names.)

Rationale: It is helpful to visitors, when they use the drop-down menu for a tag pill, to find that even an empty node ("missing" tiddler) offers a survey of the tiddlers so tagged. For example, at the top of the dropdown for the tag pill at Negatable Operators, one can choose Negatable Operators, but it's disorienting to see nothing but a "missing tiddler" message at that node. Choosing the title entry on this dropdown now yields an overview of tiddlers tagged under this category (while still also showing missing tiddler message at top). This technique of making a view template for "missing" tiddlers is a valuable one, and having an example here will be a useful pointer.

One further rationale: with some templates, such as $:/tags/ViewTemplate, it actually makes a functional/instructive difference to have the tag appear *as* a tag pill. If I visit the tiddler called "SystemTag: $:/tags/ViewTemplate" I can now verify or change the order of the tagged items using that tag pill, while having only the static list/table inhibits easy access to that information.  