### PR TITLE
Improve :sort, sortsub, :sort examples and the railroad diagram

### DIFF
--- a/editions/tw5.com/tiddlers/filters/sortsub Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/sortsub Operator.tid
@@ -1,6 +1,6 @@
 caption: sortsub
 created: 20200424160155182
-modified: 20210522162521222
+modified: 20240717115735166
 op-input: a [[selection of titles|Title Selection]]
 op-neg-output: the input, sorted into reverse order by the result of evaluating subfilter <<.param S>>
 op-output: the input, sorted into ascending order by the result of evaluating subfilter <<.param S>>
@@ -15,19 +15,23 @@ type: text/vnd.tiddlywiki
 
 Each item in the list of input titles is passed to the subfilter in turn. The subfilter transforms the input titles into the form needed for sorting. For example, the subfilter `[length[]]` transforms each input title in the number representing its length, and thus sorts the input titles according to their length.
 
-Note that within the subfilter, the "currentTiddler" variable is set to the title of the tiddler being processed. This permits subfilters like `[{!!value}divide{!!cost}]` to be used for computation. 
+Note that within the subfilter <<.place S>>, the <<.var currentTiddler>> variable is set to the title of the tiddler being processed. This permits subfilters like `[{!!value}divide{!!cost}]` to be used for computation. 
 
-The value of currentTiddler outside the subfilter is available in the variable "..currentTiddler". <<.from-version "5.2.0">>
+The value of <<.var currentTiddler>> outside the subfilter is available in the variable <<.var ..currentTiddler>>. <<.from-version "5.2.0">>
 
 The suffix <<.place T>> determines how the items are compared and can be:
 
-* "string" (the default)
-* "number" - invalid numbers are interpreted as zero
-* "integer" - invalid integers are interpreted as zero
-* "date" - invalid dates are interpreted as 1st January 1970
-* "version" - invalid versions are interpreted as "v0.0.0"
-* "alphanumeric" - treat items as alphanumerics <<.from-version "5.2.0">>
+* ''string'' (the default)
+* ''number'' - invalid numbers are interpreted as zero
+* ''integer'' - invalid integers are interpreted as zero
+* ''date'' - invalid dates are interpreted as 1st January 1970
+* ''version'' - invalid versions are interpreted as "v0.0.0"
+* ''alphanumeric'' - treat items as alphanumerics <<.from-version "5.2.0">>
 
-Note that subfilters should return the same number of items that they are passed. Any missing entries will be treated as zero or the empty string. In particular, when retrieving the value of a field with the [[get Operator]] it is helpful to guard against a missing field value using the [[else Operator]]. For example `[get[myfield]else[default-value]...`.
+<<.tip """Note that subfilters <<.place S>> ''should return the same number of items that they are passed''. In particular, when retrieving the value of a field with the <<.olink get>> operator it is helpful to guard against a missing field value using the <<.olink else>> operator. For example `...[get[myfield]else[default-value]]`.<br><br>
+
+Any ''missing'' entries will be treated as ''zero'' or the ''empty string''.""">>
+
+Also see: [[Sort Filter Run Prefix]]
 
 <<.operator-examples "sortsub">>

--- a/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210428074912172
-modified: 20230315165343329
+modified: 20240717110449956
 tags: [[Sort Filter Run Prefix]]
 title: Sort Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -21,7 +21,7 @@ Sort by newest of modified dates:
 <<.operator-example 4 "[tag[Field Operators]] :sort:date[get[modified]else[19700101]] +[limit[10]]">>
 
 Sort by title:
-<<.operator-example 5 "[tag[Field Operators]] :sort:string:casesensitive[get[caption]] +[limit[10]]">>
+<<.operator-example 5 "[tag[Field Operators]] :sort:string:caseinsensitive[get[caption]] +[limit[10]]">>
 
 Sort by title in reverse order:
 <<.operator-example 6 "[tag[Field Operators]] :sort:string:casesensitive,reverse[get[caption]] +[limit[10]]">>

--- a/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix (Examples).tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix (Examples).tid
@@ -1,5 +1,5 @@
 created: 20210428074912172
-modified: 20240717110449956
+modified: 20230315165343329
 tags: [[Sort Filter Run Prefix]]
 title: Sort Filter Run Prefix (Examples)
 type: text/vnd.tiddlywiki
@@ -21,7 +21,7 @@ Sort by newest of modified dates:
 <<.operator-example 4 "[tag[Field Operators]] :sort:date[get[modified]else[19700101]] +[limit[10]]">>
 
 Sort by title:
