### PR TITLE
Use .tid file extension in node.js for text/vnd.tiddlywiki-multiple

### DIFF
--- a/core/modules/utils/filesystem.js
+++ b/core/modules/utils/filesystem.js
@@ -238,7 +238,7 @@ exports.generateTiddlerFileInfo = function(tiddler,options) {
 	} else {
 		// Save as a .tid or a text/binary file plus a .meta file
 		var tiddlerType = tiddler.fields.type || "text/vnd.tiddlywiki";
-		if(tiddlerType === "text/vnd.tiddlywiki" || tiddler.hasField("_canonical_uri")) {
+		if(tiddlerType === "text/vnd.tiddlywiki" || tiddlerType === "text/vnd.tiddlywiki-multiple" || tiddler.hasField("_canonical_uri")) {
 			// Save as a .tid file
 			fileInfo.type = "application/x-tiddler";
 			fileInfo.hasMetaFile = false;


### PR DESCRIPTION
As mentioned in the discussion of #8406, editing `text/vnd.tiddlywiki-multiple` tiddlers in node.js causes the the files .tid extension to be removed and an extra .meta file to be created.

This PR fixes the issue by treating `text/vnd.tiddlywiki-multiple` the same as `text/vnd.tiddlywiki` and `tiddler.hasField("_canonical_uri")` when determining the file extension.