### PR TITLE
Update ViewTemplateBodyFilters.multids For Readability

### DIFF
--- a/core/wiki/config/ViewTemplateBodyFilters.multids
+++ b/core/wiki/config/ViewTemplateBodyFilters.multids
@@ -1,7 +1,7 @@
 title: $:/config/ViewTemplateBodyFilters/
 tags: $:/tags/ViewTemplateBodyFilter
 
-testcase: [tag[$:/tags/wiki-test-spec]type[text/vnd.tiddlywiki-multiple]then[$:/core/ui/TestCaseTemplate]] [tag[$:/tags/wiki-test-spec-failing]type[text/vnd.tiddlywiki-multiple]then[$:/core/ui/TestCaseTemplate]]
+testcase: [tag[$:/tags/wiki-test-spec]type[text/vnd.tiddlywiki-multiple]] [tag[$:/tags/wiki-test-spec-failing]type[text/vnd.tiddlywiki-multiple]] :then[[$:/core/ui/TestCaseTemplate]]
 stylesheet: [tag[$:/tags/Stylesheet]then[$:/core/ui/ViewTemplate/body/rendered-plain-text]]
 core-ui-tags: [tag[$:/tags/PageTemplate]] [tag[$:/tags/EditTemplate]] [tag[$:/tags/ViewTemplate]] [tag[$:/tags/KeyboardShortcut]] [tag[$:/tags/ImportPreview]] [tag[$:/tags/EditPreview]][tag[$:/tags/EditorToolbar]] [tag[$:/tags/Actions]] :then[[$:/core/ui/ViewTemplate/body/code]]
 system: [prefix[$:/boot/]] [prefix[$:/core/macros]] [prefix[$:/core/save/]] [prefix[$:/core/templates/]]  [prefix[$:/config/]] [prefix[$:/info/]] [prefix[$:/language/]] [prefix[$:/languages/]] [prefix[$:/snippets/]]  [prefix[$:/info/]] [prefix[$:/state/]] [prefix[$:/status/]] [prefix[$:/temp/]] :and[!is[image]]  :then[[$:/core/ui/ViewTemplate/body/code]]


### PR DESCRIPTION
This Cascade from 

```
[tag[$:/tags/wiki-test-spec]type[text/vnd.tiddlywiki-multiple]then[$:/core/ui/TestCaseTemplate]] [tag[$:/tags/wiki-test-spec-failing]type[text/vnd.tiddlywiki-multiple]then[$:/core/ui/TestCaseTemplate]]
```

Simplified. The redundant `then[$:/core/ui/TestCaseTemplate]` part removed

I also suggest using the same convention for all cascades, e.g. use `":then..." this makes processing cascades in third-party plugins simple.