### PR TITLE
Replace fill rules in tw5.com edition

### DIFF
--- a/editions/tw5.com/tiddlers/_tw_shared/doc-utilities/doc-styles.tid
+++ b/editions/tw5.com/tiddlers/_tw_shared/doc-utilities/doc-styles.tid
@@ -193,11 +193,11 @@ tr.doc-table-subheading {
 }
 
 .doc-block-icon .tc-image-tip {
-	fill: <<colour primary>>;
+	color: <<colour primary>>;
 }
 
 .doc-block-icon .tc-image-warning {
-	fill: <<colour alert-highlight>>;
+	color: <<colour alert-highlight>>;
 }
 
 a.doc-from-version {
@@ -215,7 +215,6 @@ a.doc-from-version.doc-from-version-new {
 }
 
 a.doc-from-version svg {
-    fill: currentColor;
     vertical-align: sub;
 }
 
@@ -224,7 +223,6 @@ a.doc-deprecated-version.tc-tiddlylink {
     border-radius: 1em;
 	background: red;
 	color: <<colour background>>;
-	fill: <<colour background>>;
     padding: 0 0.4em;
     font-size: 0.7em;
     text-transform: uppercase;

--- a/editions/tw5.com/tiddlers/cards/card-styles.tid
+++ b/editions/tw5.com/tiddlers/cards/card-styles.tid
@@ -36,7 +36,6 @@ type: text/vnd.tiddlywiki
 	border-radius: 6px;
 	padding: 0.5em;
 	color: <<colour background>>;
-	fill: <<colour background>>;
 }
 
 .tc-cards.tc-action-card .tc-card-button svg {

--- a/editions/tw5.com/tiddlers/features/Core Icons.tid
+++ b/editions/tw5.com/tiddlers/features/Core Icons.tid
@@ -37,5 +37,5 @@ Some icons take further parameters to customise how they are rendered. For examp
 
 The core icons are implemented as embedded [[SVG elements|Using SVG]], and not as full-blown SVG images. This means that they can be styled using CSS. For example, the CSS property `fill` can be used to change the colour of the icons. For example:
 
-<<wikitext-example-without-html """<span style="fill: red;">{{$:/core/images/opacity}}</span>
+<<wikitext-example-without-html """<span style="color: red;">{{$:/core/images/opacity}}</span>
 """>>

--- a/editions/tw5.com/tiddlers/hire-jeremy/HireJeremyStyles.tid
+++ b/editions/tw5.com/tiddlers/hire-jeremy/HireJeremyStyles.tid
@@ -81,7 +81,7 @@ type: text/vnd.tiddlywiki
 }
 
 [data-tiddler-title="Hire the founder of TiddlyWiki"] .tc-btn-big-green svg {
-	fill: #cece86;
+	color: #cece86;
 }
 
 .yellow-note-sidebar-wrapper {

--- a/editions/tw5.com/tiddlers/saving/SavingThumbnailsStyles.tid
+++ b/editions/tw5.com/tiddlers/saving/SavingThumbnailsStyles.tid
@@ -68,6 +68,6 @@ tags: $:/tags/Stylesheet
 
 .tc-thumbnail-tabs .tc-btn-pushed {
 	background-color: <<colour foreground>>;
-	fill: <<color background>>;
+	color: <<color background>>;
 }
 

--- a/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
+++ b/editions/tw5.com/tiddlers/system/tw5.com-styles.tid
@@ -97,7 +97,6 @@ type: text/vnd.tiddlywiki
 	font-size: 1.2em;
 	line-height: 1.4em;
 	color: #fff;
-	fill: #fff;
 }
 
 .tc-btn-download:active {

--- a/editions/tw5.com/tiddlers/variables/examples/tv-config-toolbar-class.tid
+++ b/editions/tw5.com/tiddlers/variables/examples/tv-config-toolbar-class.tid
@@ -7,7 +7,7 @@ type: text/vnd.tiddlywiki
 <style>
 .green-background {
 	background-color: green;
-	fill: white;
+	color: white;
 }
 </style>
 


### PR DESCRIPTION
Updates tiddlers in tw5.com edition to use `color` rules.