### PR TITLE
rename description to about -- to try to fix the problem with bug rep…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-description: Create a report to help us improve TiddlyWiki 5
+about: Create a report to help us improve TiddlyWiki 5
 title: "[Report] "
 type: report
 


### PR DESCRIPTION
rename description to about, which is described at: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates

