### PR TITLE
Debugging wikitext-based test

### DIFF
--- a/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js
+++ b/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js
@@ -13,6 +13,12 @@ var TEST_WIKI_TIDDLER_FILTER = "[all[tiddlers+shadows]type[text/vnd.tiddlywiki-m
 
 var widget = require("$:/core/modules/widgets/widget.js");
 
+// List any wikitext tests that you want to debug here
+// Code can then check for the value of $tw.debugWikiTextTests to decide whether to trigger the debugger
+var debugTitles = [
+	// "MultiValuedVariables/TranscludeParameterDirectly"
+];
+
 describe("Wiki-based tests", function() {
 
 	// Step through the test tiddlers
@@ -39,6 +45,10 @@ describe("Wiki-based tests", function() {
 				throw "Missing 'Output' tiddler";
 			}
 			if(wiki.tiddlerExists("ExpectedResult")) {
+				// Set the debug flag if this is one of the tests we're interested in
+				if(debugTitles.indexOf(title) !== -1) {
+					$tw.debugWikiTextTests = true;
+				}
 				// Construct the widget node
 				var text = "{{Output}}\n\n";
 				var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
@@ -51,6 +61,8 @@ describe("Wiki-based tests", function() {
 					widgetNode.invokeActionString(wiki.getTiddlerText("Actions"));
 					refreshWidgetNode(widgetNode,wrapper);
 				}
+				// Clear the debug flag
+				$tw.debugWikiTextTests = false;
 				// Test the rendering
 				expect(wrapper.innerHTML).toBe(wiki.getTiddlerText("ExpectedResult"));
 			}


### PR DESCRIPTION
I find it difficult to debug wikitext tests because there is no obvious way to set a breakpoint that is only triggered while a particular test is executing. Conventional conditional breakpoints don't work because the title of the currently executing test is not reachable from the scope of the code you want to debug.

I would be interested to know if there are better techniques, but here's the very simple approach that I've been using. It means that deep within `filters.js` one can trigger the debugger like this:

```js
if($tw.debugWikiTextTests) {
	debugger;
}
```

