### PR TITLE
Extends server routes to support multiple methods

### DIFF
--- a/core/modules/server/server.js
+++ b/core/modules/server/server.js
@@ -217,7 +217,7 @@ Server.prototype.findMatchingRoute = function(request,state) {
 		} else {
 			match = potentialRoute.path.exec(pathname);
 		}
-		if(match && request.method === potentialRoute.method) {
+		if(match && (potentialRoute.method === request.method || (Array.isArray(potentialRoute.method) && potentialRoute.method.includes(request.method)))) {
 			state.params = [];
 			for(var p=1; p<match.length; p++) {
 				state.params.push(match[p]);


### PR DESCRIPTION
This PR extends server routes to support multiple methods by allowing `exports.method` to optionally be an array of supported methods: `export.method = ["COPY","MOVE"];`

The change is backwards compatible. The use case is to be able to have a handler that can handle multiple methods, this is especially useful if the routes are being handed off to a common class that handles them all.

There is an alternative, we could add an additional `exports.methods` property that is always an array, and when loading routes first check for `exports.methods` and if absent then for backwards compatiblity check `exports.method`:

```javascript
if(match && (potentialRoute.methods?.includes(request.method) || potentialRoute.method === request.method)) {
	state.params = [];
	for(var p=1; p<match.length; p++) {
		state.params.push(match[p]);
	}
	return potentialRoute;
}

```

On a related note, is there a minimum node version that we target? The optional chaining operator is supported in Node 14+.
