### PR TITLE
[DOCS] Add some developer related search terms / links to the Developer tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/about/Developers.tid
+++ b/editions/tw5.com/tiddlers/about/Developers.tid
@@ -1,5 +1,5 @@
 created: 20150412191004348
-modified: 20240925114810504
+modified: 20250916222658564
 tags: Community Reference
 title: Developers
 type: text/vnd.tiddlywiki
@@ -8,3 +8,30 @@ type: text/vnd.tiddlywiki
 * Get involved in the [[development on GitHub|https://github.com/TiddlyWiki/TiddlyWiki5]]
 * [[GitHub Discussions|https://github.com/TiddlyWiki/TiddlyWiki5/discussions]] are for Q&A and open-ended discussion
 * [[GitHub Issues|https://github.com/TiddlyWiki/TiddlyWiki5/issues]] are for raising bug reports and proposing specific, actionable new ideas
+
+Also see:
+
+* [[Data Storage in Single File TiddlyWiki|https://tiddlywiki.com/dev/#Data%20Storage%20in%20Single%20File%20TiddlyWiki]]
+* [[Continuous Deployment|https://tiddlywiki.com/dev/#Continuous%20Deployment]]
+* [[GitHub Branches|https://tiddlywiki.com/dev/#GitHub%20Branches]]
+* [[HookMechanism|https://tiddlywiki.com/dev/#HookMechanism]]
+* [[Using ES2016 for Writing Plugins|https://tiddlywiki.com/dev/#Using%20ES2016%20for%20Writing%20Plugins]]
+* [[Adding Babel Polyfill to TiddlyWiki|https://tiddlywiki.com/dev/#Adding%20Babel%20Polyfill%20to%20TiddlyWiki]]
+* [[TiddlyWiki Drag and Drop Interoperability|https://tiddlywiki.com/dev/#TiddlyWiki%20Drag%20and%20Drop%20Interoperability]]
+* [[Javascript Widget Tutorial|https://tiddlywiki.com/dev/#Javascript%20Widget%20Tutorial]]
+* [[Using TiddlyWiki as a library in another Node.js application|https://tiddlywiki.com/dev/#Using%20TiddlyWiki%20as%20a%20library%20in%20another%20Node.js%20application]]
+* [[TiddlyWiki for Developers|https://tiddlywiki.com/dev/#TiddlyWiki%20for%20Developers]]
+* [[TiddlyWiki Coding Style Guidelines|https://tiddlywiki.com/dev/#TiddlyWiki%20Coding%20Style%20Guidelines]]
+* [[TiddlyWiki Architecture|https://tiddlywiki.com/dev/#TiddlyWiki%20Architecture]]
+* [[TiddlyWiki5 Development Environment|https://tiddlywiki.com/dev/#TiddlyWiki5%20Development%20Environment]]
+* [[Developing plugins using Node.js and GitHub|https://tiddlywiki.com/dev/#Developing%20plugins%20using%20Node.js%20and%20GitHub]]
+* [[How to create a translation for TiddlyWiki|https://tiddlywiki.com/dev/#How%20to%20create%20a%20translation%20for%20TiddlyWiki]]
+* [[JavaScript Macros|https://tiddlywiki.com/dev/#JavaScript%20Macros]]
+* [[TiddlyWiki on NW.js|https://tiddlywiki.com/dev/#TiddlyWiki%20on%20NW.js]]
+* [[How to create plugins in the browser|https://tiddlywiki.com/dev/#How%20to%20create%20plugins%20in%20the%20browser]]
+* [[Contributing to the TiddlyWiki Core|https://tiddlywiki.com/dev/#Contributing%20to%20the%20TiddlyWiki%20Core]]
+* [[Contributing to the TiddlyWiki Plugin Library|https://tiddlywiki.com/dev/#Contributing%20to%20the%20TiddlyWiki%20Plugin%20Library]]
+* [[Scripts for building tiddlywiki.com|https://tiddlywiki.com/dev/#Scripts%20for%20building%20tiddlywiki.com]]
+* [[SyncAdaptorModules|https://tiddlywiki.com/dev/#SyncAdaptorModules]]
+* [[WidgetModules|https://tiddlywiki.com/dev/#WidgetModules]]
+* [[WikiRuleModules|https://tiddlywiki.com/dev/#WikiRuleModules]]


### PR DESCRIPTION
This PR closes #948

- #948

It adds some developer related search terms / links to the Developer tiddler.

The topics have been moved to the dev-edition a long time ago. So the **search terms** have been lost at tw-com. This PR adds some of the "lost" search terms back to the main wiki. So if users search for development related stuff they should be able to find the developer edition. 
 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>