### PR TITLE
Revert "Migrate some old macros to new syntax"

### DIFF
--- a/core/wiki/macros/colour-picker.tid
+++ b/core/wiki/macros/colour-picker.tid
@@ -1,55 +1,58 @@
 title: $:/core/macros/colour-picker
 tags: $:/tags/Macro
 
-\procedure colour-picker-update-recent()
+\define colour-picker-update-recent()
 <$action-listops
 	$tiddler="$:/config/ColourPicker/Recent"
-	$subfilter="[<colour-picker-value>] [list[$:/config/ColourPicker/Recent]remove<colour-picker-value>] +[limit[8]]"
+	$subfilter="$(colour-picker-value)$ [list[$:/config/ColourPicker/Recent]remove[$(colour-picker-value)$]] +[limit[8]]"
 />
 \end
 
-\procedure colour-picker-inner(actions)
-<$button tag="a" tooltip=<<colour-picker-value>>>
-<<colour-picker-update-recent>>
-<$transclude $variable="actions"/>
-<span style.display="inline-block" style.backgroundColor=<<colour-picker-value>> style.width="100%" style.height="100%" style.borderRadius="50%"/>
+\define colour-picker-inner(actions)
+<$button tag="a" tooltip="""$(colour-picker-value)$""">
+$(colour-picker-update-recent)$
+<$transclude $variable="__actions__"/>
+
+<span style="display:inline-block; background-color: $(colour-picker-value)$; width: 100%; height: 100%; border-radius: 50%;"/>
+
 </$button>
 \end
 
+\define colour-picker-recent-inner(actions)
 \whitespace trim
-\procedure colour-picker-recent-inner(actions)
-<$set name="colour-picker-value" value=<<recentColour>>>
-<$transclude $variable="colour-picker-inner" actions=<<actions>>/>
+<$set name="colour-picker-value" value="$(recentColour)$">
+<$macrocall $name="colour-picker-inner" actions=<<__actions__>>/>
 </$set>
 \end
 
-\procedure colour-picker-recent(actions)
+\define colour-picker-recent(actions)
+\whitespace trim
 {{$:/language/ColourPicker/Recent}}<$list filter="[list[$:/config/ColourPicker/Recent]]" variable="recentColour">
 &#32;
-<$transclude $variable="colour-picker-recent-inner" actions=<<actions>>/>
+<$macrocall $name="colour-picker-recent-inner" actions=<<__actions__>>/>
 </$list>
 \end
 
-\procedure colour-picker(actions)
+\define colour-picker(actions)
+\whitespace trim
 <div class="tc-colour-chooser">
 
-<$transclude $variable="colour-picker-recent" actions=<<actions>>/>
+<$macrocall $name="colour-picker-recent" actions=<<__actions__>>/>
 
 ---
 
 <$list filter="LightPink Pink Crimson LavenderBlush PaleVioletRed HotPink DeepPink MediumVioletRed Orchid Thistle Plum Violet Magenta Fuchsia DarkMagenta Purple MediumOrchid DarkViolet DarkOrchid Indigo BlueViolet MediumPurple MediumSlateBlue SlateBlue DarkSlateBlue Lavender GhostWhite Blue MediumBlue MidnightBlue DarkBlue Navy RoyalBlue CornflowerBlue LightSteelBlue LightSlateGrey SlateGrey DodgerBlue AliceBlue SteelBlue LightSkyBlue SkyBlue DeepSkyBlue LightBlue PowderBlue CadetBlue Azure LightCyan PaleTurquoise Cyan Aqua DarkTurquoise DarkSlateGrey DarkCyan Teal MediumTurquoise LightSeaGreen Turquoise Aquamarine MediumAquamarine MediumSpringGreen MintCream SpringGreen MediumSeaGreen SeaGreen Honeydew LightGreen PaleGreen DarkSeaGreen LimeGreen Lime ForestGreen Green DarkGreen Chartreuse LawnGreen GreenYellow DarkOliveGreen YellowGreen OliveDrab Beige LightGoldenrodYellow Ivory LightYellow Yellow Olive DarkKhaki LemonChiffon PaleGoldenrod Khaki Gold Cornsilk Goldenrod DarkGoldenrod FloralWhite OldLace Wheat Moccasin Orange PapayaWhip BlanchedAlmond NavajoWhite AntiqueWhite Tan BurlyWood Bisque DarkOrange Linen Peru PeachPuff SandyBrown Chocolate SaddleBrown Seashell Sienna LightSalmon Coral OrangeRed DarkSalmon Tomato MistyRose Salmon Snow LightCoral RosyBrown IndianRed Red Brown FireBrick DarkRed Maroon White WhiteSmoke Gainsboro LightGrey Silver DarkGrey Grey DimGrey Black" variable="colour-picker-value">
 &#32;
