### PR TITLE
Refactors and extends utils.collectDOMProperties 

### DIFF
--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -266,7 +266,7 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 		assignVar(name,JSON.stringify(obj));
 	};
 	const getBoundingRect = node => node.getBoundingClientRect && node.getBoundingClientRect();
-	const assignOffsetAndPopupRect = (node) => {
+	const assignOffsetAndPopupRect = node => {
 		if(!node || !("offsetLeft" in node)) {
 			return;
 		}


### PR DESCRIPTION
Refactors $tw.utils.collectDOMProperties:
- to remove repetitive code and improve readability and maintainability.
- provide variables for scroll position
- provide variables representing the properties of the output of node.boundingClientRect(). We already make this call but were discarding some of the results.

Deferring this until v5.5 for a more considered review of how we should provide access to DOM element properties, and what properties should be included. We also need to refactor the method to accept prefixes to use for the variables associated with the different DOM nodes.
