### PR TITLE
Add th-debug-element hook and data-debug-element minimal useful info

### DIFF
--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -74,7 +74,7 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	// Create the DOM node and render children
 	var domNode = this.document.createElementNS(this.namespace,this.tag);
 	this.assignAttributes(domNode,{excludeEventAttributes: true});
-	// Allow plugins to manipulate the DOM. Eg: Add debug info
+	// Allow hooks to manipulate the DOM node. Eg: Add debug info
 	$tw.hooks.invokeHook("th-dom-rendering-element", domNode, this);
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);


### PR DESCRIPTION
This PR closes: **[IDEA] Plugin sourcing, find out UI element is caused by which plugin/tiddler** #6345

Edit: 25.Sept.25

This PR adds: 

- `th-dom-rendering-element` hook, that is called right before the DOM node is inserted into the DOM. It allows plugins to add debug info.

An example using an experimental hook can be found at: https://github.com/TiddlyWiki/TiddlyWiki5/pull/9222

----------

<details><summary>Initial Info</summary>

This PR adds: 

- `th-debug-element` hook and 
- `data-debug-element` minimal useful info to the DOM. The `transclusion` variable 
- This PR has no other requirements

If a variable `tv-debug === yes` the `data-debug-element` attribute is written to the dom. So this PR is useful on its own as seen in the screenshot.

The real power comes with plugins, that allow us to show much more info using the `th-debug-element` hook.

<img width="1885" height="876" alt="image" src="https://github.com/user-attachments/assets/a372d50e-55e7-40b5-9282-9d54c9f04030" />

@Jermolene ... This PR implements the minimal requirement in the core, that allows plugins to show much more info. 

I think the documentation will go to the tiddlywiki.com/dev edition. **Or** do you want to have it in the tw-com docs? Just let me know.

</details>
