### PR TITLE
keyboard-driven-input couldn't use slots well

### DIFF
--- a/core/wiki/macros/keyboard-driven-input.tid
+++ b/core/wiki/macros/keyboard-driven-input.tid
@@ -122,15 +122,15 @@ tags: $:/tags/Macro
 \whitespace trim
 \procedure keyboard-driven-input-actions()
 <%if [<event-key-descriptor>match[((input-accept))]] %>
-<<inputAcceptActions>>
+<$transclude $variable=inputAcceptActions $fillignore=yes />
 <%elseif [<event-key-descriptor>match[((input-accept-variant))]] %>
-<<inputAcceptVariantActions>>
+<$transclude $variable=inputAcceptVariantActions $fillignore=yes />
 <%elseif [<event-key-descriptor>match[((input-up))]] %>
-<<input-next-actions-before>>
+<$transclude $variable=input-next-actions-before $fillignore=yes />
 <%elseif [<event-key-descriptor>match[((input-down))]] %>
-<<input-next-actions-after>>
+<$transclude $variable=input-next-actions-after $fillignore=yes />
 <%elseif [<event-key-descriptor>match[((input-cancel))]] %>
-<<inputCancelActions>>
+<$transclude $variable=inputCancelActions $fillignore=yes />
 <%endif%>
 \end keyboard-driven-input-actions
 


### PR DESCRIPTION
If the `keyboard-driven-input` macro is uses in another macro or template which utilizes slots, those slots will fail, or requires bizarre and unpredictable amounts of $depth. By ignoring fill at these internal macrocalls, slots can be used without the dark sorcery of the $depth attribute.

I'd like this to get in. I'd consider this a bug. It was breaking buttons in TW5-Graph.