### PR TITLE
Support for downloading base64 files

### DIFF
--- a/core/modules/savers/download.js
+++ b/core/modules/savers/download.js
@@ -37,7 +37,7 @@ DownloadSaver.prototype.save = function(text,method,callback,options) {
 	var link = document.createElement("a");
 	// We prefer Blobs if they're available, unless we're dealing with a tiddler type declaring itself full of base64 encoded content.
 	// Then we use data urls, because browsers will know to decode the stream and download the actual binary file as intended.
-	if(Blob !== undefined && type.indexOf(";base64") < 0) {
+	if(Blob !== undefined && !type.includes(";base64")) {
 		var blob = new Blob([text], {type: type});
 		link.setAttribute("href", URL.createObjectURL(blob));
 	} else {


### PR DESCRIPTION
The blob doesn't work for downloading a tiddler type that calls itself out as a base64 type. Using data urls does work.

This change makes it possible to download png and other base64 encoded tiddlers correctly.

It's for TW5-Graph, but it struck me as rather amazing that there does not appear to be any way to download an image tiddler as an actual image. Seems like something SOMEONE would have wanted to do by now.