### PR TITLE
Use the testcase widget for the $reveal widget examples

### DIFF
--- a/editions/tw5.com/tiddlers/testcases/RevealWidget/AccordionSlider.tid
+++ b/editions/tw5.com/tiddlers/testcases/RevealWidget/AccordionSlider.tid
@@ -1,0 +1,27 @@
+created: 20240721163229297
+description: Reveal widget for accordion or slider functionality
+modified: 20240721172211283
+tags: $:/tags/wiki-test-spec
+title: TestCases/RevealWidget/AccordionSlider
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+Two distinct buttons toggle the state of the tiddler value. Two reveal widgets. The first displays the button to show the content. The second displays both the content and the button to hide the content.
++
+title: Output
+
+<$reveal type="nomatch" state="$:/state/SampleReveal2" text="show">
+
+<$button set="$:/state/SampleReveal2" setTo="show">Show me</$button>
+
+</$reveal>
+<$reveal type="match" state="$:/state/SampleReveal2" text="show">
+
+<$button set="$:/state/SampleReveal2" setTo="hide">Hide me</$button>
+
+! This is the revealed content
+And this is some text
+
+</$reveal>
+

--- a/editions/tw5.com/tiddlers/testcases/RevealWidget/AccordionSlider.tid
+++ b/editions/tw5.com/tiddlers/testcases/RevealWidget/AccordionSlider.tid
@@ -24,4 +24,7 @@ title: Output
 And this is some text
 
 </$reveal>
++
+title: ExpectedResult
 
+<div class=" tc-reveal"><p><button class="">Show me</button></p></div><div class=" tc-reveal" hidden="true"></div>

--- a/editions/tw5.com/tiddlers/testcases/RevealWidget/Popup.tid
+++ b/editions/tw5.com/tiddlers/testcases/RevealWidget/Popup.tid
@@ -1,0 +1,24 @@
+created: 20240721163229297
+description: Reveal widget for popup content
+modified: 20240721172211283
+tags: $:/tags/wiki-test-spec
+title: TestCases/RevealWidget/Popup
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+When the button is clicked, the tiddler specified by the popup attribute is filled with the click coordinates. The reveal widget uses these coordinates to position the popup content.
++
+title: Output
+
+<$button popup="$:/SamplePopupState">Pop me up!</$button>
+
+<$reveal type="popup" state="$:/SamplePopupState">
+<div class="tc-drop-down">
+
+! This is the popup
+And this is some text
+
+</div>
+</$reveal>
+

--- a/editions/tw5.com/tiddlers/testcases/RevealWidget/Popup.tid
+++ b/editions/tw5.com/tiddlers/testcases/RevealWidget/Popup.tid
@@ -21,4 +21,7 @@ And this is some text
 
 </div>
 </$reveal>
++
+title: ExpectedResult
 
+<p><button aria-expanded="false" class="">Pop me up!</button></p><p><span class=" tc-reveal" hidden="true"></span></p>

--- a/editions/tw5.com/tiddlers/testcases/RevealWidget/SimpleReveal.tid
+++ b/editions/tw5.com/tiddlers/testcases/RevealWidget/SimpleReveal.tid
@@ -20,3 +20,8 @@ title: Output
 And this is some text
 
 </$reveal>
++
+title: ExpectedResult
+
+<p><button class="">Show me</button>
+<button class="">Hide me</button></p><div class=" tc-reveal" hidden="true"></div>

--- a/editions/tw5.com/tiddlers/testcases/RevealWidget/SimpleReveal.tid
+++ b/editions/tw5.com/tiddlers/testcases/RevealWidget/SimpleReveal.tid
@@ -1,0 +1,22 @@
+created: 20240721163229297
+description: Simple content reveal
+modified: 20240721172211283
+tags: $:/tags/wiki-test-spec
+title: TestCases/RevealWidget/SimpleReveal
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+Two distinct buttons toggle the state of the tiddler value. The reveal widget displays its content for one of the two states.
++
+title: Output
+
+<$button set="$:/state/SampleReveal1" setTo="show">Show me</$button>
+<$button set="$:/state/SampleReveal1" setTo="hide">Hide me</$button>
+
+<$reveal type="match" state="$:/state/SampleReveal1" text="show">
+
+! This is the revealed content
+And this is some text
+
+</$reveal>

