### PR TITLE
tweak empty-tag-node solution, to avoid interfering with technical plugins' use of tag-space

### DIFF
--- a/editions/tw5.com/tiddlers/empty-tag-node-template.tid
+++ b/editions/tw5.com/tiddlers/empty-tag-node-template.tid
@@ -1,11 +1,11 @@
 created: 20240710161501472
-list-after: $:/core/ui/ViewTemplate/body
-modified: 20240713020832439
+list-after: 
+modified: 20240719201317702
 tags: $:/tags/ViewTemplate
 title: $:/editions/tw5.com/empty-tag-node-template
 type: 
 
-<$list filter='[<storyTiddler>!has[text]] :filter[tagging[]]'>
+<$list filter='[<storyTiddler>!has[text]!has[tags]] :filter[tagging[]]'>
 The following tiddlers are tagged with <<tag>>:
 </$list>
-<<list-links filter:"[<storyTiddler>!has[text]tagging[]]" class:"multi-columns">>
+<<list-links filter:"[<storyTiddler>!has[text]!has[tags]tagging[]]" class:"multi-columns">>


### PR DESCRIPTION
Some sophisticated tools, such as the AI plugin, use tag structure — and corresponding custom view templates — to organize data for their functionality — and they tend to do this without ever using the `text` field of the "business-end" tiddlers with which the user interacts. For users of those tools, my proposed empty-tag-node-template just added unwelcome noise (since those other custom view templates already helpfully organize the related material as needed for the task at hand, so the mere `<<list-links>>` template was redundant and distracting).

This modification to the empty-tag-node-template does 2 things: (1) It narrows the framing filter down, *suppressing* its display for tiddlers which have tags. (As far as I could tell, these plugins tend to rely on tags such as `$:/tags/AI/Conversation` to organize their tag-sub-tree).  (2) It leaves the list-after field blank, so that it will appear even further below any other custom view templates. This should further minimize risk that it will create visual noise between the title area and the view template served up by a plugin such as the AI-conversation plugin. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>