-<$transclude $variable="colour-picker-inner" actions=<<actions>>/>
+<$macrocall $name="colour-picker-inner" actions=<<__actions__>>/>
 </$list>
 
 ---
 
-<$edit-text tiddler="$:/config/ColourPicker/New" tag="input" default="" placeholder="" class="tc-tiny-gap-right"/>
+<$edit-text tiddler="$:/config/ColourPicker/New" tag="input" default="" placeholder=""/>
+&#32;
 <$edit-text tiddler="$:/config/ColourPicker/New" type="color" tag="input"/>
 <$set name="colour-picker-value" value={{$:/config/ColourPicker/New}}>
-<%if [{$:/config/ColourPicker/New}!is[blank]] %>
-<$transclude $variable="colour-picker-inner" actions=<<actions>>/>
-<%endif%>
+<$macrocall $name="colour-picker-inner" actions=<<__actions__>>/>
 </$set>
 
 </div>

--- a/core/wiki/macros/dumpvariables.tid
+++ b/core/wiki/macros/dumpvariables.tid
@@ -1,7 +1,7 @@
 title: $:/core/macros/dumpvariables
 tags: $:/tags/Macro
 
-\procedure dumpvariables()
+\define dumpvariables()
 \whitespace trim
 <ul>
 <$list filter="[variables[]]" variable="varname">

--- a/core/wiki/macros/image-picker.tid
+++ b/core/wiki/macros/image-picker.tid
@@ -1,36 +1,39 @@
+created: 20170715180840889
+modified: 20170715180914005
 tags: $:/tags/Macro
 title: $:/core/macros/image-picker
 type: text/vnd.tiddlywiki
 
-\procedure image-picker-thumbnail(actions)
-<$button tag="a" tooltip=<<imageTitle>>><$transclude $variable="actions"/><$transclude tiddler=<<imageTitle>>/></$button>
+\define image-picker-thumbnail(actions)
+<$button tag="a" tooltip="""$(imageTitle)$"""><$transclude $variable="__actions__"/><$transclude tiddler=<<imageTitle>>/></$button>
 \end
 
-\procedure image-picker-list(filter,actions)
+\define image-picker-list(filter,actions)
 \whitespace trim
-<$list filter=<<filter>> variable="imageTitle">
-<$transclude $variable="image-picker-thumbnail" actions=<<actions>>/>
+<$list filter="""$filter$""" variable="imageTitle">
+<$macrocall $name="image-picker-thumbnail" actions=<<__actions__>>/>
 &#32;
 </$list>
 \end
 
-\procedure image-picker(actions,filter:"[all[shadows+tiddlers]is[image]] -[type[application/pdf]] +[!has[draft.of]$subfilter$sort[title]]",subfilter:"")
+\define image-picker(actions,filter:"[all[shadows+tiddlers]is[image]] -[type[application/pdf]] +[!has[draft.of]$subfilter$sort[title]]",subfilter:"")
 \whitespace trim
 <div class="tc-image-chooser">
-<$let state-system=<<qualify "$:/state/image-picker/system">> tv-filter={{{ [<filter>search-replace[$subfilter$],<subfilter>] }}}>
+<$vars state-system=<<qualify "$:/state/image-picker/system">>>
 <$checkbox tiddler=<<state-system>> field="text" checked="show" unchecked="hide" default="hide">
