### PR TITLE
Fix for minor transclude wikimethod issue

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -560,18 +560,22 @@ exports.extractTranscludes = function(parseTreeRoot, title) {
 			for(var t=0; t<parseTree.length; t++) {
 				var parseTreeNode = parseTree[t];
 				if(parseTreeNode.type === "transclude") {
-					if(parseTreeNode.attributes.$tiddler && parseTreeNode.attributes.$tiddler.type === "string") {
-						var value;
-						// if it is Transclusion with Templates like `{{Index||$:/core/ui/TagTemplate}}`, the `$tiddler` will point to the template. We need to find the actual target tiddler from parent node
-						if(parentNode && parentNode.type === "tiddler" && parentNode.attributes.tiddler && parentNode.attributes.tiddler.type === "string") {
-							// Empty value (like `{{!!field}}`) means self-referential transclusion. 
-							value = parentNode.attributes.tiddler.value || title;
-						} else {
-							value = parseTreeNode.attributes.$tiddler.value;
+					if(parseTreeNode.attributes.$tiddler) {
+						if(parseTreeNode.attributes.$tiddler.type === "string") {
+							var value;
+							// if it is Transclusion with Templates like `{{Index||$:/core/ui/TagTemplate}}`, the `$tiddler` will point to the template. We need to find the actual target tiddler from parent node
+							if(parentNode && parentNode.type === "tiddler" && parentNode.attributes.tiddler && parentNode.attributes.tiddler.type === "string") {
+								// Empty value (like `{{!!field}}`) means self-referential transclusion.
+								value = parentNode.attributes.tiddler.value || title;
+							} else {
+								value = parseTreeNode.attributes.$tiddler.value;
+							}
 						}
-					} else if(parseTreeNode.attributes.tiddler && parseTreeNode.attributes.tiddler.type === "string") {
-						// Old transclude widget usage
-						value = parseTreeNode.attributes.tiddler.value;
+					} else if(parseTreeNode.attributes.tiddler) {
+						if (parseTreeNode.attributes.tiddler.type === "string") {
+							// Old transclude widget usage
+							value = parseTreeNode.attributes.tiddler.value;
+						}
 					} else if(parseTreeNode.attributes.$field && parseTreeNode.attributes.$field.type === "string") {
 						// Empty value (like `<$transclude $field='created'/>`) means self-referential transclusion. 
 						value = title;

--- a/editions/test/tiddlers/tests/test-backtranscludes.js
+++ b/editions/test/tiddlers/tests/test-backtranscludes.js
@@ -220,6 +220,22 @@ describe('Backtranscludes and transclude filter tests', function() {
 		});
 	});
 
+	describe('exclude self when target tiddler is not string', function() {
+		var wiki = new $tw.Wiki();
+
+		wiki.addTiddler({
+			title: 'TestOutgoing',
+			text: "<$transclude $tiddler={{TestOutgoing!!title}} $field='created'/> and <$transclude tiddler={{TestOutgoing!!title}} field='created'/>"});
+
+		it('should have no transclude', function() {
+			expect(wiki.filterTiddlers('TestOutgoing +[transcludes[]]').join(',')).toBe('');
+		});
+
+		it('should have no back transcludes', function() {
+			expect(wiki.filterTiddlers('TestOutgoing +[backtranscludes[]]').join(',')).toBe('');
+		});
+	});
+
 	describe('recognize transclusion defined by widget', function() {
 		var wiki = new $tw.Wiki();
 


### PR DESCRIPTION
This fixes an issue with the new `transclude[]` and `backtransclude[]` filters. If you had something like this:

```
<$transclude $tiddler={{{ some filter }}} $field=caption />

```

Then those filter operators would accidentally assume it was referencing the currentTiddler. Not so. This fixes that so that those return nothing at all, which is expected (even if not ideal).