### PR TITLE
Add issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Create a report to help us improve TiddlyWiki 5
 title: "[BUG] "
+type: bug
 body:
   - type: textarea
     id: Describe

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,7 @@ about: Suggest an idea for TiddlyWiki 5
 title: "[IDEA]"
 labels: ''
 assignees: ''
+type: feature
 
 ---
 


### PR DESCRIPTION
Add issue types for issue templates. Since it is not related to Tiddlywiki, this PR doesn't include a change note.