### PR TITLE
Update Release Info for v5.3.5 

### DIFF
--- a/editions/tw5.com/tiddlers/about/Archive.tid
+++ b/editions/tw5.com/tiddlers/about/Archive.tid
@@ -1,5 +1,5 @@
 created: 20231005205623086
-modified: 20240628132622052
+modified: 20240723172222378
 tags: About
 title: TiddlyWiki Archive
 
@@ -8,7 +8,7 @@ title: TiddlyWiki Archive
 5.1.10 5.1.11 5.1.12 5.1.13 5.1.14 5.1.15 5.1.16 5.1.17 5.1.18 5.1.19
 5.1.20 5.1.21 5.1.22 5.1.23
 5.2.0 5.2.1 5.2.2 5.2.3 5.2.4 5.2.5 5.2.6 5.2.7
-5.3.0 5.3.1 5.3.2 5.3.3 5.3.4
+5.3.0 5.3.1 5.3.2 5.3.3 5.3.4 5.3.5
 \end
 
 Older versions of TiddlyWiki are available in the [[archive|https://github.com/Jermolene/jermolene.github.io/tree/master/archive]]:

--- a/editions/tw5.com/tiddlers/releasenotes/Release 5.3.5.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/Release 5.3.5.tid
@@ -1,10 +1,11 @@
 caption: 5.3.5
 created: 20240710115948992
-modified: 20240710115948992
+description: Bugfix release for v5.3.4
+modified: 20240723172616735
+released: 20240710153600000
 tags: ReleaseNotes
 title: Release 5.3.5
 type: text/vnd.tiddlywiki
-description: Under development
 
 //[[See GitHub for detailed change history of this release|https://github.com/Jermolene/TiddlyWiki5/compare/v5.3.4...v5.3.5]]//
 


### PR DESCRIPTION
Update Release Info for v5.3.5, so the Releases tiddler and the TW Archive show the right data.  

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>