### PR TITLE
fix: UX on pasting image

### DIFF
--- a/core/ui/ImportListing.tid
+++ b/core/ui/ImportListing.tid
@@ -37,8 +37,6 @@ title: $:/core/ui/ImportListing
 
 \define suppressedField() suppressed-$(payloadTiddler)$
 
-\define newImportTitleTiddler() $:/temp/NewImportTitle-$(payloadTiddler)$
-
 \define previewPopupState() $(currentTiddler)$!!popup-$(payloadTiddler)$
 
 \define renameFieldState() $(currentTiddler)$!!state-rename-$(payloadTiddler)$


### PR DESCRIPTION
Fixed image import logic to recognize user-entered rename input even if the checkmark (✓) isn’t clicked before pressing “Import.”

https://github.com/user-attachments/assets/a3b25996-f65f-4ab8-b26e-e2428aafc45e
