### PR TITLE
Update base.tid to align tiddler-controls of edit-title

### DIFF
--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -1255,7 +1255,7 @@ button.tc-btn-invisible.tc-remove-tag-button {
 	margin-left:5px;
 }
 
-.td-tiddler-edit-title .tc-tiddler-controls {
+.tc-tiddler-edit-title .tc-tiddler-controls {
 	margin-top: -10px;
 }
 


### PR DESCRIPTION
This PR sets `vertical-align: super` on the `tiddler-controls` in `edit mode`

Before:

<img width="197" height="101" alt="Screenshot 2025-12-30 144034" src="https://github.com/user-attachments/assets/8c5bcece-2d78-40ad-a21d-8f467d3fdcfe" />

<img width="2087" height="392" alt="Screenshot 2025-12-30 144737" src="https://github.com/user-attachments/assets/a25c4afa-ff1f-4f20-b383-c07ee4664b0e" />

After:

<img width="2183" height="459" alt="Screenshot 2025-12-30 145341" src="https://github.com/user-attachments/assets/f27aa0fb-7e40-40bf-bc1f-dd3bed8dbf60" />