-<span class="tc-tiny-gap-left">{{$:/language/SystemTiddlers/Include/Prompt}}</span>
+&#32;
+{{$:/language/SystemTiddlers/Include/Prompt}}
 </$checkbox>
 <$reveal state=<<state-system>> type="match" text="hide" default="hide" tag="div">
-<$transclude $variable="image-picker-list" filter=`$(tv-filter)$ +[!is[system]]` actions=<<actions>>/>
+<$macrocall $name="image-picker-list" filter="""$filter$ +[!is[system]]""" actions=<<__actions__>>/>
 </$reveal>
 <$reveal state=<<state-system>> type="nomatch" text="hide" default="hide" tag="div">
-<$transclude $variable="image-picker-list" filter=<<tv-filter>> actions=<<actions>>/>
+<$macrocall $name="image-picker-list" filter="""$filter$""" actions=<<__actions__>>/>
 </$reveal>
-</$let>
+</$vars>
 </div>
 \end
 
-\procedure image-picker-include-tagged-images(actions)
-<$transclude $variable="image-picker" filter="[all[shadows+tiddlers]is[image]] [all[shadows+tiddlers]tag[$:/tags/Image]] -[type[application/pdf]] +[!has[draft.of]sort[title]]" actions=<<actions>>/>
+\define image-picker-include-tagged-images(actions)
+<$macrocall $name="image-picker" filter="[all[shadows+tiddlers]is[image]] [all[shadows+tiddlers]tag[$:/tags/Image]] -[type[application/pdf]] +[!has[draft.of]sort[title]]" actions=<<__actions__>>/>
 \end

--- a/core/wiki/macros/list.tid
+++ b/core/wiki/macros/list.tid
@@ -1,18 +1,14 @@
 title: $:/core/macros/list
 tags: $:/tags/Macro
 
-\procedure list-links-draggable-drop-actions()
-<$action-listops $tiddler=<<targetTiddler>> $field=<<targetField>> $subfilter="+[insertbefore<actionTiddler>,<currentTiddler>]"/>
-\end
-
+\define list-links(filter,type:"ul",subtype:"li",class:"",emptyMessage,field:"caption")
 \whitespace trim
-\procedure list-links(filter,type:"ul",subtype:"li",class:"",emptyMessage,field:"caption")
-<$genesis $type=<<type>> class=<<class>>>
-	<$list filter=<<filter>> emptyMessage=<<emptyMessage>>>
-		<$genesis $type=<<subtype>>>
+<$genesis $type=<<__type__>> class=<<__class__>>>
+	<$list filter=<<__filter__>> emptyMessage=<<__emptyMessage__>>>
+		<$genesis $type=<<__subtype__>>>
 			<$link to={{!!title}}>
 				<$let tv-wikilinks="no">
-					<$transclude field=<<field>>>
+					<$transclude field=<<__field__>>>
 						<$view field="title"/>
 					</$transclude>
 				</$let>
@@ -22,19 +18,24 @@ tags: $:/tags/Macro
 </$genesis>
 \end
 
-\procedure list-links-draggable(tiddler,field:"list",emptyMessage,type:"ul",subtype:"li",class:"",itemTemplate)
+\define list-links-draggable-drop-actions()
+<$action-listops $tiddler=<<targetTiddler>> $field=<<targetField>> $subfilter="+[insertbefore<actionTiddler>,<currentTiddler>]"/>
+\end
+
+\define list-links-draggable(tiddler,field:"list",emptyMessage,type:"ul",subtype:"li",class:"",itemTemplate)
+\whitespace trim
 <span class="tc-links-draggable-list">
-	<$let targetTiddler=<<tiddler>> targetField=<<field>>>
-		<$genesis $type=<<type>> class=<<class>>>
-			<$list filter="[<tiddler>get<field>enlist-input[]]" emptyMessage=<<emptyMessage>>>
+	<$vars targetTiddler="""$tiddler$""" targetField="""$field$""">
+		<$genesis $type=<<__type__>> class="$class$">
+			<$list filter="[list[$tiddler$!!$field$]]" emptyMessage=<<__emptyMessage__>>>
 				<$droppable
 					actions=<<list-links-draggable-drop-actions>>
