### PR TITLE
Docs: add link to Newsletter

### DIFF
--- a/community/project/teams/Newsletter Team.tid
+++ b/community/project/teams/Newsletter Team.tid
@@ -1,6 +1,6 @@
-title: Newsletter Team
-tags: Community/Team
-modified: 20250909171928024
 created: 20250909171928024
+modified: 20251022152911636
+tags: Community/Team
+title: Newsletter Team
 
-The Newsletter Team is responsible for producing the TiddlyWiki Newsletter, a monthly email newsletter that highlights news, updates, and community contributions related to TiddlyWiki.
+The Newsletter Team is responsible for producing the [[TiddlyWiki Newsletter]], a monthly email newsletter that highlights news, updates, and community contributions related to TiddlyWiki.


### PR DESCRIPTION
Added link to Newsletter tiddler in Newsletter Team card. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/.</small>