### PR TITLE
Add dropdowns for release changenotes and impact notes

### DIFF
--- a/editions/tw5.com/tiddlers/releasenotes/config/EditTemplateFields_ReleaseNote_change-category.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/config/EditTemplateFields_ReleaseNote_change-category.tid
@@ -1,0 +1,8 @@
+title: $:/config/EditTemplateFields/ReleaseNote/change-category
+
+\define options() internal translation plugin widget filters usability theme hackability nodejs performance  developer
+<$select tiddler=<<currentTiddler>> field=<<currentField>> class="tc-edit-texteditor tc-edit-fieldeditor" cancelPopups="yes">
+    <$list filter='[enlist<options>sort[title]]'>
+        <option value=<<currentTiddler>>><<currentTiddler>></option>
+    </$list>
+</$select>

--- a/editions/tw5.com/tiddlers/releasenotes/config/EditTemplateFields_ReleaseNote_change-impact-type.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/config/EditTemplateFields_ReleaseNote_change-impact-type.tid
@@ -1,0 +1,13 @@
+title: $:/config/EditTemplateFields/ReleaseNote/change-impact-type
+
+\define options()
+deprecation -- There are features or functionality that should no longer be used in new code
+compatibility-break -- Changes are included that break backwards compatibility
+pluginisation -- Functionality has been moved from the core to a plugin
+\end
+
+<$select tiddler=<<currentTiddler>> field=<<currentField>> class="tc-edit-texteditor tc-edit-fieldeditor" cancelPopups="yes">
+    <$list filter="[<options>splitregexp[\n]sort[title]]">
+        <option value={{{ [<currentTiddler>split[--]nth[]trim[]] }}}><<currentTiddler>></option>
+    </$list>
+</$select>

--- a/editions/tw5.com/tiddlers/releasenotes/config/EditTemplateFields_ReleaseNote_change-type.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/config/EditTemplateFields_ReleaseNote_change-type.tid
@@ -1,0 +1,8 @@
+title: $:/config/EditTemplateFields/ReleaseNote/change-type
+
+\define options() bugfix feature enhancement deprecation security performance
+<$select tiddler=<<currentTiddler>> field=<<currentField>> class="tc-edit-texteditor tc-edit-fieldeditor" cancelPopups="yes">
+    <$list filter='[enlist<options>sort[title]]'>
+        <option value=<<currentTiddler>>><<currentTiddler>></option>
+    </$list>
+</$select>

--- a/editions/tw5.com/tiddlers/releasenotes/config/FieldEditorFilters_ReleaseNote_impact-type-selector.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/config/FieldEditorFilters_ReleaseNote_impact-type-selector.tid
@@ -1,0 +1,8 @@
+created: 20251115021424272
+list-before: $:/config/FieldEditorFilters/default
+modified: 20251115023042502
+tags: $:/tags/FieldEditorFilter
+title: $:/config/FieldEditorFilters/ReleaseNote/impact-type-selector
+type: text/vnd.tiddlywiki
+
+[suffix[impact-type]then[$:/config/EditTemplateFields/ReleaseNote/change-impact-type]]

--- a/editions/tw5.com/tiddlers/releasenotes/config/FieldEditorFilters_ReleaseNote_type-selector.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/config/FieldEditorFilters_ReleaseNote_type-selector.tid
@@ -1,0 +1,5 @@
+title: $:/config/FieldEditorFilters/ReleaseNote/type-selector
+list-before: $:/config/FieldEditorFilters/default
+tags: $:/tags/FieldEditorFilter
+
+[suffix[change-type]then[$:/config/EditTemplateFields/ReleaseNote/change-type]]

--- a/editions/tw5.com/tiddlers/releasenotes/config/FieldEditorFilters__ReleaseNote_category-selector.tid
+++ b/editions/tw5.com/tiddlers/releasenotes/config/FieldEditorFilters__ReleaseNote_category-selector.tid
@@ -1,0 +1,5 @@
+title: $:/config/FieldEditorFilters//ReleaseNote/category-selector
+list-before: $:/config/FieldEditorFilters/default
+tags: $:/tags/FieldEditorFilter
+
+[suffix[change-category]then[$:/config/EditTemplateFields/ReleaseNote/change-category]]


### PR DESCRIPTION
Add dropdowns for release changenotes and impact notes

**New Release Notes Dropdown**

<img width="1721" height="660" alt="image" src="https://github.com/user-attachments/assets/a29b32a6-5e00-4348-b576-4f971ecfbdac" />

----

**Impact Notes** also show some description info. The field only contains the first part. 

So the question is: Should we add the description info or not?

<img width="1727" height="609" alt="image" src="https://github.com/user-attachments/assets/43747295-ad68-455f-98e0-8c60bbe877c6" />
