### PR TITLE
[DOCS] Add multi-columns class to Widgets in Wikitext

### DIFF
--- a/editions/tw5.com/tiddlers/wikitext/Widgets in WikiText.tid
+++ b/editions/tw5.com/tiddlers/wikitext/Widgets in WikiText.tid
@@ -28,4 +28,4 @@ See [[HTML in WikiText]] for more details.
 
 The available widgets include:
 
-<<list-links "[tag[Widgets]]">>
+<<list-links "[tag[Widgets]]" class:"multi-columns">>


### PR DESCRIPTION
This PR adds `multi-columns` class to Widgets in Wikitext 

<img width="1933" height="935" alt="image" src="https://github.com/user-attachments/assets/1533236d-925a-43f0-aaba-95b844eabb20" />

---
<small>Submitted using https://edit.tiddlywiki.com/.</small>