--- a/editions/tw5.com/tiddlers/testcases/RevealWidget/TextReference.tid
+++ b/editions/tw5.com/tiddlers/testcases/RevealWidget/TextReference.tid
@@ -1,0 +1,23 @@
+created: 20240721163229297
+description: Reveal widget text references
+modified: 20240721174826529
+tags: $:/tags/wiki-test-spec
+title: TestCases/RevealWidget/TextReference
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+The state attribute of the reveal widget can use the text reference syntax to refer to a specific field. In this example if the field ``jeremy`` contains the text ``tiddlywiki``, then the reveal widget's content will be displayed.
++
+title: Output
+jeremy: tiddlywiki
+
+<$reveal type="match" state="!!jeremy" text="tiddlywiki">
+~TiddlyWiki!
+</$reveal>
++
+title: ExpectedResult
+
+<p><span class=" tc-reveal">
+TiddlyWiki!
+</span></p>

--- a/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
@@ -1,7 +1,7 @@
 caption: reveal
 created: 20131024141900000
 jeremy: tiddlywiki
-modified: 20230803052644851
+modified: 20240721160212809
 tags: Widgets
 title: RevealWidget
 type: text/vnd.tiddlywiki
@@ -47,11 +47,10 @@ This is useful for edge-cases where titles may contain characters that are used 
 
 ! Examples
 
-!! Simple content reveal
-
-Here's a simple example of showing and hiding content with buttons:
-
-<<wikitext-example-without-html '<$button set="$:/state/SampleReveal1" setTo="show">Show me</$button>
+<$testcase>
+<$data title="Description" text="Simple content reveal"/>
+<$data title="Narrative" text="Two distinct buttons toggle the state of the tiddler value. The reveal widget displays its content for one of the two states."/>
+<$data title="Output" text="""<$button set="$:/state/SampleReveal1" setTo="show">Show me</$button>
 <$button set="$:/state/SampleReveal1" setTo="hide">Hide me</$button>
 
 <$reveal type="match" state="$:/state/SampleReveal1" text="show">
@@ -59,13 +58,13 @@ Here's a simple example of showing and hiding content with buttons:
 ! This is the revealed content
 And this is some text
 
-</$reveal>'>>
+</$reveal>"""/>
+</$testcase>
 
-!! Accordion or Slider
-
-An "accordion" or "slider" is a button that can be used to toggle the display of associated content.
-
-<<wikitext-example-without-html '<$reveal type="nomatch" state="$:/state/SampleReveal2" text="show">
+<$testcase>
+<$data title="Description" text="Reveal widget for accordion or slider functionality"/>
+<$data title="Narrative" text="Two distinct buttons toggle the state of the tiddler value. Two reveal widgets. The first displays the button to show the content. The second displays both the content and the button to hide the content."/>
+<$data title="Output" text="""<$reveal type="nomatch" state="$:/state/SampleReveal2" text="show">
 
 <$button set="$:/state/SampleReveal2" setTo="show">Show me</$button>
 
@@ -77,13 +76,13 @@ An "accordion" or "slider" is a button that can be used to toggle the display of
 ! This is the revealed content
 And this is some text
 
-</$reveal>'>>
+</$reveal>"""/>
+</$testcase>
 
-!! Popup
-
-Here is a simple example of a popup built with the RevealWidget:
-
-<<wikitext-example-without-html '<$button popup="$:/SamplePopupState">Pop me up!</$button>
+<$testcase>
+<$data title="Description" text="Reveal widget for popup content"/>
+<$data title="Narrative" text="When the button is clicked, the tiddler specified by the popup attribute is filled with the click coordinates. The reveal widget uses these coordinates to position the popup content."/>
+<$data title="Output" text="""<$button popup="$:/SamplePopupState">Pop me up!</$button>
 
 <$reveal type="popup" state="$:/SamplePopupState">
 <div class="tc-drop-down">
@@ -92,12 +91,13 @@ Here is a simple example of a popup built with the RevealWidget:
 And this is some text
 
 </div>
-</$reveal>'>>
+</$reveal>"""/>
+</$testcase>
 
