### PR TITLE
Show version in site title for tw5.com edition

### DIFF
--- a/editions/tw5.com/tiddlers/system/SiteTitle.tid
+++ b/editions/tw5.com/tiddlers/system/SiteTitle.tid
@@ -3,4 +3,4 @@ modified: 20131211131023829
 title: $:/SiteTitle
 type: text/vnd.tiddlywiki
 
-TiddlyWiki
+TiddlyWiki @@font-size:small; v<<version>>@@


### PR DESCRIPTION
The motivation is to make it easier for people looking at [tiddlywiki.com](https://tiddlywiki.com/) to see what the current version is.

As discussed in [this forum thread](https://talk.tiddlywiki.org/t/can-we-put-the-version-of-tw-at-the-top-of-the-hello-there-tiddler/9694).

This patch is based on the suggestion by @ericshulman in that thread.