### PR TITLE
Extends server routes exports to allow ordering

### DIFF
--- a/core-server/server/routes/delete-tiddler.js
+++ b/core-server/server/routes/delete-tiddler.js
@@ -12,6 +12,10 @@ exports.method = "DELETE";
 
 exports.path = /^\/bags\/default\/tiddlers\/(.+)$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	var title = $tw.utils.decodeURIComponentSafe(state.params[0]);
 	state.wiki.deleteTiddler(title);

--- a/core-server/server/routes/get-favicon.js
+++ b/core-server/server/routes/get-favicon.js
@@ -12,6 +12,10 @@ exports.method = "GET";
 
 exports.path = /^\/favicon.ico$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	var buffer = state.wiki.getTiddlerText("$:/favicon.ico","");
 	state.sendResponse(200,{"Content-Type": "image/x-icon"},buffer,"base64");

--- a/core-server/server/routes/get-file.js
+++ b/core-server/server/routes/get-file.js
@@ -12,6 +12,10 @@ exports.method = "GET";
 
 exports.path = /^\/files\/(.+)$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	var path = require("path"),
 		fs = require("fs"),

--- a/core-server/server/routes/get-index.js
+++ b/core-server/server/routes/get-index.js
@@ -12,6 +12,10 @@ exports.method = "GET";
 
 exports.path = /^\/$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	var text = state.wiki.renderTiddler(state.server.get("root-render-type"),state.server.get("root-tiddler")),
 		responseHeaders = {

--- a/core-server/server/routes/get-login-basic.js
+++ b/core-server/server/routes/get-login-basic.js
@@ -12,6 +12,10 @@ exports.method = "GET";
 
 exports.path = /^\/login-basic$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	if(!state.authenticatedUsername) {
 		// Challenge if there's no username

--- a/core-server/server/routes/get-status.js
+++ b/core-server/server/routes/get-status.js
@@ -12,6 +12,10 @@ exports.method = "GET";
 
 exports.path = /^\/status$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	var text = JSON.stringify({
 		username: state.authenticatedUsername || state.server.get("anon-username") || "",

--- a/core-server/server/routes/get-tiddler-html.js
+++ b/core-server/server/routes/get-tiddler-html.js
@@ -12,6 +12,10 @@ exports.method = "GET";
 
 exports.path = /^\/([^\/]+)$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	var title = $tw.utils.decodeURIComponentSafe(state.params[0]),
 		tiddler = state.wiki.getTiddler(title);

--- a/core-server/server/routes/get-tiddler.js
+++ b/core-server/server/routes/get-tiddler.js
@@ -12,6 +12,10 @@ exports.method = "GET";
 
 exports.path = /^\/recipes\/default\/tiddlers\/(.+)$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	var title = $tw.utils.decodeURIComponentSafe(state.params[0]),
 		tiddler = state.wiki.getTiddler(title),

--- a/core-server/server/routes/get-tiddlers-json.js
+++ b/core-server/server/routes/get-tiddlers-json.js
@@ -14,6 +14,10 @@ exports.method = "GET";
 
 exports.path = /^\/recipes\/default\/tiddlers.json$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	var filter = state.queryParameters.filter || DEFAULT_FILTER;
 	if(state.wiki.getTiddlerText("$:/config/Server/AllowAllExternalFilters") !== "yes") {

--- a/core-server/server/routes/put-tiddler.js
+++ b/core-server/server/routes/put-tiddler.js
@@ -12,6 +12,10 @@ exports.method = "PUT";
 
 exports.path = /^\/recipes\/default\/tiddlers\/(.+)$/;
 
+exports.info = {
+	priority: 100
+};
+
 exports.handler = function(request,response,state) {
 	var title = $tw.utils.decodeURIComponentSafe(state.params[0]),
 	fields = $tw.utils.parseJSONSafe(state.data);

--- a/core-server/server/server.js
+++ b/core-server/server/server.js
@@ -74,6 +74,11 @@ function Server(options) {
 		// console.log("Loading server route " + title);
 		self.addRoute(routeDefinition);
 	});
+	this.routes.sort((a, b) => {
+		const priorityA = a.info?.priority ?? 100,
+			priorityB = b.info?.priority ?? 100;
+		return priorityB - priorityA;
+	});
 	// Initialise the http vs https
 	this.listenOptions = null;
 	this.protocol = "http";


### PR DESCRIPTION
This PR adds support for an `info` property to server `route` module exports. The `info` object may include a `priority` field, which determines the route’s order of precedence. This helps avoid ugly hacks like having to name route tiddlers as `$:_plugins/sq/myroute.js` to have it take precedence over core routes.

Priorities are numeric and follow a descending order: routes with higher priority values are processed first, similar to how `saver` modules are prioritized.

To maintain backward compatibility with existing code, any module that omits `info` or `info.priority` is assigned a default priority of 100. Core server routes have been updated to explicitly use this default value of 100.

