### PR TITLE
WIP: Simplify button selector

### DIFF
--- a/plugins/tiddlywiki/tiddlyweb/readonly-styles.tid
+++ b/plugins/tiddlywiki/tiddlyweb/readonly-styles.tid
@@ -1,27 +1,30 @@
 title: $:/plugins/tiddlywiki/tiddlyweb/readonly
 tags: [[$:/tags/Stylesheet]]
 
-\define button-selector(title)
-button.$title$, .tc-drop-down button.$title$, div.$title$
+\procedure button-selector(title)
+\whitespace trim
+<$let formatted-title={{{ [<title>encodeuricomponent[]escapecss[]addprefix[tc-btn-]] }}} >
+button.<<formatted-title>>, .tc-drop-down button.<<formatted-title>>, div.<<formatted-title>>
+</$let>
 \end
 
-\define hide-edit-controls()
+\procedure hide-edit-controls()
 <$reveal state="$:/status/IsReadOnly" type="match" text="yes" default="yes">
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fclone>>`,`
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fdelete>>`,`
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fedit>>`,`
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fnew-here>>`,`
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fnew-journal-here>>`,`
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fimport>>`,`
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fmanager>>`,`
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fnew-image>>`,`
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fnew-journal>>`,`
-<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fnew-tiddler>> `{
+<<button-selector "$:/core/ui/Buttons/clone">>,
+<<button-selector "$:/core/ui/Buttons/delete">>,
+<<button-selector "$:/core/ui/Buttons/edit">>,
+<<button-selector "$:/core/ui/Buttons/new-here">>,
+<<button-selector "$:/core/ui/Buttons/new-journal-here">>,
+<<button-selector "$:/core/ui/Buttons/import">>,
+<<button-selector "$:/core/ui/Buttons/manager">>,
+<<button-selector "$:/core/ui/Buttons/new-image">>,
+<<button-selector "$:/core/ui/Buttons/new-journal">>,
+<<button-selector "$:/core/ui/Buttons/new-tiddler">>{
 	display: none;
-}`
+}
 </$reveal>
 \end
 
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock
 
-<<hide-edit-controls>>
+<<hide-edit-controls>>`


### PR DESCRIPTION
This is just an attempt to make the button-selector macro/procedure in Read-Only mode easier to use.

Right now, a call to it looks like:

```text
<<button-selector tc-btn-\%24\%3A\%2Fcore\%2Fui\%2FButtons\%2Fclone>>`,`
```

With this change, it would look like:

```text
<<button-selector "$:/core/ui/Buttons/clone">>,
```

You can see some discussion of this in the recent [`talk` thread #12964][tt]

## Questions ##

* Should I pull the `tc-btn-` into a second, optional parameter?  It seems not, as this macro/procedure is not currently exposed publicly, but if people often override this tiddler, perhaps they need the option?

* In the original there is some syntax I don't understand.  Why are the line-ending commas wrapped in backquotes?  Am I breaking something by not including them?  Or is it something no longer needed after the switch from macros to procedures?



  [tt]: https://talk.tiddlywiki.org/t/12964