### PR TITLE
Update droppable item to use `tv-enable-drag-and-drop` variable

### DIFF
--- a/core/ui/SideBar/Open.tid
+++ b/core/ui/SideBar/Open.tid
@@ -15,7 +15,7 @@ caption: {{$:/language/SideBar/Open/Caption}}
 
 \define droppable-item(button)
 \whitespace trim
-<$droppable actions=<<drop-actions>> enable=<<tv-allow-drag-and-drop>> tag="div">
+<$droppable actions=<<drop-actions>> enable=<<tv-enable-drag-and-drop>> tag="div">
 <<placeholder>>
 <div>
 $button$


### PR DESCRIPTION
the variable is called `tv-enable-drag-and-drop` - not `tv-allow-drag-and-drop`