### PR TITLE
Fix Slider Plugin Url

### DIFF
--- a/editions/tw5.com/tiddlers/community/plugins/Slider by Mohammad.tid
+++ b/editions/tw5.com/tiddlers/community/plugins/Slider by Mohammad.tid
@@ -1,9 +1,9 @@
 created: 20201117162655614
-modified: 20201117162926714
+modified: 20251020041616967
 tags: [[Community Plugins]]
 title: Slider by Mohammad
 type: text/vnd.tiddlywiki
-url: https://kookma.github.io/slider/
+url: https://kookma.github.io/TW-Slider/
 
 Slider is a plugin to create an ordered set of tiddlers also called Trail.
 


### PR DESCRIPTION
The Slider url is fixed.
The new address is https://kookma.github.io/TW-Slider/ 