### PR TITLE
Fix problem where view template disappears on interaction with tag pill

### DIFF
--- a/editions/tw5.com/tiddlers/empty-tag-node-template.tid
+++ b/editions/tw5.com/tiddlers/empty-tag-node-template.tid
@@ -1,11 +1,11 @@
 created: 20240710161501472
 list-after: $:/core/ui/ViewTemplate/body
-modified: 20240710165557977
+modified: 20240713020832439
 tags: $:/tags/ViewTemplate
 title: $:/editions/tw5.com/empty-tag-node-template
 type: 
 
-<$list filter='[<storyTiddler>is[missing]] :filter[tagging[]]'>
+<$list filter='[<storyTiddler>!has[text]] :filter[tagging[]]'>
 The following tiddlers are tagged with <<tag>>:
 </$list>
-<<list-links filter:"[<storyTiddler>is[missing]tagging[]]" class:"multi-columns">>
+<<list-links filter:"[<storyTiddler>!has[text]tagging[]]" class:"multi-columns">>


### PR DESCRIPTION
This is a fix to a minor problem in the view template I recently proposed.

"... view template ... shows up for any "missing" tiddler that is also the home-node for a tag, and just offers a list-links macro for tag children."

It caused unexpected behavior on interaction with the tag pill. If tag pill was used to reorder list field for tag, then the view template would suddenly disappear, since the tiddler would no longer fit the "is[missing]" filter condition. 

List filter is modified, here, to display for nodes that serve as tags (that have tag children), but where there is no text field contents.  