-<<.operator-example 5 "[tag[Field Operators]] :sort:string:caseinsensitive[get[caption]] +[limit[10]]">>
+<<.operator-example 5 "[tag[Field Operators]] :sort:string:casesensitive[get[caption]] +[limit[10]]">>
 
 Sort by title in reverse order:
 <<.operator-example 6 "[tag[Field Operators]] :sort:string:casesensitive,reverse[get[caption]] +[limit[10]]">>

--- a/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix.tid
+++ b/editions/tw5.com/tiddlers/filters/syntax/Sort Filter Run Prefix.tid
@@ -1,10 +1,11 @@
 created: 20210428083929749
 from-version: 5.2.0
-modified: 20240312203002082
+modified: 20240717120111427
 rp-input: the filter output of all previous runs so far
 rp-output: output titles replace the output of previous filter runs
 rp-purpose: sort the input titles by the result of evaluating this filter run for each item
-rp-suffix: the <<.op :sort>> filter run prefix uses a rich suffix, see below for details
+rp-suffix: the :sort filter run prefix uses a rich suffix, see below for details
+rp-suffix-name: S
 tags: [[Named Filter Run Prefix]]
 title: Sort Filter Run Prefix
 type: text/vnd.tiddlywiki
@@ -12,9 +13,19 @@ type: text/vnd.tiddlywiki
 <$railroad text="""
 \start none
 \end none
-( ( ":sort" ) 
-( : ":string" | ":alphanumeric" | ":number" | ":integer" | ":version" | ":date" )
-( : ":casesensitive" /"required for string and alphanumeric"/ | ":caseinsensitive" /"required for string and alphanumeric"/  | ":reverse" /"optional"/ | - ) | - )
+( ":sort" ) 
+( ":" ) 
+( : "string" | "alphanumeric" | "number" | "integer" | "version" | "date" )
+( ":" ) 
+{
+	(
+		(
+			( : "caseinsensitive" /"required for string and alphanumeric"/ | "casesensitive" /"required for string and alphanumeric"/)
+			| "reverse" /"optional"/ 
+		)
+	)
+	+","
+}
 [[run|"Filter Run"]]
 """/>
 
@@ -22,7 +33,7 @@ Each input title from previous runs is passed to this run in turn. The filter ru
 
 Note that within the filter run, the <<.var currentTiddler>> variable is set to the title of the tiddler being processed. This permits filter runs like `:sort:number[{!!value}divide{!!cost}]` to be used for computation. The value of <<.var currentTiddler>> outside the run is available in the variable <<.var "..currentTiddler">>.
 
-The `:sort` filter run prefix uses an extended syntax that allows for multiple suffixes, some of which are required:
+The `:sort` <<.place S>> filter run prefix uses an extended syntax that allows for multiple suffixes, some of which are required:
 
 ```
 :sort:<type>:<flaglist>[...filter run...]
@@ -30,10 +41,19 @@ The `:sort` filter run prefix uses an extended syntax that allows for multiple s
 ```
 
 * ''type'': Required. Determines how the items are compared and can be any of: ''string'', ''alphanumeric'', ''number'', ''integer'', ''version'' or ''date''.
+
 * ''flaglist'': comma separated list of the following flags:
+
 ** ''casesensitive'' or ''caseinsensitive'' (required for types `string` and `alphanumeric`).
+*** defaults to: //caseinsensitive// if the flag is missing.
+*** for clarity this parameter should be always defined.
+
 ** ''reverse'' to invert the order of the filter run (optional).
 
-Note that filter runs used with the `:sort` prefix should return the same number of items that they are passed. Any missing entries will be treated as zero or the empty string. In particular, when retrieving the value of a field with the [[get Operator]] it is helpful to guard against a missing field value using the [[else Operator]]. For example `[get[myfield]else[default-value]...`.
+<<.tip """Note that filter runs used with the `:sort` prefix ''should return the same number of items that they are passed''. In particular, when retrieving the value of a field with the [[get Operator]] it is helpful to guard against a missing field value using the [[else Operator]]. For example `...[get[myfield]else[default-value]]`.<br><br>
+
+Any ''missing'' entries will be treated as ''zero'' or the ''empty string''.""">>
+
+Also see: <<.olink sortsub>> Operator
 
 [[Examples|Sort Filter Run Prefix (Examples)]]


### PR DESCRIPTION
While writing the docs for a PR I found out, that the `:sort` filter run prefix is missing some important information about the default behaviour if suffix-flags are missing. 

- This PR improves :sort and sortsub
- It also improves the railroad diagram: It now shows that flags need to be  "comma separated"  

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>