### PR TITLE
Fix type of preferGlobal parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiddlywiki",
-  "preferGlobal": "true",
+  "preferGlobal": true,
   "version": "5.3.7-prerelease",
   "author": "Jeremy Ruston <jeremy@jermolene.com>",
   "description": "a non-linear personal web notebook",


### PR DESCRIPTION
This PR fixes the type of preferGlobal parameter. It needs to be boolean `true` instead of text `"true"`.

Everytime I open package.json, ESLint shows a problem. This PR fixes that.