-!! How to use text references with field content
-
-Here is a simple example how to use text references with field content to control the  RevealWidget. If the field ``jeremy`` is populated with text ``tiddlywiki``, a message will be displayed.
-
-<<wikitext-example-without-html '<$reveal type="match" state="!!jeremy" text="tiddlywiki">
+<$testcase>
+<$data title="Description" text="Reveal widget text references"/>
+<$data title="Narrative" text="The state attribute of the reveal widget can use the text reference syntax to refer to a specific field. In this example if the field ``jeremy`` contains the text ``tiddlywiki``, then the reveal widget's content will be displayed"/>
+<$data title="Output" jeremy="tiddlywiki" text="""<$reveal type="match" state="!!jeremy" text="tiddlywiki">
 ~TiddlyWiki!
-</$reveal>'>>
+</$reveal>"""/>
+</$testcase>

--- a/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/RevealWidget.tid
@@ -1,7 +1,7 @@
 caption: reveal
 created: 20131024141900000
 jeremy: tiddlywiki
-modified: 20240721160212809
+modified: 20240721175716320
 tags: Widgets
 title: RevealWidget
 type: text/vnd.tiddlywiki
@@ -47,57 +47,10 @@ This is useful for edge-cases where titles may contain characters that are used 
 
 ! Examples
 
-<$testcase>
-<$data title="Description" text="Simple content reveal"/>
-<$data title="Narrative" text="Two distinct buttons toggle the state of the tiddler value. The reveal widget displays its content for one of the two states."/>
-<$data title="Output" text="""<$button set="$:/state/SampleReveal1" setTo="show">Show me</$button>
-<$button set="$:/state/SampleReveal1" setTo="hide">Hide me</$button>
+<<testcase TestCases/RevealWidget/SimpleReveal>>
 
-<$reveal type="match" state="$:/state/SampleReveal1" text="show">
+<<testcase TestCases/RevealWidget/AccordionSlider>>
 
-! This is the revealed content
-And this is some text
+<<testcase TestCases/RevealWidget/Popup>>
 
-</$reveal>"""/>
-</$testcase>
-
-<$testcase>
-<$data title="Description" text="Reveal widget for accordion or slider functionality"/>
-<$data title="Narrative" text="Two distinct buttons toggle the state of the tiddler value. Two reveal widgets. The first displays the button to show the content. The second displays both the content and the button to hide the content."/>
-<$data title="Output" text="""<$reveal type="nomatch" state="$:/state/SampleReveal2" text="show">
-
-<$button set="$:/state/SampleReveal2" setTo="show">Show me</$button>
-
-</$reveal>
-<$reveal type="match" state="$:/state/SampleReveal2" text="show">
-
-<$button set="$:/state/SampleReveal2" setTo="hide">Hide me</$button>
-
-! This is the revealed content
-And this is some text
-
-</$reveal>"""/>
-</$testcase>
-
-<$testcase>
-<$data title="Description" text="Reveal widget for popup content"/>
-<$data title="Narrative" text="When the button is clicked, the tiddler specified by the popup attribute is filled with the click coordinates. The reveal widget uses these coordinates to position the popup content."/>
-<$data title="Output" text="""<$button popup="$:/SamplePopupState">Pop me up!</$button>
-
-<$reveal type="popup" state="$:/SamplePopupState">
-<div class="tc-drop-down">
-
-! This is the popup
-And this is some text
-
-</div>
-</$reveal>"""/>
-</$testcase>
-
-<$testcase>
-<$data title="Description" text="Reveal widget text references"/>
-<$data title="Narrative" text="The state attribute of the reveal widget can use the text reference syntax to refer to a specific field. In this example if the field ``jeremy`` contains the text ``tiddlywiki``, then the reveal widget's content will be displayed"/>
-<$data title="Output" jeremy="tiddlywiki" text="""<$reveal type="match" state="!!jeremy" text="tiddlywiki">
-~TiddlyWiki!
-</$reveal>"""/>
-</$testcase>
+<<testcase TestCases/RevealWidget/TextReference>>


### PR DESCRIPTION
Translate the `$reveal` examples to use the `$testcase` widget.

Directly used the `$testcase` widget rather than test case tiddlers so the user can interactively click the buttons to see the behavior.
