### PR TITLE
[DOCS] Make ReleaseTemplate use code-body

### DIFF
--- a/editions/fr-FR/tiddlers/ReleaseTemplate.tid
+++ b/editions/fr-FR/tiddlers/ReleaseTemplate.tid
@@ -1,5 +1,6 @@
 created: 20141115211411211
 title: ReleaseTemplate
+code-body: yes
 type: text/vnd.tiddlywiki
 
 <h2><$link to=<<currentTab>>><$view tiddler=<<currentTab>> field="title"/></$link></h2>

--- a/editions/tw5.com/tiddlers/releasenotes/ReleaseTemplate.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/ReleaseTemplate.tid
@@ -1,6 +1,7 @@
 created: 20211117231152248
 modified: 20211119231156728
 tags: [[Release Template]]
+code-body: yes
 title: ReleaseTemplate
 
 <h2><$link to=<<currentTab>>><$view tiddler=<<currentTab>> field="title"/></$link></h2>


### PR DESCRIPTION
Make ReleaseTemplate use code-body

To reproduce: 

- open: https://tiddlywiki.com/#ReleaseTemplate
- It shows a loooooooot of H2s with no content
- This tiddler shows up in the static https://tiddlywiki.com/alltiddlers.html#ReleaseTemplate

This PR fixes that problem