### PR TITLE
Fix sidebar tools version for v5.3.8

### DIFF
--- a/core/ui/SideBar/Tools.tid
+++ b/core/ui/SideBar/Tools.tid
@@ -7,7 +7,7 @@ caption: {{$:/language/SideBar/Tools/Caption}}
 \procedure lingo-base() $:/language/ControlPanel/
 \function config-title() [[$:/config/PageControlButtons/Visibility/$(listItem)$]substitute[]]
 
-<<lingo Basics/Version/Prompt>> <<version>>
+<<lingo Basics/Version/Prompt>><span class="tc-tiny-gap-left"><<version>></span>
 
 <$let tv-config-toolbar-icons="yes"
 	tv-config-toolbar-text="yes"


### PR DESCRIPTION
@Jermolene -- This PR fixes sidebar tools version for v5.3.8 -- It is a regression, that was introduced with v5.3.7

In v5.3.7 in the right sidebar -> tools, the version needs a tiny gap. This PR fixes the problem.

<img width="888" height="410" alt="image" src="https://github.com/user-attachments/assets/8abd3306-9bdc-4bc5-a15c-0b0770fe17eb" />
