### PR TITLE
Make markdown wikitext links readable

### DIFF
--- a/plugins/tiddlywiki/markdown/editor-operations/make-markdown-link.js
+++ b/plugins/tiddlywiki/markdown/editor-operations/make-markdown-link.js
@@ -13,15 +13,15 @@ Text editor operation to make a markdown link
 "use strict";
 
 exports["make-markdown-link"] = function(event,operation) {
-	var rx = /[()\\]/g, rs = '\\$&';
+	var rx = /[()<>\\]/g, rs = '\\$&';
 
 	if(operation.selection) {
 		var desc = operation.selection.replace(/[\[\]\\]/g, rs);
 
 		if(event.paramObject.text.indexOf("://") !== -1) {
-			operation.replacement = "[" + desc + "](" + event.paramObject.text.replace(rx, rs) + ")";
+			operation.replacement = "[" + desc + "](" + event.paramObject.text.replace(/[()\\]/g, rs) + ")";
 		} else {
-			operation.replacement = "[" + desc + "](#" + encodeURIComponent(event.paramObject.text).replace(rx, rs) + ")";
+			operation.replacement = "[" + desc + "](<#" + event.paramObject.text.replace(rx, rs) + ">)";
 		}
 		operation.cutStart = operation.selStart;
 		operation.cutEnd = operation.selEnd;
@@ -31,7 +31,7 @@ exports["make-markdown-link"] = function(event,operation) {
 				return encodeURI(m);
 			}) + ">";
 		} else {
-			operation.replacement = "[](#" + encodeURIComponent(event.paramObject.text).replace(rx, rs) + ")";
+			operation.replacement = "[](<#" + event.paramObject.text.replace(rx, rs) + ">)";
 		}
 		operation.cutStart = operation.selStart;
 		operation.cutEnd = operation.selEnd;


### PR DESCRIPTION
Tiddlywiki's markdown plugin's link toolbar button dropdown makes link with URL escaped characters, which made non-ASCII characters unreadable.

![图片](https://github.com/user-attachments/assets/ec3a9383-f426-4c7a-8114-6be4cb1a6204)

This PR fixes that by letting it uses the syntax like `[link text](<#New Tiddler>)` instead without encoding non-ASCII characters.