### PR TITLE
Ensure normalize.css is always applied

### DIFF
--- a/core/stylesheets/reset.tid
+++ b/core/stylesheets/reset.tid
@@ -1,4 +1,4 @@
-title: $:/themes/tiddlywiki/vanilla/reset
+title: $:/core/stylesheets/reset
 type: text/css
 
 /*! modern-normalize v2.0.0 | MIT License | https://github.com/sindresorhus/modern-normalize */

--- a/core/ui/RootStylesheet.tid
+++ b/core/ui/RootStylesheet.tid
@@ -4,9 +4,7 @@ code-body: yes
 \import [subfilter{$:/core/config/GlobalImportFilter}]
 \whitespace trim
 <$let currentTiddler={{$:/language}} languageTitle={{!!name}}>
-	<style type="text/css">
-		<$view tiddler="$:/themes/tiddlywiki/vanilla/reset" format="text" mode="block"/>
-	</style>
+	<style type="text/css">{{$:/core/stylesheets/reset}}</style>
 	<$list filter="[all[shadows+tiddlers]tag[$:/tags/Stylesheet]!is[draft]] -[[$:/themes/tiddlywiki/vanilla/reset]]">
 		<style type="text/css">
 			<$view format={{{ [<currentTiddler>tag[$:/tags/Stylesheet/Static]then[text]else[plainwikified]] }}} mode="block"/>

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -65,12 +65,6 @@ $else$
 
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline macrocallblock
 
-/*
-** Start with the normalize CSS reset, and then belay some of its effects
-*/
-
-{{$:/themes/tiddlywiki/vanilla/reset}}
-
 input[type="search"] {
 	outline-offset: initial;
 }


### PR DESCRIPTION
Rework of #9306 .

This PR moves normalize.css to the core and hardcodes it in root stylesheet.