### PR TITLE
Use more semantic elements

### DIFF
--- a/core/templates/server/static.sidebar.wikitext.tid
+++ b/core/templates/server/static.sidebar.wikitext.tid
@@ -1,7 +1,7 @@
 title: $:/core/templates/server/static.sidebar.wikitext
 
 \whitespace trim
-<div class="tc-sidebar-scrollable" style="overflow: auto;" role="region" aria-label={{$:/language/SideBar/Caption}}>
+<section class="tc-sidebar-scrollable" style="overflow: auto;" aria-label={{$:/language/SideBar/Caption}}>
 <div class="tc-sidebar-header">
 <h1 class="tc-site-title">
 <$transclude tiddler="$:/SiteTitle"/>
@@ -17,7 +17,7 @@ title: $:/core/templates/server/static.sidebar.wikitext
 <$link><$text text=<<currentTiddler>>/></$link>
 </div>
 </$list>
-</div>
+</section>
 <!-- Currently disabled the recent list as it is unweildy when the responsive narrow view kicks in
 <h2>
 {{$:/language/SideBar/Recent/Caption}}

--- a/core/templates/server/static.tiddler.html.tid
+++ b/core/templates/server/static.tiddler.html.tid
@@ -20,10 +20,10 @@ title: $:/core/templates/server/static.tiddler.html
 </head>
 <body class="tc-body">
 <$transclude tiddler="$:/core/templates/server/static.sidebar.wikitext" mode="inline"/>
-<section class="tc-story-river" role="main">
-<div class="tc-tiddler-frame" role="article">
+<main class="tc-story-river">
+<article class="tc-tiddler-frame">
 <$transclude tiddler="$:/core/templates/server/static.tiddler.wikitext" mode="inline"/>
-</div>
-</section>
+</article>
+</main>
 </body>
 </html>

--- a/core/ui/EditTemplate.tid
+++ b/core/ui/EditTemplate.tid
@@ -26,11 +26,10 @@ title: $:/core/ui/EditTemplate
 \end
 
 \whitespace trim
-<div
+<section
 	data-tiddler-title=<<currentTiddler>>
 	data-tags={{!!tags}}
 	class={{{ [all[shadows+tiddlers]tag[$:/tags/ClassFilters/TiddlerTemplate]!is[draft]] :map:flat[subfilter{!!text}] tc-tiddler-frame tc-tiddler-edit-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}
-	role="region"
 	aria-label={{$:/language/EditTemplate/Caption}}>
 <$fieldmangler>
 <$vars
@@ -53,4 +52,4 @@ title: $:/core/ui/EditTemplate
 </$keyboard>
 </$vars>
 </$fieldmangler>
-</div>
+</section>

--- a/core/ui/PageTemplate/story.tid
+++ b/core/ui/PageTemplate/story.tid
@@ -2,7 +2,7 @@ title: $:/core/ui/PageTemplate/story
 tags: $:/tags/PageTemplate
 
 \whitespace trim
-<section class="tc-story-river" role="main">
+<main class="tc-story-river">
 
 <section class="story-backdrop">
 
@@ -26,4 +26,4 @@ tags: $:/tags/PageTemplate
 
 </section>
 
-</section>
+</main>

--- a/core/ui/SideBarSegments/tabs.tid
+++ b/core/ui/SideBarSegments/tabs.tid
@@ -1,8 +1,8 @@
 title: $:/core/ui/SideBarSegments/tabs
 tags: $:/tags/SideBarSegment
 
-<div class="tc-sidebar-lists tc-sidebar-tabs" role="region" aria-label={{$:/language/SideBar/Caption}}>
+<section class="tc-sidebar-lists tc-sidebar-tabs" aria-label={{$:/language/SideBar/Caption}}>
 
 <$macrocall $name="tabs" tabsList="[all[shadows+tiddlers]tag[$:/tags/SideBar]!has[draft.of]]" default={{$:/config/DefaultSidebarTab}} state="$:/state/tab/sidebar" class="tc-sidebar-tabs-main" explicitState="$:/state/tab/sidebar--595412856"/>
 
-</div>
+</section>

--- a/core/ui/ViewTemplate.tid
+++ b/core/ui/ViewTemplate.tid
@@ -8,9 +8,9 @@ $:/state/folded/$(currentTiddler)$
 \define cancel-delete-tiddler-actions(message) <$action-sendmessage $message="tm-$message$-tiddler"/>
 \import [all[shadows+tiddlers]tag[$:/tags/Macro/View]!is[draft]] [all[shadows+tiddlers]tag[$:/tags/Global/View]!is[draft]]
 <$vars storyTiddler=<<currentTiddler>> tiddlerInfoState=<<qualify "$:/state/popup/tiddler-info">>>
-<div data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ [all[shadows+tiddlers]tag[$:/tags/ClassFilters/TiddlerTemplate]!is[draft]] :map:flat[subfilter{!!text}] tc-tiddler-frame tc-tiddler-view-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[shadow]is[tiddler]then[tc-tiddler-overridden-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}} role="article">
+<article data-tiddler-title=<<currentTiddler>> data-tags={{!!tags}} class={{{ [all[shadows+tiddlers]tag[$:/tags/ClassFilters/TiddlerTemplate]!is[draft]] :map:flat[subfilter{!!text}] tc-tiddler-frame tc-tiddler-view-frame [<currentTiddler>is[tiddler]then[tc-tiddler-exists]] [<currentTiddler>is[missing]!is[shadow]then[tc-tiddler-missing]] [<currentTiddler>is[shadow]then[tc-tiddler-exists tc-tiddler-shadow]] [<currentTiddler>is[shadow]is[tiddler]then[tc-tiddler-overridden-shadow]] [<currentTiddler>is[system]then[tc-tiddler-system]] [{!!class}] [<currentTiddler>tags[]encodeuricomponent[]addprefix[tc-tagged-]] +[join[ ]] }}}>
 <$list filter="[all[shadows+tiddlers]tag[$:/tags/ViewTemplate]!is[draft]]" variable="listItem">
 <$transclude tiddler=<<listItem>>/>
 </$list>
-</div>
+</article>
 </$vars>


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR isn't backward compatible.**

Replaces some elements with `role` attribute to semantic HTML equivalents.

Fixes #7629