### PR TITLE
[v5.4.0] Add support for commands and startups which return Promises (then-ables)

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -2629,11 +2629,13 @@ $tw.boot.executeNextStartupTask = function(callback) {
 			$tw.boot.log(s.join(" "));
 			// Execute task
 			if(!$tw.utils.hop(task,"synchronous") || task.synchronous) {
-				task.startup();
-				if(task.name) {
-					$tw.boot.executedStartupModules[task.name] = true;
+				const thenable = task.startup();
+				if(thenable && typeof thenable.then === "function"){
+					thenable.then(asyncTaskCallback);
+					return true;
+				} else {
+					return asyncTaskCallback();
 				}
-				return $tw.boot.executeNextStartupTask(callback);
 			} else {
 				task.startup(asyncTaskCallback);
 				return true;

--- a/core-server/commander.js
+++ b/core-server/commander.js
@@ -99,16 +99,18 @@ Commander.prototype.executeNextCommand = function() {
 					}
 				}
 				if(command.info.synchronous) {
-					// Synchronous command
+					// Synchronous command (await thenables)
 					c = new command.Command(params,this);
 					err = c.execute();
-					if(err) {
+					if(err && typeof err.then === "function") {
+						err.then(e => { e ? this.callback(e) : this.executeNextCommand(); });
+					} else if(err) {
 						this.callback(err);
 					} else {
 						this.executeNextCommand();
 					}
 				} else {
-					// Asynchronous command
+					// Asynchronous command (await thenables)
 					c = new command.Command(params,this,function(err) {
 						if(err) {
 							self.callback(err);
@@ -117,7 +119,9 @@ Commander.prototype.executeNextCommand = function() {
 						}
 					});
 					err = c.execute();
-					if(err) {
+					if(err && typeof err.then === "function") {
+						err.then(e => { if(e) this.callback(e); });
+					} else if(err) {
 						this.callback(err);
 					}
 				}


### PR DESCRIPTION
Per https://github.com/TiddlyWiki/TiddlyWiki5/issues/9065#issuecomment-2983728068, Promises and async functions are now supported by TiddlyWiki, so here's the code that I've always wanted to add to the commander and startup routines to support promises. 

---

This preserves existing behavior, so if you just add the async keyword in front of your startup function or command.execute function, it will behave exactly like a sync function. This does not change the execution semantics at all, so throws are still uncaught, setting `synchronous = false` will still require you to call the callback function, and the return value of commands is still used as an error. 

The only difference is that if you return a Promise or use the async keyword, the promise will be awaited and the resolved value becomes the return value of the function. 

---

It will support any "then-able" not just an instance of the global Promise. 

```js
const thenable = task.startup();
if(thenable && typeof thenable.then === "function") {
  thenable.then(executeNextTask);
} else {
  executeNextTask();
}
```

This preserves existing behavior unless:
- in startup, you were returning promises that you expected to be ignored (but why?)
- in commands, you were returning promises as your errors (and those promises resolve to falsy values), which seems unlikely. 