### PR TITLE
Replace window.eval with Function

### DIFF
--- a/boot/boot.js
+++ b/boot/boot.js
@@ -596,7 +596,7 @@ $tw.utils.evalGlobal = function(code,context,filename,sandbox,allowGlobals) {
 	// Compile the code into a function
 	var fn;
 	if($tw.browser) {
-		fn = Function("return " + code + "\n\n//# sourceURL=" + filename)();
+		fn = Function("return " + code + "\n\n//# sourceURL=" + filename)(); // See https://github.com/TiddlyWiki/TiddlyWiki5/issues/6839
 	} else {
 		if(sandbox){
 			fn = vm.runInContext(code,sandbox,filename)


### PR DESCRIPTION
This **does not solve** #6839

Replace `window["eval"]` with `Function` constructor, which has better performance.