### PR TITLE
Removes fn wrappers and unneeded comments in browser messaging saver

### DIFF
--- a/core/modules/savers/postmessage.js
+++ b/core/modules/savers/postmessage.js
@@ -6,10 +6,7 @@ module-type: saver
 Handles saving changes via window.postMessage() to the window.parent
 
 \*/
-(function(){
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
 "use strict";
 
 /*
@@ -63,4 +60,3 @@ exports.create = function(wiki) {
 	return new PostMessageSaver(wiki);
 };
 
-})();

--- a/core/modules/utils/messaging.js
+++ b/core/modules/utils/messaging.js
@@ -8,10 +8,7 @@ Messaging utilities for use with window.postMessage() etc.
 This module intentionally has no dependencies so that it can be included in non-TiddlyWiki projects
 
 \*/
-(function(){
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
 "use strict";
 
 var RESPONSE_TIMEOUT = 2 * 1000;
@@ -122,5 +119,3 @@ BrowserMessagingPublisher.prototype.close = function() {
 };
 
 exports.BrowserMessagingPublisher = BrowserMessagingPublisher;
-
-})();


### PR DESCRIPTION
Removes fn wrappers and unneeded comments in browser messaging saver introduced in #5512 
Fixes #9615 