-					tag=<<subtype>>
+					tag="""$subtype$"""
 					enable=<<tv-enable-drag-and-drop>>
 				>
 					<div class="tc-droppable-placeholder"/>
 					<div>
-						<$transclude tiddler=<<itemTemplate>>>
+						<$transclude tiddler="""$itemTemplate$""">
 							<$link to={{!!title}}>
 								<$let tv-wikilinks="no">
 									<$transclude field="caption">
@@ -59,48 +60,50 @@ tags: $:/tags/Macro
 				</$droppable>
 			</$tiddler>
 		</$genesis>
-	</$let>
+	</$vars>
 </span>
 \end
 
-\procedure list-tagged-draggable-drop-actions(tag)
+\define list-tagged-draggable-drop-actions(tag)
+\whitespace trim
 <!-- Save the current ordering of the tiddlers with this tag -->
-<$set name="order" filter="[<tag>tagging[]]">
+<$set name="order" filter="[<__tag__>tagging[]]">
 	<!-- Remove any list-after or list-before fields from the tiddlers with this tag -->
-	<$list filter="[<tag>tagging[]]">
+	<$list filter="[<__tag__>tagging[]]">
 		<$action-deletefield $field="list-before"/>
 		<$action-deletefield $field="list-after"/>
 	</$list>
 	<!-- Save the new order to the Tag Tiddler -->
-	<$action-listops $tiddler=<<tag>> $field="list" $filter="+[enlist<order>] +[insertbefore<actionTiddler>,<currentTiddler>]"/>
+	<$action-listops $tiddler=<<__tag__>> $field="list" $filter="+[enlist<order>] +[insertbefore<actionTiddler>,<currentTiddler>]"/>
 	<!-- Make sure the newly added item has the right tag -->
 	<!-- Removing this line makes dragging tags within the dropdown work as intended -->
-	<!--<$action-listops $tiddler=<<actionTiddler>> $tags=<<tag>>/>-->
+	<!--<$action-listops $tiddler=<<actionTiddler>> $tags=<<__tag__>>/>-->
 	<!-- Using the following 5 lines as replacement makes dragging titles from outside into the dropdown apply the tag -->
-	<$list filter="[<actionTiddler>!contains:tags<tag>]">
+	<$list filter="[<actionTiddler>!contains:tags<__tag__>]">
 		<$fieldmangler tiddler=<<actionTiddler>>>
-			<$action-sendmessage $message="tm-add-tag" $param=<<tag>>/>
+			<$action-sendmessage $message="tm-add-tag" $param=<<__tag__>>/>
 		</$fieldmangler>
 	</$list>
 </$set>
 \end
 
-\procedure list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div",storyview:"")
+\define list-tagged-draggable(tag,subFilter,emptyMessage,itemTemplate,elementTag:"div",storyview:"")
+\whitespace trim
 <span class="tc-tagged-draggable-list">
-	<$set name="tag" value=<<tag>>>
+	<$set name="tag" value=<<__tag__>>>
 		<$list
-			filter=`[<tag>tagging[]$(subFilter)$]`
-			emptyMessage=<<emptyMessage>>
-			storyview=<<storyview>>
+			filter="[<__tag__>tagging[]$subFilter$]"
+			emptyMessage=<<__emptyMessage__>>
+			storyview=<<__storyview__>>
 		>
-			<$genesis $type=<<elementTag>> class="tc-menu-list-item">
+			<$genesis $type=<<__elementTag__>> class="tc-menu-list-item">
 				<$droppable
-					actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<tag>>/>"""
+					actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>"""
 					enable=<<tv-enable-drag-and-drop>>
 				>
-					<$genesis $type=<<elementTag>> class="tc-droppable-placeholder"/>
-					<$genesis $type=<<elementTag>>>
-						<$transclude tiddler=<<itemTemplate>>>
+					<$genesis $type=<<__elementTag__>> class="tc-droppable-placeholder"/>
+					<$genesis $type=<<__elementTag__>>>
+						<$transclude tiddler="""$itemTemplate$""">
 							<$link to={{!!title}}>
 								<$let tv-wikilinks="no">
 									<$transclude field="caption">
