### PR TITLE
exports.search: don't break the loop if encoding is base64

### DIFF
--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -1443,7 +1443,7 @@ exports.search = function(text,options) {
 			// Don't search the text field if the content type is binary
 			var fieldName = searchFields[fieldIndex];
 			if(fieldName === "text" && contentTypeInfo.encoding !== "utf8") {
-				break;
+				continue;
 			}
 			var str = tiddler.fields[fieldName],
 				t;


### PR DESCRIPTION
This makes it possible to find tiddlers with base64 encoding using `search:*:words[searchterm]` for example

fixes #9246

The fix is not to **break** from the **for loop** but to **continue** if the field is text and the encoding is base64:

```
		for(var fieldIndex=0; notYetFound.length>0 && fieldIndex<searchFields.length; fieldIndex++) {
			// Don't search the text field if the content type is binary
			var fieldName = searchFields[fieldIndex];
			if(fieldName === "text" && contentTypeInfo.encoding !== "utf8") {
				break;
			}
```

fix:

```
		for(var fieldIndex=0; notYetFound.length>0 && fieldIndex<searchFields.length; fieldIndex++) {
			// Don't search the text field if the content type is binary
			var fieldName = searchFields[fieldIndex];
			if(fieldName === "text" && contentTypeInfo.encoding !== "utf8") {
				continue;
			}
```