### PR TITLE
[DOCS] edit-text widget "autoHeight" parameter takes precedence over "rows"

### DIFF
--- a/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
+++ b/editions/tw5.com/tiddlers/widgets/EditTextWidget.tid
@@ -1,7 +1,7 @@
 caption: edit-text
 created: 20131024141900000
 heading: 
-modified: 20240627184331133
+modified: 20251117015051685
 tags: Widgets
 temp: 
 title: EditTextWidget
@@ -35,7 +35,7 @@ The content of the `<$edit-text>` widget is ignored.
 |size |The size of the input field (in characters). This exact result depends on browser and font. Use the `class` attribute to style width for precise control |
 |autoHeight |Either "yes" or "no" to specify whether to automatically resize `textarea` editors to fit their content (defaults to "yes") |
 |minHeight |Minimum height for automatically resized `textarea` editors, specified in CSS length units such as "px", "em" or "%" |
-|rows|Sets the rows attribute of a generated textarea |
+|rows|Sets the rows attribute of a generated textarea. ''autoHeight'' takes precedence |
 |cancelPopups |<<.from-version "5.1.23">> if set to "yes", cancels all popups when the input gets focus |
 |inputActions |<<.from-version 5.1.23>> Optional actions that are triggered every time an input event occurs within the input field or textarea.<br><<.from-version "5.2.1">> The variable `actionValue` is available to the `inputActions` and contains the value of the input field. |
 |refreshTitle |<<.from-version 5.1.23>> An optional tiddler title that makes the input field update whenever the specified tiddler changes |


### PR DESCRIPTION
Since edit-text widget "autoHeight" parameter takes precedence over "rows" it should be documented. 
Missing this info did just cost me close to an hour :( 

---
<small>Submitted using https://edit.tiddlywiki.com/.</small>