### PR TITLE
Update StoryList.tid to Work in Different Layouts

### DIFF
--- a/core/ui/Filters/StoryList.tid
+++ b/core/ui/Filters/StoryList.tid
@@ -1,5 +1,5 @@
 title: $:/core/Filters/StoryList
 tags: $:/tags/Filter
-filter: [list<tv-story-list>] -$:/AdvancedSearch
+filter: [<tv-story-list>is[variable]then<tv-story-list>else[$:/StoryList]] =>storylist [list<storylist>] -$:/AdvancedSearch
 description: {{$:/language/Filters/StoryList}}
 


### PR DESCRIPTION
See https://talk.tiddlywiki.org/t/stay-organized-by-using-multiple-desktops-in-tiddlywiki/12752/7 and the solution proposed by @ericshulman.

All PageTemplate elements are enclosed within that `$navigator` widget, so it should be possible to use those two variables in filters instead of hard-coding the values.