### PR TITLE
Improve handling of $link widget's draggable="no"

### DIFF
--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -139,10 +139,8 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 			dragTiddlerFn: function() {return self.to;},
 			widget: this
 		});
-	} else {
-                //set the resulting <a> tag draggable attribute to false
-                //to improve browser's compliance with user's intent
-                domNode.setAttribute("draggable","false");
+	} else if(this.draggable === "no") {
+		domNode.setAttribute("draggable","false");
 	}
 	// Assign data- attributes
 	this.assignAttributes(domNode,{


### PR DESCRIPTION
This basic PR intends to improve browsers compliance with user's intent when the widget's `draggable` attribute is set to `no` achieved by setting the resulting `<a>` tag's `draggable` attribute to `false` .

Currently, the user's desire to disable drag and drop when creating a `<$link` widget by specifying attribute `draggable="no"` **does not carry this intent in the resulting HTML** `<a` tag with a matching `draggable="false"` attribute. Thus browsers still allow the user to drag the link. 

PR submitted following the discussion and screen captures at https://talk.tiddlywiki.org/t/question-regarding-the-link-widget-when-its-draggable-attribute-is-set-to-no/13319/4 and associated recommendation for a PR.