### PR TITLE
savetiddlers extension is now Firefox-only

### DIFF
--- a/editions/fr-FR/tiddlers/community/resources/_savetiddlers_ Extension for Firefox by buggyj.tid
+++ b/editions/fr-FR/tiddlers/community/resources/_savetiddlers_ Extension for Firefox by buggyj.tid
@@ -1,0 +1,17 @@
+caption: savetiddlers
+color: #4DB6AC
+community-author: buggyj
+created: 20171109171935039
+delivery: Browser Extension
+description: Extension pour les navigateur Firefox
+fr-title: 
+method: save
+modified: 20250809092435788
+tags: Firefox Saving [[Other Resources]] plugins
+title: savetiddlers: Extension for Firefox by buggyj
+type: text/vnd.tiddlywiki
+url: https://github.com/buggyj/savetiddlers
+
+Une extension Mozilla Firefox qui fluidifie l'utilisation de [[l'enregistreur HTML5 par défaut|Saving with the HTML5 fallback saver]] de <<tw>>, et le rend presque aussi convivial que [[TiddlyFox]] une fois configurée.
+
+{{!!url}}

--- a/editions/ja-JP/tiddlers/community/resources/_savetiddlers_ Extension for Firefox by buggyj.tid
+++ b/editions/ja-JP/tiddlers/community/resources/_savetiddlers_ Extension for Firefox by buggyj.tid
@@ -1,0 +1,18 @@
+caption: savetiddlers
+color: #4DB6AC
+community-author: buggyj
+created: 20171109171935039
+delivery: Browser Extension
+description: Firefoxのブラウザ拡張機能
+method: save
+modified: 20250809092435788
+original-modified: 20250809092435788
+tags: Firefox Saving [[Other Resources]] plugins
+title: savetiddlers: Extension for Firefox by buggyj
+ja-title: buggyjによるFirefoxの"savetiddlers"拡張機能
+type: text/vnd.tiddlywiki
+url: https://github.com/buggyj/savetiddlers
+
+Mozilla Firefoxの拡張機能で、TiddlyWikiの組み込み[[HTML5セーバー|Saving with the HTML5 saver]]による使いにくさの一部を解消し、正しく設定すれば[[TiddlyFox]]とほぼ同じくらい簡単に使用できるようになります。
+
+{{!!url}}


### PR DESCRIPTION
[As of early 2025](https://github.com/buggyj/savetiddlers/commit/d59064120a471ab6664ee82ad0d034dd9c2fde1e), savetiddlers is a Firefox-only extension. This pull request updates tiddlywiki.com with this fact.

I made a few small changes to the formatting also, outlined in the first commit. I used explicit link syntax, realising later only when I tested it that PascalCase links are enabled on tiddlywiki.com, so TiddlyFox was linked anyway.
Oh well, it is still correct. :)
 
I also updated the French and Japanese translations. I speak neither language and used machine translation to validate the change. I made it so the filenames and titles match 1:1 between English and the translations, and I believe that means it should work out of the box, but I haven't tested that part to be certain.