### PR TITLE
Fix github linguist unmarking generated files not working

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-boot/ -linguist-generated
+boot/** -linguist-generated
 **/tiddlywiki.files linguist-language=JSON
 **/tiddlywiki.info linguist-language=JSON
 **/plugin.info linguist-language=JSON


### PR DESCRIPTION
See #9384 . This PR won't include a change note.

Sadly, it will not work for existing PRs, unless they include the updated `.gitattributes`.