### PR TITLE
[DOCS] Add docs about deprecated classes

### DIFF
--- a/editions/tw5.com/tiddlers/Deprecated Core Classes.tid
+++ b/editions/tw5.com/tiddlers/Deprecated Core Classes.tid
@@ -9,5 +9,5 @@ type: text/vnd.tiddlywiki
 These [[Core Classes]] are considered deprecated. It is not recommend to use them for styling.
 
 * `tc-tagged-*` <<.deprecated-since 5.1.16>> Use [[Custom styles by data-tags]] instead.
-* `tc-reveal` <<.deprecated-since 5.3.8>> This class is used in TiddlyWiki so excessively that it has no value for styling.
+* `tc-reveal` <<.deprecated-since 5.3.8>> for styling purposes as it is subject to change.
 * `tc-language-(language code)` <<.deprecated-since 5.3.8>> Please use [[:lang()|https://developer.mozilla.org/en-US/docs/Web/CSS/:lang]] instead.


### PR DESCRIPTION
This PR adds docs about deprecated classes, including:

* `tc-tagged-*`
* `tc-reveal` See #8709