### PR TITLE
Make impact note for #9337 less verbose / repetitive

### DIFF
--- a/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9337 - math-filters .tid
+++ b/editions/tw5.com/tiddlers/releasenotes/5.4.0/#9337 - math-filters .tid
@@ -1,7 +1,7 @@
-title: $:/changenotes/5.4.0/#9337/compatibility-break/math-filters
+title: $:/changenotes/5.4.0/#9337/impacts/math-filters
 changenote: $:/changenotes/5.4.0/#9337
-created - 20251112152513384
-modified - 20251112152513384
+created: 20251112152513384
+modified: 20251209160312626
 tags: $:/tags/ImpactNote
 description: filter output changes for some math filter operators when input list is empty
 impact-type: compatibility-break


### PR DESCRIPTION
The impact note repeated the text of the change note which did not look good in the Release Notes. This purely cosmetic PR remedies that.