### PR TITLE
Revert "list-tagged-draggable shows caption field if it is available"

### DIFF
--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -102,11 +102,7 @@ tags: $:/tags/Macro
 					<$genesis $type=<<elementTag>>>
 						<$transclude tiddler=<<itemTemplate>>>
 							<$link to={{!!title}}>
-								<$let tv-wikilinks="no">
-									<$transclude field="caption">
-										<$view field="title"/>
-									</$transclude>
-								</$let>
+								<$view field="title"/>
 							</$link>
 						</$transclude>
 					</$genesis>


### PR DESCRIPTION
Reverts TiddlyWiki/TiddlyWiki5#8721

See https://talk.tiddlywiki.org/t/what-gtd-todo-plugin-or-template-are-you-using/1836/25