### PR TITLE
Allow unused variables in function headers and caught exceptions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -290,10 +290,12 @@ js.configs.recommended,
         "@stylistic/wrap-iife": "off",
         "@stylistic/wrap-regex": "off",
         "@stylistic/yield-star-spacing": "error",
-        yoda: "off",
-        // temporary rules
+        "yoda": "off",
         "no-useless-escape": "off",
-        "no-unused-vars": "warn",
+        "no-unused-vars": ["warn", {
+            "args": "none",
+            "caughtErrors": "none"
+        }],
         "no-empty": "off",
         "@stylistic/no-extra-semi": "off",
         "no-redeclare": "off",


### PR DESCRIPTION
@Jermolene

This PR allows unused variables in function headers and caught exception headers. Like in `try() catch(e)` where `e` is not used.

Local unused variables still create a **warning** no error