### PR TITLE
Adds a workflow that checks for CLA signatures

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,25 @@
+name: Check CLA Signature
+on:
+  pull_request:
+    types:
+      - opened
+jobs:
+  check_cla:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - run: |
+        if ! curl -s https://raw.githubusercontent.com/Jermolene/TiddlyWiki5/tiddlywiki-com/licenses/cla-individual.md | grep -o "@$USER,"; then
+          echo "CLA not signed"
+          gh pr comment "$NUMBER" -b "@$USER It appears that this is your first contribution to the project, welcome.
+          
+          With apologies for the bureaucracy, please could you prepare a separate PR to the 'tiddlywiki-com' branch with your signature for the Contributor License Agreement (see [contributing.md](https://github.com/Jermolene/TiddlyWiki5/blob/master/contributing.md))."
+        else
+          echo "CLA already signed"
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
+        USER: ${{ github.actor }}


### PR DESCRIPTION
This PR adds a simple and fast workflow that checks to see if the author of a PR has signed the CLA.

If the CLA has not been signed, a comment is added to the PR with directions to sign it.

The check itself is rudimentary, looking for the following pattern: `@username,`