### PR TITLE
Set arrow function parens to always

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,7 +58,7 @@ js.configs.recommended,
         "array-callback-return": "off",
         "@stylistic/array-element-newline": "off",
         "arrow-body-style": "error",
-        "@stylistic/arrow-parens": ["error", "as-needed"],
+        "@stylistic/arrow-parens": ["error", "always"],
         "@stylistic/arrow-spacing": ["error", {
             after: true,
             before: true,


### PR DESCRIPTION
I think this setting improves human readability for arrow function code. eg: $:/core/modules/utils/base64.js 

**will look like this:**

```
exports.btoa = (binstr) => window.btoa(binstr);
exports.atob = (b64) => window.atob(b64);

function base64ToBytes(base64) {
	const binString = exports.atob(base64);
	return Uint8Array.from(binString, (m) => m.codePointAt(0));
};

function bytesToBase64(bytes) {
	const binString = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join("");
	return exports.btoa(binString);
};

exports.base64EncodeUtf8 = (str) => bytesToBase64(new TextEncoder().encode(str));

exports.base64DecodeUtf8 = (str) => new TextDecoder().decode(base64ToBytes(str));
```

**instead of this** (current code)

```
exports.btoa = binstr => window.btoa(binstr);
exports.atob = b64 => window.atob(b64);

function base64ToBytes(base64) {
	const binString = exports.atob(base64);
	return Uint8Array.from(binString, m => m.codePointAt(0));
};

function bytesToBase64(bytes) {
	const binString = Array.from(bytes, byte => String.fromCodePoint(byte)).join("");
	return exports.btoa(binString);
};

exports.base64EncodeUtf8 = str => bytesToBase64(new TextEncoder().encode(str));

exports.base64DecodeUtf8 = str => new TextDecoder().decode(base64ToBytes(str));
```

IMO this is especially important for consistency, where "single" parameter arrow functions are near arrow functions which have several parameters. At the moment they look different. 
