### PR TITLE
chore: bump checkout action v4 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "${{ env.NODE_VERSION }}"
@@ -30,7 +30,7 @@ jobs:
       TW5_BUILD_MAIN_EDITION: "./editions/prerelease"
       TW5_BUILD_OUTPUT: "./output/prerelease"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "${{ env.NODE_VERSION }}"
@@ -62,7 +62,7 @@ jobs:
       TW5_BUILD_OUTPUT: "./output"
       TW5_BUILD_ARCHIVE: "./output"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "${{ env.NODE_VERSION }}"

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Bumps Github's checkout action from v4 to [v5](https://github.com/actions/checkout/releases/tag/v5.0.0).