### PR TITLE
Update import.tid to Delete the StateTiddler for Select All

### DIFF
--- a/core/ui/ViewTemplate/body/import.tid
+++ b/core/ui/ViewTemplate/body/import.tid
@@ -6,6 +6,7 @@ title: $:/core/ui/ViewTemplate/body/import
 \whitespace trim
 <$action-confirm $message={{$:/language/Import/Listing/Cancel/Warning}} >
 <$action-deletetiddler $tiddler=<<currentTiddler>>/>
+<$action-deletetiddler $tiddler="$:/state/import/select-all"/>
 <$action-sendmessage $message="tm-close-tiddler" title=<<currentTiddler>>/>
 </$action-confirm>
 \end


### PR DESCRIPTION
The leftover after canceling import operation is deleted now by adding:

```
<$action-deletetiddler $tiddler="$:/state/import/select-all"/>
```

This PR closes #8398