### PR TITLE
Updates check-CLA workflow and fixes a permissions issue

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,13 +1,17 @@
 name: Check CLA Signature
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
+      - reopened
+    paths-ignore:
+      - 'licenses/cla-individual.md'
 jobs:
   check_cla:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    if: ${{ (github.event.pull_request.user.login != github.repository_owner) }}
     steps:
     - run: |
         if ! curl -s https://raw.githubusercontent.com/Jermolene/TiddlyWiki5/tiddlywiki-com/licenses/cla-individual.md | grep -o "@$USER,"; then
@@ -17,6 +21,7 @@ jobs:
           With apologies for the bureaucracy, please could you prepare a separate PR to the 'tiddlywiki-com' branch with your signature for the Contributor License Agreement (see [contributing.md](https://github.com/Jermolene/TiddlyWiki5/blob/master/contributing.md))."
         else
           echo "CLA already signed"
+          gh pr comment "$NUMBER" -b "**$USER** has signed the Contributor License Agreement (see [contributing.md](https://github.com/Jermolene/TiddlyWiki5/blob/master/contributing.md))"
         fi
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR makes the following changes in the workflow which checks for CLA signatures:
- fixes a permission issue to allow pull requests by users other than the repository owner to trigger the workflow successfully. This is achieved by using the `pull_request_target` trigger which executes in the context of the master branch of the TiddlyWiki repo rather than the context of the submitted code, and can therefore safely have write access to the PR.
- skips the check for PRs targeting the path 'licenses/cla-individual.md' to avoid recursion.
- skips the check for PRs created by the repository owner
- also posts a message when the PR author has previously signed the PR

To Do: as a separate workflow in a separate PR, comment on each open PR by a given author when there CLA signature is merged.