### PR TITLE
Replace style for links to shadow tiddlers

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -469,6 +469,7 @@ a.tc-tiddlylink-resolves {
 
 a.tc-tiddlylink-shadow {
 	border-left: 2px dotted;
+	padding-left: 4px;
 }
 
 a.tc-tiddlylink-shadow.tc-tiddlylink-resolves {
@@ -2853,6 +2854,7 @@ a.tc-tiddlylink.tc-plugin-info:hover > .tc-plugin-info-chunk .tc-plugin-info-sta
 
 .tc-chooser-item .tc-tiddlylink {
 	border-left: none;
+	padding-left: none;
 	display: block;
 	text-decoration: none;
 	background-color: transparent;


### PR DESCRIPTION
Closes #1205.

This PR modifies styles of links to shadow tiddlers to:

* Plain shadow: dotted border on the left
* Overriden shadow: solid border on the left

<img width="1396" height="706" alt="image" src="https://github.com/user-attachments/assets/f23d8526-21fe-4770-baa1-3960ad0658d5" />
