### PR TITLE
docs: update more links for PR maker

### DIFF
--- a/editions/tw5.com/tiddlers/TiddlyWiki Docs PR Maker.tid
+++ b/editions/tw5.com/tiddlers/TiddlyWiki Docs PR Maker.tid
@@ -1,11 +1,10 @@
 created: 20240313100515958
-modified: 20240313103959789
+modified: 20251023154747366
 tags: Editions
 title: TiddlyWiki Docs PR Maker
 
-''~TiddlyWiki Docs PR Maker'' is a special edition of tiddlywiki.com designed to help you contribute to and improve the documentation made by [[@saqimtiaz|https://github.com/saqimtiaz/]].
-
-https://saqimtiaz.github.io/tw5-docs-pr-maker/
+''~TiddlyWiki Docs PR Maker'' is a special edition of tiddlywiki.com designed to help you contribute to and improve the documentation.
+https://edit.tiddlywiki.com
 
 All changes made to the documentation can be very easily submitted to GitHub -- the pull request will be automatically made, hence the "PR Maker" name of the edition.
 

--- a/editions/tw5.com/tiddlers/community/Improving TiddlyWiki Documentation.tid
+++ b/editions/tw5.com/tiddlers/community/Improving TiddlyWiki Documentation.tid
@@ -1,5 +1,5 @@
 created: 20140820151051019
-modified: 20240313114828368
+modified: 20251023154718268
 tags: Community
 title: Improving TiddlyWiki Documentation
 type: text/vnd.tiddlywiki
@@ -20,7 +20,7 @@ You can choose to edit the documentation using the [[TiddlyWiki Docs PR Maker]] 
 
 !! Using [[Docs PR Maker|TiddlyWiki Docs PR Maker]] edition
 
-# Go to https://saqimtiaz.github.io/tw5-docs-pr-maker/ or click the link displayed in the ribbon underneath the title when editing a tiddler on tiddlywiki.com
+# Go to https://edit.tiddlywiki.com or click the link displayed in the ribbon underneath the title when editing a tiddler on tiddlywiki.com
 # Go through the quick introduction where you will need to provide your ~GitHub username and a ~GitHub access token (you will be guided in creating one)
 # Edit or create tiddlers to update the documentation, the wiki will keep track of all changes
 # Click the "Submit updates" button and check if all the tiddlers that you edited are included in the submission; if not, drag them into the box


### PR DESCRIPTION
Updated documentation links for PR maker, however these tiddler do need a rewrite so that we can deprecate the name PR maker. 

---
<small>Submitted using https://edit.tiddlywiki.com/.</small>