### PR TITLE
Fix low-contrast stability badges on hover

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2576,6 +2576,11 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk > svg {
 	fill: <<colour background>>;
 }
 
+a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk .tc-plugin-info-stability {
+	border: 1px solid <<colour background>>;
+	color: <<colour background>>;
+}
+
 .tc-plugin-info-chunk {
 	margin: 2px;
 }


### PR DESCRIPTION
Let stability badges use background color on hover to make it visible.

![图片](https://github.com/user-attachments/assets/a2cc9a5f-26d3-4dc5-bfbf-a646d20b04a1)
