### PR TITLE
Quick fix to some deprecated class methods

### DIFF
--- a/core/modules/utils/deprecated.js
+++ b/core/modules/utils/deprecated.js
@@ -44,15 +44,15 @@ exports.domMatchesSelector = (node,selector) => node.matches(selector);
 exports.hasClass = (el,className) => el.classList && el.classList.contains(className);
 
 exports.addClass = function(el,className) {
-	el.classList && el.classList.add(className);
+	el.classList && className && el.classList.add(className);
 };
 
 exports.removeClass = function(el,className) {
-	el.classList && el.classList.remove(className);
+	el.classList && className && el.classList.remove(className);
 };
 
 exports.toggleClass = function(el,className,status) {
-	el.classList && el.classList.toggle(className, status);
+	el.classList && className && el.classList.toggle(className, status);
 };
 
 exports.getLocationPath = () => window.location.origin + window.location.pathname;


### PR DESCRIPTION
In v5.3.8, the droppable Widget sometimes called addClass with an empty string. Nothing would happen.

in v5.4.0-prerelease, the calling addClass (which is now in a deprecated module) with an empty string causes RSoD. This breaks TW5-Graph stuff. And probably some other people's stuff.

This is the fix for that.

No, I will not do release notes, since I'm fixing a bug that has not yet been released.

This'll be our little secret.