### PR TITLE
Ensures that getting variable info for a function doesnt pollute parent widget

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -343,7 +343,7 @@ Widget.prototype.makeFakeWidgetWithVariables = function(variables) {
 				}
 			} else {
 				opts = opts || {};
-				opts.variables = variables;
+				opts.variables = $tw.utils.extend({},variables,opts.variables);
 				return self.getVariable(name,opts);
 			};
 		},


### PR DESCRIPTION
Fixes #9629 

Before this fix, the following code output nothing:
```
\function myvar(element) [<element>]
\function call(element) [[myvar]is[variable]then<element>]

<<call abc>>
```

Removing the call to `is[variable]` makes the code behave as expected. During the filter execution, the local variable `element` was being overwritten by a parameter with the same name in the `is[variable]` call, causing the value of `element` in the filter run to be polluted.

