### PR TITLE
[DOCS] Add Repo-link to "Installing official plugins on Node.js"

### DIFF
--- a/editions/tw5.com/tiddlers/nodejs/Installing official plugins on Node.js.tid
+++ b/editions/tw5.com/tiddlers/nodejs/Installing official plugins on Node.js.tid
@@ -1,5 +1,5 @@
 created: 20220611123344385
-modified: 20251209214037324
+modified: 20220617132351460
 tags: [[TiddlyWiki on Node.js]] PluginsCS
 title: Installing official plugins on Node.js
 type: text/vnd.tiddlywiki


### PR DESCRIPTION
This PR adds a link to the TW GitHub repo to the "Installing official plugins on Node.js" tiddler 

---
<small>Submitted using https://edit.tiddlywiki.com/.</small>