@@ -115,11 +118,11 @@ tags: $:/tags/Macro
 		</$list>
 		<$tiddler tiddler="">
 			<$droppable
-				actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<tag>>/>"""
+				actions="""<$macrocall $name="list-tagged-draggable-drop-actions" tag=<<__tag__>>/>"""
 				enable=<<tv-enable-drag-and-drop>>
 			>
-				<$genesis $type=<<elementTag>> class="tc-droppable-placeholder"/>
-				<$genesis $type=<<elementTag>> style="height:0.5em;"/>
+				<$genesis $type=<<__elementTag__>> class="tc-droppable-placeholder"/>
+				<$genesis $type=<<__elementTag__>> style="height:0.5em;"/>
 			</$droppable>
 		</$tiddler>
 	</$set>

--- a/core/wiki/macros/translink.tid
+++ b/core/wiki/macros/translink.tid
@@ -1,28 +1,28 @@
 title: $:/core/macros/translink
 tags: $:/tags/Macro
 
-\procedure translink(title,mode:"block")
+\define translink(title,mode:"block")
 \whitespace trim
-<%if [<mode>match[block]] %>
+<$list filter="[<__mode__>match[block]]">
 <div class="tc-translink">
 <div>
-<$link to=<<title>>>
-<h1><$text text=<<title>>/></h1>
+<$link to="""$title$""">
+<h1><$text text="""$title$"""/></h1>
 </$link>
-<$transclude tiddler=<<title>> mode="block">
-<$set name="currentTiddler" value=<<title>>><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>
+<$transclude tiddler="""$title$""" mode="block">
+<$set name="currentTiddler" value="""$title$"""><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>
 </$transclude>
 </div>
 </div>
-<%endif%>
-<%if [<mode>match[inline]] %>
+</$list>
+<$list filter="[<__mode__>match[inline]]">
 <span class="tc-translink">
-<$link to=<<title>> class="tc-tiny-gap-right">
-<$text text=<<title>>/>
+<$link to="""$title$""">
+<$text text="""$title$"""/>
 </$link>
-(<$transclude tiddler=<<title>> mode="inline">
-<$set name="currentTiddler" value=<<title>>><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>
+&#32;(<$transclude tiddler="""$title$""" mode="inline">
+<$set name="currentTiddler" value="""$title$"""><$transclude tiddler="$:/language/MissingTiddler/Hint"/></$set>
 </$transclude>)
 </span>
-<%endif%>
+</$list>
 \end

--- a/core/wiki/macros/tree.tid
+++ b/core/wiki/macros/tree.tid
@@ -1,58 +1,62 @@
 title: $:/core/macros/tree
 tags: $:/tags/Macro
 
-\procedure leaf-link(full-title,chunk,separator: "/")
-<$link to=<<full-title>>><$text text=<<chunk>>/></$link>
+\define leaf-link(full-title,chunk,separator: "/")
+<$link to=<<__full-title__>>><$text text=<<__chunk__>>/></$link>
 \end
 
+\define leaf-node(prefix,chunk)
 \whitespace trim
-\procedure leaf-node(prefix,chunk)
 <li>
-<$list filter="[<prefix>addsuffix<chunk>is[shadow]] [<prefix>addsuffix<chunk>is[tiddler]]" variable="full-title">
-<$list filter="[<full-title>removeprefix<prefix>]" variable="chunk">
-<span class="tc-tiny-gap-right">{{$:/core/images/file}}</span><$transclude $variable="leaf-link" full-title=<<full-title>> chunk=<<chunk>>/>
+<$list filter="[<__prefix__>addsuffix<__chunk__>is[shadow]] [<__prefix__>addsuffix<__chunk__>is[tiddler]]" variable="full-title">
+<$list filter="[<full-title>removeprefix<__prefix__>]" variable="chunk">
+<span>{{$:/core/images/file}}</span>&#32;<$macrocall $name="leaf-link" full-title=<<full-title>> chunk=<<chunk>>/>
 </$list>
 </$list>
 </li>
 \end
 
-\procedure branch-node(prefix,chunk,separator: "/")
+\define branch-node(prefix,chunk,separator: "/")
+\whitespace trim
 <li>
-<$set name="reveal-state" value={{{ [[$:/state/tree/]addsuffix<prefix>addsuffix<chunk>] }}}>
+<$set name="reveal-state" value={{{ [[$:/state/tree/]addsuffix<__prefix__>addsuffix<__chunk__>] }}}>
 <$reveal type="nomatch" stateTitle=<<reveal-state>> text="show">
 <$button setTitle=<<reveal-state>> setTo="show" class="tc-btn-invisible">
-{{$:/core/images/folder}}&#32;<$text text=<<chunk>>/>
+{{$:/core/images/folder}}&#32;<$text text=<<__chunk__>>/>
 </$button>
 </$reveal>
 <$reveal type="match" stateTitle=<<reveal-state>> text="show">
 <$button setTitle=<<reveal-state>> setTo="hide" class="tc-btn-invisible">
-{{$:/core/images/folder}}&#32;<$text text=<<chunk>>/>
+{{$:/core/images/folder}}&#32;<$text text=<<__chunk__>>/>
 </$button>
 </$reveal>
-<span class="tc-tiny-gap-left">(<$count filter="[all[shadows+tiddlers]removeprefix<prefix>removeprefix<chunk>] -[<prefix>addsuffix<chunk>]"/>)</span>
+&#32;
+<span>(<$count filter="[all[shadows+tiddlers]removeprefix<__prefix__>removeprefix<__chunk__>] -[<__prefix__>addsuffix<__chunk__>]"/>)</span>
 <$reveal type="match" stateTitle=<<reveal-state>> text="show">
-<$transclude $variable="tree-node" prefix={{{ [<prefix>addsuffix<chunk>] }}} separator=<<separator>>/>
+<$macrocall $name="tree-node" prefix={{{ [<__prefix__>addsuffix<__chunk__>] }}} separator=<<__separator__>>/>
 </$reveal>
 </$set>
 </li>
 \end
 
-\procedure tree-node(prefix,separator: "/")
+\define tree-node(prefix,separator: "/")
+\whitespace trim
 <ol>
-<$list filter="[all[shadows+tiddlers]removeprefix<prefix>splitbefore<separator>sort[]!suffix<separator>]" variable="chunk">
-<$transclude $variable="leaf-node" prefix=<<prefix>> chunk=<<chunk>> separator=<<separator>>/>
+<$list filter="[all[shadows+tiddlers]removeprefix<__prefix__>splitbefore<__separator__>sort[]!suffix<__separator__>]" variable="chunk">
+<$macrocall $name="leaf-node" prefix=<<__prefix__>> chunk=<<chunk>> separator=<<__separator__>>/>
 </$list>
-<$list filter="[all[shadows+tiddlers]removeprefix<prefix>splitbefore<separator>sort[]suffix<separator>]" variable="chunk">
-<$transclude $variable="branch-node" prefix=<<prefix>> chunk=<<chunk>> separator=<<separator>>/>
+<$list filter="[all[shadows+tiddlers]removeprefix<__prefix__>splitbefore<__separator__>sort[]suffix<__separator__>]" variable="chunk">
+<$macrocall $name="branch-node" prefix=<<__prefix__>> chunk=<<chunk>> separator=<<__separator__>>/>
 </$list>
 </ol>
 \end
 
-\procedure tree(prefix: "$:/",separator: "/")
+\define tree(prefix: "$:/",separator: "/")
+\whitespace trim
 <div class="tc-tree">
-<span><$text text=<<prefix>>/></span>
+<span><$text text=<<__prefix__>>/></span>
 <div>
-<$transclude $variable="tree-node" prefix=<<prefix>> separator=<<separator>>/>
+<$macrocall $name="tree-node" prefix=<<__prefix__>> separator=<<__separator__>>/>
 </div>
 </div>
 \end


### PR DESCRIPTION
These changes broke the list-tagged-draggable macro

Reverts TiddlyWiki/TiddlyWiki5#8768