### PR TITLE
tw5.com: remove duplicate text from Forums tiddler

### DIFF
--- a/editions/tw5.com/tiddlers/community/Forums.tid
+++ b/editions/tw5.com/tiddlers/community/Forums.tid
@@ -26,7 +26,6 @@ For the convenience of existing users, we also continue to operate the original 
 
 * [[TiddlyWiki Subreddit|https://www.reddit.com/r/TiddlyWiki5/]]
 * Chat on Discord at https://discord.gg/HFFZVQ8
-* [[TiddlyWiki Subreddit|https://www.reddit.com/r/TiddlyWiki5/]]
 
 !! Developers
 


### PR DESCRIPTION
The text on `Forums.tid` has been duplicated since 4dc89f63621f5ab5aca1a3f2d1174081d523dbd9 three months ago.

This PR addresses that by removing the duplicate text.