### PR TITLE
[DISCUSS] Strip all core comments

### DIFF
--- a/core/modules/background-actions.js
+++ b/core/modules/background-actions.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/background-actions.js
 type: application/javascript
 module-type: global
-
-Class to dispatch actions when filters change
-
 \*/
 
 "use strict";
@@ -15,7 +12,7 @@ class BackgroundActionDispatcher {
 		this.wiki = wiki;
 		this.nextTrackedFilterId = 1;
 		this.trackedFilters = new Map(); // Use Map for better key management
-		// Track the filter for the background actions
+
 		this.filterTracker.track({
 			filterString: "[all[tiddlers+shadows]tag[$:/tags/BackgroundAction]!is[draft]]",
 			fnEnter: title => this.trackFilter(title),
@@ -56,13 +53,6 @@ class BackgroundActionDispatcher {
 	}
 }
 
-/*
-Represents an individual tracked filter. Options include:
-wiki: wiki to use
-title: title of the tiddler being tracked
-trackFilter: filter string to track changes
-actions: actions to be executed when the filter changes
-*/
 class BackgroundActionTracker {
 	constructor({wiki, title, trackFilter, actions}) {
 		this.wiki = wiki;

--- a/core/modules/config.js
+++ b/core/modules/config.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/config.js
 type: application/javascript
 module-type: config
-
-Core configuration constants
-
 \*/
 
 "use strict";

--- a/core/modules/deserializers.js
+++ b/core/modules/deserializers.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/deserializers.js
 type: application/javascript
 module-type: tiddlerdeserializer
-
-Functions to deserialise tiddlers from a block of text
-
 \*/
 
 "use strict";
@@ -37,12 +34,6 @@ exports["application/json"] = function(text,fields) {
 	return results;
 };
 
-/*
-Parse an HTML file into tiddlers. There are three possibilities:
-# A TiddlyWiki classic HTML file containing `text/x-tiddlywiki` tiddlers
-# A TiddlyWiki5 HTML file containing `text/vnd.tiddlywiki` tiddlers
-# An ordinary HTML file
-*/
 exports["text/html"] = function(text,fields) {
 	var results = [];
 	// Check if we've got an old-style store area
@@ -60,11 +51,11 @@ exports["text/html"] = function(text,fields) {
 		results.push.apply(results,deserializeNewStoreArea(text,newStoreAreaMarkerRegExp.lastIndex,newStoreAreaMatch[1],fields));
 		newStoreAreaMatch = newStoreAreaMarkerRegExp.exec(text);
 	}
-	// Return if we had either an old-style or a new-style store area
+
 	if(storeAreaMatch || haveHadNewStoreArea) {
 		return results;
 	}
-	// Otherwise, check whether we've got an encrypted file
+
 	var encryptedStoreArea = $tw.utils.extractEncryptedStoreArea(text);
 	if(encryptedStoreArea) {
 		// If so, attempt to decrypt it using the current password
@@ -124,30 +115,18 @@ function deserializeStoreArea(text,storeAreaEnd,isTiddlyWiki5,fields) {
 	return results;
 }
 
-/*
-Utility function to parse an old-style tiddler DIV in a *.tid file. It looks like this:
-
-<div title="Title" creator="JoeBloggs" modifier="JoeBloggs" created="201102111106" modified="201102111310" tags="myTag [[my long tag]]">
-<pre>The text of the tiddler (without the expected HTML encoding).
-</pre>
-</div>
-
-Note that the field attributes are HTML encoded, but that the body of the <PRE> tag is not encoded.
-
-When these tiddler DIVs are encountered within a TiddlyWiki HTML file then the body is encoded in the usual way.
-*/
-var deserializeTiddlerDiv = function(text /* [,fields] */) {
+var deserializeTiddlerDiv = function(text) {
 	// Slot together the default results
 	var result = {};
 	if(arguments.length > 1) {
 		for(var f=1; f<arguments.length; f++) {
 			var fields = arguments[f];
 			for(var t in fields) {
-				result[t] = fields[t];		
+				result[t] = fields[t];
 			}
 		}
 	}
-	// Parse the DIV body
+
 	var startRegExp = /^\s*<div\s+([^>]*)>(\s*<pre>)?/gi,
 		endRegExp,
 		match = startRegExp.exec(text);

--- a/core/modules/editor/engines/framed.js
+++ b/core/modules/editor/engines/framed.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/engines/framed.js
 type: application/javascript
 module-type: library
-
-Text editor engine based on a simple input or textarea within an iframe. This is done so that the selection is preserved even when clicking away from the textarea
-
 \*/
 
 "use strict";
@@ -56,7 +53,7 @@ function FramedEngine(options) {
 	} else {
 		this.domNode.value = this.value;
 	}
-	// Set the attributes
+
 	if(this.widget.editType && this.widget.editTag !== "textarea") {
 		this.domNode.setAttribute("type",this.widget.editType);
 	}
@@ -78,7 +75,7 @@ function FramedEngine(options) {
 	if(this.widget.isDisabled === "yes") {
 		this.domNode.setAttribute("disabled",true);
 	}
-	// Copy the styles from the dummy textarea
+
 	this.copyStyles();
 	// Add event listeners
 	$tw.utils.addEventListeners(this.domNode,[
@@ -99,13 +96,10 @@ function FramedEngine(options) {
 			{name: "click",handlerObject: this.widget,handlerMethod: "handleClickEvent"}
 		]);
 	}
-	// Insert the element into the DOM
+
 	this.iframeDoc.body.appendChild(this.domNode);
 }
 
-/*
-Copy styles from the dummy text area to the textarea in the iframe
-*/
 FramedEngine.prototype.copyStyles = function() {
 	// Copy all styles
 	$tw.utils.copyStyles(this.dummyTextArea,this.domNode);
@@ -127,14 +121,11 @@ FramedEngine.prototype.setText = function(text,type) {
 		if(this.domNode.ownerDocument.activeElement !== this.domNode) {
 			this.updateDomNodeText(text);
 		}
-		// Fix the height if needed
+
 		this.fixHeight();
 	}
 };
 
-/*
-Update the DomNode with the new text
-*/
 FramedEngine.prototype.updateDomNodeText = function(text) {
 	try {
 		this.domNode.value = text;
@@ -143,16 +134,10 @@ FramedEngine.prototype.updateDomNodeText = function(text) {
 	}
 };
 
-/*
-Get the text of the engine
-*/
 FramedEngine.prototype.getText = function() {
 	return this.domNode.value;
 };
 
-/*
-Fix the height of textarea to fit content
-*/
 FramedEngine.prototype.fixHeight = function() {
 	// Make sure styles are updated
 	this.copyStyles();
@@ -172,9 +157,6 @@ FramedEngine.prototype.fixHeight = function() {
 	}
 };
 
-/*
-Focus the engine node
-*/
 FramedEngine.prototype.focus  = function() {
 	if(this.domNode.focus) {
 		this.domNode.focus();
@@ -184,18 +166,12 @@ FramedEngine.prototype.focus  = function() {
 	}
 };
 
-/*
-Handle a focus event
-*/
 FramedEngine.prototype.handleFocusEvent = function(event) {
 	if(this.widget.editCancelPopups) {
 		$tw.popup.cancel(0);
 	}
 };
 
-/*
-Handle a keydown event
- */
 FramedEngine.prototype.handleKeydownEvent = function(event) {
 	if ($tw.keyboardManager.handleKeydownEvent(event, {onlyPriority: true})) {
 		return true;
@@ -204,17 +180,11 @@ FramedEngine.prototype.handleKeydownEvent = function(event) {
 	return this.widget.handleKeydownEvent(event);
 };
 
-/*
-Handle a click
-*/
 FramedEngine.prototype.handleClickEvent = function(event) {
 	this.fixHeight();
 	return true;
 };
 
-/*
-Handle a dom "input" event which occurs when the text has changed
-*/
 FramedEngine.prototype.handleInputEvent = function(event) {
 	this.widget.saveChanges(this.getText());
 	this.fixHeight();
@@ -224,9 +194,6 @@ FramedEngine.prototype.handleInputEvent = function(event) {
 	return true;
 };
 
-/*
-Create a blank structure representing a text operation
-*/
 FramedEngine.prototype.createTextOperation = function() {
 	var operation = {
 		text: this.domNode.value,
@@ -242,9 +209,6 @@ FramedEngine.prototype.createTextOperation = function() {
 	return operation;
 };
 
-/*
-Execute a text operation
-*/
 FramedEngine.prototype.executeTextOperation = function(operation) {
 	// Perform the required changes to the text area and the underlying tiddler
 	var newText = operation.text;

--- a/core/modules/editor/engines/simple.js
+++ b/core/modules/editor/engines/simple.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/engines/simple.js
 type: application/javascript
 module-type: library
-
-Text editor engine based on a simple input or textarea tag
-
 \*/
 
 "use strict";
@@ -30,7 +27,7 @@ function SimpleEngine(options) {
 	} else {
 		this.domNode.value = this.value;
 	}
-	// Set the attributes
+
 	if(this.widget.editType && this.widget.editTag !== "textarea") {
 		this.domNode.setAttribute("type",this.widget.editType);
 	}
@@ -55,7 +52,7 @@ function SimpleEngine(options) {
 	if(this.widget.isDisabled === "yes") {
 		this.domNode.setAttribute("disabled",true);
 	}
-	// Add an input event handler
+
 	$tw.utils.addEventListeners(this.domNode,[
 		{name: "focus", handlerObject: this, handlerMethod: "handleFocusEvent"},
 		{name: "input", handlerObject: this, handlerMethod: "handleInputEvent"}
@@ -65,22 +62,16 @@ function SimpleEngine(options) {
 	this.widget.domNodes.push(this.domNode);
 }
 
-/*
-Set the text of the engine if it doesn't currently have focus
-*/
 SimpleEngine.prototype.setText = function(text,type) {
 	if(!this.domNode.isTiddlyWikiFakeDom) {
 		if(this.domNode.ownerDocument.activeElement !== this.domNode || text === "") {
 			this.updateDomNodeText(text);
 		}
-		// Fix the height if needed
+
 		this.fixHeight();
 	}
 };
 
-/*
-Update the DomNode with the new text
-*/
 SimpleEngine.prototype.updateDomNodeText = function(text) {
 	try {
 		this.domNode.value = text;
@@ -89,16 +80,10 @@ SimpleEngine.prototype.updateDomNodeText = function(text) {
 	}
 };
 
-/*
-Get the text of the engine
-*/
 SimpleEngine.prototype.getText = function() {
 	return this.domNode.value;
 };
 
-/*
-Fix the height of textarea to fit content
-*/
 SimpleEngine.prototype.fixHeight = function() {
 	// If .editRows is initialised, it takes precedence
 	if((this.widget.editTag === "textarea") && !this.widget.editRows) {
@@ -114,9 +99,6 @@ SimpleEngine.prototype.fixHeight = function() {
 	}
 };
 
-/*
-Focus the engine node
-*/
 SimpleEngine.prototype.focus = function() {
 	if(this.domNode.focus) {
 		this.domNode.focus();
@@ -126,9 +108,6 @@ SimpleEngine.prototype.focus = function() {
 	}
 };
 
-/*
-Handle a dom "input" event which occurs when the text has changed
-*/
 SimpleEngine.prototype.handleInputEvent = function(event) {
 	this.widget.saveChanges(this.getText());
 	this.fixHeight();
@@ -138,9 +117,6 @@ SimpleEngine.prototype.handleInputEvent = function(event) {
 	return true;
 };
 
-/*
-Handle a dom "focus" event
-*/
 SimpleEngine.prototype.handleFocusEvent = function(event) {
 	if(this.widget.editCancelPopups) {
 		$tw.popup.cancel(0);
@@ -156,16 +132,10 @@ SimpleEngine.prototype.handleFocusEvent = function(event) {
 	return true;
 };
 
-/*
-Create a blank structure representing a text operation
-*/
 SimpleEngine.prototype.createTextOperation = function() {
 	return null;
 };
 
-/*
-Execute a text operation
-*/
 SimpleEngine.prototype.executeTextOperation = function(operation) {
 };
 

--- a/core/modules/editor/factory.js
+++ b/core/modules/editor/factory.js
@@ -2,16 +2,12 @@
 title: $:/core/modules/editor/factory.js
 type: application/javascript
 module-type: library
-
-Factory for constructing text editor widgets with specified engines for the toolbar and non-toolbar cases
-
 \*/
 
 "use strict";
 
 var DEFAULT_MIN_TEXT_AREA_HEIGHT = "100px"; // Minimum height of textareas in pixels
 
-// Configuration tiddlers
 var HEIGHT_MODE_TITLE = "$:/config/TextEditor/EditorHeight/Mode";
 var ENABLE_TOOLBAR_TITLE = "$:/config/TextEditor/EnableToolbar";
 
@@ -141,9 +137,6 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		return {value: value || "", type: type, update: update};
 	};
 
-	/*
-	Handle an edit text operation message from the toolbar
-	*/
 	EditTextWidget.prototype.handleEditTextOperationMessage = function(event) {
 		// Prepare information about the operation
 		var operation = this.engine.createTextOperation();
@@ -152,16 +145,13 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		if(handler) {
 			handler.call(this,event,operation);
 		}
-		// Execute the operation via the engine
+
 		var newText = this.engine.executeTextOperation(operation);
 		// Fix the tiddler height and save changes
 		this.engine.fixHeight();
 		this.saveChanges(newText);
 	};
 
-	/*
-	Compute the internal state of the widget
-	*/
 	EditTextWidget.prototype.execute = function() {
 		// Get our parameters
 		this.editTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
@@ -201,7 +191,7 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 			}
 			type = type || "text";
 		}
-		// Get the rest of our parameters
+
 		this.editTag = this.getAttribute("tag",tag) || "input";
 		this.editType = this.getAttribute("type",type);
 		// Make the child widgets
@@ -211,9 +201,6 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		this.editShowToolbar = (this.editShowToolbar === "yes") && !!(this.children && this.children.length > 0) && (!this.document.isTiddlyWikiFakeDom);
 	};
 
-	/*
-	Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-	*/
 	EditTextWidget.prototype.refresh = function(changedTiddlers) {
 		var changedAttributes = this.computeAttributes();
 		// Completely rerender if any of our attributes have changed
@@ -234,24 +221,14 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		}
 	};
 
-	/*
-	Update the editor with new text. This method is separate from updateEditorDomNode()
-	so that subclasses can override updateEditor() and still use updateEditorDomNode()
-	*/
 	EditTextWidget.prototype.updateEditor = function(text,type) {
 		this.updateEditorDomNode(text,type);
 	};
 
-	/*
-	Update the editor dom node with new text
-	*/
 	EditTextWidget.prototype.updateEditorDomNode = function(text,type) {
 		this.engine.setText(text,type);
 	};
 
-	/*
-	Save changes back to the tiddler store
-	*/
 	EditTextWidget.prototype.saveChanges = function(text) {
 		var editInfo = this.getEditInfo();
 		if(text !== editInfo.value) {
@@ -259,9 +236,6 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		}
 	};
 
-	/*
-	Handle a dom "keydown" event, which we'll bubble up to our container for the keyboard widgets benefit
-	*/
 	EditTextWidget.prototype.handleKeydownEvent = function(event) {
 		// Check for a keyboard shortcut
 		if(this.toolbarNode) {
@@ -282,20 +256,17 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 				}
 			}
 		}
-		// Propogate the event to the container
+
 		if(this.propogateKeydownEvent(event)) {
 			// Ignore the keydown if it was already handled
 			event.preventDefault();
 			event.stopPropagation();
 			return true;
 		}
-		// Otherwise, process the keydown normally
+
 		return false;
 	};
 
-	/*
-	Propogate keydown events to our container for the keyboard widgets benefit
-	*/
 	EditTextWidget.prototype.propogateKeydownEvent = function(event) {
 		var newEvent = this.cloneEvent(event,["keyCode","code","which","key","metaKey","ctrlKey","altKey","shiftKey"]);
 		return !this.parentDomNode.dispatchEvent(newEvent);
@@ -318,16 +289,12 @@ function editTextWidgetFactory(toolbarEngine,nonToolbarEngine) {
 		return dispatchNode.dispatchEvent(newEvent);
 	};
 
-	/*
-	Propogate drag and drop events with File data to our container for the dropzone widgets benefit.
-	If there are no Files, let the browser handle it.
-	*/
 	EditTextWidget.prototype.handleDropEvent = function(event) {
 		if($tw.utils.dragEventContainsFiles(event)) {
 			event.preventDefault();
 			event.stopPropagation();
 			this.dispatchDOMEvent(this.cloneEvent(event,["dataTransfer"]));
-		} 
+		}
 	};
 
 	EditTextWidget.prototype.handlePasteEvent = function(event) {

--- a/core/modules/editor/operations/bitmap/clear.js
+++ b/core/modules/editor/operations/bitmap/clear.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/bitmap/clear.js
 type: application/javascript
 module-type: bitmapeditoroperation
-
-Bitmap editor operation to clear the image
-
 \*/
 
 "use strict";

--- a/core/modules/editor/operations/bitmap/resize.js
+++ b/core/modules/editor/operations/bitmap/resize.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/bitmap/resize.js
 type: application/javascript
 module-type: bitmapeditoroperation
-
-Bitmap editor operation to resize the image
-
 \*/
 
 "use strict";
@@ -17,7 +14,7 @@ exports["resize"] = function(event) {
 	if(newWidth > 0 && newHeight > 0 && !(newWidth === this.currCanvas.width && newHeight === this.currCanvas.height)) {
 		this.changeCanvasSize(newWidth,newHeight);
 	}
-	// Update the input controls
+
 	this.refreshToolbar();
 	// Save the image into the tiddler
 	this.saveChanges();

--- a/core/modules/editor/operations/bitmap/rotate-left.js
+++ b/core/modules/editor/operations/bitmap/rotate-left.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/bitmap/rotate-left.js
 type: application/javascript
 module-type: bitmapeditoroperation
-
-Bitmap editor operation to rotate the image left by 90 degrees
-
 \*/
 
 "use strict";

--- a/core/modules/editor/operations/text/excise.js
+++ b/core/modules/editor/operations/text/excise.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/text/excise.js
 type: application/javascript
 module-type: texteditoroperation
-
-Text editor operation to excise the selection to a new tiddler
-
 \*/
 
 "use strict";

--- a/core/modules/editor/operations/text/insert-text.js
+++ b/core/modules/editor/operations/text/insert-text.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/text/insert-text.js
 type: application/javascript
 module-type: texteditoroperation
-
-Text editor operation insert text at the caret position. If there is a selection it is replaced.
-
 \*/
 
 "use strict";

--- a/core/modules/editor/operations/text/make-link.js
+++ b/core/modules/editor/operations/text/make-link.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/text/make-link.js
 type: application/javascript
 module-type: texteditoroperation
-
-Text editor operation to make a link
-
 \*/
 
 "use strict";

--- a/core/modules/editor/operations/text/prefix-lines.js
+++ b/core/modules/editor/operations/text/prefix-lines.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/text/prefix-lines.js
 type: application/javascript
 module-type: texteditoroperation
-
-Text editor operation to add a prefix to the selected lines
-
 \*/
 
 "use strict";
@@ -26,16 +23,16 @@ exports["prefix-lines"] = function(event,operation) {
 			line = line.substring(event.paramObject.character.length);
 			count++;
 		}
-		// Remove any whitespace
+
 		while(line.charAt(0) === " ") {
 			line = line.substring(1);
 		}
-		// We're done if we removed the exact required prefix, otherwise add it
+
 		if(count !== targetCount) {
 			// Apply the prefix
 			line =  prefix + " " + line;
 		}
-		// Save the modified line
+
 		lines[index] = line;
 	});
 	// Stitch the replacement text together and set the selection

--- a/core/modules/editor/operations/text/replace-all.js
+++ b/core/modules/editor/operations/text/replace-all.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/text/replace-all.js
 type: application/javascript
 module-type: texteditoroperation
-
-Text editor operation to replace the entire text
-
 \*/
 
 "use strict";

--- a/core/modules/editor/operations/text/replace-selection.js
+++ b/core/modules/editor/operations/text/replace-selection.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/text/replace-selection.js
 type: application/javascript
 module-type: texteditoroperation
-
-Text editor operation to replace the selection
-
 \*/
 
 "use strict";

--- a/core/modules/editor/operations/text/save-selection.js
+++ b/core/modules/editor/operations/text/save-selection.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/text/save-selection.js
 type: application/javascript
 module-type: texteditoroperation
-
-Text editor operation to save the current selection in a specified tiddler
-
 \*/
 
 "use strict";

--- a/core/modules/editor/operations/text/wrap-lines.js
+++ b/core/modules/editor/operations/text/wrap-lines.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/text/wrap-lines.js
 type: application/javascript
 module-type: texteditoroperation
-
-Text editor operation to wrap the selected lines with a prefix and suffix
-
 \*/
 
 "use strict";
@@ -15,14 +12,14 @@ exports["wrap-lines"] = function(event,operation) {
 	if($tw.utils.endsWith(operation.text.substring(0,operation.selStart), prefix + "\n") &&
 			$tw.utils.startsWith(operation.text.substring(operation.selEnd), "\n" + suffix)) {
 		// Selected text is already surrounded by prefix and suffix: Remove them
-		// Cut selected text plus prefix and suffix
+
 		operation.cutStart = operation.selStart - (prefix.length + 1);
 		operation.cutEnd = operation.selEnd + suffix.length + 1;
 		// Also cut the following newline (if there is any)
 		if (operation.text[operation.cutEnd] === "\n") {
 			operation.cutEnd++;
 		}
-		// Replace with selection
+
 		operation.replacement = operation.text.substring(operation.selStart,operation.selEnd);
 		// Select text that was in between prefix and suffix
 		operation.newSelStart = operation.cutStart;

--- a/core/modules/editor/operations/text/wrap-selection.js
+++ b/core/modules/editor/operations/text/wrap-selection.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/editor/operations/text/wrap-selection.js
 type: application/javascript
 module-type: texteditoroperation
-
-Text editor operation to wrap the selection with the specified prefix and suffix
-
 \*/
 
 "use strict";
@@ -17,11 +14,11 @@ exports["wrap-selection"] = function(event,operation) {
 		selLength = o.selEnd - o.selStart;
 
 	// This function detects, if trailing spaces are part of the selection __and__ if the user wants to handle them
-	// Returns "yes", "start", "end", "no" (default)
+
 	//	yes .. there are trailing spaces at both ends
-	//	start .. there are trailing spaces at the start
+
 	//	end .. there are trailing spaces at the end
-	//	no .. no trailing spaces are taken into account
+
 	var trailingSpaceAt = function(sel) {
 		var _start,
 			_end,
@@ -64,7 +61,6 @@ exports["wrap-selection"] = function(event,operation) {
 		}
 	}
 
-	// options: lenPrefix, lenSuffix
 	function removePrefixSuffix(options) {
 		options = options || {};
 		var _lenPrefix = options.lenPrefix || 0;

--- a/core/modules/filter-tracker.js
+++ b/core/modules/filter-tracker.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/filter-tracker.js
 type: application/javascript
 module-type: global
-
-Class to track the results of a filter string
-
 \*/
 
 "use strict";
@@ -21,14 +18,6 @@ class FilterTracker {
 		this.processChanges(changes);
 	}
 
-	/*
-	Add a tracker to the filter tracker. Returns null if any of the parameters are invalid, or a tracker id if the tracker was added successfully. Options include:
-	filterString: the filter string to track
-	fnEnter: function to call when a title enters the filter results. Called even if the tiddler does not actually exist. Called as (title), and should return a truthy value that is stored in the tracker as the "enterValue"
-	fnLeave: function to call when a title leaves the filter results. Called as (title,enterValue)
-	fnChange: function to call when a tiddler changes in the filter results. Only called for filter results that identify a tiddler or shadow tiddler. Called as (title,enterValue), and may optionally return a replacement enterValue
-	fnProcess: function to call each time the tracker is processed, after any enter, leave or change functions are called. Called as (changes)
-	*/
 	track(options = {}) {
 		const {
 			filterString,

--- a/core/modules/filterrunprefixes/all.js
+++ b/core/modules/filterrunprefixes/all.js
@@ -2,17 +2,10 @@
 title: $:/core/modules/filterrunprefixes/all.js
 type: application/javascript
 module-type: filterrunprefix
-
-Union of sets without de-duplication.
-Equivalent to = filter run prefix.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.all = function(operationSubFunction) {
 	return function(results,source,widget) {
 		results.push.apply(results, operationSubFunction(source,widget));

--- a/core/modules/filterrunprefixes/and.js
+++ b/core/modules/filterrunprefixes/and.js
@@ -2,17 +2,10 @@
 title: $:/core/modules/filterrunprefixes/and.js
 type: application/javascript
 module-type: filterrunprefix
-
-Intersection of sets.
-Equivalent to + filter run prefix.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.and = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		// This replaces all the elements of the array, but keeps the actual array so that references to it are preserved

--- a/core/modules/filterrunprefixes/cascade.js
+++ b/core/modules/filterrunprefixes/cascade.js
@@ -6,9 +6,6 @@ module-type: filterrunprefix
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.cascade = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		if(results.length !== 0) {

--- a/core/modules/filterrunprefixes/else.js
+++ b/core/modules/filterrunprefixes/else.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filterrunprefixes/else.js
 type: application/javascript
 module-type: filterrunprefix
-
-Equivalent to ~ filter run prefix.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.else = function(operationSubFunction) {
 	return function(results,source,widget) {
 		if(results.length === 0) {

--- a/core/modules/filterrunprefixes/except.js
+++ b/core/modules/filterrunprefixes/except.js
@@ -2,17 +2,10 @@
 title: $:/core/modules/filterrunprefixes/except.js
 type: application/javascript
 module-type: filterrunprefix
-
-Difference of sets.
-Equivalent to - filter run prefix.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.except = function(operationSubFunction) {
 	return function(results,source,widget) {
 		results.remove(operationSubFunction(source,widget));

--- a/core/modules/filterrunprefixes/filter.js
+++ b/core/modules/filterrunprefixes/filter.js
@@ -2,14 +2,10 @@
 title: $:/core/modules/filterrunprefixes/filter.js
 type: application/javascript
 module-type: filterrunprefix
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.filter = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		if(results.length > 0) {

--- a/core/modules/filterrunprefixes/intersection.js
+++ b/core/modules/filterrunprefixes/intersection.js
@@ -2,14 +2,10 @@
 title: $:/core/modules/filterrunprefixes/intersection.js
 type: application/javascript
 module-type: filterrunprefix
-
 \*/
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.intersection = function(operationSubFunction) {
 	return function(results,source,widget) {
 		if(results.length !== 0) {

--- a/core/modules/filterrunprefixes/let.js
+++ b/core/modules/filterrunprefixes/let.js
@@ -2,18 +2,10 @@
 title: $:/core/modules/filterrunprefixes/let.js
 type: application/javascript
 module-type: filterrunprefix
-
-Assign a value to a variable
-
 \*/
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.let = function(operationSubFunction,options) {
 	// Return the filter run prefix function
 	return function(results,source,widget) {
@@ -30,7 +22,7 @@ exports.let = function(operationSubFunction,options) {
 		if(typeof name !== "string" || name.length === 0) {
 			return;
 		}
-		// Assign the result of the subfunction to the variable
+
 		var variables = {};
 		variables[name] = resultList;
 		// Return the variables

--- a/core/modules/filterrunprefixes/map.js
+++ b/core/modules/filterrunprefixes/map.js
@@ -6,9 +6,6 @@ module-type: filterrunprefix
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.map = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		if(results.length > 0) {

--- a/core/modules/filterrunprefixes/or.js
+++ b/core/modules/filterrunprefixes/or.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filterrunprefixes/or.js
 type: application/javascript
 module-type: filterrunprefix
-
-Equivalent to a filter run with no prefix.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.or = function(operationSubFunction) {
 	return function(results,source,widget) {
 		results.pushTop(operationSubFunction(source,widget));

--- a/core/modules/filterrunprefixes/reduce.js
+++ b/core/modules/filterrunprefixes/reduce.js
@@ -6,9 +6,6 @@ module-type: filterrunprefix
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.reduce = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		if(results.length > 0) {

--- a/core/modules/filterrunprefixes/sort.js
+++ b/core/modules/filterrunprefixes/sort.js
@@ -2,14 +2,10 @@
 title: $:/core/modules/filterrunprefixes/sort.js
 type: application/javascript
 module-type: filterrunprefix
-
 \*/
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.sort = function(operationSubFunction,options) {
 	return function(results,source,widget) {
 		if(results.length > 0) {
@@ -33,7 +29,7 @@ exports.sort = function(operationSubFunction,options) {
 			for(var t=0; t<inputTitles.length; t++) {
 				indexes[t] = t;
 			}
-			// Sort the indexes
+
 			compareFn = $tw.utils.makeCompareFunction(sortType,{defaultType: "string", invert:invert, isCaseSensitive:isCaseSensitive});
 			indexes = indexes.sort(function(a,b) {
 					return compareFn(sortKeys[a],sortKeys[b]);

--- a/core/modules/filterrunprefixes/then.js
+++ b/core/modules/filterrunprefixes/then.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filterrunprefixes/then.js
 type: application/javascript
 module-type: filterrunprefix
-
-Replace results of previous runs unless empty
-
 \*/
 
 "use strict";
 
-/*
-Export our filter prefix function
-*/
 exports.then = function(operationSubFunction) {
 	return function(results,source,widget) {
 		if(results.length !== 0) {

--- a/core/modules/filters.js
+++ b/core/modules/filters.js
@@ -2,39 +2,28 @@
 title: $:/core/modules/filters.js
 type: application/javascript
 module-type: wikimethod
-
-Adds tiddler filtering methods to the $tw.Wiki object.
-
 \*/
 
 "use strict";
 
 var widgetClass = require("$:/core/modules/widgets/widget.js").widget;
 
-/* Maximum permitted filter recursion depth */
 var MAX_FILTER_DEPTH = 300;
 
-/*
-Parses an operation (i.e. a run) within a filter string
-	operators: Array of array of operator nodes into which results should be inserted
-	filterString: filter string
-	p: start position within the string
-Returns the new start position, after the parsed operation
-*/
 function parseFilterOperation(operators,filterString,p) {
 	var nextBracketPos, operator;
 	// Skip the starting square bracket
 	if(filterString.charAt(p++) !== "[") {
 		throw "Missing [ in filter expression";
 	}
-	// Process each operator in turn
+
 	do {
 		operator = {};
 		// Check for an operator prefix
 		if(filterString.charAt(p) === "!") {
 			operator.prefix = filterString.charAt(p++);
 		}
-		// Get the operator name
+
 		nextBracketPos = filterString.substring(p).search(/[\[\{<\/\(]/);
 		if(nextBracketPos === -1) {
 			throw "Missing [ in filter expression";
@@ -55,12 +44,12 @@ function parseFilterOperation(operators,filterString,p) {
 				$tw.utils.each(subsuffix.split(","),function(entry) {
 					entry = $tw.utils.trim(entry);
 					if(entry) {
-						operator.suffixes[operator.suffixes.length - 1].push(entry); 
+						operator.suffixes[operator.suffixes.length - 1].push(entry);
 					}
 				});
 			});
 		}
-		// Empty operator means: title
+
 		else if(operator.operator === "") {
 			operator.operator = "title";
 		}
@@ -125,20 +114,16 @@ function parseFilterOperation(operators,filterString,p) {
 			}
 		}
 
-		// Push this operator
 		operators.push(operator);
 	} while(filterString.charAt(p) !== "]");
 	// Skip the ending square bracket
 	if(filterString.charAt(p++) !== "]") {
 		throw "Missing ] in filter expression";
 	}
-	// Return the parsing position
+
 	return p;
 }
 
-/*
-Parse a filter string
-*/
 exports.parseFilter = function(filterString) {
 	filterString = filterString || "";
 	var results = [], // Array of arrays of operator nodes {operator:,operand:}
@@ -147,11 +132,11 @@ exports.parseFilter = function(filterString) {
 	var whitespaceRegExp = /(\s+)/mg,
 		// Groups:
 		// 1 - entire filter run prefix
-		// 2 - filter run prefix itself
+
 		// 3 - filter run prefix suffixes
-		// 4 - opening square bracket following filter run prefix
+
 		// 5 - double quoted string following filter run prefix
-		// 6 - single quoted string following filter run prefix
+
 		// 7 - anything except for whitespace and square brackets
 		operandRegExp = /((?:\+|\-|~|(?:=>?)|\:(\w+)(?:\:([\w\:, ]*))?)?)(?:(\[)|(?:"([^"]*)")|(?:'([^']*)')|([^\s\[\]]+))/mg;
 	while(p < filterString.length) {
@@ -161,7 +146,7 @@ exports.parseFilter = function(filterString) {
 		if(match && match.index === p) {
 			p = p + match[0].length;
 		}
-		// Match the start of the operation
+
 		if(p < filterString.length) {
 			operandRegExp.lastIndex = p;
 			var operation = {
@@ -178,7 +163,7 @@ exports.parseFilter = function(filterString) {
 					if(match[2]) {
 						operation.namedPrefix = match[2];
 					}
-					// Suffixes for filter run prefix
+
 					if(match[3]) {
 						operation.suffixes = [];
 						$tw.utils.each(match[3].split(":"),function(subsuffix) {
@@ -192,7 +177,7 @@ exports.parseFilter = function(filterString) {
 						});
 					}
 				}
-				// Opening square bracket
+
 				if(match[4]) {
 					p = parseFilterOperation(operation.operators,filterString,p);
 				} else {
@@ -202,7 +187,7 @@ exports.parseFilter = function(filterString) {
 				// No filter run prefix
 				p = parseFilterOperation(operation.operators,filterString,p);
 			}
-			// Quoted strings and unquoted title
+
 			if(match[5] || match[6] || match[7]) { // Double quoted string, single quoted string or unquoted title
 				operation.operators.push(
 					{operator: "title", operands: [{text: match[5] || match[6] || match[7]}]}
@@ -235,11 +220,6 @@ exports.filterTiddlers = function(filterString,widget,source) {
 	return fn.call(this,source,widget);
 };
 
-/*
-Compile a filter into a function with the signature fn(source,widget) where:
-source: an iterator function for the source tiddlers, called source(iterator), where iterator is called as iterator(tiddler,title)
-widget: an optional widget node for retrieving the current tiddler etc.
-*/
 exports.compileFilter = function(filterString) {
 	if(!this.filterCache) {
 		this.filterCache = Object.create(null);
@@ -257,7 +237,7 @@ exports.compileFilter = function(filterString) {
 			return [$tw.language.getString("Error/Filter") + ": " + e];
 		};
 	}
-	// Get the hashmap of filter operator functions
+
 	var filterOperators = this.getFilterOperators();
 	// Assemble array of functions, one for each operation
 	var operationFunctions = [];
@@ -302,7 +282,7 @@ exports.compileFilter = function(filterString) {
 							operand.value = "";
 							operand.multiValue = [];
 						}
-						operand.isMultiValueOperand = true;	
+						operand.isMultiValueOperand = true;
 					} else {
 						operand.value = operand.text;
 						operand.multiValue = [operand.value];
@@ -360,7 +340,7 @@ exports.compileFilter = function(filterString) {
 					return filterRunPrefixes["else"](operationSubFunction, options);
 				case "=>": // This operation is applied to the main results so far, and the results are assigned to a variable
 					return filterRunPrefixes["let"](operationSubFunction, options);
-				default: 
+				default:
 					if(operation.namedPrefix && filterRunPrefixes[operation.namedPrefix]) {
 						return filterRunPrefixes[operation.namedPrefix](operationSubFunction, options);
 					} else {
@@ -402,7 +382,7 @@ exports.compileFilter = function(filterString) {
 	});
 	if(this.filterCacheCount >= 2000) {
 		// To prevent memory leak, we maintain an upper limit for cache size.
-		// Reset if exceeded. This should give us 95% of the benefit
+
 		// that no cache limit would give us.
 		this.filterCache = Object.create(null);
 		this.filterCacheCount = 0;

--- a/core/modules/filters/addprefix.js
+++ b/core/modules/filters/addprefix.js
@@ -2,18 +2,10 @@
 title: $:/core/modules/filters/addprefix.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for adding a prefix to each title in the list. This is
-especially useful in contexts where only a filter expression is allowed
-and macro substitution isn't available.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.addprefix = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/addsuffix.js
+++ b/core/modules/filters/addsuffix.js
@@ -2,18 +2,10 @@
 title: $:/core/modules/filters/addsuffix.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for adding a suffix to each title in the list. This is
-especially useful in contexts where only a filter expression is allowed
-and macro substitution isn't available.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.addsuffix = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/after.js
+++ b/core/modules/filters/after.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/after.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning the tiddler from the current list that is after the tiddler named in the operand.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.after = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/all.js
+++ b/core/modules/filters/all.js
@@ -2,11 +2,6 @@
 title: $:/core/modules/filters/all.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for selecting tiddlers
-
-[all[shadows+tiddlers]]
-
 \*/
 
 "use strict";
@@ -21,9 +16,6 @@ function getAllFilterOperators() {
 	return allFilterOperators;
 }
 
-/*
-Export our filter function
-*/
 exports.all = function(source,operator,options) {
 	// Check for common optimisations
 	var subops = operator.operand.split("+");
@@ -38,7 +30,7 @@ exports.all = function(source,operator,options) {
 	} else if(subops.length === 2 && subops[0] === "shadows" && subops[1] === "tiddlers") {
 		return options.wiki.eachShadowPlusTiddlers;
 	}
-	// Do it the hard way
+
 	// Get our suboperators
 	var allFilterOperators = getAllFilterOperators();
 	// Cycle through the suboperators accumulating their results

--- a/core/modules/filters/all/current.js
+++ b/core/modules/filters/all/current.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/all/current.js
 type: application/javascript
 module-type: allfilteroperator
-
-Filter function for [all[current]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.current = function(source,prefix,options) {
 	var currTiddlerTitle = options.widget && options.widget.getVariable("currentTiddler");
 	if(currTiddlerTitle) {

--- a/core/modules/filters/all/missing.js
+++ b/core/modules/filters/all/missing.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/all/missing.js
 type: application/javascript
 module-type: allfilteroperator
-
-Filter function for [all[missing]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.missing = function(source,prefix,options) {
 	return options.wiki.getMissingTitles();
 };

--- a/core/modules/filters/all/orphans.js
+++ b/core/modules/filters/all/orphans.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/all/orphans.js
 type: application/javascript
 module-type: allfilteroperator
-
-Filter function for [all[orphans]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.orphans = function(source,prefix,options) {
 	return options.wiki.getOrphanTitles();
 };

--- a/core/modules/filters/all/shadows.js
+++ b/core/modules/filters/all/shadows.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/all/shadows.js
 type: application/javascript
 module-type: allfilteroperator
-
-Filter function for [all[shadows]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.shadows = function(source,prefix,options) {
 	return options.wiki.allShadowTitles();
 };

--- a/core/modules/filters/all/tags.js
+++ b/core/modules/filters/all/tags.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/all/tags.js
 type: application/javascript
 module-type: allfilteroperator
-
-Filter function for [all[tags]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.tags = function(source,prefix,options) {
 	return Object.keys(options.wiki.getTagMap());
 };

--- a/core/modules/filters/all/tiddlers.js
+++ b/core/modules/filters/all/tiddlers.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/all/tiddlers.js
 type: application/javascript
 module-type: allfilteroperator
-
-Filter function for [all[tiddlers]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.tiddlers = function(source,prefix,options) {
 	return options.wiki.allTitles();
 };

--- a/core/modules/filters/backlinks.js
+++ b/core/modules/filters/backlinks.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/backlinks.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning all the backlinks from a tiddler
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.backlinks = function(source,operator,options) {
 	var results = new $tw.utils.LinkedList();
 	source(function(tiddler,title) {

--- a/core/modules/filters/backtranscludes.js
+++ b/core/modules/filters/backtranscludes.js
@@ -2,15 +2,9 @@
 title: $:/core/modules/filters/backtranscludes.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning all the backtranscludes from a tiddler
-
 \*/
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.backtranscludes = function(source,operator,options) {
 	var results = new $tw.utils.LinkedList();
 	source(function(tiddler,title) {

--- a/core/modules/filters/before.js
+++ b/core/modules/filters/before.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/before.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning the tiddler from the current list that is before the tiddler named in the operand.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.before = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/commands.js
+++ b/core/modules/filters/commands.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/commands.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the names of the commands available in this wiki
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.commands = function(source,operator,options) {
 	var results = [];
 	$tw.utils.each($tw.commands,function(commandInfo,name) {

--- a/core/modules/filters/compare.js
+++ b/core/modules/filters/compare.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/filters/compare.js
 type: application/javascript
 module-type: filteroperator
-
-General purpose comparison operator
-
 \*/
 
 "use strict";

--- a/core/modules/filters/contains.js
+++ b/core/modules/filters/contains.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/contains.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for finding values in array fields
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.contains = function(source,operator,options) {
 	var results = [],
 		fieldname = operator.suffix || "list";

--- a/core/modules/filters/count.js
+++ b/core/modules/filters/count.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/count.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning the number of entries in the current list.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.count = function(source,operator,options) {
 	var count = 0;
 	source(function(tiddler,title) {

--- a/core/modules/filters/crypto.js
+++ b/core/modules/filters/crypto.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/filters/crypto.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operators for cryptography, using the Stanford JavaScript library
-
 \*/
 
 "use strict";

--- a/core/modules/filters/days.js
+++ b/core/modules/filters/days.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/days.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator that selects tiddlers with a specified date field within a specified date interval.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.days = function(source,operator,options) {
 	var results = [],
 		fieldName = operator.suffix || "modified",

--- a/core/modules/filters/deserializers.js
+++ b/core/modules/filters/deserializers.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/deserializers.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the names of the deserializers in this wiki
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.deserializers = function(source,operator,options) {
 	var results = [];
 	$tw.utils.each($tw.Wiki.tiddlerDeserializerModules,function(deserializer,type) {

--- a/core/modules/filters/duplicateslugs.js
+++ b/core/modules/filters/duplicateslugs.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/duplicateslugs.js
 type: application/javascript
 module-type: filteroperator
-
-Filter function for [duplicateslugs[]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.duplicateslugs = function(source,operator,options) {
 	var slugs = Object.create(null), // Hashmap by slug of title, replaced with "true" if the duplicate title has already been output
 		results = [];

--- a/core/modules/filters/each.js
+++ b/core/modules/filters/each.js
@@ -2,17 +2,10 @@
 title: $:/core/modules/filters/each.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator that selects one tiddler for each unique value of the specified field.
-With suffix "list", selects all tiddlers that are values in a specified list field.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.each = function(source,operator,options) {
 	var results =[] ,
 	value,values = {},

--- a/core/modules/filters/eachday.js
+++ b/core/modules/filters/eachday.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/eachday.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator that selects one tiddler for each unique day covered by the specified date field
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.eachday = function(source,operator,options) {
 	var results = [],
 		values = [],

--- a/core/modules/filters/editiondescription.js
+++ b/core/modules/filters/editiondescription.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/editiondescription.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the descriptions of the specified edition names
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.editiondescription = function(source,operator,options) {
 	var results = [];
 	if($tw.node) {

--- a/core/modules/filters/editions.js
+++ b/core/modules/filters/editions.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/editions.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the names of the available editions in this wiki
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.editions = function(source,operator,options) {
 	var results = [];
 	if($tw.node) {

--- a/core/modules/filters/else.js
+++ b/core/modules/filters/else.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/else.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for replacing an empty input list with a constant, passing a non-empty input list straight through
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.else = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/encodings.js
+++ b/core/modules/filters/encodings.js
@@ -2,16 +2,9 @@
 title: $:/core/modules/filters/decodeuricomponent.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for applying decodeURIComponent() to each item.
-
 \*/
 
 "use strict";
-
-/*
-Export our filter functions
-*/
 
 exports.decodebase64 = function(source,operator,options) {
 	var results = [];

--- a/core/modules/filters/enlist.js
+++ b/core/modules/filters/enlist.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/enlist.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning its operand parsed as a list
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.enlist = function(source,operator,options) {
 	var allowDuplicates = false;
 	switch(operator.suffix) {

--- a/core/modules/filters/field.js
+++ b/core/modules/filters/field.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/field.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for comparing fields for equality
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.field = function(source,operator,options) {
 	var results = [],indexedResults,
 		fieldname = operator.suffix || operator.operator || "title";

--- a/core/modules/filters/fields.js
+++ b/core/modules/filters/fields.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/fields.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the names of the fields on the selected tiddlers
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.fields = function(source,operator,options) {
 	var results = [],
 		fieldName,
@@ -28,13 +22,13 @@ exports.fields = function(source,operator,options) {
 				for(fieldName in tiddler.fields) {
 					(operand.indexOf(fieldName) !== -1) ? "" : $tw.utils.pushTop(results,fieldName);
 				}
-			} // else if
+			}
 			else {
 				for(fieldName in tiddler.fields) {
 					$tw.utils.pushTop(results,fieldName);
 				}
-			} // else
-		} // if (tiddler)
+			}
+		}
 	});
 	return results;
 };

--- a/core/modules/filters/filter.js
+++ b/core/modules/filters/filter.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/filter.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning those input titles that pass a subfilter
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.filter = function(source,operator,options) {
 	var filterFn = options.wiki.compileFilter(operator.operand),
 		results = [],

--- a/core/modules/filters/format.js
+++ b/core/modules/filters/format.js
@@ -17,9 +17,6 @@ function getFormatFilterOperators() {
 	return formatFilterOperators;
 }
 
-/*
-Export our filter function
-*/
 exports.format = function(source,operator,options) {
 	// Dispatch to the correct formatfilteroperator
 	var formatFilterOperators = getFormatFilterOperators();

--- a/core/modules/filters/format/date.js
+++ b/core/modules/filters/format/date.js
@@ -6,9 +6,6 @@ module-type: formatfilteroperator
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.date = function(source,operand,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/format/json.js
+++ b/core/modules/filters/format/json.js
@@ -6,9 +6,6 @@ module-type: formatfilteroperator
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.json = function(source,operand,options) {
 	var results = [],
 		spaces = null;

--- a/core/modules/filters/format/relativedate.js
+++ b/core/modules/filters/format/relativedate.js
@@ -6,9 +6,6 @@ module-type: formatfilteroperator
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.relativedate = function(source,operand,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/format/timestamp.js
+++ b/core/modules/filters/format/timestamp.js
@@ -6,9 +6,6 @@ module-type: formatfilteroperator
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.timestamp = function(source,operand,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/format/titlelist.js
+++ b/core/modules/filters/format/titlelist.js
@@ -6,9 +6,6 @@ module-type: formatfilteroperator
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.titlelist = function(source,operand,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/function.js
+++ b/core/modules/filters/function.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/function.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning those input titles that are returned from a function
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.function = function(source,operator,options) {
 	var functionName = operator.operands[0],
 		params = [],
@@ -24,13 +18,13 @@ exports.function = function(source,operator,options) {
 	if(variableInfo && variableInfo.srcVariable && variableInfo.srcVariable.isFunctionDefinition) {
 		results = variableInfo.resultList ? variableInfo.resultList : [variableInfo.text];
 	}
-	// Return the input list if the function wasn't found
+
 	if(!results) {
 		results = [];
 		source(function(tiddler,title) {
 			results.push(title);
-		});	
+		});
 	}
-	// console.log(`function ${functionName} with params ${JSON.stringify(params)} results: ${JSON.stringify(results)}`);
+
 	return results;
 };

--- a/core/modules/filters/get.js
+++ b/core/modules/filters/get.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/get.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for replacing tiddler titles by the value of the field specified in the operand.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.get = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/getindex.js
+++ b/core/modules/filters/getindex.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/getindex.js
 type: application/javascript
 module-type: filteroperator
-
-returns the value at a given index of datatiddlers
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.getindex = function(source,operator,options) {
 	var data,title,results = [];
 	if(operator.operand){

--- a/core/modules/filters/getvariable.js
+++ b/core/modules/filters/getvariable.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/getvariable.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for replacing input values by the value of the variable with the same name, or blank if the variable is missing
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.getvariable = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/has.js
+++ b/core/modules/filters/has.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/has.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for checking if a tiddler has the specified field or index
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.has = function(source,operator,options) {
 	var results = [],
 		invert = operator.prefix === "!";

--- a/core/modules/filters/haschanged.js
+++ b/core/modules/filters/haschanged.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/haschanged.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returns tiddlers from the list that have a non-zero changecount.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.haschanged = function(source,operator,options) {
 	var results = [];
 	if(operator.prefix === "!") {

--- a/core/modules/filters/indexes.js
+++ b/core/modules/filters/indexes.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/indexes.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the indexes of a data tiddler
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.indexes = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/insertafter.js
+++ b/core/modules/filters/insertafter.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/insertafter.js
 type: application/javascript
 module-type: filteroperator
-
-Insert an item after another item in a list
-
 \*/
 
 "use strict";
 
-/*
-Order a list
-*/
 exports.insertafter = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
@@ -24,7 +18,7 @@ exports.insertafter = function(source,operator,options) {
 		if(pos !== -1) {
 			results.splice(pos,1);
 		}
-		// Insert the entry after the target marker
+
 		pos = results.indexOf(target);
 		if(pos !== -1) {
 			results.splice(pos+1,0,operator.operand);

--- a/core/modules/filters/insertbefore.js
+++ b/core/modules/filters/insertbefore.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/insertbefore.js
 type: application/javascript
 module-type: filteroperator
-
-Insert an item before another item in a list
-
 \*/
 
 "use strict";
 
-/*
-Order a list
-*/
 exports.insertbefore = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
@@ -24,7 +18,7 @@ exports.insertbefore = function(source,operator,options) {
 		if(pos !== -1) {
 			results.splice(pos,1);
 		}
-		// Insert the entry before the target marker
+
 		pos = results.indexOf(target);
 		if(pos !== -1) {
 			results.splice(pos,0,operator.operand);

--- a/core/modules/filters/is.js
+++ b/core/modules/filters/is.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/filters/is.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for checking tiddler properties
-
 \*/
 
 "use strict";
@@ -19,9 +16,6 @@ function getIsFilterOperators() {
 	return isFilterOperators;
 }
 
-/*
-Export our filter function
-*/
 exports.is = function(source,operator,options) {
 	// Dispatch to the correct isfilteroperator
 	var isFilterOperators = getIsFilterOperators();

--- a/core/modules/filters/is/binary.js
+++ b/core/modules/filters/is/binary.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/binary.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[binary]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.binary = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {

--- a/core/modules/filters/is/blank.js
+++ b/core/modules/filters/is/blank.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/blank.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[blank]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.blank = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {

--- a/core/modules/filters/is/current.js
+++ b/core/modules/filters/is/current.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/current.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[current]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.current = function(source,prefix,options) {
 	var results = [],
 		currTiddlerTitle = options.widget && options.widget.getVariable("currentTiddler");

--- a/core/modules/filters/is/draft.js
+++ b/core/modules/filters/is/draft.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/draft.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[draft]] analagous to [has[draft.of]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.draft = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {

--- a/core/modules/filters/is/image.js
+++ b/core/modules/filters/is/image.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/image.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[image]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.image = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {

--- a/core/modules/filters/is/missing.js
+++ b/core/modules/filters/is/missing.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/missing.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[missing]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.missing = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {

--- a/core/modules/filters/is/orphan.js
+++ b/core/modules/filters/is/orphan.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/orphan.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[orphan]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.orphan = function(source,prefix,options) {
 	var results = [],
 		orphanTitles = options.wiki.getOrphanTitles();

--- a/core/modules/filters/is/shadow.js
+++ b/core/modules/filters/is/shadow.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/shadow.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[shadow]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.shadow = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {

--- a/core/modules/filters/is/system.js
+++ b/core/modules/filters/is/system.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/system.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[system]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.system = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {

--- a/core/modules/filters/is/tag.js
+++ b/core/modules/filters/is/tag.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/tag.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[tag]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.tag = function(source,prefix,options) {
 	var results = [],
 		tagMap = options.wiki.getTagMap();

--- a/core/modules/filters/is/tiddler.js
+++ b/core/modules/filters/is/tiddler.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/tiddler.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[tiddler]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.tiddler = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {

--- a/core/modules/filters/is/variable.js
+++ b/core/modules/filters/is/variable.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/is/variable.js
 type: application/javascript
 module-type: isfilteroperator
-
-Filter function for [is[variable]]
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.variable = function(source,prefix,options) {
 	var results = [];
 	if(prefix === "!") {

--- a/core/modules/filters/json-ops.js
+++ b/core/modules/filters/json-ops.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/filters/json-ops.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operators for JSON operations
-
 \*/
 
 "use strict";
@@ -129,9 +126,6 @@ exports["jsondelete"] = function(source,operator,options) {
 	return results;
 };
 
-/*
-Given a JSON data structure and an array of index strings, return an array of the string representation of the values at the end of the index chain, or "undefined" if any of the index strings are invalid
-*/
 function getDataItemValueAsStrings(data,indexes) {
 	// Get the item
 	var item = getDataItem(data,indexes);
@@ -139,9 +133,6 @@ function getDataItemValueAsStrings(data,indexes) {
 	return convertDataItemValueToStrings(item);
 }
 
-/*
-Given a JSON data structure and an array of index strings, return an array of the string representation of the keys of the item at the end of the index chain, or "undefined" if any of the index strings are invalid
-*/
 function getDataItemKeysAsStrings(data,indexes) {
 	// Get the item
 	var item = getDataItem(data,indexes);
@@ -149,9 +140,6 @@ function getDataItemKeysAsStrings(data,indexes) {
 	return convertDataItemKeysToStrings(item);
 }
 
-/*
-Return an array of the string representation of the values of a data item, or "undefined" if the item is undefined
-*/
 function convertDataItemValueToStrings(item) {
 	// Return the item as a string
 	if(item === undefined) {
@@ -182,9 +170,6 @@ function convertDataItemValueToStrings(item) {
 	return [item.toString()];
 }
 
-/*
-Return an array of the string representation of the keys of a data item, or "undefined" if the item is undefined
-*/
 function convertDataItemKeysToStrings(item) {
 	// Return the item as a string
 	if(item === undefined) {
@@ -238,10 +223,6 @@ function getItemAtIndex(item,index) {
 	}
 }
 
-/*
-Traverse the index chain and return the item at the specified depth.
-Returns the item at the end of the traversal, or undefined if traversal fails.
-*/
 function traverseIndexChain(data,indexes,stopBeforeLast) {
 	if(indexes.length === 0 || (indexes.length === 1 && indexes[0] === "")) {
 		return data;
@@ -260,47 +241,38 @@ function traverseIndexChain(data,indexes,stopBeforeLast) {
 	return item;
 }
 
-/*
-Given a JSON data structure and an array of index strings, return the value at the end of the index chain, or "undefined" if any of the index strings are invalid
-*/
 function getDataItem(data,indexes) {
 	return traverseIndexChain(data,indexes,false);
 }
 
-/*
-Given a JSON data structure, an array of index strings and a value, return the data structure with the value added at the end of the index chain. If any of the index strings are invalid then the JSON data structure is returned unmodified. If the root item is targetted then a different data object will be returned
-*/
 function setDataItem(data,indexes,value) {
 	// Ignore attempts to assign undefined
 	if(value === undefined) {
 		return data;
 	}
-	// Check for the root item
+
 	if(indexes.length === 0 || (indexes.length === 1 && indexes[0] === "")) {
 		return value;
 	}
-	// Traverse the JSON data structure using the index chain up to the parent
+
 	var current = traverseIndexChain(data,indexes,true);
 	if(current === undefined) {
 		// Return the original JSON data structure if any of the index strings are invalid
 		return data;
 	}
-	// Add the value to the end of the index chain
+
 	var lastIndex = indexes[indexes.length - 1];
 	if(Array.isArray(current)) {
 		lastIndex = $tw.utils.parseInt(lastIndex);
 		if(lastIndex < 0) { lastIndex = lastIndex + current.length };
 	}
-	// Only set indexes on objects and arrays
+
 	if(typeof current === "object") {
 		current[lastIndex] = value;
 	}
 	return data;
 }
 
-/*
-Given a JSON data structure and an array of index strings, return the data structure with the item at the end of the index chain deleted. If any of the index strings are invalid then the JSON data structure is returned unmodified. If the root item is targetted then the JSON data structure is returned unmodified.
-*/
 function deleteDataItem(data,indexes) {
 	// Check for the root item - don't delete the root
 	if(indexes.length === 0 || (indexes.length === 1 && indexes[0] === "")) {

--- a/core/modules/filters/limit.js
+++ b/core/modules/filters/limit.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/limit.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for chopping the results to a specified maximum number of entries
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.limit = function(source,operator,options) {
 	var results = [];
 	// Convert to an array

--- a/core/modules/filters/links.js
+++ b/core/modules/filters/links.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/links.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning all the links from a tiddler
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.links = function(source,operator,options) {
 	var results = new $tw.utils.LinkedList();
 	source(function(tiddler,title) {

--- a/core/modules/filters/list.js
+++ b/core/modules/filters/list.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/list.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning the tiddlers whose title is listed in the operand tiddler
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.list = function(source,operator,options) {
 	var results = [],
 		tr = $tw.utils.parseTextReference(operator.operand),

--- a/core/modules/filters/listed.js
+++ b/core/modules/filters/listed.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/listed.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning all tiddlers that have the selected tiddlers in a list
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.listed = function(source,operator,options) {
 	var field = operator.operand || "list",
 		results = [];

--- a/core/modules/filters/listops.js
+++ b/core/modules/filters/listops.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/listops.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operators for manipulating the current selection list
-
 \*/
 
 "use strict";
 
-/*
-Order a list
-*/
 exports.order = function(source,operator,options) {
 	var results = [];
 	if(operator.operand.toLowerCase() === "reverse") {
@@ -26,9 +20,6 @@ exports.order = function(source,operator,options) {
 	return results;
 };
 
-/*
-Reverse list
-*/
 exports.reverse = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {
@@ -37,9 +28,6 @@ exports.reverse = function(source,operator,options) {
 	return results;
 };
 
-/*
-First entry/entries in list
-*/
 exports.first = function(source,operator,options) {
 	var count = $tw.utils.getInt(operator.operand,1),
 		results = [];
@@ -49,9 +37,6 @@ exports.first = function(source,operator,options) {
 	return results.slice(0,count);
 };
 
-/*
-Last entry/entries in list
-*/
 exports.last = function(source,operator,options) {
 	var count = $tw.utils.getInt(operator.operand,1),
 		results = [];
@@ -62,9 +47,6 @@ exports.last = function(source,operator,options) {
 	return results.slice(-count);
 };
 
-/*
-All but the first entry/entries of the list
-*/
 exports.rest = function(source,operator,options) {
 	var count = $tw.utils.getInt(operator.operand,1),
 		results = [];
@@ -76,9 +58,6 @@ exports.rest = function(source,operator,options) {
 exports.butfirst = exports.rest;
 exports.bf = exports.rest;
 
-/*
-All but the last entry/entries of the list
-*/
 exports.butlast = function(source,operator,options) {
 	var count = $tw.utils.getInt(operator.operand,1),
 		results = [];
@@ -90,9 +69,6 @@ exports.butlast = function(source,operator,options) {
 };
 exports.bl = exports.butlast;
 
-/*
-The nth member of the list
-*/
 exports.nth = function(source,operator,options) {
 	var count = $tw.utils.getInt(operator.operand,1),
 		results = [];
@@ -102,9 +78,6 @@ exports.nth = function(source,operator,options) {
 	return results.slice(count - 1,count);
 };
 
-/*
-The zero based nth member of the list
-*/
 exports.zth = function(source,operator,options) {
 	var count = $tw.utils.getInt(operator.operand,0),
 		results = [];

--- a/core/modules/filters/lookup.js
+++ b/core/modules/filters/lookup.js
@@ -2,22 +2,10 @@
 title: $:/core/modules/filters/lookup.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator that looks up values via a title prefix
-
-[lookup:<defaultvalue>:<field OR index>[<prefix>],[<field-name OR index-name>]]
-
-Prepends the prefix to the selected items and returns the specified 
-field or index value. If the 2nd suffix does not exist, it defaults to field.
-If the second operand is missing it defaults to "text" for fields, and "0" for indexes
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.lookup = function(source,operator,options) {
 	var results = [],
 		suffixes = operator.suffixes || [],

--- a/core/modules/filters/match.js
+++ b/core/modules/filters/match.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/match.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for checking if a title matches a string
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.match = function(source,operator,options) {
 	var results = [],
 		suffixes = (operator.suffixes || [])[0] || [];

--- a/core/modules/filters/math.js
+++ b/core/modules/filters/math.js
@@ -2,16 +2,6 @@
 title: $:/core/modules/filters/math.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operators for math. Unary/binary operators work on each item in turn, and return a new item list.
-
-Sum/product/maxall/minall operate on the entire list, returning a single item.
-
-Note that strings are converted to numbers automatically. Trailing non-digits are ignored.
-
-* "" converts to 0
-* "12kk" converts to 12
-
 \*/
 
 "use strict";
@@ -104,29 +94,29 @@ exports.log = makeNumericBinaryOperator(
 
 exports.sum = makeNumericReducingOperator(
 	function(accumulator,value) {return accumulator + value},
-	0 // Initial value
+	0
 );
 
 exports.product = makeNumericReducingOperator(
 	function(accumulator,value) {return accumulator * value},
-	1 // Initial value
+	1
 );
 
 exports.maxall = makeNumericReducingOperator(
 	function(accumulator,value) {return Math.max(accumulator,value)},
-	-Infinity // Initial value
+	-Infinity
 );
 
 exports.minall = makeNumericReducingOperator(
 	function(accumulator,value) {return Math.min(accumulator,value)},
-	Infinity // Initial value
+	Infinity
 );
 
 exports.median = makeNumericArrayOperator(
 	function(values) {
 		var len = values.length, median;
 		values.sort(function(a,b) {return a-b});
-		if(len % 2) { 
+		if(len % 2) {
 			// Odd, return the middle number
 			median = values[(len - 1) / 2];
 		} else {

--- a/core/modules/filters/minlength.js
+++ b/core/modules/filters/minlength.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/minlength.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for filtering out titles that don't meet the minimum length in the operand
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.minlength = function(source,operator,options) {
 	var results = [],
 		minLength = parseInt(operator.operand || "",10) || 0;

--- a/core/modules/filters/moduleproperty.js
+++ b/core/modules/filters/moduleproperty.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/moduleproperty.js
 type: application/javascript
 module-type: filteroperator
-
-Filter [[module-name]moduleproperty[name]] retrieve a module property
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.moduleproperty = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/modules.js
+++ b/core/modules/filters/modules.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/modules.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the titles of the modules of a given type in this wiki
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.modules = function(source,operator,options) {
 	var results = [];
 	if(operator.operands.length >= 2) {
@@ -19,7 +13,7 @@ exports.modules = function(source,operator,options) {
 		source(function(tiddler,title) {
 			$tw.utils.each($tw.modules.types[title],function(moduleInfo,moduleName) {
 				if(require(moduleName)[operator.operands[0]] === operator.operands[1]) {
-					results.push(moduleName);					
+					results.push(moduleName);
 				}
 			});
 		});

--- a/core/modules/filters/moduletypes.js
+++ b/core/modules/filters/moduletypes.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/moduletypes.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the names of the module types in this wiki
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.moduletypes = function(source,operator,options) {
 	var results = [];
 	$tw.utils.each($tw.modules.types,function(moduleInfo,type) {

--- a/core/modules/filters/next.js
+++ b/core/modules/filters/next.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/next.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning the tiddler whose title occurs next in the list supplied in the operand tiddler
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.next = function(source,operator,options) {
 	var results = [],
 		list = options.wiki.getTiddlerList(operator.operand);

--- a/core/modules/filters/plugintiddlers.js
+++ b/core/modules/filters/plugintiddlers.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/plugintiddlers.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the titles of the shadow tiddlers within a plugin
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.plugintiddlers = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/prefix.js
+++ b/core/modules/filters/prefix.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/prefix.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for checking if a title starts with a prefix
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.prefix = function(source,operator,options) {
 	var results = [],
 		suffixes = (operator.suffixes || [])[0] || [];

--- a/core/modules/filters/previous.js
+++ b/core/modules/filters/previous.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/previous.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning the tiddler whose title occurs immediately prior in the list supplied in the operand tiddler
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.previous = function(source,operator,options) {
 	var results = [],
 		list = options.wiki.getTiddlerList(operator.operand);

--- a/core/modules/filters/range.js
+++ b/core/modules/filters/range.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/range.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for generating a numeric range.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.range = function(source,operator,options) {
 	var results = [];
 	// For backwards compatibility, if there is only one operand, try to split it using one of the delimiters
@@ -19,14 +13,14 @@ exports.range = function(source,operator,options) {
 	if(parts.length === 1) {
 		parts = operator.operand.split(/[,:;]/g);
 	}
-	// Process the parts
+
 	var beg, end, inc, i, fixed = 0;
 	for (i=0; i<parts.length; i++) {
 		// Validate real number
 		if(!/^\s*[+-]?((\d+(\.\d*)?)|(\.\d+))\s*$/.test(parts[i])) {
 			return ["range: bad number \"" + parts[i] + "\""];
 		}
-		// Count digits; the most precise number determines decimal places in output.
+
 		var frac = /\.\d+/.exec(parts[i]);
 		if(frac) {
 			fixed = Math.max(fixed,frac[0].length-1);
@@ -61,14 +55,14 @@ exports.range = function(source,operator,options) {
 	if(inc === 0) {
 		return ["range: increment 0 causes infinite loop"];
 	}
-	// May need to count backwards
+
 	var direction = ((end < beg) ? -1 : 1);
 	inc *= direction;
 	// Estimate number of resulting elements
 	if((end - beg) / inc > 10000) {
 		return ["range: too many steps (over 10K)"];
 	}
-	// Avoid rounding error on last step
+
 	end += direction * 0.5 * Math.pow(0.1,fixed);
 	var safety = 10010;
 	// Enumerate the range
@@ -90,7 +84,7 @@ exports.range = function(source,operator,options) {
 	if(safety<0) {
 		return ["range: unexpectedly large output"];
 	}
-	// Reverse?
+
 	if(operator.prefix === "!") {
 		results.reverse();
 	}

--- a/core/modules/filters/reduce.js
+++ b/core/modules/filters/reduce.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/reduce.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator evaluates a subfilter for each item, making the running total available in the variable `accumulator`, and the current index available in the variable `index`
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.reduce = function(source,operator,options) {
 	// Accumulate the list
 	var results = [];

--- a/core/modules/filters/regexp.js
+++ b/core/modules/filters/regexp.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/regexp.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for regexp matching
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.regexp = function(source,operator,options) {
 	var results = [],
 		fieldname = operator.suffix || "title",
@@ -43,7 +37,7 @@ exports.regexp = function(source,operator,options) {
 	} catch(e) {
 		return ["" + e];
 	}
-	// Process the incoming tiddlers
+
 	if(operator.prefix === "!") {
 		source(function(tiddler,title) {
 			var text = getFieldString(tiddler,title);

--- a/core/modules/filters/removeprefix.js
+++ b/core/modules/filters/removeprefix.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/removeprefix.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for removing a prefix from each title in the list. Titles that do not start with the prefix are removed.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.removeprefix = function(source,operator,options) {
 	var results = [],
 		suffixes = (operator.suffixes || [])[0] || [];

--- a/core/modules/filters/removesuffix.js
+++ b/core/modules/filters/removesuffix.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/removesuffix.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for removing a suffix from each title in the list. Titles that do not end with the suffix are removed.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.removesuffix = function(source,operator,options) {
 	var results = [],
 		suffixes = (operator.suffixes || [])[0] || [];

--- a/core/modules/filters/sameday.js
+++ b/core/modules/filters/sameday.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/sameday.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator that selects tiddlers with a modified date field on the same day as the provided value.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.sameday = function(source,operator,options) {
 	var results = [],
 		fieldName = operator.suffix || "modified",

--- a/core/modules/filters/search.js
+++ b/core/modules/filters/search.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/search.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for searching for the text in the operand tiddler
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.search = function(source,operator,options) {
 	var invert = operator.prefix === "!";
 	if(operator.suffixes) {
@@ -20,7 +14,7 @@ exports.search = function(source,operator,options) {
 			},
 			excludeFields = false,
 			fieldList = operator.suffixes[0] || [],
-			firstField = fieldList[0] || "", 
+			firstField = fieldList[0] || "",
 			firstChar = firstField.charAt(0),
 			fields;
 		if(firstChar === "-") {

--- a/core/modules/filters/shadowsource.js
+++ b/core/modules/filters/shadowsource.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/shadowsource.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the source plugins for shadow tiddlers
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.shadowsource = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/slugify.js
+++ b/core/modules/filters/slugify.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/filters/slugify.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for slugifying a tiddler title
-
 \*/
 
 "use strict";

--- a/core/modules/filters/sort.js
+++ b/core/modules/filters/sort.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/sort.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for sorting
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.sort = function(source,operator,options) {
 	var results = prepare_results(source);
 	options.wiki.sortTiddlers(results,operator.operands[0] || "title",operator.prefix === "!",false,false,undefined,operator.operands[1]);

--- a/core/modules/filters/sortsub.js
+++ b/core/modules/filters/sortsub.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/sortsub.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for sorting by a subfilter
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.sortsub = function(source,operator,options) {
 	// Compile the subfilter
 	var filterFn = options.wiki.compileFilter(operator.operand);

--- a/core/modules/filters/splitbefore.js
+++ b/core/modules/filters/splitbefore.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/splitbefore.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator that splits each result on the first occurance of the specified separator and returns the unique values.
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.splitbefore = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/storyviews.js
+++ b/core/modules/filters/storyviews.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/storyviews.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the names of the story views in this wiki
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.storyviews = function(source,operator,options) {
 	var results = [],
 		storyviews = {};

--- a/core/modules/filters/strings.js
+++ b/core/modules/filters/strings.js
@@ -2,11 +2,6 @@
 title: $:/core/modules/filters/strings.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operators for strings. Unary/binary operators work on each item in turn, and return a new item list.
-
-Sum/product/maxall/minall operate on the entire list, returning a single item.
-
 \*/
 
 "use strict";
@@ -94,7 +89,7 @@ function diffLineWordMode(text1,text2,mode) {
 exports.makepatches = function(source,operator,options) {
 	var suffix = operator.suffix || "",
 		result = [];
-		
+
 	source(function(tiddler,title) {
 		let diffs, patches;
 		if(suffix === "lines" || suffix === "words") {

--- a/core/modules/filters/subfilter.js
+++ b/core/modules/filters/subfilter.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/subfilter.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning its operand evaluated as a filter
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.subfilter = function(source,operator,options) {
 	var list = options.wiki.filterTiddlers(operator.operand,options.widget,source);
 	if(operator.prefix === "!") {

--- a/core/modules/filters/substitute.js
+++ b/core/modules/filters/substitute.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/substitute.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for substituting variables and embedded filter expressions with their corresponding values
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.substitute = function(source,operator,options) {
 	var results = [],
 		operands = [];
@@ -28,4 +22,3 @@ exports.substitute = function(source,operator,options) {
 	});
 	return results;
 };
-

--- a/core/modules/filters/subtiddlerfields.js
+++ b/core/modules/filters/subtiddlerfields.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/subtiddlerfields.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the names of the fields on the selected subtiddlers of the plugin named in the operand
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.subtiddlerfields = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/suffix.js
+++ b/core/modules/filters/suffix.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/suffix.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for checking if a title ends with a suffix
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.suffix = function(source,operator,options) {
 	var results = [],
 		suffixes = (operator.suffixes || [])[0] || [];

--- a/core/modules/filters/tag.js
+++ b/core/modules/filters/tag.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/tag.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for checking for the presence of a tag
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.tag = function(source,operator,options) {
 	var results = [],indexedResults;
 	if((operator.suffix || "").toLowerCase() === "strict" && !operator.operand) {

--- a/core/modules/filters/tagging.js
+++ b/core/modules/filters/tagging.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/tagging.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning all tiddlers that are tagged with the selected tiddlers
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.tagging = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/tags.js
+++ b/core/modules/filters/tags.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/tags.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning all the tags of the selected tiddlers
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.tags = function(source,operator,options) {
 	var tags = {};
 	source(function(tiddler,title) {

--- a/core/modules/filters/then.js
+++ b/core/modules/filters/then.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/then.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for replacing any titles with a constant
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.then = function(source,operator,options) {
 	var results = [];
 	source(function(tiddler,title) {

--- a/core/modules/filters/title.js
+++ b/core/modules/filters/title.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/title.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for comparing title fields for equality
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.title = function(source,operator,options) {
 	var results = [];
 	if(operator.prefix === "!") {

--- a/core/modules/filters/transcludes.js
+++ b/core/modules/filters/transcludes.js
@@ -2,15 +2,9 @@
 title: $:/core/modules/filters/transcludes.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning all the transcludes from a tiddler
-
 \*/
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.transcludes = function(source,operator,options) {
 	var results = new $tw.utils.LinkedList();
 	source(function(tiddler,title) {

--- a/core/modules/filters/unknown.js
+++ b/core/modules/filters/unknown.js
@@ -2,27 +2,19 @@
 title: $:/core/modules/filters/unknown.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for handling unknown filter operators.
-
-Not intended to be used directly by end users, hence the square brackets around the name.
-
 \*/
 
 "use strict";
 
 var fieldFilterOperatorFn = require("$:/core/modules/filters/field.js").field;
 
-/*
-Export our filter function
-*/
 exports["[unknown]"] = function(source,operator,options) {
 	// Check for a user defined filter operator
 	if(operator.operator.indexOf(".") !== -1) {
 		var params = [];
 		$tw.utils.each(operator.multiValueOperands,function(paramList) {
 			params.push({value: paramList[0] || "",multiValue: paramList});
-		});	
+		});
 		var variableInfo = options.widget && options.widget.getVariableInfo && options.widget.getVariableInfo(operator.operator,{params: params, source: source});
 		if(variableInfo && variableInfo.srcVariable) {
 			var list = variableInfo.resultList ? variableInfo.resultList : [variableInfo.text];
@@ -39,6 +31,6 @@ exports["[unknown]"] = function(source,operator,options) {
 			}
 		}
 	}
-	// Otherwise, use the "field" operator
+
 	return fieldFilterOperatorFn(source,operator,options);
 };

--- a/core/modules/filters/untagged.js
+++ b/core/modules/filters/untagged.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/untagged.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator returning all the selected tiddlers that are untagged
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.untagged = function(source,operator,options) {
 	var results = [],
 		expected = (operator.prefix === "!");

--- a/core/modules/filters/variables.js
+++ b/core/modules/filters/variables.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/variables.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the names of the active variables
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.variables = function(source,operator,options) {
 	var names = [],
 		widget = options.widget;

--- a/core/modules/filters/wikiparserrules.js
+++ b/core/modules/filters/wikiparserrules.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/wikiparserrules.js
 type: application/javascript
 module-type: filteroperator
-
-Filter operator for returning the names of the wiki parser rules in this wiki
-
 \*/
 
 "use strict";
 
-/*
-Export our filter function
-*/
 exports.wikiparserrules = function(source,operator,options) {
 	var results = [],
 		operand = operator.operand;

--- a/core/modules/filters/x-listops.js
+++ b/core/modules/filters/x-listops.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/filters/x-listops.js
 type: application/javascript
 module-type: filteroperator
-
-Extended filter operators to manipulate the current list.
-
 \*/
 
 	"use strict";
 
-	/*
-	Fetch titles from the current list
-	*/
 	var prepare_results = function (source) {
 	var results = [];
 		source(function (tiddler, title) {
@@ -20,9 +14,6 @@ Extended filter operators to manipulate the current list.
 		return results;
 	};
 
-	/*
-	Moves a number of items from the tail of the current list before the item named in the operand
-	*/
 	exports.putbefore = function (source, operator) {
 		var results = prepare_results(source),
 			index = results.indexOf(operator.operand),
@@ -32,9 +23,6 @@ Extended filter operators to manipulate the current list.
 			results.slice(0, index).concat(results.slice(-count)).concat(results.slice(index, -count));
 	};
 
-	/*
-	Moves a number of items from the tail of the current list after the item named in the operand
-	*/
 	exports.putafter = function (source, operator) {
 		var results = prepare_results(source),
 			index = results.indexOf(operator.operand),
@@ -44,9 +32,6 @@ Extended filter operators to manipulate the current list.
 			results.slice(0, index + 1).concat(results.slice(-count)).concat(results.slice(index + 1, -count));
 	};
 
-	/*
-	Replaces the item named in the operand with a number of items from the tail of the current list
-	*/
 	exports.replace = function (source, operator) {
 		var results = prepare_results(source),
 			index = results.indexOf(operator.operand),
@@ -56,27 +41,18 @@ Extended filter operators to manipulate the current list.
 			results.slice(0, index).concat(results.slice(-count)).concat(results.slice(index + 1, -count));
 	};
 
-	/*
-	Moves a number of items from the tail of the current list to the head of the list
-	*/
 	exports.putfirst = function (source, operator) {
 		var results = prepare_results(source),
 			count = $tw.utils.getInt(operator.suffix,1);
 		return results.slice(-count).concat(results.slice(0, -count));
 	};
 
-	/*
-	Moves a number of items from the head of the current list to the tail of the list
-	*/
 	exports.putlast = function (source, operator) {
 		var results = prepare_results(source),
 			count = $tw.utils.getInt(operator.suffix,1);
 		return results.slice(count).concat(results.slice(0, count));
 	};
 
-	/*
-	Moves the item named in the operand a number of places forward or backward in the list
-	*/
 	exports.move = function (source, operator) {
 		var results = prepare_results(source),
 			index = results.indexOf(operator.operand),
@@ -86,9 +62,6 @@ Extended filter operators to manipulate the current list.
 		return results.slice(0, offset).concat(marker).concat(results.slice(offset));
 	};
 
-	/*
-	Returns the items from the current list that are after the item named in the operand
-	*/
 	exports.allafter = function (source, operator) {
 		var results = prepare_results(source),
 			index = results.indexOf(operator.operand);
@@ -97,9 +70,6 @@ Extended filter operators to manipulate the current list.
 			results.slice(index + 1);
 	};
 
-	/*
-	Returns the items from the current list that are before the item named in the operand
-	*/
 	exports.allbefore = function (source, operator) {
 		var results = prepare_results(source),
 			index = results.indexOf(operator.operand);
@@ -108,9 +78,6 @@ Extended filter operators to manipulate the current list.
 			results.slice(0, index);
 	};
 
-	/*
-	Appends the items listed in the operand array to the tail of the current list
-	*/
 	exports.append = function (source, operator) {
 		var append = $tw.utils.parseStringArray(operator.operand, "true"),
 			results = prepare_results(source),
@@ -120,9 +87,6 @@ Extended filter operators to manipulate the current list.
 			results.concat(append.slice(0, count));
 	};
 
-	/*
-	Prepends the items listed in the operand array to the head of the current list
-	*/
 	exports.prepend = function (source, operator) {
 		var prepend = $tw.utils.parseStringArray(operator.operand, "true"),
 			results = prepare_results(source),
@@ -132,9 +96,6 @@ Extended filter operators to manipulate the current list.
 			prepend.slice(0, count).concat(results);
 	};
 
-	/*
-	Returns all items from the current list except the items listed in the operand array
-	*/
 	exports.remove = function (source, operator) {
 		var array = $tw.utils.parseStringArray(operator.operand, "true"),
 			results = prepare_results(source),
@@ -156,9 +117,6 @@ Extended filter operators to manipulate the current list.
 		return results;
 	};
 
-	/*
-	Returns all items from the current list sorted in the order of the items in the operand array
-	*/
 	exports.sortby = function (source, operator) {
 		var results = prepare_results(source);
 		if (!results || results.length < 2) {
@@ -171,9 +129,6 @@ Extended filter operators to manipulate the current list.
 		return results;
 	};
 
-	/*
-	Removes all duplicate items from the current list
-	*/
 	exports.unique = function (source, operator) {
 		var results = prepare_results(source);
 		var set = results.reduce(function (a, b) {
@@ -211,9 +166,6 @@ Extended filter operators to manipulate the current list.
 		return results;
 	}
 
-	/*
-	Toggles an item in the current list.
-	*/
 	exports.toggle = function(source,operator) {
 		return cycleValueInArray(prepare_results(source),operator.operands);
 	}

--- a/core/modules/indexers/back-indexer.js
+++ b/core/modules/indexers/back-indexer.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/indexers/back-indexer.js
 type: application/javascript
 module-type: indexer
-
-By parsing the tiddler text, indexes the tiddlers' back links, back transclusions, block level back links.
-
 \*/
 function BackIndexer(wiki) {
 	this.wiki = wiki;
@@ -32,14 +29,6 @@ function BackSubIndexer(indexer,extractor) {
 	this.wiki = indexer.wiki;
 	this.indexer = indexer;
 	this.extractor = extractor;
-	/**
-	 * {
-	 *   [target title, e.g. tiddler title being linked to]:
-	 *     {
-	 * 		   [source title, e.g. tiddler title that has link syntax in its text]: true
-	 * 	   }
-	 * }
-	 */
 	this.index = null;
 }
 
@@ -66,9 +55,6 @@ BackSubIndexer.prototype.rebuild = function() {
 	this.index = null;
 }
 
-/*
-* Get things that is being referenced in the text, e.g. tiddler names in the link syntax.
-*/
 BackSubIndexer.prototype._getTarget = function(tiddler) {
 	if(this.wiki.isBinaryTiddler(tiddler.fields.text)) {
 		return [];

--- a/core/modules/indexers/field-indexer.js
+++ b/core/modules/indexers/field-indexer.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/indexers/field-indexer.js
 type: application/javascript
 module-type: indexer
-
-Indexes the tiddlers with each field value
-
 \*/
 
 "use strict";
@@ -21,7 +18,6 @@ FieldIndexer.prototype.init = function() {
 	this.addIndexMethods();
 }
 
-// Provided for testing
 FieldIndexer.prototype.setMaxIndexedValueLength = function(length) {
 	this.index = null;
 	this.maxIndexedValueLength = length;
@@ -53,17 +49,11 @@ FieldIndexer.prototype.addIndexMethods = function() {
 	};
 };
 
-/*
-Tear down and then rebuild the index as if all tiddlers have changed
-*/
 FieldIndexer.prototype.rebuild = function() {
 	// Invalidate the index so that it will be rebuilt when it is next used
 	this.index = null;
 };
 
-/*
-Build the index for a particular field
-*/
 FieldIndexer.prototype.buildIndexForField = function(name) {
 	var self = this;
 	// Hashmap by field name of hashmap by field value of array of tiddler titles
@@ -83,17 +73,13 @@ FieldIndexer.prototype.buildIndexForField = function(name) {
 	});
 };
 
-/*
-Update the index in the light of a tiddler value changing; note that the title must be identical. (Renames are handled as a separate delete and create)
-updateDescriptor: {old: {tiddler: <tiddler>, shadow: <boolean>, exists: <boolean>},new: {tiddler: <tiddler>, shadow: <boolean>, exists: <boolean>}}
-*/
 FieldIndexer.prototype.update = function(updateDescriptor) {
 	var self = this;
 	// Don't do anything if the index hasn't been built yet
 	if(this.index === null) {
 		return;
 	}
-	// Remove the old tiddler from the index
+
 	if(updateDescriptor.old.tiddler) {
 		$tw.utils.each(this.index,function(indexEntry,name) {
 			if(name in updateDescriptor.old.tiddler.fields) {
@@ -108,7 +94,7 @@ FieldIndexer.prototype.update = function(updateDescriptor) {
 			}
 		});
 	}
-	// Add the new tiddler to the index
+
 	if(updateDescriptor["new"].tiddler) {
 		$tw.utils.each(this.index,function(indexEntry,name) {
 			if(name in updateDescriptor["new"].tiddler.fields) {
@@ -128,7 +114,7 @@ FieldIndexer.prototype.lookup = function(name,value) {
 	if(value.length >= this.maxIndexedValueLength) {
 		return null;
 	}
-	// Update the index if it has yet to be built
+
 	if(this.index === null || !this.index[name]) {
 		this.buildIndexForField(name);
 	}

--- a/core/modules/indexers/tag-indexer.js
+++ b/core/modules/indexers/tag-indexer.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/indexers/tag-indexer.js
 type: application/javascript
 module-type: indexer
-
-Indexes the tiddlers with each tag
-
 \*/
 
 "use strict";
@@ -88,6 +85,5 @@ TagSubIndexer.prototype.lookup = function(tag) {
 		return [];
 	}
 };
-
 
 exports.TagIndexer = TagIndexer;

--- a/core/modules/info/mediaquerytracker.js
+++ b/core/modules/info/mediaquerytracker.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/info/mediaquerytracker.js
 type: application/javascript
 module-type: info
-
-Initialise $:/info/ tiddlers derived from media queries via 
-
 \*/
 
 "use strict";
@@ -45,7 +42,7 @@ exports.getInfoTiddlerFields = function(updateInfoTiddlersCallback) {
 				enterValue.mqList.removeEventListener("change",enterValue.handler);
 			}
 		}
-		// Track media query tracker tiddlers
+
 		function fnEnter(title) {
 			return track(title);
 		}

--- a/core/modules/info/platform.js
+++ b/core/modules/info/platform.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/info/platform.js
 type: application/javascript
 module-type: info
-
-Initialise basic platform $:/info/ tiddlers
-
 \*/
 
 "use strict";

--- a/core/modules/keyboard.js
+++ b/core/modules/keyboard.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/keyboard.js
 type: application/javascript
 module-type: global
-
-Keyboard handling utilities
-
 \*/
 
 "use strict";
@@ -149,9 +146,6 @@ function KeyboardManager(options) {
 	});
 }
 
-/*
-Return an array of keycodes for the modifier keys ctrl, shift, alt, meta
-*/
 KeyboardManager.prototype.getModifierKeys = function() {
 	return [
 		16, // Shift
@@ -160,23 +154,10 @@ KeyboardManager.prototype.getModifierKeys = function() {
 		20, // CAPS LOCK
 		91, // Meta (left)
 		93, // Meta (right)
-		224 // Meta (Firefox)
+		224
 	]
 };
 
-/*
-Parses a key descriptor into the structure:
-{
-	keyCode: numeric keycode
-	shiftKey: boolean
-	altKey: boolean
-	ctrlKey: boolean
-	metaKey: boolean
-}
-Key descriptors have the following format:
-	ctrl+enter
-	ctrl+shift+alt+A
-*/
 KeyboardManager.prototype.parseKeyDescriptor = function(keyDescriptor,options) {
 	var components = keyDescriptor.split(/\+|\-/),
 		info = {
@@ -199,7 +180,7 @@ KeyboardManager.prototype.parseKeyDescriptor = function(keyDescriptor,options) {
 		} else if(s === "meta" || s === "cmd" || s === "win") {
 			info.metaKey = true;
 		}
-		// Replace named keys with their code
+
 		if(this.namedKeys[s]) {
 			info.keyCode = this.namedKeys[s];
 		}
@@ -214,9 +195,6 @@ KeyboardManager.prototype.parseKeyDescriptor = function(keyDescriptor,options) {
 	}
 };
 
-/*
-Parse a list of key descriptors into an array of keyInfo objects. The key descriptors can be passed as an array of strings or a space separated string
-*/
 KeyboardManager.prototype.parseKeyDescriptors = function(keyDescriptors,options) {
 	var self = this;
 	options = options || {};
@@ -258,10 +236,10 @@ KeyboardManager.prototype.getPrintableShortcuts = function(keyInfoArray) {
 		result = [];
 	$tw.utils.each(keyInfoArray,function(keyInfo) {
 		if(keyInfo) {
-			result.push((keyInfo.ctrlKey ? "ctrl-" : "") + 
-				   (keyInfo.shiftKey ? "shift-" : "") + 
-				   (keyInfo.altKey ? "alt-" : "") + 
-				   (keyInfo.metaKey ? self.metaKeyName : "") + 
+			result.push((keyInfo.ctrlKey ? "ctrl-" : "") +
+				   (keyInfo.shiftKey ? "shift-" : "") +
+				   (keyInfo.altKey ? "alt-" : "") +
+				   (keyInfo.metaKey ? self.metaKeyName : "") +
 				   (self.keyNames[keyInfo.keyCode]));
 		}
 	});
@@ -270,10 +248,10 @@ KeyboardManager.prototype.getPrintableShortcuts = function(keyInfoArray) {
 
 KeyboardManager.prototype.checkKeyDescriptor = function(event,keyInfo) {
 	return keyInfo &&
-			event.keyCode === keyInfo.keyCode && 
-			event.shiftKey === keyInfo.shiftKey && 
-			event.altKey === keyInfo.altKey && 
-			event.ctrlKey === keyInfo.ctrlKey && 
+			event.keyCode === keyInfo.keyCode &&
+			event.shiftKey === keyInfo.shiftKey &&
+			event.altKey === keyInfo.altKey &&
+			event.ctrlKey === keyInfo.ctrlKey &&
 			event.metaKey === keyInfo.metaKey;
 };
 
@@ -291,14 +269,14 @@ KeyboardManager.prototype.getMatchingKeyDescriptor = function(event,keyInfoArray
 };
 
 KeyboardManager.prototype.getEventModifierKeyDescriptor = function(event) {
-	return event.ctrlKey && !event.shiftKey	&& !event.altKey && !event.metaKey ? "ctrl" : 
-		event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey ? "shift" : 
-		event.ctrlKey && event.shiftKey && !event.altKey && !event.metaKey ? "ctrl-shift" : 
-		event.altKey && !event.shiftKey && !event.ctrlKey && !event.metaKey ? "alt" : 
-		event.altKey && event.shiftKey && !event.ctrlKey && !event.metaKey ? "alt-shift" : 
-		event.altKey && event.ctrlKey && !event.shiftKey && !event.metaKey ? "ctrl-alt" : 
-		event.altKey && event.shiftKey && event.ctrlKey && !event.metaKey ? "ctrl-alt-shift" : 
-		event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey ? "meta" : 
+	return event.ctrlKey && !event.shiftKey	&& !event.altKey && !event.metaKey ? "ctrl" :
+		event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey ? "shift" :
+		event.ctrlKey && event.shiftKey && !event.altKey && !event.metaKey ? "ctrl-shift" :
+		event.altKey && !event.shiftKey && !event.ctrlKey && !event.metaKey ? "alt" :
+		event.altKey && event.shiftKey && !event.ctrlKey && !event.metaKey ? "alt-shift" :
+		event.altKey && event.ctrlKey && !event.shiftKey && !event.metaKey ? "ctrl-alt" :
+		event.altKey && event.shiftKey && event.ctrlKey && !event.metaKey ? "ctrl-alt-shift" :
+		event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey ? "meta" :
 		event.metaKey && event.ctrlKey && !event.shiftKey && !event.altKey ? "meta-ctrl" :
 		event.metaKey && event.ctrlKey && event.shiftKey && !event.altKey ? "meta-ctrl-shift" :
 		event.metaKey && event.ctrlKey && event.shiftKey && event.altKey ? "meta-ctrl-alt-shift" : "normal";
@@ -320,11 +298,6 @@ KeyboardManager.prototype.updateShortcutLists = function(tiddlerList) {
 	}
 };
 
-/*
-event: the keyboard event object
-options:
-	onlyPriority: true if only priority global shortcuts should be invoked
-*/
 KeyboardManager.prototype.handleKeydownEvent = function(event, options) {
 	options = options || {};
 	var key, action;

--- a/core/modules/language.js
+++ b/core/modules/language.js
@@ -2,36 +2,21 @@
 title: $:/core/modules/language.js
 type: application/javascript
 module-type: global
-
-The $tw.Language() manages translateable strings
-
 \*/
 
 "use strict";
 
-/*
-Create an instance of the language manager. Options include:
-wiki: wiki from which to retrieve translation tiddlers
-*/
 function Language(options) {
 	options = options || "";
 	this.wiki = options.wiki || $tw.wiki;
 }
 
-/*
-Return a wikified translateable string. The title is automatically prefixed with "$:/language/"
-Options include:
-variables: optional hashmap of variables to supply to the language wikification
-*/
 Language.prototype.getString = function(title,options) {
 	options = options || {};
 	title = "$:/language/" + title;
 	return this.wiki.renderTiddler("text/plain",title,{variables: options.variables});
 };
 
-/*
-Return a raw, unwikified translateable string. The title is automatically prefixed with "$:/language/"
-*/
 Language.prototype.getRawString = function(title) {
 	title = "$:/language/" + title;
 	return this.wiki.getTiddlerText(title);

--- a/core/modules/macros/changecount.js
+++ b/core/modules/macros/changecount.js
@@ -2,24 +2,14 @@
 title: $:/core/modules/macros/changecount.js
 type: application/javascript
 module-type: macro
-
-Macro to return the changecount for the current tiddler
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "changecount";
 
 exports.params = [];
 
-/*
-Run the macro
-*/
 exports.run = function() {
 	return this.wiki.getChangeCount(this.getVariable("currentTiddler")) + "";
 };

--- a/core/modules/macros/contrastcolour.js
+++ b/core/modules/macros/contrastcolour.js
@@ -2,16 +2,9 @@
 title: $:/core/modules/macros/contrastcolour.js
 type: application/javascript
 module-type: macro
-
-Macro to choose which of two colours has the highest contrast with a base colour
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "contrastcolour";
 
@@ -22,9 +15,6 @@ exports.params = [
 	{name: "colourB"}
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(target,fallbackTarget,colourA,colourB) {
 	var rgbTarget = $tw.utils.parseCSSColor(target) || $tw.utils.parseCSSColor(fallbackTarget);
 	if(!rgbTarget) {
@@ -42,7 +32,7 @@ exports.run = function(target,fallbackTarget,colourA,colourB) {
 		// If neither colour is readable, return a crude inverse of the target
 		return [255 - rgbTarget[0],255 - rgbTarget[1],255 - rgbTarget[2],rgbTarget[3]];
 	}
-	// Colour brightness formula derived from http://www.w3.org/WAI/ER/WD-AERT/#color-contrast
+
 	var brightnessTarget = rgbTarget[0] * 0.299 + rgbTarget[1] * 0.587 + rgbTarget[2] * 0.114,
 		brightnessA = rgbColourA[0] * 0.299 + rgbColourA[1] * 0.587 + rgbColourA[2] * 0.114,
 		brightnessB = rgbColourB[0] * 0.299 + rgbColourB[1] * 0.587 + rgbColourB[2] * 0.114;

--- a/core/modules/macros/csvtiddlers.js
+++ b/core/modules/macros/csvtiddlers.js
@@ -2,16 +2,9 @@
 title: $:/core/modules/macros/csvtiddlers.js
 type: application/javascript
 module-type: macro
-
-Macro to output tiddlers matching a filter to CSV
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "csvtiddlers";
 
@@ -20,9 +13,6 @@ exports.params = [
 	{name: "format"},
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(filter,format) {
 	var self = this,
 		tiddlers = this.wiki.filterTiddlers(filter),
@@ -40,7 +30,7 @@ exports.run = function(filter,format) {
 			}
 		}
 	}
-	// Sort the fields and bring the standard ones to the front
+
 	fields.sort();
 	"title text modified modifier created creator".split(" ").reverse().forEach(function(value,index) {
 		var p = fields.indexOf(value);
@@ -62,7 +52,7 @@ exports.run = function(filter,format) {
 			if(tiddler) {
 				for(f=0; f<fields.length; f++) {
 					row.push(quoteAndEscape(tiddler ? tiddler.getFieldString(fields[f]) || "" : ""));
-				}	
+				}
 			}
 		output.push(row.join(","));
 	}

--- a/core/modules/macros/displayshortcuts.js
+++ b/core/modules/macros/displayshortcuts.js
@@ -2,16 +2,9 @@
 title: $:/core/modules/macros/displayshortcuts.js
 type: application/javascript
 module-type: macro
-
-Macro to display a list of keyboard shortcuts in human readable form. Notably, it resolves named shortcuts like `((bold))` to the underlying keystrokes.
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "displayshortcuts";
 
@@ -22,9 +15,6 @@ exports.params = [
 	{name: "suffix"}
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(shortcuts,prefix,separator,suffix) {
 	var shortcutArray = $tw.keyboardManager.getPrintableShortcuts($tw.keyboardManager.parseKeyDescriptors(shortcuts,{
 		wiki: this.wiki

--- a/core/modules/macros/jsontiddler.js
+++ b/core/modules/macros/jsontiddler.js
@@ -2,16 +2,9 @@
 title: $:/core/modules/macros/jsontiddler.js
 type: application/javascript
 module-type: macro
-
-Macro to output a single tiddler to JSON
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "jsontiddler";
 
@@ -19,9 +12,6 @@ exports.params = [
 	{name: "title"}
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(title) {
 	title = title || this.getVariable("currentTiddler");
 	var tiddler = !!title && this.wiki.getTiddler(title),
@@ -33,4 +23,3 @@ exports.run = function(title) {
 	}
 	return JSON.stringify(fields,null,$tw.config.preferences.jsonSpaces);
 };
-

--- a/core/modules/macros/jsontiddlers.js
+++ b/core/modules/macros/jsontiddlers.js
@@ -2,16 +2,9 @@
 title: $:/core/modules/macros/jsontiddlers.js
 type: application/javascript
 module-type: macro
-
-Macro to output tiddlers matching a filter to JSON
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "jsontiddlers";
 
@@ -20,9 +13,6 @@ exports.params = [
 	{name: "spaces"}
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(filter,spaces) {
 	return this.wiki.getTiddlersAsJson(filter,$tw.utils.parseInt(spaces));
 };

--- a/core/modules/macros/makedatauri.js
+++ b/core/modules/macros/makedatauri.js
@@ -2,18 +2,9 @@
 title: $:/core/modules/macros/makedatauri.js
 type: application/javascript
 module-type: macro
-
-Macro to convert a string of text to a data URI
-
-<<makedatauri text:"Text to be converted" type:"text/vnd.tiddlywiki">>
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "makedatauri";
 
@@ -23,9 +14,6 @@ exports.params = [
 	{name: "_canonical_uri"}
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(text,type,_canonical_uri) {
 	return $tw.utils.makeDataUri(text,type,_canonical_uri);
 };

--- a/core/modules/macros/now.js
+++ b/core/modules/macros/now.js
@@ -2,16 +2,9 @@
 title: $:/core/modules/macros/now.js
 type: application/javascript
 module-type: macro
-
-Macro to return a formatted version of the current time
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "now";
 
@@ -19,9 +12,6 @@ exports.params = [
 	{name: "format"}
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(format) {
 	return $tw.utils.formatDateString(new Date(),format || "0hh:0mm, DDth MMM YYYY");
 };

--- a/core/modules/macros/qualify.js
+++ b/core/modules/macros/qualify.js
@@ -2,16 +2,9 @@
 title: $:/core/modules/macros/qualify.js
 type: application/javascript
 module-type: macro
-
-Macro to qualify a state tiddler title according
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "qualify";
 
@@ -19,9 +12,6 @@ exports.params = [
 	{name: "title"}
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(title) {
 	return title + "-" + this.getStateQualifier();
 };

--- a/core/modules/macros/resolvepath.js
+++ b/core/modules/macros/resolvepath.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/macros/resolvepath.js
 type: application/javascript
 module-type: macro
-
-Resolves a relative path for an absolute rootpath.
-
 \*/
 
 "use strict";
@@ -16,9 +13,6 @@ exports.params = [
 	{name: "root"}
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(source, root) {
 	return $tw.utils.resolvePath(source, root);
 };

--- a/core/modules/macros/unusedtitle.js
+++ b/core/modules/macros/unusedtitle.js
@@ -2,8 +2,6 @@
 title: $:/core/modules/macros/unusedtitle.js
 type: application/javascript
 module-type: macro
-
-Macro to return a new title that is unused in the wiki. It can be given a name as a base.
 \*/
 
 "use strict";
@@ -17,16 +15,13 @@ exports.params = [
 	{name: "startCount"}
 ];
 
-/*
-Run the macro
-*/
 exports.run = function(baseName,separator,template,startCount) {
 	separator = separator || " ";
 	startCount = startCount || 0;
 	if(!baseName) {
 		baseName = $tw.language.getString("DefaultNewTiddlerTitle");
 	}
-	// $tw.wiki.generateNewTitle = function(baseTitle,options)
+
 	// options.prefix must be a string!
 	return this.wiki.generateNewTitle(baseName, {"prefix": separator, "template": template, "startCount": startCount}).trim();
 };

--- a/core/modules/macros/version.js
+++ b/core/modules/macros/version.js
@@ -2,24 +2,14 @@
 title: $:/core/modules/macros/version.js
 type: application/javascript
 module-type: macro
-
-Macro to return the TiddlyWiki core version number
-
 \*/
 
 "use strict";
-
-/*
-Information about this macro
-*/
 
 exports.name = "version";
 
 exports.params = [];
 
-/*
-Run the macro
-*/
 exports.run = function() {
 	return $tw.version;
 };

--- a/core/modules/parsers/audioparser.js
+++ b/core/modules/parsers/audioparser.js
@@ -2,13 +2,8 @@
 title: $:/core/modules/parsers/audioparser.js
 type: application/javascript
 module-type: parser
-
-The audio parser parses an audio tiddler into an embeddable HTML element
-
 \*/
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
 "use strict";
 
 var AudioParser = function(type,text,options) {
@@ -20,7 +15,7 @@ var AudioParser = function(type,text,options) {
 				style: {type: "string", value: "width: 100%; object-fit: contain"}
 			}
 		};
-		
+
 	// Pass through source information
 	if(options._canonical_uri) {
 		element.attributes.src = {type: "string", value: options._canonical_uri};
@@ -29,12 +24,11 @@ var AudioParser = function(type,text,options) {
 		element.attributes.src = {type: "string", value: "data:" + type + ";base64," + text};
 		element.attributes.type = {type: "string", value: type};
 	}
-	
-	// Pass through tiddler title if available
+
 	if(options.title) {
 		element.attributes.tiddler = {type: "string", value: options.title};
 	}
-	
+
 	this.tree = [element];
 	this.source = text;
 	this.type = type;
@@ -44,4 +38,3 @@ exports["audio/ogg"] = AudioParser;
 exports["audio/mpeg"] = AudioParser;
 exports["audio/mp3"] = AudioParser;
 exports["audio/mp4"] = AudioParser;
-	

--- a/core/modules/parsers/binaryparser.js
+++ b/core/modules/parsers/binaryparser.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/binaryparser.js
 type: application/javascript
 module-type: parser
-
-The binary parser parses a binary tiddler into a warning message and download link
-
 \*/
 
 "use strict";
@@ -42,16 +39,16 @@ var BinaryParser = function(type,text,options) {
 	// Set the link href to external or internal data URI
 	if(options._canonical_uri) {
 		link.attributes.href = {
-			type: "string", 
+			type: "string",
 			value: options._canonical_uri
 		};
 	} else if(text) {
 		link.attributes.href = {
-			type: "string", 
+			type: "string",
 			value: "data:" + type + ";base64," + text
 		};
 	}
-	// Combine warning message and download link in a div
+
 	var element = {
 		type: "element",
 		tag: "div",

--- a/core/modules/parsers/csvparser.js
+++ b/core/modules/parsers/csvparser.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/csvparser.js
 type: application/javascript
 module-type: parser
-
-The CSV text parser processes CSV files into a table wrapped in a scrollable widget
-
 \*/
 
 "use strict";
@@ -18,7 +15,6 @@ var CsvParser = function(type,text,options) {
 		options.separator = "\t";
 	}
 
-	// Table framework
 	this.tree = [{
 		"type": "scrollable", "children": [{
 			"type": "element", "tag": "table", "children": [{

--- a/core/modules/parsers/htmlparser.js
+++ b/core/modules/parsers/htmlparser.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/htmlparser.js
 type: application/javascript
 module-type: parser
-
-The HTML parser displays text as raw HTML
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/imageparser.js
+++ b/core/modules/parsers/imageparser.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/imageparser.js
 type: application/javascript
 module-type: parser
-
-The image parser parses an image into an embeddable HTML element
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -2,32 +2,10 @@
 title: $:/core/modules/utils/parseutils.js
 type: application/javascript
 module-type: utils
-
-Utility functions concerned with parsing text into tokens.
-
-Most functions have the following pattern:
-
-* The parameters are:
-** `source`: the source string being parsed
-** `pos`: the current parse position within the string
-** Any further parameters are used to identify the token that is being parsed
-* The return value is:
-** null if the token was not found at the specified position
-** an object representing the token with the following standard fields:
-*** `type`: string indicating the type of the token
-*** `start`: start position of the token in the source string
-*** `end`: end position of the token in the source string
-*** Any further fields required to describe the token
-
-The exception is `skipWhiteSpace`, which just returns the position after the whitespace.
-
 \*/
 
 "use strict";
 
-/*
-Look for a whitespace token. Returns null if not found, otherwise returns {type: "whitespace", start:, end:,}
-*/
 exports.parseWhiteSpace = function(source,pos) {
 	var p = pos,c;
 	while(true) {
@@ -49,9 +27,6 @@ exports.parseWhiteSpace = function(source,pos) {
 	}
 };
 
-/*
-Convenience wrapper for parseWhiteSpace. Returns the position after the whitespace
-*/
 exports.skipWhiteSpace = function(source,pos) {
 	var c;
 	while(true) {
@@ -64,9 +39,6 @@ exports.skipWhiteSpace = function(source,pos) {
 	}
 };
 
-/*
-Look for a given string token. Returns null if not found, otherwise returns {type: "token", value:, start:, end:,}
-*/
 exports.parseTokenString = function(source,pos,token) {
 	var match = source.indexOf(token,pos) === pos;
 	if(match) {
@@ -80,10 +52,6 @@ exports.parseTokenString = function(source,pos,token) {
 	return null;
 };
 
-/*
-Look for a token matching a regex. Returns null if not found, otherwise returns {type: "regexp", match:, start:, end:,}
-Use the "Y" (sticky) flag to avoid searching the entire rest of the string
-*/
 exports.parseTokenRegExp = function(source,pos,reToken) {
 	var node = {
 		type: "regexp",
@@ -99,9 +67,6 @@ exports.parseTokenRegExp = function(source,pos,reToken) {
 	}
 };
 
-/*
-Look for a string literal. Returns null if not found, otherwise returns {type: "string", value:, start:, end:,}
-*/
 exports.parseStringLiteral = function(source,pos) {
 	var node = {
 		type: "string",
@@ -122,10 +87,6 @@ exports.parseStringLiteral = function(source,pos) {
 	}
 };
 
-/*
-Returns an array of {name:} with an optional "default" property. Options include:
-requireParenthesis: require the parameter definition to be wrapped in parenthesis
-*/
 exports.parseParameterDefinition = function(paramString,options) {
 	options = options || {};
 	if(options.requireParenthesis) {
@@ -172,9 +133,6 @@ exports.parseMacroParameters = function(node,source,pos) {
 	return node;
 }
 
-/*
-Look for a macro invocation parameter. Returns null if not found, or {type: "macro-parameter", name:, value:, start:, end:}
-*/
 exports.parseMacroParameter = function(source,pos) {
 	var node = {
 		type: "macro-parameter",
@@ -205,14 +163,11 @@ exports.parseMacroParameter = function(source,pos) {
 	if(token.match[1]) {
 		node.name = token.match[1];
 	}
-	// Update the end position
+
 	node.end = pos;
 	return node;
 };
 
-/*
-Look for a macro invocation. Returns null if not found, or {type: "transclude", attributes:, start:, end:}
-*/
 exports.parseMacroInvocationAsTransclusion = function(source,pos) {
 	var node = {
 		type: "transclude",
@@ -241,7 +196,7 @@ exports.parseMacroInvocationAsTransclusion = function(source,pos) {
 	if(!$tw.utils.parseWhiteSpace(source,pos) && !(source.charAt(pos) === ">" && source.charAt(pos + 1) === ">") ) {
 		return null;
 	}
-	// Process attributes
+
 	pos = $tw.utils.parseMacroParametersAsAttributes(node,source,pos);
 	// Skip whitespace
 	pos = $tw.utils.skipWhiteSpace(source,pos);
@@ -254,10 +209,6 @@ exports.parseMacroInvocationAsTransclusion = function(source,pos) {
 	return node;
 };
 
-/*
-Look for an MVV (multi-valued variable) reference as a transclusion, i.e. ((varname)) or ((varname params))
-Returns null if not found, or a parse tree node of type "transclude" with isMVV: true
-*/
 exports.parseMVVReferenceAsTransclusion = function(source,pos) {
 	var node = {
 		type: "transclude",
@@ -294,9 +245,6 @@ exports.parseMVVReferenceAsTransclusion = function(source,pos) {
 	return node;
 };
 
-/*
-Parse macro parameters as attributes. Returns the position after the last attribute
-*/
 exports.parseMacroParametersAsAttributes = function(node,source,pos) {
 	var position = 0,
 		attribute = $tw.utils.parseMacroParameterAsAttribute(source,pos);
@@ -315,9 +263,6 @@ exports.parseMacroParametersAsAttributes = function(node,source,pos) {
 	return pos;
 };
 
-/*
-Parse a macro parameter as an attribute. Returns null if not found, otherwise returns {name:, type: "filtered|string|indirect|macro", value|filter|textReference:, start:, end:,}, with the name being optional
-*/
 exports.parseMacroParameterAsAttribute = function(source,pos) {
 	var node = {
 		start: pos
@@ -407,14 +352,11 @@ exports.parseMacroParameterAsAttribute = function(source,pos) {
 	if(!node.type) {
 		return null;
 	}
-	// Update the end position
+
 	node.end = pos;
 	return node;
 };
 
-/*
-Look for a macro invocation. Returns null if not found, or {type: "macrocall", name:, params:, start:, end:}
-*/
 exports.parseMacroInvocation = function(source,pos) {
 	var node = {
 		type: "macrocall",
@@ -465,7 +407,7 @@ exports.parseFilterVariable = function(source) {
 		node.name = source;
 		return node;
 	}
-	// Get the variable name
+
 	var nameMatch = $tw.utils.parseTokenRegExp(source,pos,reName);
 	if(nameMatch) {
 		node.name = nameMatch.match[1];
@@ -476,9 +418,6 @@ exports.parseFilterVariable = function(source) {
 	return node;
 };
 
-/*
-Look for an HTML attribute definition. Returns null if not found, otherwise returns {name:, type: "filtered|string|indirect|macro", value|filter|textReference:, start:, end:,}
-*/
 exports.parseAttribute = function(source,pos) {
 	var node = {
 		start: pos
@@ -569,7 +508,7 @@ exports.parseAttribute = function(source,pos) {
 		node.type = "string";
 		node.value = "true";
 	}
-	// Update the end position
+
 	node.end = pos;
 	return node;
 };

--- a/core/modules/parsers/pdfparser.js
+++ b/core/modules/parsers/pdfparser.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/pdfparser.js
 type: application/javascript
 module-type: parser
-
-The PDF parser embeds a PDF viewer
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/textparser.js
+++ b/core/modules/parsers/textparser.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/textparser.js
 type: application/javascript
 module-type: parser
-
-The plain text parser processes blocks of source text into a degenerate parse tree consisting of a single text node
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/videoparser.js
+++ b/core/modules/parsers/videoparser.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/videoparser.js
 type: application/javascript
 module-type: parser
-
-The video parser parses a video tiddler into an embeddable HTML element
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/codeblock.js
+++ b/core/modules/parsers/wikiparser/rules/codeblock.js
@@ -2,15 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/codeblock.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text rule for code blocks. For example:
-
-```
-	```
-	This text will not be //wikified//
-	```
-```
-
 \*/
 
 "use strict";
@@ -44,7 +35,7 @@ exports.parse = function() {
 		text = this.parser.source.substr(this.parser.pos);
 		this.parser.pos = this.parser.sourceLength;
 	}
-	// Return the $codeblock widget
+
 	return [{
 			type: "codeblock",
 			attributes: {

--- a/core/modules/parsers/wikiparser/rules/codeinline.js
+++ b/core/modules/parsers/wikiparser/rules/codeinline.js
@@ -2,14 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/codeinline.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for code runs. For example:
-
-```
-	This is a `code run`.
-	This is another ``code run``
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/commentblock.js
+++ b/core/modules/parsers/wikiparser/rules/commentblock.js
@@ -2,21 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/commentblock.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text block rule for HTML comments. For example:
-
-```
-<!-- This is a comment -->
-\define macroX()
-<!-- This is a comment -->
-xxxx
-\end
-<!-- This is a comment -->
-
-```
-
-Note that the syntax for comments is simplified to an opening "<!--" sequence and a closing "-->" sequence -- HTML itself implements a more complex format (see http://ostermiller.org/findhtmlcomment.html)
-
 \*/
 
 "use strict";
@@ -42,7 +27,6 @@ exports.findNextMatch = function(startPos) {
 	}
 	return undefined;
 };
-
 
 exports.parse = function() {
 	// Move past the match

--- a/core/modules/parsers/wikiparser/rules/commentinline.js
+++ b/core/modules/parsers/wikiparser/rules/commentinline.js
@@ -2,15 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/commentinline.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for HTML comments. For example:
-
-```
-<!-- This is a comment -->
-```
-
-Note that the syntax for comments is simplified to an opening "<!--" sequence and a closing "-->" sequence -- HTML itself implements a more complex format (see http://ostermiller.org/findhtmlcomment.html)
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/conditional.js
+++ b/core/modules/parsers/wikiparser/rules/conditional.js
@@ -2,13 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/conditional.js
 type: application/javascript
 module-type: wikirule
-
-Conditional shortcut syntax
-
-```
-This is a <%if [{something}] %>Elephant<%elseif [{else}] %>Pelican<%else%>Crocodile<%endif%>
-```
-
 \*/
 "use strict";
 
@@ -30,20 +23,17 @@ exports.findNextMatch = function(startPos) {
 	if(!this.match) {
 		return undefined;
 	}
-	// Check for the next %>
+
 	this.terminateIfRegExp.lastIndex = this.match.index;
 	this.terminateIfMatch = this.terminateIfRegExp.exec(this.parser.source);
 	// If not found then return no match
 	if(!this.terminateIfMatch) {
 		return undefined;
 	}
-	// Return the position at which the construction was found
+
 	return this.match.index;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Get the filter condition
 	var filterCondition = this.parser.source.substring(this.match.index + this.match[0].length,this.terminateIfMatch.index);
@@ -84,7 +74,7 @@ exports.parseIfClause = function(filterCondition) {
 		var reEnd = new RegExp(reEndString,"mg");
 		ex = this.parser.parseInlineRunTerminatedExtended(reEnd,{eatTerminator: true});
 	}
-	// Put the body into the list template
+
 	listWidget.children[0].children = ex.tree;
 	// Check for an else or elseif
 	if(ex.match) {
@@ -102,13 +92,13 @@ exports.parseIfClause = function(filterCondition) {
 				var reEnd = new RegExp(reEndString,"mg");
 				ex = this.parser.parseInlineRunTerminatedExtended(reEnd,{eatTerminator: true});
 			}
-			// Put the parsed content inside the list empty template
+
 			listWidget.children[1].children = ex.tree;
 		} else if(ex.match[3] === "elseif") {
 			// Parse the elseif clause by reusing this parser, passing the new filter condition
 			listWidget.children[1].children = this.parseIfClause(ex.match[4]);
 		}
 	}
-	// Return the parse tree node
+
 	return [listWidget];
 };

--- a/core/modules/parsers/wikiparser/rules/dash.js
+++ b/core/modules/parsers/wikiparser/rules/dash.js
@@ -2,15 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/dash.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for dashes. For example:
-
-```
-This is an en-dash: --
-
-This is an em-dash: ---
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/emphasis/bold.js
+++ b/core/modules/parsers/wikiparser/rules/emphasis/bold.js
@@ -2,20 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/emphasis/bold.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for emphasis - bold. For example:
-
-```
-	This is ''bold'' text
-```
-
-This wikiparser can be modified using the rules eg:
-
-```
-\rules except bold 
-\rules only bold 
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/emphasis/italic.js
+++ b/core/modules/parsers/wikiparser/rules/emphasis/italic.js
@@ -2,20 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/emphasis/italic.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for emphasis - italic. For example:
-
-```
-	This is //italic// text
-```
-
-This wikiparser can be modified using the rules eg:
-
-```
-\rules except italic
-\rules only italic
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/emphasis/strikethrough.js
+++ b/core/modules/parsers/wikiparser/rules/emphasis/strikethrough.js
@@ -2,20 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/emphasis/strikethrough.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for emphasis - strikethrough. For example:
-
-```
-	This is ~~strikethrough~~ text
-```
-
-This wikiparser can be modified using the rules eg:
-
-```
-\rules except strikethrough 
-\rules only strikethrough 
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/emphasis/subscript.js
+++ b/core/modules/parsers/wikiparser/rules/emphasis/subscript.js
@@ -2,20 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/emphasis/subscript.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for emphasis - subscript. For example:
-
-```
-	This is ,,subscript,, text
-```
-
-This wikiparser can be modified using the rules eg:
-
-```
-\rules except subscript 
-\rules only subscript 
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/emphasis/superscript.js
+++ b/core/modules/parsers/wikiparser/rules/emphasis/superscript.js
@@ -2,20 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/emphasis/superscript.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for emphasis - superscript. For example:
-
-```
-	This is ^^superscript^^ text
-```
-
-This wikiparser can be modified using the rules eg:
-
-```
-\rules except superscript 
-\rules only superscript 
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/emphasis/underscore.js
+++ b/core/modules/parsers/wikiparser/rules/emphasis/underscore.js
@@ -2,20 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/emphasis/underscore.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for emphasis - underscore. For example:
-
-```
-	This is __underscore__ text
-```
-
-This wikiparser can be modified using the rules eg:
-
-```
-\rules except underscore 
-\rules only underscore
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/entity.js
+++ b/core/modules/parsers/wikiparser/rules/entity.js
@@ -2,13 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/entity.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for HTML entities. For example:
-
-```
-	This is a copyright symbol: &copy;
-```
-
 \*/
 
 "use strict";
@@ -22,9 +15,6 @@ exports.init = function(parser) {
 	this.matchRegExp = /(&#?[a-zA-Z0-9]{2,8};)/mg;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Get all the details of the match
 	var entityString = this.match[1];

--- a/core/modules/parsers/wikiparser/rules/extlink.js
+++ b/core/modules/parsers/wikiparser/rules/extlink.js
@@ -2,17 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/extlink.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for external links. For example:
-
-```
-An external link: https://www.tiddlywiki.com/
-
-A suppressed external link: ~http://www.tiddlyspace.com/
-```
-
-External links can be suppressed by preceding them with `~`.
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js
@@ -2,17 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/filteredtranscludeblock.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text rule for block-level filtered transclusion. For example:
-
-```
-{{{ [tag[docs]] }}}
-{{{ [tag[docs]] |tooltip}}}
-{{{ [tag[docs]] ||TemplateTitle}}}
-{{{ [tag[docs]] |tooltip||TemplateTitle}}}
-{{{ [tag[docs]] }}width:40;height:50;}.class.class
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js
@@ -2,17 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/filteredtranscludeinline.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text rule for inline filtered transclusion. For example:
-
-```
-{{{ [tag[docs]] }}}
-{{{ [tag[docs]] |tooltip}}}
-{{{ [tag[docs]] ||TemplateTitle}}}
-{{{ [tag[docs]] |tooltip||TemplateTitle}}}
-{{{ [tag[docs]] }}width:40;height:50;}.class.class
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/fnprocdef.js
+++ b/core/modules/parsers/wikiparser/rules/fnprocdef.js
@@ -2,23 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/fnprocdef.js
 type: application/javascript
 module-type: wikirule
-
-Wiki pragma rule for function, procedure and widget definitions
-
-```
-\function name(param:"defaultvalue", param2:"defaultvalue")
-definition text
-\end
-
-\procedure name(param:"defaultvalue", param2:"defaultvalue")
-definition text
-\end
-
-\widget $mywidget(param:"defaultvalue", param2:"defaultvalue")
-definition text
-\end
-```
-
 \*/
 
 "use strict";
@@ -26,18 +9,12 @@ definition text
 exports.name = "fnprocdef";
 exports.types = {pragma: true};
 
-/*
-Instantiate parse rule
-*/
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
 	this.matchRegExp = /\\(function|procedure|widget)\s+([^(\s]+)\((\s*([^)]*(?:\)\)[^)]*)*))?\)(\s*\r?\n)?/mg;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Move past the macro name and parameters
 	this.parser.pos = this.matchRegExp.lastIndex;
@@ -46,7 +23,7 @@ exports.parse = function() {
 	if(this.match[3]) {
 		params = $tw.utils.parseParameterDefinition(this.match[4]);
 	}
-	// Is the remainder of the line blank after the parameter close paren?
+
 	var reEnd;
 	if(this.match[5]) {
 		// If so, it is a multiline definition and the end of the body is marked with \end
@@ -57,7 +34,7 @@ exports.parse = function() {
 		// Move past any whitespace
 		this.parser.pos = $tw.utils.skipWhiteSpace(this.parser.source,this.parser.pos);
 	}
-	// Find the end of the definition
+
 	reEnd.lastIndex = this.parser.pos;
 	var text,
 		endMatch = reEnd.exec(this.parser.source);
@@ -68,7 +45,7 @@ exports.parse = function() {
 		// We didn't find the end of the definition, so we'll make it blank
 		text = "";
 	}
-	// Save the macro definition
+
 	var parseTreeNodes = [{
 		type: "set",
 		attributes: {},

--- a/core/modules/parsers/wikiparser/rules/hardlinebreaks.js
+++ b/core/modules/parsers/wikiparser/rules/hardlinebreaks.js
@@ -2,20 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/hardlinebreaks.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for marking areas with hard line breaks. For example:
-
-```
-"""
-This is some text
-That is set like
-It is a Poem
-When it is
-Clearly
-Not
-"""
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/heading.js
+++ b/core/modules/parsers/wikiparser/rules/heading.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/heading.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text block rule for headings
-
 \*/
 
 "use strict";
@@ -18,9 +15,6 @@ exports.init = function(parser) {
 	this.matchRegExp = /(!{1,6})/mg;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Get all the details of the match
 	var headingLevel = this.match[1].length;

--- a/core/modules/parsers/wikiparser/rules/horizrule.js
+++ b/core/modules/parsers/wikiparser/rules/horizrule.js
@@ -2,13 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/horizrule.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text block rule for rules. For example:
-
-```
----
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/html.js
+++ b/core/modules/parsers/wikiparser/rules/html.js
@@ -2,20 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/html.js
 type: application/javascript
 module-type: wikirule
-
-Wiki rule for HTML elements and widgets. For example:
-
-{{{
-<aside>
-This is an HTML5 aside element
-</aside>
-
-<$slider target="MyTiddler">
-This is a widget invocation
-</$slider>
-
-}}}
-
 \*/
 
 "use strict";
@@ -35,9 +21,6 @@ exports.findNextMatch = function(startPos) {
 	return this.nextTag ? this.nextTag.start : undefined;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Retrieve the most recent match so that recursive calls don't overwrite it
 	var tag = this.nextTag;
@@ -83,13 +66,10 @@ exports.parse = function() {
 			}
 		}
 	}
-	// Return the tag
+
 	return [tag];
 };
 
-/*
-Look for an HTML tag. Returns null if not found, otherwise returns {type: "element", name:, attributes: {}, orderedAttributes: [], isSelfClosing:, start:, end:,}
-*/
 exports.parseTag = function(source,pos,options) {
 	options = options || {};
 	var token,
@@ -123,7 +103,7 @@ exports.parseTag = function(source,pos,options) {
 	if(!$tw.utils.parseWhiteSpace(source,pos) && !(source.charAt(pos) === "/") && !(source.charAt(pos) === ">") ) {
 		return null;
 	}
-	// Process attributes
+
 	var attribute = $tw.utils.parseAttribute(source,pos);
 	while(attribute) {
 		node.orderedAttributes.push(attribute);
@@ -132,7 +112,7 @@ exports.parseTag = function(source,pos,options) {
 		// Get the next attribute
 		attribute = $tw.utils.parseAttribute(source,pos);
 	}
-	// Skip whitespace
+
 	pos = $tw.utils.skipWhiteSpace(source,pos);
 	// Look for a closing slash
 	token = $tw.utils.parseTokenString(source,pos,"/");
@@ -140,7 +120,7 @@ exports.parseTag = function(source,pos,options) {
 		pos = token.end;
 		node.isSelfClosing = true;
 	}
-	// Look for a greater than sign
+
 	token = $tw.utils.parseTokenString(source,pos,">");
 	if(!token) {
 		return null;
@@ -153,7 +133,7 @@ exports.parseTag = function(source,pos,options) {
 			return null;
 		}
 	}
-	// Update the end position
+
 	node.end = pos;
 	return node;
 };
@@ -171,11 +151,11 @@ exports.findNextTag = function(source,pos,options) {
 		if(tag && this.isLegalTag(tag)) {
 			return tag;
 		}
-		// Look for the next match
+
 		reLookahead.lastIndex = match.index + 1;
 		match = reLookahead.exec(source);
 	}
-	// Failed
+
 	return null;
 };
 

--- a/core/modules/parsers/wikiparser/rules/image.js
+++ b/core/modules/parsers/wikiparser/rules/image.js
@@ -2,20 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/image.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for embedding images. For example:
-
-```
-[img[https://tiddlywiki.com/fractalveg.jpg]]
-[img width=23 height=24 [https://tiddlywiki.com/fractalveg.jpg]]
-[img width={{!!width}} height={{!!height}} [https://tiddlywiki.com/fractalveg.jpg]]
-[img[Description of image|https://tiddlywiki.com/fractalveg.jpg]]
-[img[TiddlerTitle]]
-[img[Description of image|TiddlerTitle]]
-```
-
-Generates the `<$image>` widget.
-
 \*/
 
 "use strict";
@@ -43,9 +29,6 @@ exports.parse = function() {
 	return [node];
 };
 
-/*
-Find the next image from the current position
-*/
 exports.findNextImage = function(source,pos) {
 	// A regexp for finding candidate HTML tags
 	var reLookahead = /(\[img)/g;
@@ -59,17 +42,14 @@ exports.findNextImage = function(source,pos) {
 		if(tag) {
 			return tag;
 		}
-		// Look for the next match
+
 		reLookahead.lastIndex = match.index + 1;
 		match = reLookahead.exec(source);
 	}
-	// Failed
+
 	return null;
 };
 
-/*
-Look for an image at the specified position. Returns null if not found, otherwise returns {type: "image", attributes: [], isSelfClosing:, start:, end:,}
-*/
 exports.parseImage = function(source,pos) {
 	var token,
 		node = {
@@ -102,7 +82,7 @@ exports.parseImage = function(source,pos) {
 			}
 		}
 	}
-	// Skip whitespace
+
 	pos = $tw.utils.skipWhiteSpace(source,pos);
 	// Look for the `[` after the attributes
 	token = $tw.utils.parseTokenString(source,pos,"[");

--- a/core/modules/parsers/wikiparser/rules/import.js
+++ b/core/modules/parsers/wikiparser/rules/import.js
@@ -2,13 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/import.js
 type: application/javascript
 module-type: wikirule
-
-Wiki pragma rule for importing variable definitions
-
-```
-\import [[$:/core/ui/PageMacros]] [all[shadows+tiddlers]tag[$:/tags/Macro]!has[draft.of]]
-```
-
 \*/
 
 "use strict";
@@ -16,18 +9,12 @@ Wiki pragma rule for importing variable definitions
 exports.name = "import";
 exports.types = {pragma: true};
 
-/*
-Instantiate parse rule
-*/
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
 	this.matchRegExp = /\\import[^\S\n]/mg;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	var self = this;
 	// Move past the pragma invocation

--- a/core/modules/parsers/wikiparser/rules/list.js
+++ b/core/modules/parsers/wikiparser/rules/list.js
@@ -2,43 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/list.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text block rule for lists. For example:
-
-```
-* This is an unordered list
-* It has two items
-
-# This is a numbered list
-## With a subitem
-# And a third item
-
-; This is a term that is being defined
-: This is the definition of that term
-```
-
-Note that lists can be nested arbitrarily:
-
-```
-#** One
-#* Two
-#** Three
-#**** Four
-#**# Five
-#**## Six
-## Seven
-### Eight
-## Nine
-```
-
-A CSS class can be applied to a list item as follows:
-
-```
-* List item one
-*.active List item two has the class `active`
-* List item three
-```
-
 \*/
 
 "use strict";
@@ -61,9 +24,6 @@ var listTypes = {
 };
 exports.listTypes = listTypes;
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Array of parse tree nodes for the previous row of the list
 	var listStack = [];
@@ -77,12 +37,12 @@ exports.parse = function() {
 		if(!match || match.index !== this.parser.pos) {
 			break;
 		}
-		// Check whether the list type of the top level matches
+
 		var listInfo = listTypes[match[0].charAt(0)];
 		if(listStack.length > 0 && listStack[0].tag !== listInfo.listTag) {
 			break;
 		}
-		// Move past the list marker
+
 		this.parser.pos = match.index + match[0].length;
 		// Walk through the list markers for the current row
 		for(var t=0; t<match[0].length; t++) {
@@ -91,7 +51,7 @@ exports.parse = function() {
 			if(listStack.length > t && listStack[t].tag !== listInfo.listTag) {
 				listStack.splice(t,listStack.length - t);
 			}
-			// Construct the list element or reuse the previous one at this level
+
 			if(listStack.length <= t) {
 				var listElement = {
 					type: "element",
@@ -113,7 +73,7 @@ exports.parse = function() {
 					var prevListItem = listStack[t-1].children[listStack[t-1].children.length-1];
 					prevListItem.children.push(listElement);
 				}
-				// Save this element in the stack
+
 				listStack[t] = listElement;
 			} else if(t === (match[0].length - 1)) {
 				listStack[t].children.push({
@@ -128,7 +88,7 @@ exports.parse = function() {
 		if(listStack.length > match[0].length) {
 			listStack.splice(match[0].length,listStack.length - match[0].length);
 		}
-		// Process the body of the list item into the last list item
+
 		var classStart = this.parser.pos;
 		var lastListChildren = listStack[listStack.length-1].children,
 			lastListItem = lastListChildren[lastListChildren.length-1],
@@ -144,9 +104,9 @@ exports.parse = function() {
 			lastListItem.attributes.class.start = classStart;
 			lastListItem.attributes.class.end = classEnd;
 		}
-		// Consume any whitespace following the list item
+
 		this.parser.skipWhitespace();
 	}
-	// Return the root element of the list
+
 	return [listStack[0]];
 };

--- a/core/modules/parsers/wikiparser/rules/macrocallblock.js
+++ b/core/modules/parsers/wikiparser/rules/macrocallblock.js
@@ -2,13 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/macrocallblock.js
 type: application/javascript
 module-type: wikirule
-
-Wiki rule for block macro calls
-
-```
-<<name value value2>>
-```
-
 \*/
 
 "use strict";
@@ -28,7 +21,7 @@ exports.findNextMatch = function(startPos) {
 		if(nextCall) {
 			var c = this.parser.source.charAt(nextCall.end);
 			// Ensure EOL after parsed macro
-			// If we didn't need to support IE, we'd just use /(?:\r?\n|$)/ym
+
 			if((c === "") || (c === "\n") || ((c === "\r") && this.parser.source.charAt(nextCall.end+1) === "\n")) {
 				this.nextCall = nextCall;
 				return nextStart;
@@ -39,9 +32,6 @@ exports.findNextMatch = function(startPos) {
 	return undefined;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	var call = this.nextCall;
 	call.isBlock = true;

--- a/core/modules/parsers/wikiparser/rules/macrocallinline.js
+++ b/core/modules/parsers/wikiparser/rules/macrocallinline.js
@@ -2,13 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/macrocallinline.js
 type: application/javascript
 module-type: wikirule
-
-Wiki rule for macro calls
-
-```
-<<name value value2>>
-```
-
 \*/
 
 "use strict";
@@ -33,14 +26,9 @@ exports.findNextMatch = function(startPos) {
 	return undefined;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	var call = this.nextCall;
 	this.nextCall = null;
 	this.parser.pos = call.end;
 	return [call];
 };
-
-

--- a/core/modules/parsers/wikiparser/rules/macrodef.js
+++ b/core/modules/parsers/wikiparser/rules/macrodef.js
@@ -2,15 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/macrodef.js
 type: application/javascript
 module-type: wikirule
-
-Wiki pragma rule for macro definitions
-
-```
-\define name(param:defaultvalue,param2:defaultvalue)
-definition text, including $param$ markers
-\end
-```
-
 \*/
 
 "use strict";
@@ -18,18 +9,12 @@ definition text, including $param$ markers
 exports.name = "macrodef";
 exports.types = {pragma: true};
 
-/*
-Instantiate parse rule
-*/
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
 	this.matchRegExp = /\\define\s+([^(\s]+)\(\s*([^)]*)\)(\s*\r?\n)?/mg;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Move past the macro name and parameters
 	this.parser.pos = this.matchRegExp.lastIndex;
@@ -51,7 +36,7 @@ exports.parse = function() {
 			paramMatch = reParam.exec(paramString);
 		}
 	}
-	// Is the remainder of the \define line blank after the parameter close paren?
+
 	var reEnd,isBlock = true;
 	if(this.match[3]) {
 		// If so, it is a multiline definition and the end of the body is marked with \end
@@ -63,7 +48,7 @@ exports.parse = function() {
 		// Move past any whitespace
 		this.parser.pos = $tw.utils.skipWhiteSpace(this.parser.source,this.parser.pos);
 	}
-	// Find the end of the definition
+
 	reEnd.lastIndex = this.parser.pos;
 	var text,
 		endMatch = reEnd.exec(this.parser.source);
@@ -74,7 +59,7 @@ exports.parse = function() {
 		// We didn't find the end of the definition, so we'll make it blank
 		text = "";
 	}
-	// Save the macro definition
+
 	var parseTreeNodes = [{
 		type: "set",
 		attributes: {},

--- a/core/modules/parsers/wikiparser/rules/mvvdisplayinline.js
+++ b/core/modules/parsers/wikiparser/rules/mvvdisplayinline.js
@@ -2,14 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/mvvdisplayinline.js
 type: application/javascript
 module-type: wikirule
-
-Wiki rule for inline display of multi-valued variables and filter results.
-
-Variable display: ((varname)) or ((varname||separator))
-Filter display: (((filter))) or (((filter||separator)))
-
-The default separator is ", " (comma space).
-
 \*/
 
 "use strict";
@@ -70,9 +62,6 @@ exports.findNextMatch = function(startPos) {
 	return undefined;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	var match = this.nextMatch;
 	this.nextMatch = null;

--- a/core/modules/parsers/wikiparser/rules/parameters.js
+++ b/core/modules/parsers/wikiparser/rules/parameters.js
@@ -2,14 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/parameters.js
 type: application/javascript
 module-type: wikirule
-
-Wiki pragma rule for parameter definitions
-
-```
-\parameters(param:defaultvalue,param2:defaultvalue)
-definition text
-```
-
 \*/
 
 "use strict";
@@ -17,18 +9,12 @@ definition text
 exports.name = "parameters";
 exports.types = {pragma: true};
 
-/*
-Instantiate parse rule
-*/
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
 	this.matchRegExp = /\\parameters\s*\(([^)]*)\)(\s*\r?\n)?/mg;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Move past the macro name and parameters
 	this.parser.pos = this.matchRegExp.lastIndex;

--- a/core/modules/parsers/wikiparser/rules/parsermode.js
+++ b/core/modules/parsers/wikiparser/rules/parsermode.js
@@ -2,14 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/parsermode.js
 type: application/javascript
 module-type: wikirule
-
-Wiki pragma rule for parser mode specifications
-
-```
-\parsermode block
-\parsermode inline
-```
-
 \*/
 
 "use strict";
@@ -17,18 +9,12 @@ Wiki pragma rule for parser mode specifications
 exports.name = "parsermode";
 exports.types = {pragma: true};
 
-/*
-Instantiate parse rule
-*/
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
 	this.matchRegExp = /\\parsermode[^\S\n]/mg;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Move past the pragma invocation
 	var start = this.parser.pos;

--- a/core/modules/parsers/wikiparser/rules/prettyextlink.js
+++ b/core/modules/parsers/wikiparser/rules/prettyextlink.js
@@ -2,14 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/prettyextlink.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for external links. For example:
-
-```
-[ext[https://tiddlywiki.com/fractalveg.jpg]]
-[ext[Tooltip|https://tiddlywiki.com/fractalveg.jpg]]
-```
-
 \*/
 
 "use strict";
@@ -33,9 +25,6 @@ exports.parse = function() {
 	return [this.nextLink];
 };
 
-/*
-Find the next link from the current position
-*/
 exports.findNextLink = function(source,pos) {
 	// A regexp for finding candidate links
 	var reLookahead = /(\[ext\[)/g;
@@ -49,17 +38,14 @@ exports.findNextLink = function(source,pos) {
 		if(link) {
 			return link;
 		}
-		// Look for the next match
+
 		reLookahead.lastIndex = match.index + 1;
 		match = reLookahead.exec(source);
 	}
-	// Failed
+
 	return null;
 };
 
-/*
-Look for an link at the specified position. Returns null if not found, otherwise returns {type: "element", tag: "a", attributes: [], isSelfClosing:, start:, end:,}
-*/
 exports.parseLink = function(source,pos) {
 	var token,
 		textNode = {
@@ -87,12 +73,12 @@ exports.parseLink = function(source,pos) {
 	if(closePos === -1) {
 		return null;
 	}
-	// Look for a `|` separating the tooltip
+
 	var splitPos = source.indexOf("|",pos);
 	if(splitPos === -1 || splitPos > closePos) {
 		splitPos = null;
 	}
-	// Pull out the tooltip and URL
+
 	var tooltip, URL, urlStart;
 	textNode.start = pos;
 	if(splitPos) {
@@ -113,5 +99,3 @@ exports.parseLink = function(source,pos) {
 	node.end = closePos + 2;
 	return node;
 };
-
-

--- a/core/modules/parsers/wikiparser/rules/prettylink.js
+++ b/core/modules/parsers/wikiparser/rules/prettylink.js
@@ -2,15 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/prettylink.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for pretty links. For example:
-
-```
-[[Introduction]]
-
-[[Link description|TiddlerTitle]]
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/quoteblock.js
+++ b/core/modules/parsers/wikiparser/rules/quoteblock.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/quoteblock.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text rule for quote blocks.
-
 \*/
 
 "use strict";
@@ -44,7 +41,7 @@ exports.parse = function() {
 			end: citeEnd
 		});
 	}
-	// Parse any optional cite
+
 	this.parser.skipWhitespace({treatNewlinesAsNonWhitespace: true});
 	citeStart = this.parser.pos;
 	cite = this.parser.parseInlineRun(/(\r?\n)/mg);
@@ -59,7 +56,7 @@ exports.parse = function() {
 			end: citeEnd
 		});
 	}
-	// Return the blockquote element
+
 	return [{
 		type: "element",
 		tag: "blockquote",

--- a/core/modules/parsers/wikiparser/rules/rules.js
+++ b/core/modules/parsers/wikiparser/rules/rules.js
@@ -2,14 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/rules.js
 type: application/javascript
 module-type: wikirule
-
-Wiki pragma rule for rules specifications
-
-```
-\rules except ruleone ruletwo rulethree
-\rules only ruleone ruletwo rulethree
-```
-
 \*/
 
 "use strict";
@@ -17,18 +9,12 @@ Wiki pragma rule for rules specifications
 exports.name = "rules";
 exports.types = {pragma: true};
 
-/*
-Instantiate parse rule
-*/
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
 	this.matchRegExp = /\\rules[^\S\n]/mg;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Move past the pragma invocation
 	this.parser.pos = this.matchRegExp.lastIndex;

--- a/core/modules/parsers/wikiparser/rules/styleblock.js
+++ b/core/modules/parsers/wikiparser/rules/styleblock.js
@@ -2,29 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/styleblock.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text block rule for assigning styles and classes to paragraphs and other blocks. For example:
-
-```
-@@.myClass
-@@background-color:red;
-This paragraph will have the CSS class `myClass`.
-
-* The `<ul>` around this list will also have the class `myClass`
-* List item 2
-
-@@
-```
-
-Note that classes and styles can be mixed subject to the rule that styles must precede classes. For example
-
-```
-@@.myFirstClass.mySecondClass
-@@width:100px;.myThirdClass
-This is a paragraph
-@@
-```
-
 \*/
 
 "use strict";
@@ -49,7 +26,7 @@ exports.parse = function() {
 		if(this.match[2]) {
 			classes.push(this.match[2].split(".").join(" "));
 		}
-		// Move past the match
+
 		this.parser.pos = this.matchRegExp.lastIndex;
 		// Look for another line of classes and styles
 		this.match = this.matchRegExp.exec(this.parser.source);

--- a/core/modules/parsers/wikiparser/rules/styleinline.js
+++ b/core/modules/parsers/wikiparser/rules/styleinline.js
@@ -2,16 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/styleinline.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for assigning styles and classes to inline runs. For example:
-
-```
-@@.myClass This is some text with a class@@
-@@background-color:red;This is some text with a background colour@@
-@@width:100px;.myClass This is some text with a class and a width@@
-```
-
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/syslink.js
+++ b/core/modules/parsers/wikiparser/rules/syslink.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/syslink.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for system tiddler links.
-Can be suppressed preceding them with `~`.
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/table.js
+++ b/core/modules/parsers/wikiparser/rules/table.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/table.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text block rule for tables.
-
 \*/
 
 "use strict";
@@ -43,7 +40,7 @@ var processRow = function(prevColumns) {
 					colSpanCount = 1;
 				}
 			}
-			// Move to just before the `|` terminating the cell
+
 			this.parser.pos = cellRegExp.lastIndex - 1;
 		} else if(cellMatch[1] === ">") {
 			// Colspan
@@ -88,7 +85,7 @@ var processRow = function(prevColumns) {
 				this.parser.pos++;
 				chr = this.parser.source.substr(this.parser.pos,1);
 			}
-			// Check whether this is a heading cell
+
 			var cell;
 			var start = this.parser.pos;
 			if(chr === "!") {
@@ -106,7 +103,7 @@ var processRow = function(prevColumns) {
 				$tw.utils.addAttributeToParseTreeNode(cell,"colspan",colSpanCount);
 				colSpanCount = 1;
 			}
-			// Parse the cell
+
 			cell.children = this.parser.parseInlineRun(cellTermRegExp,{eatTerminator: true});
 			// Set the alignment for the cell
 			if(vAlign) {
@@ -117,7 +114,7 @@ var processRow = function(prevColumns) {
 			} else if(spaceLeft) {
 				$tw.utils.addAttributeToParseTreeNode(cell,"align","right");
 			}
-			// Move back to the closing `|`
+
 			this.parser.pos--;
 			cell.end = this.parser.pos;
 		}
@@ -153,7 +150,7 @@ exports.parse = function() {
 				table.children.push(rowContainer);
 				currRowType = rowType;
 			}
-			// Is this a caption row?
+
 			if(currRowType === "c") {
 				// If so, move past the opening `|` of the row
 				this.parser.pos++;

--- a/core/modules/parsers/wikiparser/rules/transcludeblock.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeblock.js
@@ -2,14 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/transcludeblock.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text rule for block-level transclusion. For example:
-
-```
-{{MyTiddler}}
-{{MyTiddler||TemplateTitle}}
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/transcludeinline.js
+++ b/core/modules/parsers/wikiparser/rules/transcludeinline.js
@@ -2,14 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/transcludeinline.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text rule for inline-level transclusion. For example:
-
-```
-{{MyTiddler}}
-{{MyTiddler||TemplateTitle}}
-```
-
 \*/
 
 "use strict";

--- a/core/modules/parsers/wikiparser/rules/typedblock.js
+++ b/core/modules/parsers/wikiparser/rules/typedblock.js
@@ -2,25 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/typedblock.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text rule for typed blocks. For example:
-
-```
-$$$.js
-This will be rendered as JavaScript
-$$$
-
-$$$.svg
-<svg xmlns="http://www.w3.org/2000/svg" width="150" height="100">
-  <circle cx="100" cy="50" r="40" stroke="black" stroke-width="2" fill="red" />
-</svg>
-$$$
-
-$$$text/vnd.tiddlywiki>text/html
-This will be rendered as an //HTML representation// of WikiText
-$$$
-```
-
 \*/
 
 "use strict";
@@ -56,7 +37,7 @@ exports.parse = function() {
 		text = this.parser.source.substr(this.parser.pos);
 		this.parser.pos = this.parser.sourceLength;
 	}
-	// Parse the block according to the specified type
+
 	var parser = this.parser.wiki.parseText(parseType,text,{defaultType: "text/plain"});
 	// If there's no render type, just return the parse tree
 	if(!renderType) {

--- a/core/modules/parsers/wikiparser/rules/whitespace.js
+++ b/core/modules/parsers/wikiparser/rules/whitespace.js
@@ -2,14 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/whitespace.js
 type: application/javascript
 module-type: wikirule
-
-Wiki pragma rule for whitespace specifications
-
-```
-\whitespace trim
-\whitespace notrim
-```
-
 \*/
 
 "use strict";
@@ -17,18 +9,12 @@ Wiki pragma rule for whitespace specifications
 exports.name = "whitespace";
 exports.types = {pragma: true};
 
-/*
-Instantiate parse rule
-*/
 exports.init = function(parser) {
 	this.parser = parser;
 	// Regexp to match
 	this.matchRegExp = /\\whitespace[^\S\n]/mg;
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	var self = this;
 	// Move past the pragma invocation

--- a/core/modules/parsers/wikiparser/rules/wikilink.js
+++ b/core/modules/parsers/wikiparser/rules/wikilink.js
@@ -2,17 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/wikilink.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for wiki links. For example:
-
-```
-AWikiLink
-AnotherLink
-~SuppressedLink
-```
-
-Precede a camel case word with `~` to prevent it from being recognised as a link.
-
 \*/
 
 "use strict";
@@ -26,9 +15,6 @@ exports.init = function(parser) {
 	this.matchRegExp = new RegExp($tw.config.textPrimitives.unWikiLink + "?" + $tw.config.textPrimitives.wikiLink,"mg");
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Get the details of the match
 	var linkText = this.match[0];
@@ -39,7 +25,7 @@ exports.parse = function() {
 	if(linkText.substr(0,1) === $tw.config.textPrimitives.unWikiLink) {
 		return [{type: "text", text: linkText.substr(1)}];
 	}
-	// If the link has been preceded with a blocked letter then don't treat it as a link
+
 	if(this.match.index > 0) {
 		var preRegExp = new RegExp($tw.config.textPrimitives.blockPrefixLetters,"mg");
 		preRegExp.lastIndex = this.match.index-1;

--- a/core/modules/parsers/wikiparser/rules/wikilinkprefix.js
+++ b/core/modules/parsers/wikiparser/rules/wikilinkprefix.js
@@ -2,13 +2,6 @@
 title: $:/core/modules/parsers/wikiparser/rules/wikilinkprefix.js
 type: application/javascript
 module-type: wikirule
-
-Wiki text inline rule for suppressed wiki links. For example:
-
-```
-~SuppressedLink
-```
-
 \*/
 
 "use strict";
@@ -22,9 +15,6 @@ exports.init = function(parser) {
 	this.matchRegExp = new RegExp($tw.config.textPrimitives.unWikiLink + $tw.config.textPrimitives.wikiLink,"mg");
 };
 
-/*
-Parse the most recent match
-*/
 exports.parse = function() {
 	// Get the details of the match
 	var linkText = this.match[0];

--- a/core/modules/parsers/wikiparser/wikiparser.js
+++ b/core/modules/parsers/wikiparser/wikiparser.js
@@ -2,35 +2,10 @@
 title: $:/core/modules/parsers/wikiparser/wikiparser.js
 type: application/javascript
 module-type: parser
-
-The wiki text parser processes blocks of source text into a parse tree.
-
-The parse tree is made up of nested arrays of these JavaScript objects:
-
-	{type: "element", tag: <string>, attributes: {}, children: []} - an HTML element
-	{type: "text", text: <string>} - a text node
-	{type: "entity", value: <string>} - an entity
-	{type: "raw", html: <string>} - raw HTML
-
-Attributes are stored as hashmaps of the following objects:
-
-	{type: "string", value: <string>} - literal string
-	{type: "indirect", textReference: <textReference>} - indirect through a text reference
-	{type: "macro", macro: <TBD>} - indirect through a macro invocation
-
 \*/
 
 "use strict";
 
-/*
-type: content type of text
-text: text to be parsed
-options: see below:
-	parseAsInline: true to parse text as inline instead of block
-	wiki: reference to wiki to use
-	_canonical_uri: optional URI of content if text is missing or empty
-	configTrimWhiteSpace: true to trim whitespace
-*/
 var WikiParser = function(type,text,options) {
 	this.wiki = options.wiki;
 	var self = this;
@@ -39,7 +14,7 @@ var WikiParser = function(type,text,options) {
 		this.loadRemoteTiddler(options._canonical_uri);
 		text = $tw.language.getRawString("LazyLoadingWarning");
 	}
-	// Save the parse text
+
 	this.type = type || "text/vnd.tiddlywiki";
 	this.source = text || "";
 	this.sourceLength = this.source.length;
@@ -75,7 +50,7 @@ var WikiParser = function(type,text,options) {
 		}
 		inlineRuleClasses = this.inlineRuleClasses;
 	}
-	// Instantiate the pragma parse rules
+
 	this.pragmaRules = this.instantiateRules(pragmaRuleClasses,"pragma",0);
 	// Instantiate the parser block and inline rules
 	this.blockRules = this.instantiateRules(blockRuleClasses,"block",0);
@@ -88,7 +63,7 @@ var WikiParser = function(type,text,options) {
 	} else {
 		topBranch.push.apply(topBranch,this.parseBlocks());
 	}
-	// Build rules' name map
+
 	this.usingRuleMap = {};
 	$tw.utils.each(this.pragmaRules, function (ruleInfo) { self.usingRuleMap[ruleInfo.rule.name] = Object.getPrototypeOf(ruleInfo.rule); });
 	$tw.utils.each(this.blockRules, function (ruleInfo) { self.usingRuleMap[ruleInfo.rule.name] = Object.getPrototypeOf(ruleInfo.rule); });
@@ -96,8 +71,6 @@ var WikiParser = function(type,text,options) {
 	// Return the parse tree
 };
 
-/*
-*/
 WikiParser.prototype.loadRemoteTiddler = function(url) {
 	var self = this;
 	$tw.utils.httpRequest({
@@ -117,8 +90,6 @@ WikiParser.prototype.loadRemoteTiddler = function(url) {
 	});
 };
 
-/*
-*/
 WikiParser.prototype.setupRules = function(proto,configPrefix) {
 	var self = this;
 	if(!$tw.safeMode) {
@@ -130,9 +101,6 @@ WikiParser.prototype.setupRules = function(proto,configPrefix) {
 	}
 };
 
-/*
-Instantiate an array of parse rules
-*/
 WikiParser.prototype.instantiateRules = function(classes,type,startPos) {
 	var rulesInfo = [],
 		self = this;
@@ -153,10 +121,6 @@ WikiParser.prototype.instantiateRules = function(classes,type,startPos) {
 	return rulesInfo;
 };
 
-/*
-Skip any whitespace at the current position. Options are:
-	treatNewlinesAsNonWhitespace: true if newlines are NOT to be treated as whitespace
-*/
 WikiParser.prototype.skipWhitespace = function(options) {
 	options = options || {};
 	var whitespaceRegExp = options.treatNewlinesAsNonWhitespace ? /([^\S\n]+)/mg : /(\s+)/mg;
@@ -167,9 +131,6 @@ WikiParser.prototype.skipWhitespace = function(options) {
 	}
 };
 
-/*
-Get the next match out of an array of parse rule instances
-*/
 WikiParser.prototype.findNextMatch = function(rules,startPos) {
 	// Find the best matching rule by finding the closest match position
 	var matchingRule,
@@ -190,9 +151,6 @@ WikiParser.prototype.findNextMatch = function(rules,startPos) {
 	return matchingRule;
 };
 
-/*
-Parse any pragmas at the beginning of a block of parse text
-*/
 WikiParser.prototype.parsePragmas = function() {
 	var currentTreeBranch = this.tree;
 	while(true) {
@@ -203,14 +161,14 @@ WikiParser.prototype.parsePragmas = function() {
 		if(this.pos >= this.sourceLength) {
 			break;
 		}
-		// Check if we've arrived at a pragma rule match
+
 		var nextMatch = this.findNextMatch(this.pragmaRules,this.pos);
 		// If not, just exit
 		if(!nextMatch || nextMatch.matchIndex !== this.pos) {
 			this.pos = savedPos;
 			break;
 		}
-		// Process the pragma rule
+
 		var start = this.pos;
 		var subTree = nextMatch.rule.parse();
 		if(subTree.length > 0) {
@@ -223,23 +181,19 @@ WikiParser.prototype.parsePragmas = function() {
 			subTree[0].children = [];
 			currentTreeBranch = subTree[0].children;
 		}
-		// Skip whitespace after the pragma
+
 		this.skipWhitespace();
 	}
 	return currentTreeBranch;
 };
 
-/*
-Parse a block from the current position
-	terminatorRegExpString: optional regular expression string that identifies the end of plain paragraphs. Must not include capturing parenthesis
-*/
 WikiParser.prototype.parseBlock = function(terminatorRegExpString) {
 	var terminatorRegExp = terminatorRegExpString ? new RegExp(terminatorRegExpString + "|\\r?\\n\\r?\\n","mg") : /(\r?\n\r?\n)/mg;
 	this.skipWhitespace();
 	if(this.pos >= this.sourceLength) {
 		return [];
 	}
-	// Look for a block rule that applies at the current position
+
 	var nextMatch = this.findNextMatch(this.blockRules,this.pos);
 	if(nextMatch && nextMatch.matchIndex === this.pos) {
 		var start = this.pos;
@@ -259,10 +213,6 @@ WikiParser.prototype.parseBlock = function(terminatorRegExpString) {
 	return [{type: "element", tag: "p", children: children, start: start, end: end, rule: "parseblock" }];
 };
 
-/*
-Parse a series of blocks of text until a terminating regexp is encountered or the end of the text
-	terminatorRegExpString: terminating regular expression
-*/
 WikiParser.prototype.parseBlocks = function(terminatorRegExpString) {
 	if(terminatorRegExpString) {
 		return this.parseBlocksTerminated(terminatorRegExpString);
@@ -271,9 +221,6 @@ WikiParser.prototype.parseBlocks = function(terminatorRegExpString) {
 	}
 };
 
-/*
-Parse a block from the current position to the end of the text
-*/
 WikiParser.prototype.parseBlocksUnterminated = function() {
 	var tree = [];
 	while(this.pos < this.sourceLength) {
@@ -282,17 +229,11 @@ WikiParser.prototype.parseBlocksUnterminated = function() {
 	return tree;
 };
 
-/*
-Parse blocks of text until a terminating regexp is encountered. Wrapper for parseBlocksTerminatedExtended that just returns the parse tree
-*/
 WikiParser.prototype.parseBlocksTerminated = function(terminatorRegExpString) {
 	var ex = this.parseBlocksTerminatedExtended(terminatorRegExpString);
 	return ex.tree;
 };
 
-/*
-Parse blocks of text until a terminating regexp is encountered
-*/
 WikiParser.prototype.parseBlocksTerminatedExtended = function(terminatorRegExpString) {
 	var terminatorRegExp = new RegExp(terminatorRegExpString,"mg"),
 		result = {
@@ -320,13 +261,6 @@ WikiParser.prototype.parseBlocksTerminatedExtended = function(terminatorRegExpSt
 	return result;
 };
 
-/*
-Parse a run of text at the current position
-	terminatorRegExp: a regexp at which to stop the run
-	options: see below
-Options available:
-	eatTerminator: move the parse position past any encountered terminator (default false)
-*/
 WikiParser.prototype.parseInlineRun = function(terminatorRegExp,options) {
 	if(terminatorRegExp) {
 		return this.parseInlineRunTerminated(terminatorRegExp,options);
@@ -423,7 +357,7 @@ WikiParser.prototype.parseInlineRunTerminatedExtended = function(terminatorRegEx
 			terminatorMatch = terminatorRegExp.exec(this.source);
 		}
 	}
-	// Process the remaining text
+
 	if(this.pos < this.sourceLength) {
 		this.pushTextWidget(tree,this.source.substr(this.pos),this.pos,this.sourceLength);
 	}
@@ -433,9 +367,6 @@ WikiParser.prototype.parseInlineRunTerminatedExtended = function(terminatorRegEx
 	};
 };
 
-/*
-Push a text widget onto an array, respecting the configTrimWhiteSpace setting
-*/
 WikiParser.prototype.pushTextWidget = function(array,text,start,end) {
 	if(this.configTrimWhiteSpace) {
 		text = $tw.utils.trim(text);
@@ -445,9 +376,6 @@ WikiParser.prototype.pushTextWidget = function(array,text,start,end) {
 	}
 };
 
-/*
-Parse zero or more class specifiers `.classname`
-*/
 WikiParser.prototype.parseClasses = function() {
 	var classRegExp = /\.([^\s\.]+)/mg,
 		classNames = [];
@@ -461,11 +389,6 @@ WikiParser.prototype.parseClasses = function() {
 	return classNames;
 };
 
-/*
-Amend the rules used by this instance of the parser
-	type: `only` keeps just the named rules, `except` keeps all but the named rules
-	names: array of rule names
-*/
 WikiParser.prototype.amendRules = function(type,names) {
 	names = names || [];
 	// Define the filter function
@@ -477,7 +400,7 @@ WikiParser.prototype.amendRules = function(type,names) {
 	} else {
 		return;
 	}
-	// Define a function to process each of our rule arrays
+
 	var processRuleArray = function(ruleArray) {
 		for(var t=ruleArray.length-1; t>=0; t--) {
 			if((names.indexOf(ruleArray[t].rule.name) === -1) === target) {

--- a/core/modules/parsers/wikiparser/wikirulebase.js
+++ b/core/modules/parsers/wikiparser/wikirulebase.js
@@ -2,29 +2,17 @@
 title: $:/core/modules/parsers/wikiparser/rules/wikirulebase.js
 type: application/javascript
 module-type: global
-
-Base class for wiki parser rules
-
 \*/
 
 "use strict";
 
-/*
-This constructor is always overridden with a blank constructor, and so shouldn't be used
-*/
 var WikiRuleBase = function() {
 };
 
-/*
-To be overridden by individual rules
-*/
 WikiRuleBase.prototype.init = function(parser) {
 	this.parser = parser;
 };
 
-/*
-Default implementation of findNextMatch uses RegExp matching
-*/
 WikiRuleBase.prototype.findNextMatch = function(startPos) {
 	this.matchRegExp.lastIndex = startPos;
 	this.match = this.matchRegExp.exec(this.parser.source);

--- a/core/modules/pluginswitcher.js
+++ b/core/modules/pluginswitcher.js
@@ -2,21 +2,10 @@
 title: $:/core/modules/pluginswitcher.js
 type: application/javascript
 module-type: global
-
-Manages switching plugins for themes and languages.
-
 \*/
 
 "use strict";
 
-/*
-options:
-wiki: wiki store to be used
-pluginType: type of plugin to be switched
-controllerTitle: title of tiddler used to control switching of this resource
-defaultPlugins: array of default plugins to be used if nominated plugin isn't found
-onSwitch: callback when plugin is switched (single parameter is array of plugin titles)
-*/
 function PluginSwitcher(options) {
 	this.wiki = options.wiki;
 	this.pluginType = options.pluginType;

--- a/core/modules/saver-handler.js
+++ b/core/modules/saver-handler.js
@@ -2,18 +2,10 @@
 title: $:/core/modules/saver-handler.js
 type: application/javascript
 module-type: global
-
-The saver handler tracks changes to the store and handles saving the entire wiki via saver modules.
-
 \*/
 
 "use strict";
 
-/*
-Instantiate the saver handler with the following options:
-wiki: wiki to be synced
-dirtyTracking: true if dirty tracking should be performed
-*/
 function SaverHandler(options) {
 	var self = this;
 	this.wiki = options.wiki;
@@ -26,7 +18,7 @@ function SaverHandler(options) {
 	if($tw.browser) {
 		this.initSavers();
 	}
-	// Only do dirty tracking if required
+
 	if($tw.browser && this.dirtyTracking) {
 		// Compile the dirty tiddler filter
 		this.filterFn = this.wiki.compileFilter(this.wiki.getTiddlerText(this.titleSyncFilter));
@@ -160,7 +152,7 @@ SaverHandler.prototype.saveWiki = function(options) {
 		return false;
 	}
 	var	variables = options.variables || {},
-		template = (options.template || 
+		template = (options.template ||
 		           wiki.getTiddlerText("$:/config/SaveWikiButton/Template","$:/core/save/all")).trim(),
 		downloadType = options.downloadType || "text/plain",
 		text = wiki.renderTiddler(downloadType,template,options),
@@ -190,16 +182,10 @@ SaverHandler.prototype.saveWiki = function(options) {
 	return false;
 };
 
-/*
-Checks whether the wiki is dirty (ie the window shouldn't be closed)
-*/
 SaverHandler.prototype.isDirty = function() {
 	return this.numChanges > 0;
 };
 
-/*
-Update the document body with the class "tc-dirty" if the wiki has unsaved/unsynced changes
-*/
 SaverHandler.prototype.updateDirtyStatus = function() {
 	var self = this;
 	if($tw.browser) {

--- a/core/modules/savers/andtidwiki.js
+++ b/core/modules/savers/andtidwiki.js
@@ -2,11 +2,7 @@
 title: $:/core/modules/savers/andtidwiki.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via the AndTidWiki Android app
-
 \*/
-
 
 "use strict";
 
@@ -45,7 +41,7 @@ AndTidWiki.prototype.save = function(text,method,callback,options) {
 		if(pathname.indexOf("file://") === 0) {
 			pathname = pathname.substr(7);
 		}
-		// Strip any query or location part
+
 		var p = pathname.indexOf("?");
 		if(p !== -1) {
 			pathname = pathname.substr(0,p);
@@ -54,33 +50,24 @@ AndTidWiki.prototype.save = function(text,method,callback,options) {
 		if(p !== -1) {
 			pathname = pathname.substr(0,p);
 		}
-		// Save the file
+
 		window.twi.saveFile(pathname,text);
 	}
-	// Call the callback
+
 	callback(null);
 	return true;
 };
 
-/*
-Information about this saver
-*/
 AndTidWiki.prototype.info = {
 	name: "andtidwiki",
 	priority: 1600,
 	capabilities: ["save", "autosave", "download"]
 };
 
-/*
-Static method that returns true if this saver is capable of working
-*/
 exports.canSave = function(wiki) {
 	return !!window.twi && !!window.twi.saveFile;
 };
 
-/*
-Create an instance of this saver
-*/
 exports.create = function(wiki) {
 	return new AndTidWiki(wiki);
 };

--- a/core/modules/savers/custom.js
+++ b/core/modules/savers/custom.js
@@ -2,12 +2,6 @@
 title: $:/core/modules/savers/custom.js
 type: application/javascript
 module-type: saver
-
-Looks for `window.$tw.customSaver` first on the current window, then
-on the parent window (of an iframe). If present, the saver must define
-	save: function(text,method,callback) { ... }
-and the saver may define
-	priority: number
 \*/
 
 "use strict";
@@ -17,7 +11,7 @@ var findSaver = function(window) {
 		return window && window.$tw && window.$tw.customSaver;
 	} catch (err) {
 		// Catching the exception is the most reliable way to detect cross-origin iframe errors.
-		// For example, instead of saying that `window.parent.$tw` is undefined, Firefox will throw
+
 		//   Uncaught DOMException: Permission denied to access property "$tw" on cross-origin object
 		console.log({ msg: "custom saver is disabled", reason: err });
 		return null;
@@ -32,25 +26,16 @@ CustomSaver.prototype.save = function(text,method,callback) {
 	return saver.save(text, method, callback);
 };
 
-/*
-Information about this saver
-*/
 CustomSaver.prototype.info = {
 	name: "custom",
 	priority: saver.priority || 4000,
 	capabilities: ["save","autosave"]
 };
 
-/*
-Static method that returns true if this saver is capable of working
-*/
 exports.canSave = function(wiki) {
 	return !!(saver.save);
 };
 
-/*
-Create an instance of this saver
-*/
 exports.create = function(wiki) {
 	return new CustomSaver(wiki);
 };

--- a/core/modules/savers/download.js
+++ b/core/modules/savers/download.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/savers/download.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via HTML5's download APIs
-
 \*/
 
 "use strict";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var DownloadSaver = function(wiki) {
 };
 
@@ -33,10 +27,10 @@ DownloadSaver.prototype.save = function(text,method,callback,options) {
 	if(!type) {
 		type = "text/html";
 	}
-	// Set up the link
+
 	var link = document.createElement("a");
 	// We prefer Blobs if they're available, unless we're dealing with a tiddler type declaring itself full of base64 encoded content.
-	// Then we use data urls, because browsers will know to decode the stream and download the actual binary file as intended.
+
 	if(Blob !== undefined && !type.includes(";base64")) {
 		var blob = new Blob([text], {type: type});
 		link.setAttribute("href", URL.createObjectURL(blob));
@@ -52,9 +46,6 @@ DownloadSaver.prototype.save = function(text,method,callback,options) {
 	return true;
 };
 
-/*
-Information about this saver
-*/
 DownloadSaver.prototype.info = {
 	name: "download",
 	priority: 100
@@ -70,16 +61,10 @@ Object.defineProperty(DownloadSaver.prototype.info, "capabilities", {
 	}
 });
 
-/*
-Static method that returns true if this saver is capable of working
-*/
 exports.canSave = function(wiki) {
 	return document.createElement("a").download !== undefined;
 };
 
-/*
-Create an instance of this saver
-*/
 exports.create = function(wiki) {
 	return new DownloadSaver(wiki);
 };

--- a/core/modules/savers/fsosaver.js
+++ b/core/modules/savers/fsosaver.js
@@ -2,19 +2,10 @@
 title: $:/core/modules/savers/fsosaver.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via MS FileSystemObject ActiveXObject
-
-Note: Since TiddlyWiki's markup contains the MOTW, the FileSystemObject normally won't be available. 
-However, if the wiki is loaded as an .HTA file (Windows HTML Applications) then the FSO can be used.
-
 \*/
 
 "use strict";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var FSOSaver = function(wiki) {
 };
 
@@ -33,7 +24,7 @@ FSOSaver.prototype.save = function(text,method,callback) {
 	} else {
 		return false;
 	}
-	// Save the file (as UTF-16)
+
 	var fso = new ActiveXObject("Scripting.FileSystemObject");
 	var file = fso.OpenTextFile(pathname,2,-1,-1);
 	file.Write(text);
@@ -43,27 +34,18 @@ FSOSaver.prototype.save = function(text,method,callback) {
 	return true;
 };
 
-/*
-Information about this saver
-*/
 FSOSaver.prototype.info = {
 	name: "FSOSaver",
 	priority: 120,
 	capabilities: ["save", "autosave"]
 };
 
-/*
-Static method that returns true if this saver is capable of working
-*/
 exports.canSave = function(wiki) {
 	try {
 		return (window.location.protocol === "file:") && !!(new ActiveXObject("Scripting.FileSystemObject"));
 	} catch(e) { return false; }
 };
 
-/*
-Create an instance of this saver
-*/
 exports.create = function(wiki) {
 	return new FSOSaver(wiki);
 };

--- a/core/modules/savers/gitea.js
+++ b/core/modules/savers/gitea.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/savers/gitea.js
 type: application/javascript
 module-type: saver
-
-Saves wiki by pushing a commit to the gitea
-
 \*/
 
 "use strict";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var GiteaSaver = function(wiki) {
 	this.wiki = wiki;
 };

--- a/core/modules/savers/github.js
+++ b/core/modules/savers/github.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/savers/github.js
 type: application/javascript
 module-type: saver
-
-Saves wiki by pushing a commit to the GitHub v3 REST API
-
 \*/
 
 "use strict";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var GitHubSaver = function(wiki) {
 	this.wiki = wiki;
 };

--- a/core/modules/savers/gitlab.js
+++ b/core/modules/savers/gitlab.js
@@ -2,22 +2,15 @@
 title: $:/core/modules/savers/gitlab.js
 type: application/javascript
 module-type: saver
-
-Saves wiki by pushing a commit to the GitLab REST API
-
 \*/
 
 "use strict";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var GitLabSaver = function(wiki) {
 	this.wiki = wiki;
 };
 
 GitLabSaver.prototype.save = function(text,method,callback) {
-	/* See https://docs.gitlab.com/ee/api/repository_files.html */
 	var self = this,
 		username = this.wiki.getTiddlerText("$:/GitLab/Username"),
 		password = $tw.utils.getPassword("gitlab"),

--- a/core/modules/savers/manualdownload.js
+++ b/core/modules/savers/manualdownload.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/savers/manualdownload.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via HTML5's download APIs
-
 \*/
 
 "use strict";
@@ -12,9 +9,6 @@ Handles saving changes via HTML5's download APIs
 // Title of the tiddler containing the download message
 var downloadInstructionsTitle = "$:/language/Modals/Download";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var ManualDownloadSaver = function(wiki) {
 };
 
@@ -27,25 +21,16 @@ ManualDownloadSaver.prototype.save = function(text,method,callback) {
 	return true;
 };
 
-/*
-Information about this saver
-*/
 ManualDownloadSaver.prototype.info = {
 	name: "manualdownload",
 	priority: 0,
 	capabilities: ["save", "download"]
 };
 
-/*
-Static method that returns true if this saver is capable of working
-*/
 exports.canSave = function(wiki) {
 	return true;
 };
 
-/*
-Create an instance of this saver
-*/
 exports.create = function(wiki) {
 	return new ManualDownloadSaver(wiki);
 };

--- a/core/modules/savers/msdownload.js
+++ b/core/modules/savers/msdownload.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/savers/msdownload.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via window.navigator.msSaveBlob()
-
 \*/
 
 "use strict";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var MsDownloadSaver = function(wiki) {
 };
 
@@ -22,7 +16,7 @@ MsDownloadSaver.prototype.save = function(text,method,callback) {
 	if(p !== -1) {
 		filename = document.location.pathname.substr(p+1);
 	}
-	// Set up the link
+
 	var blob = new Blob([text], {type: "text/html"});
 	window.navigator.msSaveBlob(blob,filename);
 	// Callback that we succeeded
@@ -30,25 +24,16 @@ MsDownloadSaver.prototype.save = function(text,method,callback) {
 	return true;
 };
 
-/*
-Information about this saver
-*/
 MsDownloadSaver.prototype.info = {
 	name: "msdownload",
 	priority: 110,
 	capabilities: ["save", "download"]
 };
 
-/*
-Static method that returns true if this saver is capable of working
-*/
 exports.canSave = function(wiki) {
 	return !!window.navigator.msSaveBlob;
 };
 
-/*
-Create an instance of this saver
-*/
 exports.create = function(wiki) {
 	return new MsDownloadSaver(wiki);
 };

--- a/core/modules/savers/postmessage.js
+++ b/core/modules/savers/postmessage.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/savers/postmessage.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via window.postMessage() to the window.parent
-
 \*/
 
 "use strict";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var PostMessageSaver = function(wiki) {
 	this.publisher = new $tw.utils.BrowserMessagingPublisher({type: "SAVE"});
 };
@@ -59,4 +53,3 @@ Create an instance of this saver
 exports.create = function(wiki) {
 	return new PostMessageSaver(wiki);
 };
-

--- a/core/modules/savers/put.js
+++ b/core/modules/savers/put.js
@@ -2,19 +2,10 @@
 title: $:/core/modules/savers/put.js
 type: application/javascript
 module-type: saver
-
-Saves wiki by performing a PUT request to the server
-
-Works with any server which accepts a PUT request
-to the current URL, such as a WebDAV server.
-
 \*/
 
 "use strict";
 
-/*
-Retrieve ETag if available
-*/
 var retrieveETag = function(self) {
 	var headers = {
 		Accept: "*/*"
@@ -36,16 +27,12 @@ var retrieveETag = function(self) {
 	});
 };
 
-
-/*
-Select the appropriate saver module and set it up
-*/
 var PutSaver = function(wiki) {
 	this.wiki = wiki;
 	var self = this;
 	var uri = this.uri();
 	// Async server probe. Until probe finishes, save will fail fast
-	// See also https://github.com/TiddlyWiki/TiddlyWiki5/issues/2276
+
 	$tw.utils.httpRequest({
 		url: uri,
 		type: "OPTIONS",
@@ -64,7 +51,7 @@ PutSaver.prototype.uri = function() {
 };
 
 // TODO: in case of edit conflict
-// Prompt: Do you want to save over this? Y/N
+
 // Merging would be ideal, and may be possible using future generic merge flow
 PutSaver.prototype.save = function(text,method,callback) {
 	if(!this.serverAcceptsPuts) {
@@ -111,25 +98,16 @@ PutSaver.prototype.save = function(text,method,callback) {
 	return true;
 };
 
-/*
-Information about this saver
-*/
 PutSaver.prototype.info = {
 	name: "put",
 	priority: 2000,
 	capabilities: ["save","autosave"]
 };
 
-/*
-Static method that returns true if this saver is capable of working
-*/
 exports.canSave = function(wiki) {
 	return /^https?:/.test(location.protocol);
 };
 
-/*
-Create an instance of this saver
-*/
 exports.create = function(wiki) {
 	return new PutSaver(wiki);
 };

--- a/core/modules/savers/tiddlyfox.js
+++ b/core/modules/savers/tiddlyfox.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/savers/tiddlyfox.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via the TiddlyFox file extension
-
 \*/
 
 "use strict";
@@ -21,11 +18,11 @@ TiddlyFoxSaver.prototype.save = function(text,method,callback) {
 		if(pathname.indexOf("file://localhost/") === 0) {
 			pathname = "file://" + pathname.substr(16);
 		}
-		// Windows path file:///x:/blah/blah --> x:\blah\blah
+
 		if(/^file\:\/\/\/[A-Z]\:\//i.test(pathname)) {
 			// Remove the leading slash and convert slashes to backslashes
 			pathname = pathname.substr(8).replace(/\//g,"\\");
-		// Firefox Windows network path file://///server/share/blah/blah --> //server/share/blah/blah
+		// Firefox Windows network path file://
 		} else if(pathname.indexOf("file://///") === 0) {
 			pathname = "\\\\" + unescape(pathname.substr(10)).replace(/\//g,"\\");
 		// Mac/Unix local path file:///path/path --> /path/path
@@ -38,7 +35,7 @@ TiddlyFoxSaver.prototype.save = function(text,method,callback) {
 		} else {
 			pathname = "\\\\" + unescape(pathname.substr(7)).replace(new RegExp("/","g"),"\\");
 		}
-		// Create the message element and put it in the message box
+
 		var message = document.createElement("div");
 		message.setAttribute("data-tiddlyfox-path",$tw.utils.decodeURIComponentSafe(pathname));
 		message.setAttribute("data-tiddlyfox-content",text);
@@ -57,25 +54,16 @@ TiddlyFoxSaver.prototype.save = function(text,method,callback) {
 	}
 };
 
-/*
-Information about this saver
-*/
 TiddlyFoxSaver.prototype.info = {
 	name: "tiddlyfox",
 	priority: 1500,
 	capabilities: ["save", "autosave"]
 };
 
-/*
-Static method that returns true if this saver is capable of working
-*/
 exports.canSave = function(wiki) {
 	return true;
 };
 
-/*
-Create an instance of this saver
-*/
 exports.create = function(wiki) {
 	return new TiddlyFoxSaver(wiki);
 };

--- a/core/modules/savers/tiddlyie.js
+++ b/core/modules/savers/tiddlyie.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/savers/tiddlyie.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via Internet Explorer BHO extenion (TiddlyIE)
-
 \*/
 
 "use strict";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var TiddlyIESaver = function(wiki) {
 };
 
@@ -22,7 +16,7 @@ TiddlyIESaver.prototype.save = function(text,method,callback) {
 		var pathname = unescape(document.location.pathname);
 		// Test for a Windows path of the form /x:/blah...
 		if(/^\/[A-Z]\:\/[^\/]+/i.test(pathname)) {	// ie: ^/[a-z]:/[^/]+ (is this better?: ^/[a-z]:/[^/]+(/[^/]+)*\.[^/]+ )
-			// Remove the leading slash
+
 			pathname = pathname.substr(1);
 			// Convert slashes to backslashes
 			pathname = pathname.replace(/\//g,"\\");
@@ -42,25 +36,16 @@ TiddlyIESaver.prototype.save = function(text,method,callback) {
 	}
 };
 
-/*
-Information about this saver
-*/
 TiddlyIESaver.prototype.info = {
 	name: "tiddlyiesaver",
 	priority: 1500,
 	capabilities: ["save"]
 };
 
-/*
-Static method that returns true if this saver is capable of working
-*/
 exports.canSave = function(wiki) {
 	return (window.location.protocol === "file:");
 };
 
-/*
-Create an instance of this saver
-*/
 exports.create = function(wiki) {
 	return new TiddlyIESaver(wiki);
 };

--- a/core/modules/savers/twedit.js
+++ b/core/modules/savers/twedit.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/savers/twedit.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via the TWEdit iOS app
-
 \*/
 
 "use strict";

--- a/core/modules/savers/upload.js
+++ b/core/modules/savers/upload.js
@@ -2,18 +2,10 @@
 title: $:/core/modules/savers/upload.js
 type: application/javascript
 module-type: saver
-
-Handles saving changes via upload to a server.
-
-Designed to be compatible with BidiX's UploadPlugin at http://tiddlywiki.bidix.info/#UploadPlugin
-
 \*/
 
 "use strict";
 
-/*
-Select the appropriate saver module and set it up
-*/
 var UploadSaver = function(wiki) {
 	this.wiki = wiki;
 };
@@ -51,7 +43,7 @@ UploadSaver.prototype.save = function(text,method,callback) {
 	var uploadFormName = "UploadPlugin";
 	var head = [];
 	head.push("--" + boundary + "\r\nContent-disposition: form-data; name=\"UploadPlugin\"\r\n");
-	head.push("backupDir=" + backupDir + ";user=" + username + ";password=" + password + ";uploaddir=" + uploadDir + ";;"); 
+	head.push("backupDir=" + backupDir + ";user=" + username + ";password=" + password + ";uploaddir=" + uploadDir + ";;");
 	head.push("\r\n" + "--" + boundary);
 	head.push("Content-disposition: form-data; name=\"userfile\"; filename=\"" + uploadFilename + "\"");
 	head.push("Content-Type: text/html;charset=UTF-8");

--- a/core/modules/startup/browser-messaging.js
+++ b/core/modules/startup/browser-messaging.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/browser-messaging.js
 type: application/javascript
 module-type: startup
-
-Browser message handling
-
 \*/
 
 "use strict";
@@ -15,9 +12,6 @@ exports.platforms = ["browser"];
 exports.after = ["startup"];
 exports.synchronous = true;
 
-/*
-Load a specified url as an iframe and call the callback when it is loaded. If the url is already loaded then the existing iframe instance is used
-*/
 function loadIFrame(url,callback) {
 	// Check if iframe already exists
 	var iframeInfo = $tw.browserMessaging.iframeInfoMap[url];
@@ -81,7 +75,7 @@ function saveIFrameInfoTiddler(iframeInfo) {
 exports.startup = function() {
 	// Initialise the store of iframes we've created
 	$tw.browserMessaging = {
-		iframeInfoMap: {} // Hashmap by URL of {url:,status:"loading/loaded",domNode:}
+		iframeInfoMap: {}
 	};
 	// Listen for widget messages to control loading the plugin library
 	$tw.rootWidget.addEventListener("tm-load-plugin-library",function(event) {
@@ -144,7 +138,7 @@ exports.startup = function() {
 	// Listen for window messages from other windows
 	window.addEventListener("message",function listener(event){
 		// console.log("browser-messaging: ",document.location.toString())
-		// console.log("browser-messaging: Received message from",event.origin);
+
 		// console.log("browser-messaging: Message content",event.data);
 		switch(event.data.verb) {
 			case "GET-RESPONSE":

--- a/core/modules/startup/eventbus.js
+++ b/core/modules/startup/eventbus.js
@@ -2,8 +2,6 @@
 title: $:/core/modules/startup/eventbus.js
 type: application/javascript
 module-type: startup
-
-Event bus for cross module communication
 \*/
 
 exports.name = "eventbus";

--- a/core/modules/startup/favicon.js
+++ b/core/modules/startup/favicon.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup/favicon.js
 type: application/javascript
 module-type: startup
-
-Favicon handling
-
 \*/
 
 "use strict";

--- a/core/modules/startup/info.js
+++ b/core/modules/startup/info.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup/info.js
 type: application/javascript
 module-type: startup
-
-Initialise $:/info tiddlers via $:/temp/info-plugin pseudo-plugin
-
 \*/
 
 "use strict";
@@ -19,7 +16,7 @@ var TITLE_INFO_PLUGIN = "$:/temp/info-plugin";
 
 exports.startup = function() {
 	// Function to bake the info plugin with new tiddlers
-	// additions: array of tiddler field objects
+
 	// removals: array of titles to remove
 	var updateInfoPlugin = function(additions = [], removals = []) {
 		// Get the existing tiddlers

--- a/core/modules/startup/load-modules.js
+++ b/core/modules/startup/load-modules.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup/load-modules.js
 type: application/javascript
 module-type: startup
-
-Load core modules
-
 \*/
 
 "use strict";
@@ -38,7 +35,7 @@ exports.startup = function() {
 	$tw.wiki.initParsers();
 	// --------------------------
 	// The rest of the startup process here is not strictly to do with loading modules, but are needed before other startup
-	// modules are executed. It is easier to put them here than to introduce a new startup module
+
 	// --------------------------
 	// Create a root widget for attaching event handlers. By using it as the parentWidget for another widget tree, one can reuse the event handlers
 	$tw.rootWidget = new widget.widget({

--- a/core/modules/startup/password.js
+++ b/core/modules/startup/password.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup/password.js
 type: application/javascript
 module-type: startup
-
-Password handling
-
 \*/
 
 "use strict";

--- a/core/modules/startup/plugins.js
+++ b/core/modules/startup/plugins.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup/plugins.js
 type: application/javascript
 module-type: startup
-
-Startup logic concerned with managing plugins
-
 \*/
 
 "use strict";
@@ -41,7 +38,7 @@ exports.startup = function() {
 		if(requireReloadDueToPluginChange) {
 			$tw.wiki.addTiddler({title: TITLE_REQUIRE_RELOAD_DUE_TO_PLUGIN_CHANGE,text: "yes"});
 		}
-		// Read or delete the plugin info of the changed tiddlers
+
 		if(changesToProcess.length > 0) {
 			var changes = $tw.wiki.readPluginInfo(changesToProcess);
 			if(changes.modifiedPlugins.length > 0 || changes.deletedPlugins.length > 0) {
@@ -78,4 +75,3 @@ exports.startup = function() {
 		}
 	});
 };
-

--- a/core/modules/startup/render.js
+++ b/core/modules/startup/render.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup/render.js
 type: application/javascript
 module-type: startup
-
-Title, stylesheet and page rendering
-
 \*/
 
 "use strict";
@@ -99,7 +96,7 @@ exports.startup = function() {
 				onlyThrottledTiddlersHaveChanged = false;
 			}
 		}
-		// Defer the change if only drafts have changed
+
 		if(timerId) {
 			clearTimeout(timerId);
 		}

--- a/core/modules/startup/rootwidget.js
+++ b/core/modules/startup/rootwidget.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup/rootwidget.js
 type: application/javascript
 module-type: startup
-
-Setup the root widget and the core root widget handlers
-
 \*/
 
 "use strict";

--- a/core/modules/startup/startup.js
+++ b/core/modules/startup/startup.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup.js
 type: application/javascript
 module-type: startup
-
-Miscellaneous startup logic for both the client and server.
-
 \*/
 
 "use strict";
@@ -20,12 +17,12 @@ exports.startup = function() {
 		$tw.browser.isIE = (/msie|trident/i.test(navigator.userAgent));
 		$tw.browser.isFirefox = !!document.mozFullScreenEnabled;
 		// 2023-07-21 Edge returns UA below. So we use "isChromeLike"
-		//'mozilla/5.0 (windows nt 10.0; win64; x64) applewebkit/537.36 (khtml, like gecko) chrome/114.0.0.0 safari/537.36 edg/114.0.1823.82'
+
 		$tw.browser.isChromeLike = navigator.userAgent.toLowerCase().indexOf("chrome") > -1;
 		$tw.browser.hasTouch = !!window.matchMedia && window.matchMedia("(pointer: coarse)").matches;
 		$tw.browser.isMobileChrome = $tw.browser.isChromeLike && $tw.browser.hasTouch;
 	}
-	// Platform detection
+
 	$tw.platform = {};
 	if($tw.browser) {
 		$tw.platform.isMac = /Mac/.test(navigator.platform);
@@ -47,7 +44,7 @@ exports.startup = function() {
 				break;
 		}
 	}
-	// Initialise version
+
 	$tw.version = $tw.utils.extractVersionInfo();
 	// Kick off the language manager and switcher
 	$tw.language = new $tw.Language();
@@ -91,7 +88,7 @@ exports.startup = function() {
 			handlerMethod: "handleKeydownEvent"
 		}]);
 	}
-	// Execute any startup actions
+
 	$tw.rootWidget.invokeActionsByTag("$:/tags/StartupAction");
 	if($tw.browser) {
 		$tw.rootWidget.invokeActionsByTag("$:/tags/StartupAction/Browser");
@@ -99,7 +96,7 @@ exports.startup = function() {
 	if($tw.node) {
 		$tw.rootWidget.invokeActionsByTag("$:/tags/StartupAction/Node");
 	}
-	// Clear outstanding tiddler store change events to avoid an unnecessary refresh cycle at startup
+
 	$tw.wiki.clearTiddlerEventQueue();
 	// Find a working syncadaptor
 	$tw.syncadaptor = undefined;

--- a/core/modules/startup/story.js
+++ b/core/modules/startup/story.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup/story.js
 type: application/javascript
 module-type: startup
-
-Load core modules
-
 \*/
 
 "use strict";
@@ -27,8 +24,6 @@ var CONFIG_UPDATE_HISTORY = "$:/config/Navigation/UpdateHistory"; // Can be "yes
 var CONFIG_PERMALINKVIEW_COPY_TO_CLIPBOARD = "$:/config/Navigation/Permalinkview/CopyToClipboard"; // Can be "yes" (default) or "no"
 var CONFIG_PERMALINKVIEW_UPDATE_ADDRESS_BAR = "$:/config/Navigation/Permalinkview/UpdateAddressBar"; // Can be "yes" (default) or "no"
 
-
-// Links to help, if there is no param
 var HELP_OPEN_EXTERNAL_WINDOW = "http://tiddlywiki.com/#WidgetMessage%3A%20tm-open-external-window";
 
 exports.startup = function() {
@@ -109,11 +104,6 @@ exports.startup = function() {
 	}
 };
 
-/*
-Process the location hash to open the specified tiddlers. Options:
-disableHistory: if true $:/History is NOT updated
-defaultToCurrentStory: If true, the current story is retained as the default, instead of opening the default tiddlers
-*/
 function openStartupTiddlers(options) {
 	options = options || {};
 	// Work out the target tiddler and the story filter. "null" means "unspecified"
@@ -129,7 +119,7 @@ function openStartupTiddlers(options) {
 			storyFilter = $tw.utils.decodeURIComponentSafe(hash.substr(split + 1).trim());
 		}
 	}
-	// If the story wasn't specified use the current tiddlers or a blank story
+
 	if(storyFilter === null) {
 		if(options.defaultToCurrentStory) {
 			var currStoryList = $tw.wiki.getTiddlerList(DEFAULT_STORY_TITLE);
@@ -142,7 +132,7 @@ function openStartupTiddlers(options) {
 			}
 		}
 	}
-	// Process the story filter to get the story list
+
 	var storyList = $tw.wiki.filterTiddlers(storyFilter);
 	// Invoke any hooks that want to change the default story list
 	storyList = $tw.hooks.invokeHook("th-opening-default-tiddlers-list",storyList);
@@ -172,15 +162,6 @@ function openStartupTiddlers(options) {
 	}
 }
 
-/*
-options: See below
-options.updateAddressBar: "permalink", "permaview" or "no" (defaults to "permaview")
-options.updateHistory: "yes" or "no" (defaults to "no")
-options.copyToClipboard: "permalink", "permaview" or "no" (defaults to "no")
-options.targetTiddler: optional title of target tiddler for permalink
-options.successNotification: optional title of tiddler to use as the notification in case of success
-options.failureNotification: optional title of tiddler to use as the notification in case of failure
-*/
 function updateLocationHash(options) {
 	// Get the story and the history stack
 	var storyList = $tw.wiki.getTiddlerList(DEFAULT_STORY_TITLE),
@@ -193,12 +174,12 @@ function updateLocationHash(options) {
 		if(historyList.length > 0) {
 			targetTiddler = historyList[historyList.length-1].title;
 		}
-		// Blank the target tiddler if it isn't present in the story
+
 		if(storyList.indexOf(targetTiddler) === -1) {
 			targetTiddler = "";
 		}
 	}
-	// Assemble the location hash
+
 	switch(options.updateAddressBar) {
 		case "permalink":
 			$tw.locationHash = "#" + encodeURIComponent(targetTiddler);
@@ -207,7 +188,7 @@ function updateLocationHash(options) {
 			$tw.locationHash = "#" + encodeURIComponent(targetTiddler) + ":" + encodeURIComponent($tw.utils.stringifyList(storyList));
 			break;
 	}
-	// Copy URL to the clipboard
+
 	var url = "";
 	switch(options.copyToClipboard) {
 		case "permalink":
@@ -220,7 +201,7 @@ function updateLocationHash(options) {
 	if(url) {
 		$tw.utils.copyToClipboard(url,{successNotification: options.successNotification, failureNotification: options.failureNotification});
 	}
-	// Only change the location hash if we must, thus avoiding unnecessary onhashchange events
+
 	if($tw.utils.getLocationHash() !== $tw.locationHash) {
 		if(options.updateHistory === "yes") {
 			// Assign the location hash so that history is updated

--- a/core/modules/startup/windows.js
+++ b/core/modules/startup/windows.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/startup/windows.js
 type: application/javascript
 module-type: startup
-
-Setup root widget handlers for the messages concerned with opening external browser windows
-
 \*/
 
 "use strict";
@@ -52,7 +49,7 @@ exports.startup = function() {
 			srcWindow.focus();
 			return;
 		}
-		// Initialise the document
+
 		srcDocument.write("<!DOCTYPE html><head></head><body class='tc-body tc-single-tiddler-window'></body></html>");
 		srcDocument.close();
 		srcDocument.title = windowTitle;

--- a/core/modules/story.js
+++ b/core/modules/story.js
@@ -2,19 +2,10 @@
 title: $:/core/modules/story.js
 type: application/javascript
 module-type: global
-
-Lightweight object for managing interactions with the story and history lists.
-
 \*/
 
 "use strict";
 
-/*
-Construct Story object with options:
-wiki: reference to wiki object to use to resolve tiddler titles
-storyTitle: title of story list tiddler
-historyTitle: title of history list tiddler
-*/
 function Story(options) {
 	options = options || {};
 	this.wiki = options.wiki || $tw.wiki;
@@ -40,11 +31,11 @@ Story.prototype.addToStory = function(navigateTo,navigateFromTitle,options) {
 	if(slot >= 0) {
 		return;
 	}
-	// First we try to find the position of the story element we navigated from
+
 	var fromIndex = storyList.indexOf(navigateFromTitle);
 	if(fromIndex >= 0) {
 		// The tiddler is added from inside the river
-		// Determine where to insert the tiddler; Fallback is "below"
+
 		switch(options.openLinkFromInsideRiver) {
 			case "top":
 				slot = 0;
@@ -70,7 +61,7 @@ Story.prototype.addToStory = function(navigateTo,navigateFromTitle,options) {
 			slot = 0;
 		}
 	}
-	// Add the tiddler
+
 	storyList.splice(slot,0,navigateTo);
 	// Save the story
 	this.saveStoryList(storyList);

--- a/core/modules/storyviews/classic.js
+++ b/core/modules/storyviews/classic.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/storyviews/classic.js
 type: application/javascript
 module-type: storyview
-
-Views the story as a linear sequence
-
 \*/
 
 "use strict";
@@ -39,7 +36,7 @@ ClassicStoryView.prototype.insert = function(widget) {
 		if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 			return;
 		}
-		// Get the current height of the tiddler
+
 		var computedStyle = window.getComputedStyle(targetElement),
 			currMarginBottom = parseInt(computedStyle.marginBottom,10),
 			currMarginTop = parseInt(computedStyle.marginTop,10),
@@ -79,12 +76,12 @@ ClassicStoryView.prototype.remove = function(widget) {
 		if($tw.utils.domContains(targetElement,targetElement.ownerDocument.activeElement)) {
 			targetElement.ownerDocument.activeElement.blur();
 		}
-		// Abandon if the list entry isn't a DOM element (it might be a text node)
+
 		if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 			removeElement();
 			return;
 		}
-		// Get the current height of the tiddler
+
 		var currWidth = targetElement.offsetWidth,
 			computedStyle = window.getComputedStyle(targetElement),
 			currMarginBottom = parseInt(computedStyle.marginBottom,10),

--- a/core/modules/storyviews/pop.js
+++ b/core/modules/storyviews/pop.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/storyviews/pop.js
 type: application/javascript
 module-type: storyview
-
-Animates list insertions and removals
-
 \*/
 
 "use strict";
@@ -35,9 +32,9 @@ PopStoryView.prototype.insert = function(widget) {
 	if(!targetElement || targetElement.nodeType === Node.TEXT_NODE) {
 		return;
 	}
-	// Reset once the transition is over
+
 	setTimeout(function() {
-		$tw.utils.removeStyles(targetElement, ["transition", "transform"]);		
+		$tw.utils.removeStyles(targetElement, ["transition", "transform"]);
 		$tw.utils.setStyle(widget.document.body,[
 			{"overflow-x": ""}
 		]);
@@ -51,7 +48,7 @@ PopStoryView.prototype.insert = function(widget) {
 		{transform: "scale(2)"},
 		{opacity: "0.0"}
 	]);
-	$tw.utils.removeStyle(targetElement, "transition");		
+	$tw.utils.removeStyle(targetElement, "transition");
 	$tw.utils.forceLayout(targetElement);
 	// Transition to the final position
 	$tw.utils.setStyle(targetElement,[
@@ -81,7 +78,7 @@ PopStoryView.prototype.remove = function(widget) {
 	// Remove the element at the end of the transition
 	setTimeout(removeElement,duration);
 	// Animate the closure
-	$tw.utils.removeStyles(targetElement, ["transition", "transform", "opacity"]);		
+	$tw.utils.removeStyles(targetElement, ["transition", "transform", "opacity"]);
 	$tw.utils.forceLayout(targetElement);
 	$tw.utils.setStyle(targetElement,[
 		{transition: $tw.utils.roundTripPropertyName("transform") + " " + duration + "ms ease-in-out, " +

--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/storyviews/zoomin.js
 type: application/javascript
 module-type: storyview
-
-Zooms between individual tiddlers
-
 \*/
 
 "use strict";
@@ -24,7 +21,7 @@ var ZoominListView = function(listWidget) {
 	if(history.length > 0) {
 		targetTiddler = history[history.length-1].title;
 	}
-	// Make all the tiddlers position absolute, and hide all but the top (or first) one
+
 	$tw.utils.each(this.listWidget.children,function(itemWidget,index) {
 		var domNode = itemWidget.findFirstDomNode();
 		// Abandon if the list entry isn't a DOM element (it might be a text node)
@@ -55,7 +52,7 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 		this.logTextNodeRoot(targetElement);
 		return;
 	}
-	// Make the new tiddler be position absolute and visible so that we can measure it
+
 	$tw.utils.addClass(targetElement,"tc-storyview-zoomin-tiddler");
 	$tw.utils.setStyle(targetElement,[
 		{display: "block"},
@@ -118,13 +115,10 @@ ZoominListView.prototype.navigateTo = function(historyInfo) {
 			}
 		},duration);
 	}
-	// Scroll the target into view
+
 //	$tw.pageScroller.scrollIntoView(targetElement);
 };
 
-/*
-Find the first child DOM node of a widget that has the class "tc-title"
-*/
 function findTitleDomNode(widget,targetClass) {
 	targetClass = targetClass || "tc-title";
 	var domNode = widget.findFirstDomNode();
@@ -161,12 +155,12 @@ ZoominListView.prototype.remove = function(widget) {
 		removeElement();
 		return;
 	}
-	// Abandon if hidden
+
 	if(targetElement.style.display != "block" ) {
 		removeElement();
 		return;
 	}
-	// Set up the tiddler that is being closed
+
 	$tw.utils.addClass(targetElement,"tc-storyview-zoomin-tiddler");
 	$tw.utils.setStyle(targetElement,[
 		{display: "block"},
@@ -199,7 +193,7 @@ ZoominListView.prototype.remove = function(widget) {
 			this.currentTiddlerDomNode = toWidgetDomNode;
 		}
 	}
-	// Animate them both
+
 	// Force layout
 	$tw.utils.forceLayout(this.listWidget.parentDomNode);
 	// First, the tiddler we're closing
@@ -212,7 +206,7 @@ ZoominListView.prototype.remove = function(widget) {
 	]);
 	setTimeout(function() {
 		$tw.utils.removeStyles(toWidgetDomNode, ["transformOrigin", "transform", "transition", "opacity", "zIndex"]);
-	}, duration);	
+	}, duration);
 	setTimeout(removeElement,duration);
 	// Now the tiddler we're going back to
 	if(toWidgetDomNode) {

--- a/core/modules/syncer.js
+++ b/core/modules/syncer.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/syncer.js
 type: application/javascript
 module-type: global
-
-The syncer tracks changes to the store and synchronises them to a remote data store represented as a "sync adaptor"
-
 \*/
 
 "use strict";
 
-/*
-Defaults
-*/
 Syncer.prototype.titleIsLoggedIn = "$:/status/IsLoggedIn";
 Syncer.prototype.titleIsAnonymous = "$:/status/IsAnonymous";
 Syncer.prototype.titleIsReadOnly = "$:/status/IsReadOnly";
@@ -88,7 +82,7 @@ function Syncer(options) {
 		if(filteredChanges.length > 0) {
 			self.processTaskQueue();
 		} else {
-			// Look for deletions of tiddlers we're already syncing	
+			// Look for deletions of tiddlers we're already syncing
 			var outstandingDeletion = false
 			$tw.utils.each(changes,function(change,title,object) {
 				if(change.deleted && $tw.utils.hop(self.tiddlerInfo,title)) {
@@ -120,7 +114,7 @@ function Syncer(options) {
 				self.login(username,password,function() {});
 			} else {
 				// No username and password, so we display a prompt
-				self.handleLoginEvent();				
+				self.handleLoginEvent();
 			}
 		});
 		$tw.rootWidget.addEventListener("tm-logout",function() {
@@ -133,22 +127,19 @@ function Syncer(options) {
 			$tw.utils.copyToClipboard($tw.utils.getSystemInfo() + "\n\nLog:\n" + self.logger.getBuffer());
 		});
 	}
-	// Listen out for lazyLoad events
+
 	if(!this.disableUI && this.wiki.getTiddlerText(this.titleSyncDisableLazyLoading) !== "yes") {
 		this.wiki.addEventListener("lazyLoad",function(title) {
 			self.handleLazyLoadEvent(title);
-		});		
+		});
 	}
-	// Get the login status
+
 	this.getStatus(function(err,isLoggedIn) {
 		// Do a sync from the server
 		self.syncFromServer();
 	});
 }
 
-/*
-Show a generic network error alert
-*/
 Syncer.prototype.displayError = function(msg,err) {
 	if(err === ($tw.language.getString("Error/XMLHttpRequest") + ": 0")) {
 		this.loggerConnection.alert($tw.language.getString("Error/NetworkErrorAlert"));
@@ -158,30 +149,21 @@ Syncer.prototype.displayError = function(msg,err) {
 	}
 };
 
-/*
-Return an array of the tiddler titles that are subjected to syncing
-*/
 Syncer.prototype.getSyncedTiddlers = function(source) {
 	return this.filterFn.call(this.wiki,source);
 };
 
-/*
-Return an array of the tiddler titles that are subjected to syncing
-*/
 Syncer.prototype.getTiddlerRevision = function(title) {
 	if(this.syncadaptor && this.syncadaptor.getTiddlerRevision) {
 		return this.syncadaptor.getTiddlerRevision(title);
 	} else {
-		return this.wiki.getTiddler(title).fields.revision;	
-	} 
+		return this.wiki.getTiddler(title).fields.revision;
+	}
 };
 
-/*
-Read (or re-read) the latest tiddler info from the store
-*/
 Syncer.prototype.readTiddlerInfo = function() {
 	// Hashmap by title of {revision:,changeCount:,adaptorInfo:}
-	// "revision" is the revision of the tiddler last seen on the server, and "changecount" is the corresponding local changecount
+
 	this.tiddlerInfo = {};
 	// Record information for known tiddlers
 	var self = this,
@@ -198,9 +180,6 @@ Syncer.prototype.readTiddlerInfo = function() {
 	});
 };
 
-/*
-Checks whether the wiki is dirty (ie the window shouldn't be closed)
-*/
 Syncer.prototype.isDirty = function() {
 	var self = this;
 	function checkIsDirty() {
@@ -298,7 +277,7 @@ Synchronise from the server by reading the skinny tiddler list and queuing up lo
 Syncer.prototype.syncFromServer = function() {
 	if(this.canSyncFromServer()) {
 		this.forceSyncFromServer = true;
-		this.processTaskQueue();	
+		this.processTaskQueue();
 	}
 };
 
@@ -306,17 +285,11 @@ Syncer.prototype.canSyncFromServer = function() {
 	return !!this.syncadaptor.getUpdatedTiddlers || !!this.syncadaptor.getSkinnyTiddlers;
 }
 
-/*
-Force load a tiddler from the server
-*/
 Syncer.prototype.enqueueLoadTiddler = function(title) {
 	this.titlesToBeLoaded[title] = true;
 	this.processTaskQueue();
 };
 
-/*
-Lazily load a skinny tiddler if we can
-*/
 Syncer.prototype.handleLazyLoadEvent = function(title) {
 	// Ignore if the syncadaptor doesn't handle it
 	if(!this.syncadaptor.supportsLazyLoading) {
@@ -334,9 +307,6 @@ Syncer.prototype.handleLazyLoadEvent = function(title) {
 	}
 };
 
-/*
-Dispay a password prompt and allow the user to login
-*/
 Syncer.prototype.handleLoginEvent = function() {
 	var self = this;
 	this.getStatus(function(err,isLoggedIn,username) {
@@ -350,9 +320,6 @@ Syncer.prototype.handleLoginEvent = function() {
 	});
 };
 
-/*
-Dispay a password prompt
-*/
 Syncer.prototype.displayLoginPrompt = function() {
 	var self = this;
 	var promptInfo = $tw.passwordPrompt.createPrompt({
@@ -366,12 +333,6 @@ Syncer.prototype.displayLoginPrompt = function() {
 	});
 };
 
-/*
-Attempt to login to TiddlyWeb.
-	username: username
-	password: password
-	callback: invoked with arguments (err,isLoggedIn)
-*/
 Syncer.prototype.login = function(username,password,callback) {
 	this.logger.log("Attempting to login as",username);
 	var self = this;
@@ -391,9 +352,6 @@ Syncer.prototype.login = function(username,password,callback) {
 	}
 };
 
-/*
-Attempt to log out of TiddlyWeb
-*/
 Syncer.prototype.handleLogoutEvent = function() {
 	this.logger.log("Attempting to logout");
 	var self = this;
@@ -408,16 +366,10 @@ Syncer.prototype.handleLogoutEvent = function() {
 	}
 };
 
-/*
-Immediately refresh from the server
-*/
 Syncer.prototype.handleRefreshEvent = function() {
 	this.syncFromServer();
 };
 
-/*
-Process the next task
-*/
 Syncer.prototype.processTaskQueue = function() {
 	var self = this;
 	// Only process a task if the sync adaptor is fully initialised and we're not already performing
@@ -467,14 +419,6 @@ Syncer.prototype.triggerTimeout = function(interval) {
 	},interval || self.taskTimerInterval);
 };
 
-/*
-Choose the next sync task. We prioritise saves to the server, then getting updates from the server, then deletes to the server, then loads from the server
-
-Returns either:
-* a task object
-* the boolean true if there are pending sync tasks that aren't yet due
-* null if there's no pending sync tasks (just the next poll)
-*/
 Syncer.prototype.chooseNextTask = function() {
 	var now = new Date(),
 		thresholdLastSaved = now - this.throttleInterval,
@@ -498,11 +442,11 @@ Syncer.prototype.chooseNextTask = function() {
 			}
 		}
 	}
-	// Second we check for an outstanding sync from server
+
 	if(this.forceSyncFromServer || (this.timestampLastSyncFromServer && (now.valueOf() >= (this.timestampLastSyncFromServer.valueOf() + this.pollTimerInterval)))) {
 		return new SyncFromServerTask(this);
 	}
-	// Third, we check tiddlers that are known from the server but not currently in the store, and so need deleting on the server
+
 	titles = Object.keys(this.tiddlerInfo);
 	for(index=0; index<titles.length; index++) {
 		title = titles[index];
@@ -512,13 +456,13 @@ Syncer.prototype.chooseNextTask = function() {
 			return new DeleteTiddlerTask(this,title);
 		}
 	}
-	// Finally, check for tiddlers that need loading
+
 	title = Object.keys(this.titlesToBeLoaded)[0];
 	if(title) {
 		delete this.titlesToBeLoaded[title];
 		return new LoadTiddlerTask(this,title);
 	}
-	// No tasks are ready now, but might be in the future
+
 	return havePending;
 };
 
@@ -578,7 +522,7 @@ DeleteTiddlerTask.prototype.run = function(callback) {
 		if(err) {
 			return callback(err);
 		}
-		// Remove the info stored about this tiddler
+
 		delete self.syncer.tiddlerInfo[self.title];
 		// Invoke the callback
 		callback(null);
@@ -678,11 +622,11 @@ SyncFromServerTask.prototype.run = function(callback) {
 					if(!tiddler || tiddler.fields.text === undefined) {
 						self.syncer.storeTiddler(tiddlerFields);
 					}
-					// Do a full load of this tiddler
+
 					self.syncer.titlesToBeLoaded[tiddlerFields.title] = true;
 				}
 			}
-			// Delete any tiddlers that were previously reported but missing this time
+
 			$tw.utils.each(previousTitles,function(title) {
 				if(syncSystemFromServer || !self.syncer.wiki.isSystemTiddler(title)) {
 					delete self.syncer.tiddlerInfo[title];

--- a/core/modules/tiddler.js
+++ b/core/modules/tiddler.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/tiddler.js
 type: application/javascript
 module-type: tiddlermethod
-
-Extension methods for the $tw.Tiddler object (constructor and methods required at boot time are in boot/boot.js)
-
 \*/
 
 "use strict";
@@ -27,7 +24,7 @@ exports.getFieldString = function(field,defaultValue) {
 	if(value === undefined || value === null) {
 		return defaultValue || "";
 	}
-	// Stringify the field with the associated tiddler field module (if any)
+
 	var fieldModule = $tw.Tiddler.fieldModules[field];
 	if(fieldModule && fieldModule.stringify) {
 		return fieldModule.stringify.call(this,value);
@@ -36,9 +33,6 @@ exports.getFieldString = function(field,defaultValue) {
 	}
 };
 
-/*
-Get the value of a field as an array / list
-*/
 exports.getFieldList = function(field) {
 	var value = this.getFieldString(field,null);
 	// Check for a missing field
@@ -48,10 +42,6 @@ exports.getFieldList = function(field) {
 	return $tw.utils.parseStringArray(value);
 };
 
-/*
-Get all the fields as a hashmap of strings. Options:
-	exclude: an array of field names to exclude
-*/
 exports.getFieldStrings = function(options) {
 	options = options || {};
 	var exclude = options.exclude || [];
@@ -66,10 +56,6 @@ exports.getFieldStrings = function(options) {
 	return fields;
 };
 
-/*
-Get all the fields as a name:value block. Options:
-	exclude: an array of field names to exclude
-*/
 exports.getFieldStringBlock = function(options) {
 	options = options || {};
 	var exclude = options.exclude || [],

--- a/core/modules/upgraders/plugins.js
+++ b/core/modules/upgraders/plugins.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/upgraders/plugins.js
 type: application/javascript
 module-type: upgrader
-
-Upgrader module that checks that plugins are newer than any already installed version
-
 \*/
 
 "use strict";

--- a/core/modules/upgraders/system.js
+++ b/core/modules/upgraders/system.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/upgraders/system.js
 type: application/javascript
 module-type: upgrader
-
-Upgrader module that suppresses certain system tiddlers that shouldn't be imported
-
 \*/
 
 "use strict";

--- a/core/modules/upgraders/themetweaks.js
+++ b/core/modules/upgraders/themetweaks.js
@@ -2,18 +2,6 @@
 title: $:/core/modules/upgraders/themetweaks.js
 type: application/javascript
 module-type: upgrader
-
-Upgrader module that handles the change in theme tweak storage introduced in 5.0.14-beta.
-
-Previously, theme tweaks were stored in two data tiddlers:
-
-* $:/themes/tiddlywiki/vanilla/metrics
-* $:/themes/tiddlywiki/vanilla/settings
-
-Now, each tweak is stored in its own separate tiddler.
-
-This upgrader copies any values from the old format to the new. The old data tiddlers are not deleted in case they have been used to store additional indexes.
-
 \*/
 
 "use strict";

--- a/core/modules/utils/base64.js
+++ b/core/modules/utils/base64.js
@@ -2,16 +2,9 @@
 title: $:/core/modules/utils/base64.js
 type: application/javascript
 module-type: utils-browser
-
-Base64 utility functions
-
 \*/
 
 "use strict";
-
-/*
-Base64 utility functions that work in either browser or Node.js
-*/
 
 exports.btoa = binstr => window.btoa(binstr);
 exports.atob = b64 => window.atob(b64);

--- a/core/modules/utils/crypto.js
+++ b/core/modules/utils/crypto.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/utils/crypto.js
 type: application/javascript
 module-type: utils
-
-Utility functions related to crypto.
-
 \*/
 
 "use strict";
 
-/*
-Look for an encrypted store area in the text of a TiddlyWiki file
-*/
 exports.extractEncryptedStoreArea = function(text) {
 	var encryptedStoreAreaStartMarker = "<pre id=\"encryptedStoreArea\" type=\"text/plain\" style=\"display:none;\">",
 		encryptedStoreAreaStart = text.indexOf(encryptedStoreAreaStartMarker);
@@ -24,9 +18,6 @@ exports.extractEncryptedStoreArea = function(text) {
 	return null;
 };
 
-/*
-Attempt to extract the tiddlers from an encrypted store area using the current password. If the password is not provided then the password in the password store will be used
-*/
 exports.decryptStoreArea = function(encryptedStoreArea,password) {
 	var decryptedText = $tw.crypto.decrypt(encryptedStoreArea,password);
 	if(decryptedText) {
@@ -43,16 +34,6 @@ exports.decryptStoreArea = function(encryptedStoreArea,password) {
 	}
 };
 
-
-/*
-Attempt to extract the tiddlers from an encrypted store area using the current password. If that fails, the user is prompted for a password.
-encryptedStoreArea: text of the TiddlyWiki encrypted store area
-callback: function(tiddlers) called with the array of decrypted tiddlers
-
-The following configuration settings are supported:
-
-$tw.config.usePasswordVault: causes any password entered by the user to also be put into the system password vault
-*/
 exports.decryptStoreAreaInteractive = function(encryptedStoreArea,callback,options) {
 	// Try to decrypt with the current password
 	var tiddlers = $tw.utils.decryptStoreArea(encryptedStoreArea);
@@ -70,7 +51,7 @@ exports.decryptStoreAreaInteractive = function(encryptedStoreArea,callback,optio
 				if(!data) {
 					return false;
 				}
-				// Attempt to decrypt the tiddlers
+
 				var tiddlers = $tw.utils.decryptStoreArea(encryptedStoreArea,data.password);
 				if(tiddlers) {
 					if($tw.config.usePasswordVault) {

--- a/core/modules/utils/csv.js
+++ b/core/modules/utils/csv.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/csv.js
 type: application/javascript
 module-type: utils
-
-A barebones CSV parser
-
 \*/
 
 "use strict";
@@ -14,21 +11,21 @@ var QUOTE = '"';
 var getCellInfo = function(text, start, length, SEPARATOR) {
 	var isCellQuoted = text.charAt(start) === QUOTE;
 	var cellStart = isCellQuoted ? start + 1 : start;
-	
+
 	if (text.charAt(i) === SEPARATOR) {
 		return [cellStart, cellStart, false];
 	}
-	
+
 	for (var i = cellStart; i < length; i++) {
 		var cellCharacter = text.charAt(i);
 		var isEOL = cellCharacter === "\n" || cellCharacter === "\r";
-		
+
 		if (isEOL && !isCellQuoted) {
 			return [cellStart, i, false];
-			
+
 		} else if (cellCharacter === SEPARATOR && !isCellQuoted) {
 			return [cellStart, i, false];
-			
+
 		} else if (cellCharacter === QUOTE && isCellQuoted) {
 			var nextCharacter = i + 1 < length ? text.charAt(i + 1) : '';
 			if (nextCharacter !== QUOTE) {
@@ -38,21 +35,21 @@ var getCellInfo = function(text, start, length, SEPARATOR) {
 			}
 		}
 	}
-	
+
 	return [cellStart, i, isCellQuoted];
 }
-	
+
 exports.parseCsvString = function(text, options) {
 	if (!text) {
 		return [];
 	}
-	
+
 	options = options || {};
 	var SEPARATOR = options.separator || ",",
 		length = text.length,
 		rows = [],
 		nextRow = [];
-		
+
 	for (var i = 0; i < length; i++) {
 		var cellInfo = getCellInfo(text, i, length, SEPARATOR);
 		var cellText = text.substring(cellInfo[0], cellInfo[1]);
@@ -61,12 +58,12 @@ exports.parseCsvString = function(text, options) {
 			cellInfo[1]++;
 		}
 		nextRow.push(cellText);
-		
+
 		i = cellInfo[1];
-		
+
 		var character = text.charAt(i);
 		var nextCharacter = i + 1 < length ? text.charAt(i + 1) : '';
-		
+
 		if (character === "\r" || character === "\n") {
 			// Edge case for empty rows
 			if (nextRow.length === 1 && nextRow[0] === '') {
@@ -74,34 +71,30 @@ exports.parseCsvString = function(text, options) {
 			}
 			rows.push(nextRow);
 			nextRow = [];
-			
+
 			if (character === "\r") {
 				var nextCharacter = i + 1 < length ? text.charAt(i + 1) : '';
-				
+
 				if (nextCharacter === "\n") {
 					i++;
 				}
 			}
 		}
 	}
-	
-	// Special case if last cell in last row is an empty cell
+
 	if (text.charAt(length - 1) === SEPARATOR) {
 		nextRow.push("");
 	}
-	
+
 	rows.push(nextRow);
-	
+
 	return rows;
 }
 
-/*
-Parse a CSV string with a header row and return an array of hashmaps.
-*/
 exports.parseCsvStringWithHeader = function(text,options) {
 	var csv = $tw.utils.parseCsvString(text, options);
 	var headers = csv[0];
-	
+
 	csv = csv.slice(1);
 	for (var i = 0; i < csv.length; i++) {
 		var row = csv[i];

--- a/core/modules/utils/deprecated.js
+++ b/core/modules/utils/deprecated.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/deprecated.js
 type: application/javascript
 module-type: utils
-
-Deprecated util functions
-
 \*/
 
 exports.logTable = data => console.table(data);

--- a/core/modules/utils/diff-match-patch/diff_match_patch_uncompressed.js
+++ b/core/modules/utils/diff-match-patch/diff_match_patch_uncompressed.js
@@ -16,7 +16,7 @@ var __spreadValues$1 = (a, b) => {
     }
   return a;
 };
-const defaultOptions = /* @__PURE__ */ Object.freeze({
+const defaultOptions = Object.freeze({
   diffTimeout: 1,
   diffEditCost: 4,
   matchThreshold: 0.5,
@@ -45,7 +45,7 @@ function diffMain(text1, text2, options, opt_checklines = true, opt_deadline) {
     if (resolved.diffTimeout <= 0)
       opt_deadline = Number.MAX_VALUE;
     else
-      opt_deadline = (/* @__PURE__ */ new Date()).getTime() + resolved.diffTimeout * 1e3;
+      opt_deadline = ( new Date()).getTime() + resolved.diffTimeout * 1e3;
   }
   const deadline = opt_deadline;
   if (text1 == null || text2 == null)
@@ -172,7 +172,7 @@ function diffBisect(text1, text2, options, deadline) {
   let k2start = 0;
   let k2end = 0;
   for (let d = 0; d < max_d; d++) {
-    if ((/* @__PURE__ */ new Date()).getTime() > deadline)
+    if (( new Date()).getTime() > deadline)
       break;
     for (let k1 = -d + k1start; k1 <= d - k1end; k1 += 2) {
       const k1_offset = v_offset + k1;
@@ -985,18 +985,18 @@ function patchMake(a, opt_b, opt_c, options = {}) {
       diffCleanupEfficiency(diffs);
     }
   } else if (a && typeof a == "object" && typeof opt_b == "undefined" && typeof opt_c == "undefined") {
-    diffs = /** @type {Diff[]} */
+    diffs =
     a;
     text1 = diffText1(diffs);
   } else if (typeof a == "string" && opt_b && typeof opt_b == "object" && typeof opt_c == "undefined") {
-    text1 = /** @type {string} */
+    text1 =
     a;
-    diffs = /** @type {Diff[]} */
+    diffs =
     opt_b;
   } else if (typeof a == "string" && typeof opt_b == "string" && opt_c && typeof opt_c == "object") {
-    text1 = /** @type {string} */
+    text1 =
     a;
-    diffs = /** @type {Diff[]} */
+    diffs =
     opt_c;
   } else {
     throw new Error("Unknown call format to patch_make.");

--- a/core/modules/utils/dom/animations/slide.js
+++ b/core/modules/utils/dom/animations/slide.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/dom/animations/slide.js
 type: application/javascript
 module-type: animation
-
-A simple slide animation that varies the height of the element
-
 \*/
 
 "use strict";

--- a/core/modules/utils/dom/animator.js
+++ b/core/modules/utils/dom/animator.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/dom/animator.js
 type: application/javascript
 module-type: utils
-
-Orchestrates animations and transitions
-
 \*/
 
 "use strict";
@@ -31,7 +28,7 @@ Animator.prototype.perform = function(type,domNode,options) {
 			}
 		};
 	}
-	// Call the animation
+
 	chosenAnimation(domNode,options);
 };
 

--- a/core/modules/utils/dom/browser.js
+++ b/core/modules/utils/dom/browser.js
@@ -2,18 +2,10 @@
 title: $:/core/modules/utils/dom/browser.js
 type: application/javascript
 module-type: utils
-
-Browser feature detection
-
 \*/
 
 "use strict";
 
-/*
-Set style properties of an element
-	element: dom node
-	styles: ordered array of {name: value} pairs
-*/
 exports.setStyle = function(element,styles) {
 	if(element.nodeType === 1) { // Element.ELEMENT_NODE
 		for(var t=0; t<styles.length; t++) {
@@ -24,31 +16,15 @@ exports.setStyle = function(element,styles) {
 	}
 };
 
-/*
-Remove style properties of an element
-  element: dom node
-	styleProperties: ordered array of string property names
-*/
 exports.removeStyles = function(element, styleProperties) {
 	for (var i=0; i<styleProperties.length; i++) {
 		element.style.removeProperty($tw.utils.convertStyleNameToPropertyName(styleProperties[i]));
 	}
 }
 
-/*
-Remove single style property of an element
-  element: dom node
-	styleProperty: string property name
-*/
 exports.removeStyle = function(element, styleProperty) {
 	$tw.utils.removeStyles(element, [styleProperty])
 }
-
-/*
-Converts a standard CSS property name into the local browser-specific equivalent. For example:
-	"background-color" --> "backgroundColor"
-	"transition" --> "webkitTransition"
-*/
 
 var styleNameCache = {}; // We'll cache the style name conversions
 
@@ -92,18 +68,9 @@ exports.convertPropertyNameToStyleName = function(propertyName) {
 	return styleName;
 };
 
-/*
-Round trip a stylename to a property name and back again. For example:
-	"transform" --> "webkitTransform" --> "-webkit-transform"
-*/
 exports.roundTripPropertyName = function(propertyName) {
 	return $tw.utils.convertPropertyNameToStyleName($tw.utils.convertStyleNameToPropertyName(propertyName));
 };
-
-/*
-Converts a standard event name into the local browser specific equivalent. For example:
-	"animationEnd" --> "webkitAnimationEnd"
-*/
 
 var eventNameCache = {}; // We'll cache the conversions
 

--- a/core/modules/utils/dom/csscolorparser.js
+++ b/core/modules/utils/dom/csscolorparser.js
@@ -1,26 +1,25 @@
 // (c) Dean McNamee <dean@gmail.com>, 2012.
-//
+
 // https://github.com/deanm/css-color-parser-js
-//
+
 // Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
+
 // deal in the Software without restriction, including without limitation the
-// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+
 // sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+
 //
-// The above copyright notice and this permission notice shall be included in
+
 // all copies or substantial portions of the Software.
-//
+
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+
 // IN THE SOFTWARE.
 
-// http://www.w3.org/TR/css3-color/
 var kCSSColorTable = {
   "transparent": [0,0,0,0], "aliceblue": [240,248,255,1],
   "antiquewhite": [250,235,215,1], "aqua": [0,255,255,1],
@@ -135,7 +134,6 @@ function parseCSSColor(css_str) {
   // Color keywords (and transparent) lookup.
   if (str in kCSSColorTable) return kCSSColorTable[str].slice();  // dup.
 
-  // #abc and #abc123 syntax.
   if (str[0] === '#') {
     if (str.length === 4) {
       var iv = parseInt(str.substr(1), 16);  // TODO(deanm): Stricter parsing.
@@ -179,7 +177,7 @@ function parseCSSColor(css_str) {
       case 'hsl':
         if (params.length !== 3) return null;
         var h = (((parseFloat(params[0]) % 360) + 360) % 360) / 360;  // 0 .. 1
-        // NOTE(deanm): According to the CSS spec s/l should only be
+
         // percentages, but we don't bother and let float or percentage.
         var s = parse_css_float(params[1]);
         var l = parse_css_float(params[2]);

--- a/core/modules/utils/dom/dom.js
+++ b/core/modules/utils/dom/dom.js
@@ -2,19 +2,12 @@
 title: $:/core/modules/utils/dom.js
 type: application/javascript
 module-type: utils
-
-Various static DOM-related utility functions.
-
 \*/
 
 "use strict";
 
 var Popup = require("$:/core/modules/utils/dom/popup.js");
 
-
-/*
-Select text in a an input or textarea (setSelectionRange crashes on certain input types)
-*/
 exports.setSelectionRangeSafe = function(node,start,end,direction) {
 	try {
 		node.setSelectionRange(start,end,direction);
@@ -23,9 +16,6 @@ exports.setSelectionRangeSafe = function(node,start,end,direction) {
 	}
 };
 
-/*
-Select the text in an input or textarea by position
-*/
 exports.setSelectionByPosition = function(node,selectFromStart,selectFromEnd) {
 	$tw.utils.setSelectionRangeSafe(node,selectFromStart,node.value.length - selectFromEnd);
 };
@@ -36,9 +26,6 @@ exports.removeChildren = function(node) {
 	}
 };
 
-/*
-Get the first parent element that has scrollbars or use the body as fallback.
-*/
 exports.getScrollContainer = function(el) {
 	var doc = el.ownerDocument;
 	while(el.parentNode) {
@@ -50,14 +37,6 @@ exports.getScrollContainer = function(el) {
 	return doc.body;
 };
 
-/*
-Get the scroll position of the viewport
-Returns:
-	{
-		x: horizontal scroll position in pixels,
-		y: vertical scroll position in pixels
-	}
-*/
 exports.getScrollPosition = function(srcWindow) {
 	var scrollWindow = srcWindow || window;
 	if("scrollX" in scrollWindow) {
@@ -67,9 +46,6 @@ exports.getScrollPosition = function(srcWindow) {
 	}
 };
 
-/*
-Adjust the height of a textarea to fit its content, preserving scroll position, and return the height
-*/
 exports.resizeTextAreaToFit = function(domNode,minHeight) {
 	// Get the scroll container and register the current scroll position
 	var container = $tw.utils.getScrollContainer(domNode),
@@ -92,9 +68,6 @@ exports.resizeTextAreaToFit = function(domNode,minHeight) {
 	return newHeight;
 };
 
-/*
-Gets the bounding rectangle of an element in absolute page coordinates
-*/
 exports.getBoundingPageRect = function(element) {
 	var scrollPos = $tw.utils.getScrollPosition(element.ownerDocument.defaultView),
 		clientRect = element.getBoundingClientRect();
@@ -108,9 +81,6 @@ exports.getBoundingPageRect = function(element) {
 	};
 };
 
-/*
-Saves a named password in the browser
-*/
 exports.savePassword = function(name,password) {
 	var done = false;
 	try {
@@ -124,9 +94,6 @@ exports.savePassword = function(name,password) {
 	}
 };
 
-/*
-Retrieve a named password from the browser
-*/
 exports.getPassword = function(name) {
 	var value;
 	try {
@@ -140,16 +107,10 @@ exports.getPassword = function(name) {
 	}
 };
 
-/*
-Force layout of a dom node and its descendents
-*/
 exports.forceLayout = function(element) {
 	var dummy = element.offsetWidth;
 };
 
-/*
-Pulse an element for debugging purposes
-*/
 exports.pulseElement = function(element) {
 	// Event handler to remove the class at the end
 	element.addEventListener($tw.browser.animationEnd,function handler(event) {
@@ -162,15 +123,6 @@ exports.pulseElement = function(element) {
 	$tw.utils.addClass(element,"pulse");
 };
 
-/*
-Attach specified event handlers to a DOM node
-domNode: where to attach the event handlers
-events: array of event handlers to be added (see below)
-Each entry in the events array is an object with these properties:
-handlerFunction: optional event handler function
-handlerObject: optional event handler object
-handlerMethod: optionally specifies object handler method name (defaults to `handleEvent`)
-*/
 exports.addEventListeners = function(domNode,events) {
 	$tw.utils.each(events,function(eventInfo) {
 		var handler;
@@ -189,9 +141,6 @@ exports.addEventListeners = function(domNode,events) {
 	});
 };
 
-/*
-Get the computed styles applied to an element as an array of strings of individual CSS properties
-*/
 exports.getComputedStyles = function(domNode) {
 	var textAreaStyles = window.getComputedStyle(domNode,null),
 		styleDefs = [],
@@ -203,23 +152,14 @@ exports.getComputedStyles = function(domNode) {
 	return styleDefs;
 };
 
-/*
-Apply a set of styles passed as an array of strings of individual CSS properties
-*/
 exports.setStyles = function(domNode,styleDefs) {
 	domNode.style.cssText = styleDefs.join("");
 };
 
-/*
-Copy the computed styles from a source element to a destination element
-*/
 exports.copyStyles = function(srcDomNode,dstDomNode) {
 	$tw.utils.setStyles(dstDomNode,$tw.utils.getComputedStyles(srcDomNode));
 };
 
-/*
-Copy plain text to the clipboard on browsers that support it
-*/
 exports.copyToClipboard = function(text,options) {
 	options = options || {};
 	text = text || "";
@@ -252,9 +192,6 @@ exports.copyToClipboard = function(text,options) {
 	document.body.removeChild(textArea);
 };
 
-/*
-Collect DOM variables
-*/
 exports.collectDOMVariables = function(selectedNode,domNode,event) {
 	var variables = {},
 	    selectedNodeRect,
@@ -263,7 +200,7 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 		$tw.utils.each(selectedNode.attributes,function(attribute) {
 			variables["dom-" + attribute.name] = attribute.value.toString();
 		});
-		
+
 		if("offsetLeft" in selectedNode) {
 			// Add variables with a (relative and absolute) popup coordinate string for the selected node
 			var nodeRect = {
@@ -288,7 +225,7 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 			variables["tv-selectednode-height"] = selectedNode.offsetHeight.toString();
 		}
 	}
-	
+
 	if(domNode && ("offsetWidth" in domNode)) {
 		variables["tv-widgetnode-width"] = domNode.offsetWidth.toString();
 		variables["tv-widgetnode-height"] = domNode.offsetHeight.toString();
@@ -301,7 +238,7 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 			variables["event-fromselected-posx"] = (event.clientX - selectedNodeRect.left).toString();
 			variables["event-fromselected-posy"] = (event.clientY - selectedNodeRect.top).toString();
 		}
-		
+
 		if(domNode) {
 			// Add variables for event X and Y position relative to event catcher node
 			domNodeRect = domNode.getBoundingClientRect();
@@ -309,16 +246,12 @@ exports.collectDOMVariables = function(selectedNode,domNode,event) {
 			variables["event-fromcatcher-posy"] = (event.clientY - domNodeRect.top).toString();
 		}
 
-		// Add variables for event X and Y position relative to the viewport
 		variables["event-fromviewport-posx"] = event.clientX.toString();
 		variables["event-fromviewport-posy"] = event.clientY.toString();
 	}
 	return variables;
 };
 
-/*
-Make sure the CSS selector is not invalid
-*/
 exports.querySelectorSafe = function(selector,baseElement) {
 	baseElement = baseElement || document;
 	try {

--- a/core/modules/utils/dom/dragndrop.js
+++ b/core/modules/utils/dom/dragndrop.js
@@ -2,23 +2,10 @@
 title: $:/core/modules/utils/dom/dragndrop.js
 type: application/javascript
 module-type: utils
-
-Browser data transfer utilities, used with the clipboard and drag and drop
-
 \*/
 
 "use strict";
 
-/*
-Options:
-
-domNode: dom node to make draggable
-selector: CSS selector to identify element within domNode to be used as drag handle (optional)
-dragImageType: "pill", "blank" or "dom" (the default)
-dragTiddlerFn: optional function to retrieve the title of tiddler to drag
-dragFilterFn: optional function to retreive the filter defining a list of tiddlers to drag
-widget: widget to use as the context for the filter
-*/
 exports.makeDraggable = function(options) {
 	var dragImageType = options.dragImageType || "dom",
 		dragImage,
@@ -27,13 +14,13 @@ exports.makeDraggable = function(options) {
 	if(!options.selector && ((domNode.tagName || "").toLowerCase() !== "a")) {
 		domNode.setAttribute("draggable","true");
 	}
-	// Add event handlers
+
 	$tw.utils.addEventListeners(domNode,[
 		{name: "dragstart", handlerFunction: function(event) {
 			if(event.dataTransfer === undefined) {
 				return false;
 			}
-			// Collect the tiddlers being dragged
+
 			var dragTiddler = options.dragTiddlerFn && options.dragTiddlerFn(),
 				dragFilter = options.dragFilterFn && options.dragFilterFn(),
 				titles = dragTiddler ? [dragTiddler] : [],
@@ -64,7 +51,7 @@ exports.makeDraggable = function(options) {
 				var inner = options.widget.document.createElement("div");
 				inner.className = "tc-tiddler-dragger-inner";
 				inner.appendChild(options.widget.document.createTextNode(
-					titles.length === 1 ? 
+					titles.length === 1 ?
 						titles[0] :
 						titles.length + " tiddlers"
 				));
@@ -104,7 +91,7 @@ exports.makeDraggable = function(options) {
 					dataTransfer.setData("text/plain",titleString);
 					dataTransfer.setData("text/x-moz-url","data:text/vnd.tiddler," + encodeURIComponent(jsonData));
 				}
-				// If browser is Chrome-like and has a touch-input device do NOT .setData
+
 				if(!($tw.browser.isMobileChrome)) {
 					dataTransfer.setData("URL","data:text/vnd.tiddler," + encodeURIComponent(jsonData));
 				}
@@ -133,7 +120,7 @@ exports.makeDraggable = function(options) {
 					variables["actionTiddler"] = titleString;
 					options.widget.invokeActionString(endActions,options.widget,event,variables);
 				}
-				// Remove the dragging class on the element being dragged
+
 				$tw.utils.removeClass(domNode,"tc-dragging");
 				// Delete the drag image element
 				if(dragImage) {

--- a/core/modules/utils/dom/http.js
+++ b/core/modules/utils/dom/http.js
@@ -2,18 +2,10 @@
 title: $:/core/modules/utils/dom/http.js
 type: application/javascript
 module-type: utils
-
-HTTP support
-
 \*/
 
 "use strict";
 
-/*
-Manage tm-http-request events. Options include:
-wiki: Reference to the wiki to be used for state tiddler tracking
-stateTrackerTitle: Title of tiddler to be used for state tiddler tracking
-*/
 function HttpClient(options) {
 	options = options || {};
 	this.nextId = 1;
@@ -23,9 +15,6 @@ function HttpClient(options) {
 	this.updateRequestTracker();
 }
 
-/*
-Return the index into this.requests[] corresponding to a given ID. Returns null if not found
-*/
 HttpClient.prototype.getRequestIndex = function(targetId) {
 	var targetIndex = null;
 	$tw.utils.each(this.requests,function(requestInfo,index) {
@@ -36,9 +25,6 @@ HttpClient.prototype.getRequestIndex = function(targetId) {
 	return targetIndex;
 };
 
-/*
-Update the state tiddler that is tracking the outstanding requests
-*/
 HttpClient.prototype.updateRequestTracker = function() {
 	this.wiki.addTiddler({title: this.stateTrackerTitle, text: "" + this.requests.length});
 };
@@ -81,29 +67,6 @@ HttpClient.prototype.cancelHttpRequest = function(targetId) {
 	}
 };
 
-/*
-Initiate an HTTP request. Options:
-wiki: wiki to be used for executing action strings
-url: URL for request
-method: method eg GET, POST
-body: text of request body
-binary: set to "yes" to force binary processing of response payload
-oncompletion: action string to be invoked on completion
-onprogress: action string to be invoked on progress updates
-bindStatus: optional title of tiddler to which status ("pending", "complete", "error") should be written
-bindProgress: optional title of tiddler to which the progress of the request (0 to 100) should be bound
-variables: hashmap of variable name to string value passed to action strings
-headers: hashmap of header name to header value to be sent with the request
-passwordHeaders: hashmap of header name to password store name to be sent with the request
-queryStrings: hashmap of query string parameter name to parameter value to be sent with the request
-passwordQueryStrings: hashmap of query string parameter name to password store name to be sent with the request
-basicAuthUsername: plain username for basic authentication
-basicAuthUsernameFromStore: name of password store entry containing username
-basicAuthPassword: plain password for basic authentication
-basicAuthPasswordFromStore: name of password store entry containing password
-bearerAuthToken: plain text token for bearer authentication
-bearerAuthTokenFromStore: name of password store entry contain bear authorization token
-*/
 function HttpClientRequest(options) {
 	var self = this;
 	console.log("Initiating an HTTP request",options)
@@ -192,7 +155,6 @@ HttpClientRequest.prototype.send = function(callback) {
 					data: (data || "").toString(),
 					headers: JSON.stringify(headers)
 				};
-				/* Convert data from binary to base64 */
 				if (xhr.responseType === "arraybuffer") {
 					var binary = "",
 						bytes = new Uint8Array(data),
@@ -231,16 +193,6 @@ HttpClientRequest.prototype.cancel = function() {
 
 exports.HttpClient = HttpClient;
 
-/*
-Make an HTTP request. Options are:
-	url: URL to retrieve
-	headers: hashmap of headers to send
-	type: GET, PUT, POST etc
-	callback: function invoked with (err,data,xhr)
-	progress: optional function invoked with (lengthComputable,loaded,total)
-	returnProp: string name of the property to return as first argument of callback
-	responseType: "text" or "arraybuffer"
-*/
 exports.httpRequest = function(options) {
 	var type = options.type || "GET",
 		url = options.url,
@@ -302,7 +254,7 @@ exports.httpRequest = function(options) {
 				options.callback(null,this[returnProp],this);
 				return;
 			}
-		// Something went wrong
+
 		options.callback($tw.language.getString("Error/XMLHttpRequest") + ": " + this.status,this[returnProp],this);
 		}
 	};
@@ -313,7 +265,7 @@ exports.httpRequest = function(options) {
 			options.progress(event.lengthComputable,event.loaded,event.total);
 		};
 	}
-	// Make the request
+
 	request.open(type,url,true);
 	// Headers
 	if(headers) {
@@ -327,7 +279,7 @@ exports.httpRequest = function(options) {
 	if(!hasHeader("X-Requested-With") && !isSimpleRequest(type,headers) && useDefaultHeaders) {
 		request.setRequestHeader("X-Requested-With","TiddlyWiki");
 	}
-	// Send data
+
 	try {
 		request.send(data);
 	} catch(e) {

--- a/core/modules/utils/dom/keyboard.js
+++ b/core/modules/utils/dom/keyboard.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/dom/keyboard.js
 type: application/javascript
 module-type: utils
-
-Keyboard utilities; now deprecated. Instead, use $tw.keyboardManager
-
 \*/
 
 "use strict";

--- a/core/modules/utils/dom/modal.js
+++ b/core/modules/utils/dom/modal.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/dom/modal.js
 type: application/javascript
 module-type: utils
-
-Modal message mechanism
-
 \*/
 
 "use strict";
@@ -17,15 +14,6 @@ var Modal = function(wiki) {
 	this.modalCount = 0;
 };
 
-/*
-Display a modal dialogue
-	title: Title of tiddler to display
-	options: see below
-Options include:
-	downloadLink: Text of a big download link to include
-	event: widget event
-	variables: from event.paramObject
-*/
 Modal.prototype.display = function(title,options) {
 	options = options || {};
 	this.srcDocument = options.variables && (options.variables.rootwindow === "true" ||
@@ -40,7 +28,7 @@ Modal.prototype.display = function(title,options) {
 	if(!tiddler) {
 		return;
 	}
-	// Create the variables
+
 	var variables = $tw.utils.extend({
 			currentTiddler: title,
 			"tv-story-list": (options.event && options.event.widget ? options.event.widget.getVariable("tv-story-list") : ""),
@@ -137,7 +125,7 @@ Modal.prototype.display = function(title,options) {
 		modalLink.appendChild(this.srcDocument.createTextNode("Right-click to save changes"));
 		modalBody.appendChild(modalLink);
 	}
-	// Render the footer of the message
+
 	if(tiddler.fields && tiddler.fields.help) {
 		var link = this.srcDocument.createElement("a");
 		link.setAttribute("href",tiddler.fields.help);

--- a/core/modules/utils/dom/notifier.js
+++ b/core/modules/utils/dom/notifier.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/dom/notifier.js
 type: application/javascript
 module-type: utils
-
-Notifier mechanism
-
 \*/
 
 "use strict";
@@ -15,12 +12,6 @@ var Notifier = function(wiki) {
 	this.wiki = wiki;
 };
 
-/*
-Display a notification
-	title: Title of tiddler containing the notification text
-	options: see below
-Options include:
-*/
 Notifier.prototype.display = function(title,options) {
 	options = options || {};
 	// Create the wrapper divs
@@ -33,7 +24,7 @@ Notifier.prototype.display = function(title,options) {
 	if(!tiddler) {
 		return;
 	}
-	// Add classes and roles
+
 	$tw.utils.addClass(notification,"tc-notification");
 	notification.setAttribute("role","alert");
 	// Create the variables

--- a/core/modules/utils/dom/popup.js
+++ b/core/modules/utils/dom/popup.js
@@ -2,45 +2,20 @@
 title: $:/core/modules/utils/dom/popup.js
 type: application/javascript
 module-type: utils
-
-Module that creates a $tw.utils.Popup object prototype that manages popups in the browser
-
 \*/
 
 "use strict";
 
-/*
-Creates a Popup object with these options:
-	rootElement: the DOM element to which the popup zapper should be attached
-*/
 var Popup = function(options) {
 	options = options || {};
 	this.rootElement = options.rootElement || document.documentElement;
 	this.popups = []; // Array of {title:,wiki:,domNode:} objects
 };
 
-/*
-Global regular expression for parsing the location of a popup.
-This is also used by the Reveal widget.
-*/
 exports.popupLocationRegExp = /^(@?)\((-?[0-9\.E]+),(-?[0-9\.E]+),(-?[0-9\.E]+),(-?[0-9\.E]+)\)$/
 
-/*
-Objekt containing the available prefixes for coordinates build with the `buildCoordinates` function:
- - csOffsetParent: Uses a coordinate system based on the offset parent (no prefix).
- - csAbsolute: Use an absolute coordinate system (prefix "@").
-*/
 exports.coordinatePrefix = { csOffsetParent: "", csAbsolute: "@" }
 
-/*
-Trigger a popup open or closed. Parameters are in a hashmap:
-	title: title of the tiddler where the popup details are stored
-	domNode: dom node to which the popup will be positioned (one of domNode or domNodeRect is required)
-	domNodeRect: rectangle to which the popup will be positioned
-	wiki: wiki
-	force: if specified, forces the popup state to true or false (instead of toggling it)
-	floating: if true, skips registering the popup, meaning that it will need manually clearing
-*/
 Popup.prototype.triggerPopup = function(options) {
 	// Check if this popup is already active
 	var index = this.findPopup(options.title);
@@ -49,7 +24,7 @@ Popup.prototype.triggerPopup = function(options) {
 	if(options.force !== undefined) {
 		state = options.force;
 	}
-	// Show or cancel the popup according to the new state
+
 	if(state) {
 		this.show(options);
 	} else {
@@ -101,7 +76,7 @@ Popup.prototype.popupInfo = function(domNode) {
 		}
 		node = node.parentNode;
 	}
-	// Then count the number of ancestor popups
+
 	node = domNode;
 	while(node) {
 		if($tw.utils.hasClass(node,"tc-popup")) {
@@ -116,9 +91,6 @@ Popup.prototype.popupInfo = function(domNode) {
 	return info;
 };
 
-/*
-Display a popup by adding it to the stack
-*/
 Popup.prototype.show = function(options) {
 	// Find out what was clicked on
 	var info = this.popupInfo(options.domNode);
@@ -134,7 +106,7 @@ Popup.prototype.show = function(options) {
 			noStateReference: options.noStateReference
 		});
 	}
-	// Set the state tiddler
+
 	var rect;
 	if(options.domNodeRect) {
 		rect = options.domNodeRect;
@@ -148,7 +120,7 @@ Popup.prototype.show = function(options) {
 	}
 	if(options.absolute && options.domNode) {
 		// Walk the offsetParent chain and add the position of the offsetParents to make
-		// the position absolute to the root node of the page.
+
 		var currentNode = options.domNode.offsetParent;
 		while(currentNode) {
 			rect.left += currentNode.offsetLeft;
@@ -162,16 +134,12 @@ Popup.prototype.show = function(options) {
 	} else {
 		options.wiki.setTextReference(options.title,popupRect);
 	}
-	// Add the click handler if we have any popups
+
 	if(this.popups.length > 0) {
 		this.rootElement.addEventListener("click",this,true);
 	}
 };
 
-/*
-Cancel all popups at or above a specified level or DOM node
-level: popup level to cancel (0 cancels all popups)
-*/
 Popup.prototype.cancel = function(level) {
 	var numPopups = this.popups.length;
 	level = Math.max(0,Math.min(level,numPopups));
@@ -190,23 +158,10 @@ Popup.prototype.cancel = function(level) {
 	}
 };
 
-/*
-Returns true if the specified title and text identifies an active popup.
-This function is safe to call, even if the popup class was not initialized.
-*/
 exports.readPopupState = function(text) {
 	return exports.popupLocationRegExp.test(text);
 };
 
-/*
-Parses a coordinate string in the format `(x,y,w,h)` or `@(x,y,z,h)` and returns
-an object containing the position, width and height. The absolute-Mark is boolean
-value that indicates the coordinate system of the coordinates. If they start with
-an `@`, `absolute` is set to true and the coordinates are relative to the root
-element. If the initial `@` is missing, they are relative to the offset parent
-element and `absoute` is false.
-This function is safe to call, even if the popup class was not initialized.
-*/
 exports.parseCoordinates = function(coordinates) {
 	var match = exports.popupLocationRegExp.exec(coordinates);
 	if(match) {
@@ -222,14 +177,6 @@ exports.parseCoordinates = function(coordinates) {
 	}
 }
 
-/*
-Builds a coordinate string from a coordinate system identifier and an object
-containing the left, top, width and height values.
-Use constants defined in coordinatePrefix to specify a coordinate system.
-If one of the parameters is invalid for building a coordinate string `(0,0,0,0)`
-will be returned.
-This function is safe to call, even if the popup class was not initialized.
-*/
 exports.buildCoordinates = function(prefix,position) {
 	var coord = prefix + "(" + position.left + "," + position.top + "," + position.width + "," + position.height + ")";
 	if (exports.popupLocationRegExp.test(coord)) {

--- a/core/modules/utils/dom/scroller.js
+++ b/core/modules/utils/dom/scroller.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/utils/dom/scroller.js
 type: application/javascript
 module-type: utils
-
-Module that creates a $tw.utils.Scroller object prototype that manages scrolling in the browser
-
 \*/
 
 "use strict";
 
-/*
-Event handler for when the `tm-scroll` event hits the document body
-*/
 var PageScroller = function() {
 	this.idRequestFrame = null;
 	this.requestAnimationFrame = window.requestAnimationFrame ||
@@ -41,9 +35,6 @@ PageScroller.prototype.cancelScroll = function(srcWindow) {
 	}
 };
 
-/*
-Handle an event
-*/
 PageScroller.prototype.handleEvent = function(event) {
 	if(event.type === "tm-scroll") {
 		var options = {};
@@ -60,9 +51,6 @@ PageScroller.prototype.handleEvent = function(event) {
 	return true;
 };
 
-/*
-Handle a scroll event hitting the page document
-*/
 PageScroller.prototype.scrollIntoView = function(element,callback,options) {
 	var self = this,
 		duration = $tw.utils.hop(options,"animationDuration") ? parseInt(options.animationDuration) : $tw.utils.getAnimationDuration(),
@@ -76,7 +64,7 @@ PageScroller.prototype.scrollIntoView = function(element,callback,options) {
 	if(toolbar) {
 		offset = toolbar.offsetHeight;
 	}
-	// Get the client bounds of the element and adjust by the scroll position
+
 	var getBounds = function() {
 			var clientBounds = typeof callback === 'function' ? callback() : element.getBoundingClientRect(),
 				scrollPosition = $tw.utils.getScrollPosition(srcWindow);

--- a/core/modules/utils/errors.js
+++ b/core/modules/utils/errors.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/errors.js
 type: application/javascript
 module-type: utils
-
-Custom errors for TiddlyWiki.
-
 \*/
 
 function TranscludeRecursionError() {
@@ -12,7 +9,6 @@ function TranscludeRecursionError() {
 	this.signatures = Object.create(null);
 };
 
-/* Maximum permitted depth of the widget tree for recursion detection */
 TranscludeRecursionError.MAX_WIDGET_TREE_DEPTH = 1000;
 
 TranscludeRecursionError.prototype = Object.create(Error);

--- a/core/modules/utils/escapecss.js
+++ b/core/modules/utils/escapecss.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/escapecss.js
 type: application/javascript
 module-type: utils-browser
-
-Provides CSS.escape() functionality.
-
 \*/
 
 "use strict";

--- a/core/modules/utils/fakedom.js
+++ b/core/modules/utils/fakedom.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/fakedom.js
 type: application/javascript
 module-type: global
-
-A barebones implementation of DOM interfaces needed by the rendering mechanism.
-
 \*/
 
 "use strict";
@@ -87,7 +84,7 @@ var TW_Style = function(el) {
 			if (property in target) {
 				return target[property];
 			}
-			// Otherwise, return the corresponding property from _style
+
 			return el._style[$tw.utils.convertStyleNameToPropertyName(property)] || "";
 		},
 		set: function(target, property, value) {
@@ -109,7 +106,6 @@ var TW_Element = function(tag, namespace) {
 	this.style = new TW_Style(this); // Proxy for style management
 	this.namespaceURI = namespace || "http://www.w3.org/1999/xhtml";
 };
-
 
 Object.setPrototypeOf(TW_Element.prototype,TW_Node.prototype);
 

--- a/core/modules/utils/linked-list.js
+++ b/core/modules/utils/linked-list.js
@@ -2,10 +2,6 @@
 module-type: utils
 title: $:/core/modules/utils/linkedlist.js
 type: application/javascript
-
-This is a doubly-linked indexed list intended for manipulation, particularly
-pushTop, which it does with significantly better performance than an array.
-
 \*/
 
 "use strict";
@@ -38,11 +34,7 @@ LinkedList.prototype.remove = function(value) {
 	}
 };
 
-/*
-Push behaves like array.push and accepts multiple string arguments. But it also
-accepts a single array argument too, to be consistent with its other methods.
-*/
-LinkedList.prototype.push = function(/* values */) {
+LinkedList.prototype.push = function() {
 	var i, values = arguments;
 	if($tw.utils.isArray(values[0])) {
 		values = values[0];
@@ -120,7 +112,7 @@ function _removeOne(list,value) {
 		next = nextEntry[0];
 		prev = prevEntry[0];
 	}
-	// Relink preceding element.
+
 	ref = list.next.get(prev);
 	if(Array.isArray(ref)) {
 		var i = ref.indexOf(value);
@@ -129,7 +121,6 @@ function _removeOne(list,value) {
 		list.next.set(prev,next);
 	}
 
-	// Now relink following element
 	ref = list.prev.get(next);
 	if(Array.isArray(ref)) {
 		var i = ref.indexOf(value);
@@ -138,7 +129,6 @@ function _removeOne(list,value) {
 		list.prev.set(next,prev);
 	}
 
-	// Delink actual value. If it uses arrays, just remove first entries.
 	if(Array.isArray(nextEntry) && nextEntry.length > 1) {
 		nextEntry.shift();
 		prevEntry.shift();
@@ -166,7 +156,7 @@ function _linkToEnd(list,value) {
 		list.next.set(value,null);
 		list.prev.set(value,last);
 	}
-	// Make the old last point to this new one.
+
 	if(value !== last) {
 		var array = list.next.get(last);
 		if(Array.isArray(array)) {
@@ -177,7 +167,7 @@ function _linkToEnd(list,value) {
 		list.prev.set(null,value);
 	} else {
 		// Edge case, the pushed value was already the last value.
-		// The second-to-last nextPtr for that value must point to itself now.
+
 		var array = list.next.get(last);
 		array[array.length-2] = value;
 	}

--- a/core/modules/utils/logger.js
+++ b/core/modules/utils/logger.js
@@ -2,18 +2,12 @@
 title: $:/core/modules/utils/logger.js
 type: application/javascript
 module-type: utils
-
-A basic logging implementation
-
 \*/
 
 "use strict";
 
 var ALERT_TAG = "$:/tags/Alert";
 
-/*
-Make a new logger
-*/
 function Logger(componentName,options) {
 	options = options || {};
 	this.componentName = componentName || "";
@@ -30,10 +24,7 @@ Logger.prototype.setSaveBuffer = function(logger) {
 	this.saveBufferLogger = logger;
 };
 
-/*
-Log a message
-*/
-Logger.prototype.log = function(/* args */) {
+Logger.prototype.log = function() {
 	var self = this;
 	if(this.enable) {
 		if(this.saveBufferLogger.save) {
@@ -49,27 +40,18 @@ Logger.prototype.log = function(/* args */) {
 			logMessage[logMessage.length-1] += $tw.utils.terminalColour();
 			return Function.apply.call(console.log, console, logMessage);
 		}
-	} 
+	}
 };
 
-/*
-Read the message buffer
-*/
 Logger.prototype.getBuffer = function() {
 	return this.saveBufferLogger.buffer;
 };
 
-/*
-Log a structure as a table
-*/
 Logger.prototype.table = function(value) {
 	(console.table || console.log)(value);
 };
 
-/*
-Alert a message
-*/
-Logger.prototype.alert = function(/* args */) {
+Logger.prototype.alert = function() {
 	if(this.enable) {
 		// Prepare the text of the alert
 		var text = Array.prototype.join.call(arguments," ");
@@ -114,9 +96,6 @@ Logger.prototype.alert = function(/* args */) {
 	}
 };
 
-/*
-Clear outstanding alerts
-*/
 Logger.prototype.clearAlerts = function() {
 	var self = this;
 	if($tw.browser && this.alertCount > 0) {

--- a/core/modules/utils/messaging.js
+++ b/core/modules/utils/messaging.js
@@ -2,25 +2,12 @@
 title: $:/core/modules/utils/messaging.js
 type: application/javascript
 module-type: utils-browser
-
-Messaging utilities for use with window.postMessage() etc.
-
-This module intentionally has no dependencies so that it can be included in non-TiddlyWiki projects
-
 \*/
 
 "use strict";
 
 var RESPONSE_TIMEOUT = 2 * 1000;
 
-/*
-Class to handle subscribing to publishers
-
-target: Target window (eg iframe.contentWindow)
-type: String indicating type of item for which subscriptions are being provided (eg "SAVING")
-onsubscribe: Function to be invoked with err parameter when the subscription is established, or there is a timeout
-onmessage: Function to be invoked when a new message arrives, invoked with (data,callback). The callback is invoked with the argument (response)
-*/
 function BrowserMessagingSubscriber(options) {
 	var self = this;
 	this.target = options.target;
@@ -32,7 +19,7 @@ function BrowserMessagingSubscriber(options) {
 	this.channel.port1.addEventListener("message",function(event) {
 		if(this.timerID) {
 			clearTimeout(this.timerID);
-			this.timerID = null;		
+			this.timerID = null;
 		}
 		if(event.data) {
 			if(event.data.verb === "SUBSCRIBED") {
@@ -50,7 +37,7 @@ function BrowserMessagingSubscriber(options) {
 	// Set a timer so that if we don't hear from the iframe before a timeout we alert the user
 	this.timerID = setTimeout(function() {
 		if(!self.hasConfirmed) {
-			self.onsubscribe("NO_RESPONSE");				
+			self.onsubscribe("NO_RESPONSE");
 		}
 	},RESPONSE_TIMEOUT);
 	this.channel.port1.start();
@@ -95,7 +82,7 @@ BrowserMessagingPublisher.prototype.send = function(data,callback) {
 	if(!this.hostIsListening || !this.port) {
 		return false;
 	}
-	// Create a channel for the confirmation
+
 	var channel = new MessageChannel();
 	channel.port1.addEventListener("message",function(event) {
 		if(event.data && event.data.verb === "OK") {
@@ -114,7 +101,7 @@ BrowserMessagingPublisher.prototype.close = function() {
 	if(this.port) {
 		this.port.close();
 		this.hostIsListening = false;
-		this.port = null;		
+		this.port = null;
 	}
 };
 

--- a/core/modules/utils/parsetree.js
+++ b/core/modules/utils/parsetree.js
@@ -2,17 +2,10 @@
 title: $:/core/modules/utils/parsetree.js
 type: application/javascript
 module-type: utils
-
-Parse tree utility functions.
-
 \*/
 
 "use strict";
 
-/*
-Add attribute to parse tree node
-Can be invoked as (node,name,value) or (node,attr)
-*/
 exports.addAttributeToParseTreeNode = function(node,name,value) {
 	var attribute = typeof name === "object" ? name : {name: name, type: "string", value: value};
 	name = attribute.name;
@@ -100,9 +93,6 @@ exports.findParseTreeNode = function(nodeArray,search) {
 	return undefined;
 };
 
-/*
-Helper to get the text of a parse tree node or array of nodes
-*/
 exports.getParseTreeText = function getParseTreeText(tree) {
 	var output = [];
 	if($tw.utils.isArray(tree)) {

--- a/core/modules/utils/performance.js
+++ b/core/modules/utils/performance.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/utils/performance.js
 type: application/javascript
 module-type: global
-
-Performance measurement.
-
 \*/
 
 "use strict";
@@ -22,9 +19,6 @@ Performance.prototype.showGreeting = function() {
 	}
 };
 
-/*
-Wrap performance reporting around a top level function
-*/
 Performance.prototype.report = function(name,fn) {
 	var self = this;
 	if(this.enabled) {
@@ -62,9 +56,6 @@ Performance.prototype.log = function() {
 	self.logger.table(results);
 };
 
-/*
-Wrap performance measurements around a subfunction
-*/
 Performance.prototype.measure = function(name,fn) {
 	var self = this;
 	if(this.enabled) {

--- a/core/modules/utils/pluginmaker.js
+++ b/core/modules/utils/pluginmaker.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/utils/pluginmaker.js
 type: application/javascript
 module-type: utils
-
-A quick and dirty way to pack up plugins within the browser.
-
 \*/
 
 "use strict";
 
-/*
-Repack a plugin, and then delete any non-shadow payload tiddlers
-*/
 exports.repackPlugin = function(title,additionalTiddlers,excludeTiddlers) {
 	additionalTiddlers = additionalTiddlers || [];
 	excludeTiddlers = excludeTiddlers || [];
@@ -20,12 +14,12 @@ exports.repackPlugin = function(title,additionalTiddlers,excludeTiddlers) {
 	if(!pluginTiddler) {
 		throw "No such tiddler as " + title;
 	}
-	// Extract the JSON
+
 	var jsonPluginTiddler = $tw.utils.parseJSONSafe(pluginTiddler.fields.text,null);
 	if(!jsonPluginTiddler) {
 		throw "Cannot parse plugin tiddler " + title + "\n" + $tw.language.getString("Error/Caption") + ": " + e;
 	}
-	// Get the list of tiddlers
+
 	var tiddlers = Object.keys(jsonPluginTiddler.tiddlers);
 	// Add the additional tiddlers
 	$tw.utils.pushTop(tiddlers,additionalTiddlers);
@@ -35,7 +29,7 @@ exports.repackPlugin = function(title,additionalTiddlers,excludeTiddlers) {
 			tiddlers.splice(t,1);
 		}
 	}
-	// Pack up the tiddlers into a block of JSON
+
 	var plugins = {};
 	$tw.utils.each(tiddlers,function(title) {
 		var tiddler = $tw.wiki.getTiddler(title),
@@ -59,7 +53,7 @@ exports.repackPlugin = function(title,additionalTiddlers,excludeTiddlers) {
 	if(pluginVersion.build) {
 		version += "+" + pluginVersion.build;
 	}
-	// Save the tiddler
+
 	$tw.wiki.addTiddler(new $tw.Tiddler(pluginTiddler,{text: JSON.stringify({tiddlers: plugins},null,4), version: version},$tw.wiki.getModificationFields()));
 	// Delete any non-shadow constituent tiddlers
 	$tw.utils.each(tiddlers,function(title) {

--- a/core/modules/utils/transliterate.js
+++ b/core/modules/utils/transliterate.js
@@ -2,18 +2,10 @@
 title: $:/core/modules/utils/transliterate.js
 type: application/javascript
 module-type: utils
-
-Transliteration static utility functions.
-
 \*/
 
 "use strict";
 
-/*
-Transliterate string to ASCII
-
-(Some pairs taken from http://semplicewebsites.com/removing-accents-javascript)
-*/
 exports.transliterationPairs = {
 	"Á":"A",
 	"Ă":"A",

--- a/core/modules/utils/utils.js
+++ b/core/modules/utils/utils.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/utils/utils.js
 type: application/javascript
 module-type: utils
-
-Various static utility functions.
-
 \*/
 
 "use strict";
 
-/*
-Display a message, in colour if we're on a terminal
-*/
 exports.log = function(text,colour) {
 	console.log($tw.node ? exports.terminalColour(colour) + text + exports.terminalColour() : text);
 };
@@ -41,25 +35,15 @@ exports.terminalColourLookup = {
 	"light gray": "0;37"
 };
 
-/*
-Display a warning, in colour if we're on a terminal
-*/
 exports.warning = function(text) {
 	exports.log(text,"brown/orange");
 };
 
-/*
-Return the integer represented by the str (string).
-Return the dflt (default) parameter if str is not a base-10 number.
-*/
 exports.getInt = function(str,deflt) {
 	var i = parseInt(str,10);
 	return isNaN(i) ? deflt : i;
 };
 
-/*
-Repeatedly replaces a substring within a string. Like String.prototype.replace, but without any of the default special handling of $ sequences in the replace string
-*/
 exports.replaceString = function(text,search,replace) {
 	return text.replace(search,function() {
 		return replace;
@@ -96,24 +80,14 @@ exports.trimSuffix = function(str,unwanted) {
 	}
 };
 
-/*
-Convert a string to sentence case (ie capitalise first letter)
-*/
 exports.toSentenceCase = function(str) {
 	return (str || "").replace(/^\S/, function(c) {return c.toUpperCase();});
 };
 
-/*
-Convert a string to title case (ie capitalise each initial letter)
-*/
 exports.toTitleCase = function(str) {
 	return (str || "").replace(/(^|\s)\S/g, function(c) {return c.toUpperCase();});
 };
 
-/*
-Find the line break preceding a given position in a string
-Returns position immediately after that line break, or the start of the string
-*/
 exports.findPrecedingLineBreak = function(text,pos) {
 	var result = text.lastIndexOf("\n",pos - 1);
 	if(result === -1) {
@@ -127,9 +101,6 @@ exports.findPrecedingLineBreak = function(text,pos) {
 	return result;
 };
 
-/*
-Find the line break following a given position in a string
-*/
 exports.findFollowingLineBreak = function(text,pos) {
 	// Cut to just past the following line break, or to the end of the text
 	var result = text.indexOf("\n",pos);
@@ -143,18 +114,10 @@ exports.findFollowingLineBreak = function(text,pos) {
 	return result;
 };
 
-/*
-Return the number of keys in an object
-*/
 exports.count = function(object) {
 	return Object.keys(object || {}).length;
 };
 
-/*
-Remove entries from an array
-	array: array to modify
-	value: a single value to remove, or an array of values to remove
-*/
 exports.removeArrayEntries = function(array,value) {
 	var t,p;
 	if($tw.utils.isArray(value)) {
@@ -173,9 +136,6 @@ exports.removeArrayEntries = function(array,value) {
 	return array;
 };
 
-/*
-Check whether any members of a hashmap are present in another hashmap
-*/
 exports.checkDependencies = function(dependencies,changes) {
 	var hit = false;
 	$tw.utils.each(changes,function(change,title) {
@@ -186,7 +146,7 @@ exports.checkDependencies = function(dependencies,changes) {
 	return hit;
 };
 
-exports.extend = function(object /* [, src] */) {
+exports.extend = function(object) {
 	$tw.utils.each(Array.prototype.slice.call(arguments, 1), function(source) {
 		if(source) {
 			for(var property in source) {
@@ -251,15 +211,15 @@ exports.copyObjectPropertiesSafe = function(object) {
 		if(seen.has(obj)) {
 			return undefined;
 		}
-		// primitives and null are safe
+
 		if(typeof obj !== "object" || obj === null) {
 			return obj;
 		}
-		// skip DOM elements
+
 		if(isDOMElement(obj)) {
 			return undefined;
 		}
-		// copy arrays, preserving positions
+
 		if(Array.isArray(obj)) {
 			return obj.map(item => {
 				const value = safeCopy(item);
@@ -443,7 +403,7 @@ exports.formatDateString = function(date,template) {
 			}]
 		];
 	// If the user wants everything in UTC, shift the datestamp
-	// Optimize for format string that essentially means
+
 	// 'return raw UTC (tiddlywiki style) date string.'
 	if(t.indexOf("[UTC]") == 0 ) {
 		if(t == "[UTC]YYYY0MM0DD0hh0mm0ssXXX")
@@ -508,13 +468,6 @@ exports.getHours12 = function(date) {
 	return h > 12 ? h-12 : ( h > 0 ? h : 12 );
 };
 
-/*
-Convert a date delta in milliseconds into a string representation of "23 seconds ago", "27 minutes ago" etc.
-	delta: delta in milliseconds
-Returns an object with these members:
-	description: string describing the delta period
-	updatePeriod: time in millisecond until the string will be inaccurate
-*/
 exports.getRelativeDate = function(delta) {
 	var futurep = false;
 	if(delta < 0) {
@@ -635,42 +588,35 @@ exports.stringify = function(s, rawUnicode) {
 	var regex = rawUnicode ? /[\x00-\x1f]/g : /[\x00-\x1f\x80-\uFFFF]/g;
 	return (s || "")
 		.replace(/\\/g, "\\\\")            // backslash
-		.replace(/"/g, '\\"')              // double quote character
-		.replace(/'/g, "\\'")              // single quote character
-		.replace(/\r/g, "\\r")             // carriage return
-		.replace(/\n/g, "\\n")             // line feed
+		.replace(/"/g, '\\"')
+		.replace(/'/g, "\\'")
+		.replace(/\r/g, "\\r")
+		.replace(/\n/g, "\\n")
 		.replace(regex, exports.escape);   // non-ASCII characters
 };
 
 // Turns a string into a legal JSON string
-// Derived from peg.js, thanks to David Majda
+
 exports.jsonStringify = function(s, rawUnicode) {
 	// See http://www.json.org/
 	var regex = rawUnicode ? /[\x00-\x1f]/g : /[\x00-\x1f\x80-\uFFFF]/g;
 	return (s || "")
-		.replace(/\\/g, "\\\\")            // backslash
-		.replace(/"/g, '\\"')              // double quote character
-		.replace(/\r/g, "\\r")             // carriage return
-		.replace(/\n/g, "\\n")             // line feed
-		.replace(/\x08/g, "\\b")           // backspace
-		.replace(/\x0c/g, "\\f")           // formfeed
-		.replace(/\t/g, "\\t")             // tab
+		.replace(/\\/g, "\\\\")
+		.replace(/"/g, '\\"')
+		.replace(/\r/g, "\\r")
+		.replace(/\n/g, "\\n")
+		.replace(/\x08/g, "\\b")
+		.replace(/\x0c/g, "\\f")
+		.replace(/\t/g, "\\t")
 		.replace(regex,function(s) {
 			return "\\u" + $tw.utils.pad(s.charCodeAt(0).toString(16).toUpperCase(),4);
 		}); // non-ASCII characters
 };
 
-/*
-Escape the RegExp special characters with a preceding backslash
-*/
 exports.escapeRegExp = function(s) {
 	return s.replace(/[\-\/\\\^\$\*\+\?\.\(\)\|\[\]\{\}]/g, "\\$&");
 };
 
-/*
-Extended version of encodeURIComponent that encodes additional characters including
-those that are illegal within filepaths on various platforms including Windows
-*/
 exports.encodeURIComponentExtended = function(s) {
 	return encodeURIComponent(s).replace(/[!'()*]/g,function(c) {
 		return "%" + c.charCodeAt(0).toString(16).toUpperCase();
@@ -684,7 +630,6 @@ exports.isLinkExternal = function(to) {
 };
 
 exports.nextTick = function(fn) {
-/*global window: false */
 	if(typeof process === "undefined") {
 		// Apparently it would be faster to use postMessage - http://dbaron.org/log/20100309-faster-timeouts
 		window.setTimeout(fn,0);
@@ -693,36 +638,18 @@ exports.nextTick = function(fn) {
 	}
 };
 
-/*
-Convert a hyphenated CSS property name into a camel case one
-*/
 exports.unHyphenateCss = function(propName) {
 	return propName.replace(/-([a-z])/gi, function(match0,match1) {
 		return match1.toUpperCase();
 	});
 };
 
-/*
-Convert a camelcase CSS property name into a dashed one ("backgroundColor" --> "background-color")
-*/
 exports.hyphenateCss = function(propName) {
 	return propName.replace(/([A-Z])/g, function(match0,match1) {
 		return "-" + match1.toLowerCase();
 	});
 };
 
-/*
-Parse a text reference of one of these forms:
-* title
-* !!field
-* title!!field
-* title##index
-* etc
-Returns an object with the following fields, all optional:
-* title: tiddler title
-* field: tiddler field name
-* index: JSON property index
-*/
 exports.parseTextReference = function(textRef) {
 	// Separate out the title, field name and/or JSON indices
 	var reTextRef = /(?:(.*?)!!(.+))|(?:(.*?)##(.+))|(.*)/mg,

--- a/core/modules/widgets/action-confirm.js
+++ b/core/modules/widgets/action-confirm.js
@@ -1,9 +1,7 @@
 /*\
-
 title: $:/core/modules/widgets/action-confirm.js
 type: application/javascript
 module-type: widget
-
 \*/
 
 "use strict";
@@ -14,14 +12,8 @@ var ConfirmWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ConfirmWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ConfirmWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
@@ -29,18 +21,12 @@ ConfirmWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 ConfirmWidget.prototype.execute = function() {
 	this.message = this.getAttribute("$message",$tw.language.getString("ConfirmAction"));
 	this.prompt = (this.getAttribute("$prompt","yes") == "no" ? false : true);
 	this.makeChildWidgets();
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 ConfirmWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes["$message"] || changedAttributes["$prompt"]) {
@@ -50,9 +36,6 @@ ConfirmWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Invoke the action associated with this widget
-*/
 ConfirmWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var invokeActions = true,
 		handled = true,

--- a/core/modules/widgets/action-createtiddler.js
+++ b/core/modules/widgets/action-createtiddler.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/action-createtiddler.js
 type: application/javascript
 module-type: widget
-
-Action widget to create a new tiddler with a unique name and specified fields.
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var CreateTiddlerWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 CreateTiddlerWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 CreateTiddlerWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -31,9 +22,6 @@ CreateTiddlerWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 CreateTiddlerWidget.prototype.execute = function() {
 	this.actionBaseTitle = this.getAttribute("$basetitle");
 	this.hasBase = !!this.actionBaseTitle;
@@ -48,9 +36,6 @@ CreateTiddlerWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 CreateTiddlerWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0) {
@@ -60,9 +45,6 @@ CreateTiddlerWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Invoke the action associated with this widget
-*/
 CreateTiddlerWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var title = this.wiki.getTiddlerText("$:/language/DefaultNewTiddlerTitle"), // Get the initial new-tiddler title
 		fields = {},
@@ -82,7 +64,7 @@ CreateTiddlerWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	} else if (this.hasBase && this.actionOverwrite === "yes") {
 		title = this.actionBaseTitle
 	}
-	// NO $basetitle BUT $template parameter is available
+
 	// the title MUST be unique, otherwise the template would be overwritten
 	if (!this.hasBase && this.useTemplate) {
 		title = this.wiki.generateNewTitle(this.actionTemplate);

--- a/core/modules/widgets/action-deletefield.js
+++ b/core/modules/widgets/action-deletefield.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/action-deletefield.js
 type: application/javascript
 module-type: widget
-
-Action widget to delete fields of a tiddler.
-
 \*/
 
 "use strict";
@@ -15,31 +12,19 @@ var DeleteFieldWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 DeleteFieldWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 DeleteFieldWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 };
 
-/*
-Compute the internal state of the widget
-*/
 DeleteFieldWidget.prototype.execute = function() {
 	this.actionTiddler = this.getAttribute("$tiddler",this.getVariable("currentTiddler"));
 	this.actionField = this.getAttribute("$field",null);
 	this.actionTimestamp = this.getAttribute("$timestamp","yes") === "yes";
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 DeleteFieldWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes["$tiddler"]) {
@@ -49,9 +34,6 @@ DeleteFieldWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Invoke the action associated with this widget
-*/
 DeleteFieldWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var self = this,
 		tiddler = this.wiki.getTiddler(self.actionTiddler),

--- a/core/modules/widgets/action-deletetiddler.js
+++ b/core/modules/widgets/action-deletetiddler.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/action-deletetiddler.js
 type: application/javascript
 module-type: widget
-
-Action widget to delete a tiddler.
-
 \*/
 
 "use strict";
@@ -15,30 +12,18 @@ var DeleteTiddlerWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 DeleteTiddlerWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 DeleteTiddlerWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 };
 
-/*
-Compute the internal state of the widget
-*/
 DeleteTiddlerWidget.prototype.execute = function() {
 	this.actionFilter = this.getAttribute("$filter");
 	this.actionTiddler = this.getAttribute("$tiddler");
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 DeleteTiddlerWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes["$filter"] || changedAttributes["$tiddler"]) {
@@ -48,9 +33,6 @@ DeleteTiddlerWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Invoke the action associated with this widget
-*/
 DeleteTiddlerWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var tiddlers = [];
 	if(this.actionFilter) {

--- a/core/modules/widgets/action-listops.js
+++ b/core/modules/widgets/action-listops.js
@@ -2,29 +2,17 @@
 title: $:/core/modules/widgets/action-listops.js
 type: application/javascript
 module-type: widget
-
-Action widget to apply list operations to any tiddler field (defaults to the 'list' field of the current tiddler)
-
 \*/
 "use strict";
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 var ActionListopsWidget = function(parseTreeNode, options) {
 	this.initialise(parseTreeNode, options);
 };
-/**
- * Inherit from the base widget class
- */
 ActionListopsWidget.prototype = new Widget();
-/**
- * Render this widget into the DOM
- */
 ActionListopsWidget.prototype.render = function(parent, nextSibling) {
 	this.computeAttributes();
 	this.execute();
 };
-/**
- * Compute the internal state of the widget
- */
 ActionListopsWidget.prototype.execute = function() {
 	// Get our parameters
 	this.target = this.getAttribute("$tiddler", this.getVariable(
@@ -35,9 +23,6 @@ ActionListopsWidget.prototype.execute = function() {
 	this.listIndex = this.getAttribute("$index");
 	this.filtertags = this.getAttribute("$tags");
 };
-/**
- * 	Refresh the widget by ensuring our attributes are up to date
- */
 ActionListopsWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0) {
@@ -46,9 +31,6 @@ ActionListopsWidget.prototype.refresh = function(changedTiddlers) {
 	}
 	return this.refreshChildren(changedTiddlers);
 };
-/**
- * 	Invoke the action associated with this widget
- */
 ActionListopsWidget.prototype.invokeAction = function(triggeringWidget,
 	event) {
 	//Apply the specified filters to the lists

--- a/core/modules/widgets/action-log.js
+++ b/core/modules/widgets/action-log.js
@@ -1,11 +1,7 @@
-/* eslint-disable no-unused-vars */
 /*\
 title: $:/core/modules/widgets/action-log.js
 type: application/javascript
 module-type: widget
-
-Action widget to log debug messages
-
 \*/
 
 "use strict";
@@ -16,14 +12,8 @@ var LogWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 LogWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 LogWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
@@ -35,17 +25,11 @@ LogWidget.prototype.execute = function(){
 	this.filter = this.getAttribute("$$filter");
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 LogWidget.prototype.refresh = function(changedTiddlers) {
 	this.refreshSelf();
 	return true;
 };
 
-/*
-Invoke the action associated with this widget
-*/
 LogWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	this.log();
 	return true; // Action was invoked

--- a/core/modules/widgets/action-navigate.js
+++ b/core/modules/widgets/action-navigate.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/action-navigate.js
 type: application/javascript
 module-type: widget
-
-Action widget to navigate to a tiddler
-
 \*/
 
 "use strict";
@@ -15,30 +12,18 @@ var NavigateWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 NavigateWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 NavigateWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 };
 
-/*
-Compute the internal state of the widget
-*/
 NavigateWidget.prototype.execute = function() {
 	this.actionTo = this.getAttribute("$to");
 	this.actionScroll = this.getAttribute("$scroll");
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 NavigateWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes["$to"] || changedAttributes["$scroll"]) {
@@ -48,9 +33,6 @@ NavigateWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Invoke the action associated with this widget
-*/
 NavigateWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	event = event || {};
 	var bounds = triggeringWidget && triggeringWidget.getBoundingClientRect && triggeringWidget.getBoundingClientRect(),

--- a/core/modules/widgets/action-popup.js
+++ b/core/modules/widgets/action-popup.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/action-popup.js
 type: application/javascript
 module-type: widget
-
-Action widget to trigger a popup.
-
 \*/
 
 "use strict";
@@ -17,31 +14,19 @@ var ActionPopupWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ActionPopupWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ActionPopupWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 };
 
-/*
-Compute the internal state of the widget
-*/
 ActionPopupWidget.prototype.execute = function() {
 	this.actionState = this.getAttribute("$state");
 	this.actionCoords = this.getAttribute("$coords");
 	this.floating = this.getAttribute("$floating","no") === "yes";
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 ActionPopupWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes["$state"] || changedAttributes["$coords"]) {
@@ -51,9 +36,6 @@ ActionPopupWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Invoke the action associated with this widget
-*/
 ActionPopupWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	// Trigger the popup
 	var coordinates = Popup.parseCoordinates(this.actionCoords || "");

--- a/core/modules/widgets/action-sendmessage.js
+++ b/core/modules/widgets/action-sendmessage.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/action-sendmessage.js
 type: application/javascript
 module-type: widget
-
-Action widget to send a message
-
 \*/
 
 "use strict";
@@ -15,22 +12,13 @@ var SendMessageWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 SendMessageWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 SendMessageWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 };
 
-/*
-Compute the internal state of the widget
-*/
 SendMessageWidget.prototype.execute = function() {
 	this.actionMessage = this.getAttribute("$message");
 	this.actionParam = this.getAttribute("$param");
@@ -40,9 +28,6 @@ SendMessageWidget.prototype.execute = function() {
 	this.actionValues = this.getAttribute("$values");
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 SendMessageWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(Object.keys(changedAttributes).length) {
@@ -52,9 +37,6 @@ SendMessageWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Invoke the action associated with this widget
-*/
 SendMessageWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	// Get the string parameter
 	var param = this.actionParam;
@@ -68,7 +50,7 @@ SendMessageWidget.prototype.invokeAction = function(triggeringWidget,event) {
 			paramObject[name] = values[index] || "";
 		});
 	}
-	// Add raw parameters
+
 	$tw.utils.each(this.attributes,function(attribute,name) {
 		if(name.charAt(0) !== "$") {
 			paramObject[name] = attribute;
@@ -78,7 +60,7 @@ SendMessageWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	if(this.actionName) {
 		paramObject[this.actionName] = this.actionValue;
 	}
-	// Dispatch the message
+
 	var params = {
 		type: this.actionMessage,
 		param: param,

--- a/core/modules/widgets/action-setfield.js
+++ b/core/modules/widgets/action-setfield.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/action-setfield.js
 type: application/javascript
 module-type: widget
-
-Action widget to set a single field or index on a tiddler.
-
 \*/
 
 "use strict";
@@ -15,22 +12,13 @@ var SetFieldWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 SetFieldWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 SetFieldWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 };
 
-/*
-Compute the internal state of the widget
-*/
 SetFieldWidget.prototype.execute = function() {
 	this.actionTiddler = this.getAttribute("$tiddler") || (!this.hasParseTreeNodeAttribute("$tiddler") && this.getVariable("currentTiddler"));
 	this.actionField = this.getAttribute("$field");
@@ -39,17 +27,11 @@ SetFieldWidget.prototype.execute = function() {
 	this.actionTimestamp = this.getAttribute("$timestamp","yes") === "yes";
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 SetFieldWidget.prototype.refresh = function(changedTiddlers) {
 	// Nothing to refresh
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Invoke the action associated with this widget
-*/
 SetFieldWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var self = this,
 		options = {};

--- a/core/modules/widgets/action-setmultiplefields.js
+++ b/core/modules/widgets/action-setmultiplefields.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/action-setmultiplefields.js
 type: application/javascript
 module-type: widget
-
-Action widget to set multiple fields or indexes on a tiddler
-
 \*/
 
 "use strict";
@@ -15,22 +12,13 @@ var SetMultipleFieldsWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 SetMultipleFieldsWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 SetMultipleFieldsWidget.prototype.render = function(parent,nextSibling) {
 	this.computeAttributes();
 	this.execute();
 };
 
-/*
-Compute the internal state of the widget
-*/
 SetMultipleFieldsWidget.prototype.execute = function() {
 	this.actionTiddler = this.getAttribute("$tiddler",this.getVariable("currentTiddler"));
 	this.actionFields = this.getAttribute("$fields");
@@ -39,9 +27,6 @@ SetMultipleFieldsWidget.prototype.execute = function() {
 	this.actionTimestamp = this.getAttribute("$timestamp","yes") === "yes";
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 SetMultipleFieldsWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes["$tiddler"] || changedAttributes["$fields"] || changedAttributes["$indexes"] || changedAttributes["$values"] || changedAttributes["$timestamp"]) {
@@ -51,9 +36,6 @@ SetMultipleFieldsWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Invoke the action associated with this widget
-*/
 SetMultipleFieldsWidget.prototype.invokeAction = function(triggeringWidget,event) {
 	var tiddler = this.wiki.getTiddler(this.actionTiddler),
 		names, values = this.wiki.filterTiddlers(this.actionValues,this);

--- a/core/modules/widgets/audio.js
+++ b/core/modules/widgets/audio.js
@@ -2,15 +2,8 @@
 title: $:/core/modules/widgets/audio.js
 type: application/javascript
 module-type: widget
-
-Basic Audio widget for displaying audio files.
-This is a simple implementation that can be overridden by plugins
-for more advanced functionality.
-
 \*/
 
-/*jslint node: true, browser: true */
-/*global $tw: false */
 "use strict";
 
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
@@ -19,25 +12,19 @@ var AudioWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 AudioWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 AudioWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
-	
+
 	// Create audio element
 	var audioElement = this.document.createElement("audio");
 	audioElement.setAttribute("controls", this.getAttribute("controls", "controls"));
 	audioElement.setAttribute("style", this.getAttribute("style", "width: 100%; object-fit: contain"));
 	audioElement.className = "tw-audio-element";
-	
+
 	// Set source
 	if(this.audioSource) {
 		if (this.audioSource.indexOf("data:") === 0) {
@@ -51,21 +38,17 @@ AudioWidget.prototype.render = function(parent,nextSibling) {
 			audioElement.appendChild(sourceElement);
 		}
 	}
-	
-	// Insert the audio into the DOM
+
 	parent.insertBefore(audioElement, nextSibling);
 	this.domNodes.push(audioElement);
 };
 
-/*
-Compute the internal state of the widget
-*/
 AudioWidget.prototype.execute = function() {
 	// Get the audio source and type
 	this.audioSource = this.getAttribute("src");
 	this.audioType = this.getAttribute("type");
 	this.audioControls = this.getAttribute("controls", "controls");
-	
+
 	// Try to get from tiddler attribute
 	if(!this.audioSource && this.getAttribute("tiddler")) {
 		var tiddlerTitle = this.getAttribute("tiddler");
@@ -80,14 +63,10 @@ AudioWidget.prototype.execute = function() {
 			}
 		}
 	}
-	
-	// Make sure we have a tiddler for saving timestamps
+
 	this.tiddlerTitle = this.getAttribute("tiddler");
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 AudioWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.src || changedAttributes.type || changedAttributes.controls || changedAttributes.tiddler) {
@@ -99,5 +78,3 @@ AudioWidget.prototype.refresh = function(changedTiddlers) {
 };
 
 exports.audio = AudioWidget;
-
-

--- a/core/modules/widgets/browse.js
+++ b/core/modules/widgets/browse.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/browse.js
 type: application/javascript
 module-type: widget
-
-Browse widget for browsing for files to import
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var BrowseWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 BrowseWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 BrowseWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
 	// Remember parent
@@ -42,14 +33,14 @@ BrowseWidget.prototype.render = function(parent,nextSibling) {
 	if(this.tabIndex) {
 		domNode.setAttribute("tabindex", this.tabIndex);
 	}
-	// Nw.js supports "nwsaveas" to force a "save as" dialogue that allows a new or existing file to be selected
+
 	if(this.nwsaveas) {
 		domNode.setAttribute("nwsaveas",this.nwsaveas);
 	}
 	if(this.accept) {
 		domNode.setAttribute("accept",this.accept);
 	}
-	// Nw.js supports "webkitdirectory" and "nwdirectory" to allow a directory to be selected
+
 	if(this.webkitdirectory) {
 		domNode.setAttribute("webkitdirectory",this.webkitdirectory);
 	}
@@ -59,7 +50,7 @@ BrowseWidget.prototype.render = function(parent,nextSibling) {
 	if(this.isDisabled === "yes") {
 		domNode.setAttribute("disabled", true);
 	}
-	// Add a click event handler
+
 	domNode.addEventListener("change",function (event) {
 		if(self.message) {
 			self.dispatchEvent({type: self.message, param: self.param, files: event.target.files});
@@ -84,9 +75,6 @@ BrowseWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(domNode,null);
 };
 
-/*
-Compute the internal state of the widget
-*/
 BrowseWidget.prototype.execute = function() {
 	this.browseMultiple = this.getAttribute("multiple");
 	this.deserializer = this.getAttribute("deserializer");
@@ -101,14 +89,11 @@ BrowseWidget.prototype.execute = function() {
 	this.isDisabled = this.getAttribute("disabled", "no");
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 BrowseWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0) {
 		this.refreshSelf();
-		return true;	
+		return true;
 	}
 	return false;
 };

--- a/core/modules/widgets/button.js
+++ b/core/modules/widgets/button.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/button.js
 type: application/javascript
 module-type: widget
-
-Button widget
-
 \*/
 
 "use strict";
@@ -19,14 +16,8 @@ var ButtonWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ButtonWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ButtonWidget.prototype.render = function(parent,nextSibling) {
 	var self = this,
 		tag = "button",
@@ -85,14 +76,14 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 	if(this.popup || this.popupTitle) {
 		domNode.setAttribute("aria-expanded",isPoppedUp ? "true" : "false");
 	}
-	// Set the tabindex
+
 	if(this.tabIndex) {
 		domNode.setAttribute("tabindex",this.tabIndex);
 	}
 	if(this.isDisabled === "yes") {
 		domNode.setAttribute("disabled",true);
 	}
-	// Add a click event handler
+
 	domNode.addEventListener("click",function (event) {
 		var handled = false;
 		if(self.invokeActions(self,event)) {
@@ -133,15 +124,12 @@ ButtonWidget.prototype.render = function(parent,nextSibling) {
 			widget: this
 		});
 	}
-	// Insert element
+
 	parent.insertBefore(domNode,nextSibling);
 	this.domNodes.push(domNode);
 	this.renderChildren(domNode,null);
 };
 
-/*
-We don't allow actions to propagate because we trigger actions ourselves
-*/
 ButtonWidget.prototype.allowActionPropagation = function() {
 	return false;
 };
@@ -210,9 +198,6 @@ ButtonWidget.prototype.setTiddler = function() {
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 ButtonWidget.prototype.execute = function() {
 	// Get attributes
 	this.actions = this.getAttribute("actions");
@@ -262,9 +247,6 @@ ButtonWidget.prototype.updateDomNodeClasses = function() {
 	this.domNode.className = domNodeClasses.join(" ");
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 ButtonWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.tooltip || changedAttributes.actions || changedAttributes.to || changedAttributes.message || changedAttributes.param || changedAttributes.set || changedAttributes.setTo || changedAttributes.popup || changedAttributes.hover || changedAttributes.selectedClass || changedAttributes.style || changedAttributes.dragFilter || changedAttributes.dragTiddler || (this.set && changedTiddlers[this.set]) || (this.popup && changedTiddlers[this.popup]) || (this.popupTitle && changedTiddlers[this.popupTitle]) || changedAttributes.popupAbsCoords || changedAttributes.setTitle || changedAttributes.setField || changedAttributes.setIndex || changedAttributes.popupTitle || changedAttributes.disabled || changedAttributes["default"]) {

--- a/core/modules/widgets/checkbox.js
+++ b/core/modules/widgets/checkbox.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/checkbox.js
 type: application/javascript
 module-type: widget
-
-Checkbox widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var CheckboxWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 CheckboxWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 CheckboxWidget.prototype.render = function(parent,nextSibling) {
 	var isChecked;
 	// Save the parent dom node
@@ -96,7 +87,7 @@ CheckboxWidget.prototype.getValue = function() {
 			if(value === this.checkboxUnchecked) {
 				return false;
 			}
-			// Neither value found: were both specified?
+
 			if(this.checkboxChecked && !this.checkboxUnchecked) {
 				return false; // Absence of checked value
 			}
@@ -132,7 +123,7 @@ CheckboxWidget.prototype.getValue = function() {
 			if(list.indexOf(this.checkboxUnchecked) !== -1) {
 				return false;
 			}
-			// Neither one present
+
 			if(this.checkboxChecked && !this.checkboxUnchecked) {
 				return false; // Absence of checked value
 			}
@@ -147,7 +138,7 @@ CheckboxWidget.prototype.getValue = function() {
 					return false;
 				}
 			}
-			// Neither specified, so empty list is false, non-empty is true
+
 			return !!list.length;
 		}
 	} else {
@@ -181,7 +172,7 @@ CheckboxWidget.prototype.handleChangeEvent = function(event) {
 	} else {
 		tagCheck = hasTag !== checked;
 	}
-	// Set the tag if specified
+
 	if(this.checkboxTag && (!tiddler || tagCheck)) {
 		newFields.tags = tiddler ? (tiddler.fields.tags || []).slice(0) : [];
 		var pos = newFields.tags.indexOf(this.checkboxTag);
@@ -195,21 +186,21 @@ CheckboxWidget.prototype.handleChangeEvent = function(event) {
 		}
 		hasChanged = true;
 	}
-	// Set the field if specified
+
 	if(this.checkboxField) {
 		if(!tiddler || tiddler.fields[this.checkboxField] !== value) {
 			newFields[this.checkboxField] = value;
 			hasChanged = true;
 		}
 	}
-	// Set the index if specified
+
 	if(this.checkboxIndex) {
 		var indexValue = this.wiki.extractTiddlerDataItem(this.checkboxTitle,this.checkboxIndex);
 		if(!tiddler || indexValue !== value) {
 			hasChanged = true;
 		}
 	}
-	// Set the list field (or index) if specified
+
 	if(this.checkboxListField || this.checkboxListIndex) {
 		var fieldContents, listContents, oldPos, newPos;
 		if(this.checkboxListField) {

--- a/core/modules/widgets/codeblock.js
+++ b/core/modules/widgets/codeblock.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/codeblock.js
 type: application/javascript
 module-type: widget
-
-Code block node widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var CodeBlockWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 CodeBlockWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 CodeBlockWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -38,16 +29,10 @@ CodeBlockWidget.prototype.render = function(parent,nextSibling) {
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 CodeBlockWidget.prototype.execute = function() {
 	this.language = this.getAttribute("language");
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 CodeBlockWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.code || changedAttributes.language) {

--- a/core/modules/widgets/count.js
+++ b/core/modules/widgets/count.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/count.js
 type: application/javascript
 module-type: widget
-
-Count widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var CountWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 CountWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 CountWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -32,9 +23,6 @@ CountWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(textNode);
 };
 
-/*
-Compute the internal state of the widget
-*/
 CountWidget.prototype.execute = function() {
 	// Get parameters from our attributes
 	this.filter = this.getAttribute("filter");
@@ -46,9 +34,6 @@ CountWidget.prototype.execute = function() {
 	}
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 CountWidget.prototype.refresh = function(changedTiddlers) {
 	// Re-execute the filter to get the count
 	this.computeAttributes();

--- a/core/modules/widgets/data.js
+++ b/core/modules/widgets/data.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/data.js
 type: application/javascript
 module-type: widget
-
-Widget to dynamically represent one or more tiddlers
-
 \*/
 "use strict";
 
@@ -15,14 +12,8 @@ var DataWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 DataWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 DataWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -33,16 +24,10 @@ DataWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(this.domNode);
 };
 
-/*
-Compute the internal state of the widget
-*/
 DataWidget.prototype.execute = function() {
 	// Nothing to do here
 };
 
-/*
-Read the tiddler value(s) from a data widget as an array of tiddler field objects (not $tw.Tiddler objects)
-*/
 DataWidget.prototype.readDataTiddlerValues = function() {
 	var results = [];
 	$tw.utils.each(this.dataPayload,function(tiddler,index) {
@@ -51,23 +36,17 @@ DataWidget.prototype.readDataTiddlerValues = function() {
 	return results;
 };
 
-/*
-Read the tiddler value(s) from a data widget as an array of tiddler field objects (not $tw.Tiddler objects)
-*/
 DataWidget.prototype.readDataTiddlerValuesAsJson = function() {
 	return JSON.stringify(this.readDataTiddlerValues(),null,4);
 };
 
-/*
-Compute list of tiddlers from a data widget
-*/
 DataWidget.prototype.computeDataTiddlerValues = function() {
 	var self = this;
 	// Read any attributes not prefixed with $
 	var item = Object.create(null);
 	$tw.utils.each(this.attributes,function(value,name) {
 		if(name.charAt(0) !== "$") {
-			item[name] = value;	
+			item[name] = value;
 		}
 	});
 	// Deal with $tiddler, $filter or $compound-tiddler attributes
@@ -110,7 +89,7 @@ DataWidget.prototype.computeDataTiddlerValues = function() {
 			});
 		}
 	}
-	// Return the literal item if none of the special attributes were used
+
 	if(!this.hasAttribute("$tiddler") && !this.hasAttribute("$filter") && !this.hasAttribute("$compound-tiddler") && !this.hasAttribute("$compound-filter")) {
 		if(Object.keys(item).length > 0 && !!item.title) {
 			return [new $tw.Tiddler(item)];
@@ -128,9 +107,6 @@ DataWidget.prototype.computeDataTiddlerValues = function() {
 	}
 };
 
-/*
-Helper to extract tiddlers from text/vnd.tiddlywiki-multiple tiddlers
-*/
 DataWidget.prototype.extractCompoundTiddler = function(title) {
 	var tiddler = this.wiki.getTiddler(title);
 	if(tiddler && tiddler.fields.type === "text/vnd.tiddlywiki-multiple") {
@@ -154,9 +130,6 @@ DataWidget.prototype.extractCompoundTiddler = function(title) {
 	}
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 DataWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	var newPayload = this.computeDataTiddlerValues();
@@ -169,9 +142,6 @@ DataWidget.prototype.refresh = function(changedTiddlers) {
 	}
 };
 
-/*
-Compare two arrays of tiddlers and return true if they are different
-*/
 function hasPayloadChanged(a,b) {
 	if(a.length === b.length) {
 		for(var t=0; t<a.length; t++) {

--- a/core/modules/widgets/diff-text.js
+++ b/core/modules/widgets/diff-text.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/diff-text.js
 type: application/javascript
 module-type: widget
-
-Widget to display a diff between two texts
-
 \*/
 
 "use strict";
@@ -16,9 +13,6 @@ var DiffTextWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 DiffTextWidget.prototype = new Widget();
 
 DiffTextWidget.prototype.invisibleCharacters = {
@@ -27,9 +21,6 @@ DiffTextWidget.prototype.invisibleCharacters = {
 	"\t": "⇥\t"
 };
 
-/*
-Render this widget into the DOM
-*/
 DiffTextWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -43,7 +34,7 @@ DiffTextWidget.prototype.render = function(parent,nextSibling) {
 	} else {
 		diffs = dmp.diffMain(this.getAttribute("source",""),this.getAttribute("dest",""),{diffEditCost: editCost});
 	}
-	// Apply required cleanup
+
 	switch(this.getAttribute("cleanup","semantic")) {
 		case "none":
 			// No cleanup
@@ -55,8 +46,8 @@ DiffTextWidget.prototype.render = function(parent,nextSibling) {
 			dmp.diffCleanupSemantic(diffs);
 			break;
 	}
-	// Create the elements
-	var domContainer = this.document.createElement("div"), 
+
+	var domContainer = this.document.createElement("div"),
 		domDiff = this.createDiffDom(diffs);
 	parent.insertBefore(domContainer,nextSibling);
 	// Save our container
@@ -74,9 +65,6 @@ DiffTextWidget.prototype.render = function(parent,nextSibling) {
 	domContainer.appendChild(domDiff);
 };
 
-/*
-Create DOM elements representing a list of diffs
-*/
 DiffTextWidget.prototype.createDiffDom = function(diffs) {
 	var self = this;
 	// Create the element and assign the attributes
@@ -114,9 +102,6 @@ DiffTextWidget.prototype.createDiffDom = function(diffs) {
 	return domPre;
 };
 
-/*
-Compute the internal state of the widget
-*/
 DiffTextWidget.prototype.execute = function() {
 	// Make child widgets
 	var parseTreeNodes;
@@ -133,9 +118,6 @@ DiffTextWidget.prototype.execute = function() {
 	this.makeChildWidgets(parseTreeNodes);
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 DiffTextWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.source || changedAttributes.dest || changedAttributes.cleanup || changedAttributes.mode || changedAttributes.editcost) {

--- a/core/modules/widgets/draggable.js
+++ b/core/modules/widgets/draggable.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/draggable.js
 type: application/javascript
 module-type: widget
-
-Draggable widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var DraggableWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 DraggableWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 DraggableWidget.prototype.render = function(parent,nextSibling) {
 	var self = this,
 		tag,
@@ -39,7 +30,7 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 	if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
 		tag = "div";
 	}
-	// Create our element
+
 	domNode = this.document.createElement(tag);
 	// Assign classes
 	if(this.draggableClasses) {
@@ -73,9 +64,6 @@ DraggableWidget.prototype.render = function(parent,nextSibling) {
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 DraggableWidget.prototype.execute = function() {
 	// Pick up our attributes
 	this.draggableTag = this.getAttribute("tag","div");
@@ -88,7 +76,6 @@ DraggableWidget.prototype.execute = function() {
 	// Make the child widgets
 	this.makeChildWidgets();
 };
-
 
 DraggableWidget.prototype.updateDomNodeClasses = function() {
 	var domNodeClasses = this.domNodes[0].className.split(" "),
@@ -106,9 +93,6 @@ DraggableWidget.prototype.updateDomNodeClasses = function() {
 	this.domNodes[0].setAttribute("class",domNodeClasses.join(" "))
 }
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 DraggableWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.tag || changedAttributes.selector || changedAttributes.dragimagetype || changedAttributes.enable || changedAttributes.startactions || changedAttributes.endactions) {

--- a/core/modules/widgets/droppable.js
+++ b/core/modules/widgets/droppable.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/droppable.js
 type: application/javascript
 module-type: widget
-
-Droppable widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var DroppableWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 DroppableWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 DroppableWidget.prototype.render = function(parent,nextSibling) {
 	var self = this,
 		tag = this.parseTreeNode.isBlock ? "div" : "span",
@@ -35,7 +26,7 @@ DroppableWidget.prototype.render = function(parent,nextSibling) {
 	if(this.droppableTag && $tw.config.htmlUnsafeElements.indexOf(this.droppableTag) === -1) {
 		tag = this.droppableTag;
 	}
-	// Create element and assign classes
+
 	domNode = this.document.createElement(tag);
 	this.domNode = domNode;
 	this.assignDomNodeClasses();
@@ -55,7 +46,7 @@ DroppableWidget.prototype.render = function(parent,nextSibling) {
 	} else {
 		$tw.utils.addClass(this.domNode,this.disabledClass);
 	}
-	// Insert element
+
 	parent.insertBefore(domNode,nextSibling);
 	this.domNodes.push(domNode);
 	this.renderChildren(domNode,null);
@@ -67,7 +58,7 @@ DroppableWidget.prototype.enterDrag = function(event) {
 	if(this.currentlyEntered.indexOf(event.target) === -1) {
 		this.currentlyEntered.push(event.target);
 	}
-	// If we're entering for the first time we need to apply highlighting
+
 	$tw.utils.addClass(this.domNodes[0],"tc-dragover");
 };
 
@@ -76,7 +67,7 @@ DroppableWidget.prototype.leaveDrag = function(event) {
 	if(pos !== -1) {
 		this.currentlyEntered.splice(pos,1);
 	}
-	// Remove highlighting if we're leaving externally. The hacky second condition is to resolve a problem with Firefox whereby there is an erroneous dragenter event if the node being dragged is within the dropzone
+
 	if(this.currentlyEntered.length === 0 || (this.currentlyEntered.length === 1 && this.currentlyEntered[0] === $tw.dragInProgress)) {
 		this.currentlyEntered = [];
 		if(this.domNodes[0]) {
@@ -129,7 +120,7 @@ DroppableWidget.prototype.handleDropEvent  = function(event) {
 			});
 		});
 	}
-	// Send a TitleList to performListActions
+
 	if(this.droppableListActions) {
 		$tw.utils.importDataTransfer(dataTransfer,null,function(fieldsArray) {
 			var titleList = [];
@@ -139,7 +130,7 @@ DroppableWidget.prototype.handleDropEvent  = function(event) {
 			self.performListActions($tw.utils.stringifyList(titleList),event);
 		});
 	}
-	// Tell the browser that we handled the drop
+
 	event.preventDefault();
 	// Stop the drop ripple up to any parent handlers
 	event.stopPropagation();
@@ -160,9 +151,6 @@ DroppableWidget.prototype.performActions = function(title,event) {
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 DroppableWidget.prototype.execute = function() {
 	this.droppableActions = this.getAttribute("actions");
 	this.droppableListActions = this.getAttribute("listActions");
@@ -180,9 +168,6 @@ DroppableWidget.prototype.assignDomNodeClasses = function() {
 	this.domNode.className = classes.join(" ").trim();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 DroppableWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.tag || changedAttributes.enable || changedAttributes.disabledClass ||

--- a/core/modules/widgets/dropzone.js
+++ b/core/modules/widgets/dropzone.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/dropzone.js
 type: application/javascript
 module-type: widget
-
-Dropzone widget
-
 \*/
 
 "use strict";
@@ -17,14 +14,8 @@ var DropZoneWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 DropZoneWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 DropZoneWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
 	// Remember parent
@@ -47,7 +38,7 @@ DropZoneWidget.prototype.render = function(parent,nextSibling) {
 			{name: "dragend", handlerObject: this, handlerMethod: "handleDragEndEvent"}
 		]);
 	}
-	// Insert element
+
 	parent.insertBefore(domNode,nextSibling);
 	this.renderChildren(domNode,null);
 	this.domNodes.push(domNode);
@@ -185,7 +176,7 @@ DropZoneWidget.prototype.handleDropEvent  = function(event) {
 	if(["TEXTAREA","INPUT"].indexOf(event.target.tagName) !== -1) {
 		return false;
 	}
-	// Check for this window being the source of the drag
+
 	if($tw.dragInProgress) {
 		return false;
 	}
@@ -202,7 +193,7 @@ DropZoneWidget.prototype.handleDropEvent  = function(event) {
 			deserializer: this.dropzoneDeserializer
 		});
 	}
-	// Try to import the various data types we understand
+
 	if(numFiles === 0) {
 		var fallbackTitle = self.wiki.generateNewTitle("Untitled");
 		//Use the deserializer specified if any
@@ -222,7 +213,7 @@ DropZoneWidget.prototype.handleDropEvent  = function(event) {
 			$tw.utils.importDataTransfer(dataTransfer,fallbackTitle,readFileCallback);
 		}
 	}
-	// Tell the browser that we handled the drop
+
 	event.preventDefault();
 	// Stop the drop ripple up to any parent handlers
 	event.stopPropagation();
@@ -286,19 +277,16 @@ DropZoneWidget.prototype.handlePasteEvent  = function(event) {
 				// Create tiddlers from string items
 				var tiddlerFields;
 				// It's important to give getAsString a closure with the right type
-				// So it can be added to the import queue
+
 				item.getAsString(getItem(item.type));
 			}
 		}
-		// Tell the browser that we've handled the paste
+
 		event.stopPropagation();
 		event.preventDefault();
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 DropZoneWidget.prototype.execute = function() {
 	this.dropzoneClass = this.getAttribute("class");
 	this.dropzoneDeserializer = this.getAttribute("deserializer");
@@ -312,9 +300,6 @@ DropZoneWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 DropZoneWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0) {

--- a/core/modules/widgets/edit-binary.js
+++ b/core/modules/widgets/edit-binary.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/edit-binary.js
 type: application/javascript
 module-type: widget
-
-Edit-binary widget; placeholder for editing binary tiddlers
-
 \*/
 
 "use strict";
@@ -18,14 +15,8 @@ var EditBinaryWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 EditBinaryWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 EditBinaryWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
 	// Save the parent dom node
@@ -37,9 +28,6 @@ EditBinaryWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 EditBinaryWidget.prototype.execute = function() {
 	// Get our parameters
 	var editTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
@@ -75,11 +63,11 @@ EditBinaryWidget.prototype.execute = function() {
 	// Set the link href to internal data URI (no external)
 	if(text) {
 		link.attributes.href = {
-			type: "string", 
+			type: "string",
 			value: "data:" + type + ";base64," + text
 		};
 	}
-	// Combine warning message and download link in a div
+
 	var element = {
 		type: "element",
 		tag: "div",
@@ -88,13 +76,10 @@ EditBinaryWidget.prototype.execute = function() {
 		},
 		children: [warn, link]
 	}
-	// Construct the child widgets
+
 	this.makeChildWidgets([element]);
 };
 
-/*
-Refresh by refreshing our child widget
-*/
 EditBinaryWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };

--- a/core/modules/widgets/edit-bitmap.js
+++ b/core/modules/widgets/edit-bitmap.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/edit-bitmap.js
 type: application/javascript
 module-type: widget
-
-Edit-bitmap widget
-
 \*/
 
 "use strict";
@@ -25,14 +22,8 @@ var EditBitmapWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 EditBitmapWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 EditBitmapWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
 	// Initialise the editor operations if they've not been done already

--- a/core/modules/widgets/edit-shortcut.js
+++ b/core/modules/widgets/edit-shortcut.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/edit-shortcut.js
 type: application/javascript
 module-type: widget
-
-Widget to display an editable keyboard shortcut
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var EditShortcutWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 EditShortcutWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 EditShortcutWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -32,7 +23,7 @@ EditShortcutWidget.prototype.render = function(parent,nextSibling) {
 	if(this.shortcutClass) {
 		this.inputNode.className = this.shortcutClass;
 	}
-	// Assign other attributes
+
 	if(this.shortcutStyle) {
 		this.inputNode.setAttribute("style",this.shortcutStyle);
 	}
@@ -48,7 +39,7 @@ EditShortcutWidget.prototype.render = function(parent,nextSibling) {
 	if(this.isDisabled === "yes") {
 		this.inputNode.setAttribute("disabled", true);
 	}
-	// Assign the current shortcut
+
 	this.updateInputNode();
 	// Add event handlers
 	$tw.utils.addEventListeners(this.inputNode,[
@@ -63,9 +54,6 @@ EditShortcutWidget.prototype.render = function(parent,nextSibling) {
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 EditShortcutWidget.prototype.execute = function() {
 	this.shortcutTiddler = this.getAttribute("tiddler");
 	this.shortcutField = this.getAttribute("field");
@@ -80,9 +68,6 @@ EditShortcutWidget.prototype.execute = function() {
 	this.isDisabled = this.getAttribute("disabled", "no");
 };
 
-/*
-Update the value of the input node
-*/
 EditShortcutWidget.prototype.updateInputNode = function() {
 	if(this.shortcutField) {
 		var tiddler = this.wiki.getTiddler(this.shortcutTiddler);
@@ -98,9 +83,6 @@ EditShortcutWidget.prototype.updateInputNode = function() {
 	}
 };
 
-/*
-Handle a dom "keydown" event
-*/
 EditShortcutWidget.prototype.handleKeydownEvent = function(event) {
 	// Ignore shift, ctrl, meta, alt
 	if(event.keyCode && $tw.keyboardManager.getModifierKeys().indexOf(event.keyCode) === -1) {
@@ -115,7 +97,7 @@ EditShortcutWidget.prototype.handleKeydownEvent = function(event) {
 		if(value.length > 0) {
 			this.wiki.setText(this.shortcutTiddler,this.shortcutField,this.shortcutIndex,value[0]);
 		}
-		// Ignore the keydown if it was already handled
+
 		event.preventDefault();
 		event.stopPropagation();
 		return true;
@@ -124,9 +106,6 @@ EditShortcutWidget.prototype.handleKeydownEvent = function(event) {
 	}
 };
 
-/*
-focus the input node
-*/
 EditShortcutWidget.prototype.focus = function() {
 	if(this.inputNode.focus && this.inputNode.select) {
 		this.inputNode.focus();
@@ -134,9 +113,6 @@ EditShortcutWidget.prototype.focus = function() {
 	}
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget needed re-rendering
-*/
 EditShortcutWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.placeholder || changedAttributes["default"] || changedAttributes["class"] || changedAttributes.style || changedAttributes.tooltip || changedAttributes["aria-label"] || changedAttributes.focus || changedAttributes.disabled) {

--- a/core/modules/widgets/edit-text.js
+++ b/core/modules/widgets/edit-text.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/edit-text.js
 type: application/javascript
 module-type: widget
-
-Edit-text widget
-
 \*/
 
 "use strict";

--- a/core/modules/widgets/edit.js
+++ b/core/modules/widgets/edit.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/edit.js
 type: application/javascript
 module-type: widget
-
-Edit widget is a meta-widget chooses the appropriate actual editting widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var EditWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 EditWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 EditWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -33,9 +24,6 @@ EditWidget.prototype.render = function(parent,nextSibling) {
 // Mappings from content type to editor type are stored in tiddlers with this prefix
 var EDITOR_MAPPING_PREFIX = "$:/config/EditorTypeMappings/";
 
-/*
-Compute the internal state of the widget
-*/
 EditWidget.prototype.execute = function() {
 	// Get our parameters
 	this.editTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));

--- a/core/modules/widgets/element.js
+++ b/core/modules/widgets/element.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/element.js
 type: application/javascript
 module-type: widget
-
-Element widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var ElementWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ElementWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ElementWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -31,7 +22,7 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	if($tw.config.htmlUnsafeElements.indexOf(this.tag) !== -1) {
 		this.tag = "safe-" + this.tag;
 	}
-	// Restrict tag name to digits, letts and dashes
+
 	this.tag = this.tag.replace(/[^0-9a-zA-Z\-]/mg,"");
 	// Default to a span
 	this.tag = this.tag || "span";
@@ -42,7 +33,7 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 		headingLevel = Math.min(Math.max(headingLevel + 1 + baseLevel,1),6);
 		this.tag = "h" + headingLevel;
 	}
-	// Select the namespace for the tag
+
 	var XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml",
 		tagNamespaces = {
 			svg: "http://www.w3.org/2000/svg",
@@ -60,7 +51,7 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 			this.namespace = this.getVariable("namespace",{defaultValue: XHTML_NAMESPACE});
 		}
 	}
-	// Invoke the th-rendering-element hook
+
 	var parseTreeNodes = $tw.hooks.invokeHook("th-rendering-element",null,this);
 	this.isReplaced = !!parseTreeNodes;
 	if(parseTreeNodes) {
@@ -69,7 +60,7 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 		this.renderChildren(this.parentDomNode,null);
 		return;
 	}
-	// Make the child widgets
+
 	this.makeChildWidgets();
 	// Create the DOM node and render children
 	var domNode = this.document.createElementNS(this.namespace,this.tag);
@@ -81,9 +72,6 @@ ElementWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(domNode,null);
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 ElementWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes(),
 		hasChangedAttributes = $tw.utils.count(changedAttributes) > 0;

--- a/core/modules/widgets/encrypt.js
+++ b/core/modules/widgets/encrypt.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/encrypt.js
 type: application/javascript
 module-type: widget
-
-Encrypt widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var EncryptWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 EncryptWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 EncryptWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -32,9 +23,6 @@ EncryptWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(textNode);
 };
 
-/*
-Compute the internal state of the widget
-*/
 EncryptWidget.prototype.execute = function() {
 	// Get parameters from our attributes
 	this.filter = this.getAttribute("filter","[!is[system]]");
@@ -53,9 +41,6 @@ EncryptWidget.prototype.execute = function() {
 	this.encryptedText = $tw.utils.htmlEncode($tw.crypto.encrypt(JSON.stringify(json)));
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 EncryptWidget.prototype.refresh = function(changedTiddlers) {
 	// We don't need to worry about refreshing because the encrypt widget isn't for interactive use
 	return false;

--- a/core/modules/widgets/entity.js
+++ b/core/modules/widgets/entity.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/entity.js
 type: application/javascript
 module-type: widget
-
-HTML entity widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var EntityWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 EntityWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 EntityWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -33,15 +24,9 @@ EntityWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(textNode);
 };
 
-/*
-Compute the internal state of the widget
-*/
 EntityWidget.prototype.execute = function() {
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 EntityWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.entity) {

--- a/core/modules/widgets/error.js
+++ b/core/modules/widgets/error.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/error.js
 type: application/javascript
 module-type: widget
-
-Error widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var ErrorWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ErrorWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ErrorWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -35,16 +26,10 @@ ErrorWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(domNode);
 };
 
-/*
-Compute the internal state of the widget
-*/
 ErrorWidget.prototype.execute = function() {
 	// Nothing to do for a text node
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 ErrorWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes["$message"]) {

--- a/core/modules/widgets/eventcatcher.js
+++ b/core/modules/widgets/eventcatcher.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/eventcatcher.js
 type: application/javascript
 module-type: widget
-
-Event handler widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var EventWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 EventWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 EventWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
 	// Remember parent
@@ -47,9 +38,6 @@ EventWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(domNode,null);
 };
 
-/*
-Compute the internal state of the widget
-*/
 EventWidget.prototype.execute = function() {
 	var self = this;
 	// Get attributes that require a refresh on change
@@ -65,9 +53,6 @@ EventWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Cache and pre-create all event listeners, called when first needed
-*/
 EventWidget.prototype.cacheEventListeners = function() {
 	if(this._eventListeners) {
 		return;
@@ -100,7 +85,7 @@ EventWidget.prototype.cacheEventListeners = function() {
 				if(selectedNode) {
 					clearPointerCapture(event);
 				}
-				// Remove dynamic-only listeners
+
 				this.cleanupDynamicListeners();
 				return this.handleEvent(event, type, selectedNode);
 			};
@@ -110,7 +95,6 @@ EventWidget.prototype.cacheEventListeners = function() {
 		}
 	}
 
-	// Create any listeners not already defined above
 	this.types.forEach(type => {
 		if(!this._eventListeners[type]) {
 			this._eventListeners[type] = event => {
@@ -118,7 +102,7 @@ EventWidget.prototype.cacheEventListeners = function() {
 				if(!selectedNode) {
 					return false;
 				}
-				// Handle pointer capture for pointerdown
+
 				if(type === "pointerdown") {
 					if(this.pointerCaptureMode !== "no") {
 						this.startPointerCapture(event.pointerId, event.target);
@@ -136,9 +120,6 @@ EventWidget.prototype.cacheEventListeners = function() {
 	});
 };
 
-/*
-Check if an event qualifies and return the matching selected node
-*/
 EventWidget.prototype.checkEvent = function(event, type) {
 	const domNode = this.domNode;
 	let node = event.target;
@@ -177,9 +158,6 @@ EventWidget.prototype.checkEvent = function(event, type) {
 	return node;
 };
 
-/*
-Handle the event and execute actions
-*/
 EventWidget.prototype.handleEvent = function(event, type, selectedNode) {
 	if(!selectedNode) {
 		return false;
@@ -214,7 +192,7 @@ EventWidget.prototype.handleEvent = function(event, type, selectedNode) {
 };
 
 EventWidget.prototype.startPointerCapture = function(pointerId, captureTarget) {
-	// Start capture only if none active; pointerId can be 0 
+	// Start capture only if none active; pointerId can be 0
 	if(!Number.isInteger(this._capturePointerId) && this.domNode && this.domNode.setPointerCapture) {
 		this.domNode.setPointerCapture(pointerId);
 		this._capturePointerId = pointerId;
@@ -230,9 +208,6 @@ EventWidget.prototype.stopPointerCapture = function(pointerId) {
 	this._captureTarget = undefined;
 };
 
-/*
-Attach all relevant listeners
-*/
 EventWidget.prototype.attachListeners = function() {
 	this.cacheEventListeners();
 	const domNode = this.domNode;
@@ -244,9 +219,6 @@ EventWidget.prototype.attachListeners = function() {
 	});
 };
 
-/*
-Remove dynamic active listeners
-*/
 EventWidget.prototype.cleanupDynamicListeners = function() {
 	const domNode = this.domNode;
 	Object.keys(this._captureActiveListeners || {}).forEach(type => {
@@ -255,9 +227,6 @@ EventWidget.prototype.cleanupDynamicListeners = function() {
 	this._captureActiveListeners = Object.create(null);
 };
 
-/*
-Remove all listeners
-*/
 EventWidget.prototype.removeAllListeners = function() {
 	if(Number.isInteger(this._capturePointerId)) {
 		this.stopPointerCapture(this._capturePointerId);
@@ -270,9 +239,6 @@ EventWidget.prototype.removeAllListeners = function() {
 	this._captureTarget = null;
 };
 
-/*
-Enable or disable listeners
-*/
 EventWidget.prototype.toggleListeners = function() {
 	let disabled = this.getAttribute("disabled","no") === "yes";
 	if(disabled) {
@@ -282,18 +248,12 @@ EventWidget.prototype.toggleListeners = function() {
 	}
 };
 
-/*
-Assign DOM node classes
-*/
 EventWidget.prototype.assignDomNodeClasses = function() {
 	var classes = this.getAttribute("class","").split(" ");
 	classes.push("tc-eventcatcher");
 	this.domNode.className = classes.join(" ").trim();
 };
 
-/*
-Refresh widget
-*/
 EventWidget.prototype.refresh = function(changedTiddlers) {
 	const changedAttributes = this.computeAttributes(),
 		changedKeys = Object.keys(changedAttributes),

--- a/core/modules/widgets/fieldmangler.js
+++ b/core/modules/widgets/fieldmangler.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/fieldmangler.js
 type: application/javascript
 module-type: widget
-
-Field mangler widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var FieldManglerWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 FieldManglerWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 FieldManglerWidget.prototype.render = function(parent,nextSibling) {
 	this.addEventListeners([
 		{type: "tm-remove-field", handler: "handleRemoveFieldEvent"},
@@ -36,9 +27,6 @@ FieldManglerWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 FieldManglerWidget.prototype.execute = function() {
 	// Get our parameters
 	this.mangleTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
@@ -46,9 +34,6 @@ FieldManglerWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 FieldManglerWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.tiddler) {

--- a/core/modules/widgets/fields.js
+++ b/core/modules/widgets/fields.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/fields.js
 type: application/javascript
 module-type: widget
-
-Fields widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var FieldsWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 FieldsWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 FieldsWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -32,9 +23,6 @@ FieldsWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(textNode);
 };
 
-/*
-Compute the internal state of the widget
-*/
 FieldsWidget.prototype.execute = function() {
 	// Get parameters from our attributes
 	this.tiddlerTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
@@ -91,9 +79,6 @@ FieldsWidget.prototype.execute = function() {
 	this.text = text.join("");
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 FieldsWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if( changedAttributes.tiddler || changedAttributes.template || changedAttributes.exclude ||

--- a/core/modules/widgets/fill.js
+++ b/core/modules/widgets/fill.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/fill.js
 type: application/javascript
 module-type: widget
-
-Sub-widget used by the transclude widget for specifying values for slots within transcluded content. It doesn't do anything by itself because the transclude widget only ever deals with the parse tree nodes, and doesn't instantiate the widget itself
-
 \*/
 
 "use strict";
@@ -16,9 +13,6 @@ var FillWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 FillWidget.prototype = new Widget();
 
 FillWidget.prototype.execute = function() {

--- a/core/modules/widgets/genesis.js
+++ b/core/modules/widgets/genesis.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/genesis.js
 type: application/javascript
 module-type: widget
-
-Genesis widget for dynamically creating widgets
-
 \*/
 
 "use strict";
@@ -15,9 +12,6 @@ var GenesisWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 GenesisWidget.prototype = new Widget();
 
 GenesisWidget.prototype.computeAttributes = function(options) {
@@ -29,9 +23,6 @@ GenesisWidget.prototype.computeAttributes = function(options) {
 	return Widget.prototype.computeAttributes.call(this,options);
 };
 
-/*
-Render this widget into the DOM
-*/
 GenesisWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -39,9 +30,6 @@ GenesisWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 GenesisWidget.prototype.execute = function() {
 	var self = this;
 	// Collect attributes
@@ -55,7 +43,7 @@ GenesisWidget.prototype.execute = function() {
 		this.makeChildWidgets(this.parseTreeNode.children);
 		return;
 	}
-	// Construct parse tree
+
 	var isElementWidget = this.genesisType.charAt(0) !== "$",
 		nodeType = isElementWidget ? "element" : this.genesisType.substr(1),
 		nodeTag = isElementWidget ? this.genesisType : undefined;
@@ -78,7 +66,7 @@ GenesisWidget.prototype.execute = function() {
 			$tw.utils.addAttributeToParseTreeNode(parseTreeNodes[0],varname,self.attributeValues[index] || "");
 		});
 	}
-	// Apply explicit attributes
+
 	$tw.utils.each($tw.utils.getOrderedAttributesFromParseTreeNode(this.parseTreeNode),function(attribute) {
 		var name = attribute.name;
 		if(name.charAt(0) === "$") {
@@ -96,9 +84,6 @@ GenesisWidget.prototype.execute = function() {
 	this.makeChildWidgets(parseTreeNodes);
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 GenesisWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes(),
 		filterNames = this.getAttribute("$names",""),

--- a/core/modules/widgets/image.js
+++ b/core/modules/widgets/image.js
@@ -2,25 +2,6 @@
 title: $:/core/modules/widgets/image.js
 type: application/javascript
 module-type: widget
-
-The image widget displays an image referenced with an external URI or with a local tiddler title.
-
-```
-<$image src="TiddlerTitle" width="320" height="400" class="classnames">
-```
-
-The image source can be the title of an existing tiddler or the URL of an external image.
-
-External images always generate an HTML `<img>` tag.
-
-Tiddlers that have a _canonical_uri field generate an HTML `<img>` tag with the src attribute containing the URI.
-
-Tiddlers that contain image data generate an HTML `<img>` tag with the src attribute containing a base64 representation of the image.
-
-Tiddlers that contain wikitext could be rendered to a DIV of the usual size of a tiddler, and then transformed to the size requested.
-
-The width and height attributes are interpreted as a number of pixels, and do not need to include the "px" suffix.
-
 \*/
 
 "use strict";
@@ -31,20 +12,14 @@ var ImageWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ImageWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ImageWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
 	this.execute();
 	// Create element
-	// Determine what type of image it is
+
 	var tag = "img", src = "", self = this,
 		tiddler = this.wiki.getTiddler(this.imageSource);
 	if(!tiddler) {
@@ -91,7 +66,7 @@ ImageWidget.prototype.render = function(parent,nextSibling) {
 			}
 		}
 	}
-	// Create the element and assign the attributes
+
 	var domNode = this.document.createElement(tag);
 	domNode.setAttribute("src",src);
 	if(this.imageClass) {
@@ -128,7 +103,7 @@ ImageWidget.prototype.render = function(parent,nextSibling) {
 			var variables = $tw.utils.collectDOMVariables(domNode,null,event);
 			variables["img-natural-width"] = domNode.naturalWidth.toString();
 			variables["img-natural-height"] = domNode.naturalHeight.toString();
-			self.invokeActionString(self.loadedActions,self,event,variables);		
+			self.invokeActionString(self.loadedActions,self,event,variables);
 		}
 	},false);
 	domNode.addEventListener("error",function() {
@@ -140,9 +115,6 @@ ImageWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(domNode);
 };
 
-/*
-Compute the internal state of the widget
-*/
 ImageWidget.prototype.execute = function() {
 	// Get our parameters
 	this.imageSource = this.getAttribute("source");
@@ -156,9 +128,6 @@ ImageWidget.prototype.execute = function() {
 	this.loadedActions = this.getAttribute("loadActions");
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 ImageWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes(),
 		hasChangedAttributes = $tw.utils.count(changedAttributes) > 0;

--- a/core/modules/widgets/importvariables.js
+++ b/core/modules/widgets/importvariables.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/importvariables.js
 type: application/javascript
 module-type: widget
-
-Import variable definitions from other tiddlers
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var ImportVariablesWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ImportVariablesWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ImportVariablesWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -30,9 +21,6 @@ ImportVariablesWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 	var widgetPointer = this;
 	// Got to flush all the accumulated variables
@@ -40,7 +28,7 @@ ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 	if(this.parentWidget) {
 		Object.setPrototypeOf(this.variables,this.parentWidget.variables);
 	}
-	// Get our parameters
+
 	this.filter = this.getAttribute("filter");
 	// Compute the filter
 	this.tiddlerList = tiddlerList || this.wiki.filterTiddlers(this.filter,this);
@@ -64,15 +52,15 @@ ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 				if(parseTreeNode.type === "set" || parseTreeNode.type === "setvariable") {
 					if(parseTreeNode.isMacroDefinition || parseTreeNode.isProcedureDefinition || parseTreeNode.isWidgetDefinition || parseTreeNode.isFunctionDefinition) {
 						// Macro definitions can be folded into
-						// current widget instead of adding
+
 						// another link to the chain.
 						var widget = widgetPointer.makeChildWidget(node);
 						widget.computeAttributes();
 						widget.execute();
 						// We SHALLOW copy over all variables
-						// in widget. We can't use
+
 						// $tw.utils.assign, because that copies
-						// up the prototype chain, which we
+
 						// don't want.
 						$tw.utils.each(Object.keys(widget.variables), function(key) {
 							widgetPointer.variables[key] = widget.variables[key];
@@ -82,7 +70,7 @@ ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 						// No more regenerating children for
 						// this widget. If it needs to refresh,
 						// it'll do so along with the the whole
-						// importvariable tree.
+
 						if(widgetPointer != this) {
 							widgetPointer.makeChildWidgets = function(){};
 						}
@@ -91,7 +79,7 @@ ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 				}
 				parseTreeNode = parseTreeNode.children && parseTreeNode.children[0];
 			}
-		} 
+		}
 	});
 
 	if(widgetPointer != this) {
@@ -101,9 +89,6 @@ ImportVariablesWidget.prototype.execute = function(tiddlerList) {
 	}
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 ImportVariablesWidget.prototype.refresh = function(changedTiddlers) {
 	// Recompute our attributes and the filter list
 	var changedAttributes = this.computeAttributes(),

--- a/core/modules/widgets/jsontiddler.js
+++ b/core/modules/widgets/jsontiddler.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/jsontiddler.js
 type: application/javascript
 module-type: widget
-
-Render a tiddler as JSON text
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var JSONTiddlerWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 JSONTiddlerWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 JSONTiddlerWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
 	this.parentDomNode = parent;
@@ -42,24 +33,18 @@ JSONTiddlerWidget.prototype.render = function(parent,nextSibling) {
 	if(this.attEscapeUnsafeScriptChars) {
 		json = json.replace(/</g,"\\u003C");
 	}
-	// Update the DOM
+
 	var textNode = this.document.createTextNode(json);
 	parent.insertBefore(textNode,nextSibling);
 	this.domNodes.push(textNode);
 };
 
-/*
-Compute the internal state of the widget
-*/
 JSONTiddlerWidget.prototype.execute = function() {
 	this.attTiddler = this.getAttribute("tiddler");
 	this.attExclude = this.getAttribute("exclude","");
 	this.attEscapeUnsafeScriptChars = this.getAttribute("escapeUnsafeScriptChars","no") === "yes";
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 JSONTiddlerWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0 || (this.attTiddler && changedTiddlers[this.attTiddler])) {

--- a/core/modules/widgets/keyboard.js
+++ b/core/modules/widgets/keyboard.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/keyboard.js
 type: application/javascript
 module-type: widget
-
-Keyboard shortcut widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var KeyboardWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 KeyboardWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 KeyboardWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
 	// Remember parent
@@ -34,7 +25,7 @@ KeyboardWidget.prototype.render = function(parent,nextSibling) {
 	if(this.tag && $tw.config.htmlUnsafeElements.indexOf(this.tag) === -1) {
 		tag = this.tag;
 	}
-	// Create element
+
 	var domNode = this.document.createElement(tag);
 	// Assign classes
 	this.domNode = domNode;
@@ -82,9 +73,6 @@ KeyboardWidget.prototype.dispatchMessage = function(event) {
 	this.dispatchEvent({type: this.message, param: this.param, tiddlerTitle: this.getVariable("currentTiddler")});
 };
 
-/*
-Compute the internal state of the widget
-*/
 KeyboardWidget.prototype.execute = function() {
 	var self = this;
 	// Get attributes
@@ -101,9 +89,9 @@ KeyboardWidget.prototype.execute = function() {
 			$tw.utils.each($tw.keyboardManager.lookupNames,function(platformDescriptor) {
 				self.shortcutTiddlers.push("$:/config/" + platformDescriptor + "/" + name);
 			});
-		}	
+		}
 	}
-	// Make child widgets
+
 	this.makeChildWidgets();
 };
 
@@ -113,9 +101,6 @@ KeyboardWidget.prototype.assignDomNodeClasses = function() {
 	this.domNode.className = classes.join(" ").trim();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 KeyboardWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.message || changedAttributes.param || changedAttributes.key || changedAttributes.tag) {
@@ -124,7 +109,7 @@ KeyboardWidget.prototype.refresh = function(changedTiddlers) {
 	} else if(changedAttributes["class"]) {
 		this.assignDomNodeClasses();
 	}
-	// Update the keyInfoArray if one of its shortcut-config-tiddlers has changed
+
 	if(this.shortcutTiddlers && $tw.utils.hopArray(changedTiddlers,this.shortcutTiddlers) && $tw.keyboardManager) {
 		this.keyInfoArray = $tw.keyboardManager.parseKeyDescriptors(this.key);
 	}

--- a/core/modules/widgets/let.js
+++ b/core/modules/widgets/let.js
@@ -2,16 +2,6 @@
 title: $:/core/modules/widgets/let.js
 type: application/javascript
 module-type: widget
-
-This widget allows defining multiple variables at once, while allowing
-the later variables to depend upon the earlier ones.
-
-```
-<$let currentTiddler="target" value={{!!value}} currentTiddler="different">
-  {{!!value}} will be different from <<value>>
-</$let>
-```
-
 \*/
 
 "use strict";
@@ -23,14 +13,8 @@ var LetWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 LetWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 LetWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -40,7 +24,7 @@ LetWidget.prototype.render = function(parent,nextSibling) {
 
 LetWidget.prototype.computeAttributes = function() {
 	// Before computing attributes, we must make clear that none of the
-	// existing attributes are staged for lookup, even on a refresh
+
 	var changedAttributes = {},
 		self = this;
 	this.currentValueFor = Object.create(null);
@@ -48,7 +32,7 @@ LetWidget.prototype.computeAttributes = function() {
 		var value = self.computeAttribute(attribute,{asList: true}),
 			name = attribute.name;
 		// Now that it's prepped, we're allowed to look this variable up
-		// when defining later variables
+
 		if(value !== undefined) {
 			self.currentValueFor[name] = value;
 		}
@@ -66,7 +50,7 @@ LetWidget.prototype.computeAttributes = function() {
 
 LetWidget.prototype.getVariableInfo = function(name,options) {
 	// Special handling: If this variable exists in this very $let, we can
-	// use it, but only if it's been staged.
+
 	if($tw.utils.hop(this.currentValueFor,name)) {
 		var value = this.currentValueFor[name];
 		return {
@@ -77,9 +61,6 @@ LetWidget.prototype.getVariableInfo = function(name,options) {
 	return Widget.prototype.getVariableInfo.call(this,name,options);
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 LetWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0) {

--- a/core/modules/widgets/link.js
+++ b/core/modules/widgets/link.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/link.js
 type: application/javascript
 module-type: widget
-
-Link widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var LinkWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 LinkWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 LinkWidget.prototype.render = function(parent,nextSibling) {
 	// Save the parent dom node
 	this.parentDomNode = parent;
@@ -55,9 +46,6 @@ LinkWidget.prototype.render = function(parent,nextSibling) {
 	}
 };
 
-/*
-Render this widget into the DOM
-*/
 LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	var self = this;
 	// Sanitise the specified tag
@@ -65,7 +53,7 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	if($tw.config.htmlUnsafeElements.indexOf(tag) !== -1) {
 		tag = "a";
 	}
-	// Create our element
+
 	var namespace = this.getVariable("namespace",{defaultValue: "http://www.w3.org/1999/xhtml"}),
 		domNode = this.document.createElementNS(namespace,tag);
 	// Assign classes
@@ -91,7 +79,7 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	if(classes.length > 0) {
 		domNode.setAttribute("class",classes.join(" "));
 	}
-	// Set an href
+
 	var wikilinkTransformFilter = this.getVariable("tv-filter-export-link"),
 		wikiLinkText;
 	if(wikilinkTransformFilter) {
@@ -106,17 +94,17 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 		wikiLinkText = $tw.utils.replaceString(wikiLinkTemplate,"$uri_encoded$",$tw.utils.encodeURIComponentExtended(this.to));
 		wikiLinkText = $tw.utils.replaceString(wikiLinkText,"$uri_doubleencoded$",$tw.utils.encodeURIComponentExtended($tw.utils.encodeURIComponentExtended(this.to)));
 	}
-	// Override with the value of tv-get-export-link if defined
+
 	wikiLinkText = this.getVariable("tv-get-export-link",{params: [{name: "to",value: this.to}],defaultValue: wikiLinkText});
 	if(tag === "a") {
 		var namespaceHref = (namespace === "http://www.w3.org/2000/svg") ? "http://www.w3.org/1999/xlink" : undefined;
 		domNode.setAttributeNS(namespaceHref,"href",wikiLinkText);
 	}
-	// Set the tabindex
+
 	if(this.tabIndex) {
 		domNode.setAttribute("tabindex",this.tabIndex);
 	}
-	// Set the tooltip
+
 	// HACK: Performance issues with re-parsing the tooltip prevent us defaulting the tooltip to "<$transclude field='tooltip'><$transclude field='title'/></$transclude>"
 	var tooltipWikiText = this.tooltip || this.getVariable("tv-wikilink-tooltip");
 	if(tooltipWikiText) {
@@ -152,7 +140,7 @@ LinkWidget.prototype.renderLink = function(parent,nextSibling) {
 	} else if(this.draggable === "no") {
 		domNode.setAttribute("draggable","false");
 	}
-	// Assign data- attributes
+
 	this.assignAttributes(domNode,{
 		sourcePrefix: "data-",
 		destPrefix: "data-"
@@ -193,9 +181,6 @@ LinkWidget.prototype.handleClickEvent = function(event) {
 	return false;
 };
 
-/*
-Compute the internal state of the widget
-*/
 LinkWidget.prototype.execute = function() {
 	// Pick up our attributes
 	this.to = this.getAttribute("to",this.getVariable("currentTiddler"));
@@ -223,9 +208,6 @@ LinkWidget.prototype.execute = function() {
 	this.makeChildWidgets(templateTree);
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 LinkWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0 || changedTiddlers[this.to]) {

--- a/core/modules/widgets/linkcatcher.js
+++ b/core/modules/widgets/linkcatcher.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/linkcatcher.js
 type: application/javascript
 module-type: widget
-
-Linkcatcher widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var LinkCatcherWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 LinkCatcherWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 LinkCatcherWidget.prototype.render = function(parent,nextSibling) {
 	this.addEventListeners([
 		{type: "tm-navigate", handler: "handleNavigateEvent"}
@@ -33,9 +24,6 @@ LinkCatcherWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 LinkCatcherWidget.prototype.execute = function() {
 	// Get our parameters
 	this.catchTo = this.getAttribute("to");

--- a/core/modules/widgets/list.js
+++ b/core/modules/widgets/list.js
@@ -2,27 +2,17 @@
 title: $:/core/modules/widgets/list.js
 type: application/javascript
 module-type: widget
-
-List and list item widgets
-
 \*/
 
 "use strict";
 
 var Widget = require("$:/core/modules/widgets/widget.js").widget;
 
-/*
-The list widget creates list element sub-widgets that reach back into the list widget for their configuration
-*/
-
 var ListWidget = function(parseTreeNode,options) {
 	// Main initialisation inherited from widget.js
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ListWidget.prototype = new Widget();
 
 ListWidget.prototype.initialise = function(parseTreeNode,options) {
@@ -30,16 +20,13 @@ ListWidget.prototype.initialise = function(parseTreeNode,options) {
 	if(parseTreeNode === undefined) {
 		return;
 	}
-	// First call parent constructor to set everything else up
+
 	Widget.prototype.initialise.call(this,parseTreeNode,options);
 	// Now look for <$list-template> and <$list-empty> widgets as immediate child widgets
-	// This is safe to do during initialization because parse trees never change after creation
+
 	this.findExplicitTemplates();
 }
 
-/*
-Render this widget into the DOM
-*/
 ListWidget.prototype.render = function(parent,nextSibling) {
 	// Initialise the storyviews if they've not been done already
 	if(!this.storyViews) {
@@ -177,9 +164,6 @@ ListWidget.prototype.makeJoinTemplate = function() {
 	}
 };
 
-/*
-Compose the template for a list item
-*/
 ListWidget.prototype.makeItemTemplate = function(title,index) {
 	// Check if the tiddler is a draft
 	var tiddler = this.wiki.getTiddler(title),
@@ -190,7 +174,7 @@ ListWidget.prototype.makeItemTemplate = function(title,index) {
 	if(isDraft && this.editTemplate) {
 		template = this.editTemplate;
 	}
-	// Compose the transclusion of the template
+
 	if(template) {
 		templateTree = [{type: "transclude", attributes: {tiddler: {type: "string", value: template}}}];
 	} else {
@@ -210,7 +194,7 @@ ListWidget.prototype.makeItemTemplate = function(title,index) {
 			]}]}];
 		}
 	}
-	// Return the list item
+
 	var parseTreeNode = {type: "listitem", itemTitle: title, variableName: this.variableName, children: templateTree, join: join};
 	parseTreeNode.isLast = index === this.list.length - 1;
 	if(this.counterName) {
@@ -221,9 +205,6 @@ ListWidget.prototype.makeItemTemplate = function(title,index) {
 	return parseTreeNode;
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 ListWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes(),
 		result;
@@ -231,7 +212,7 @@ ListWidget.prototype.refresh = function(changedTiddlers) {
 	if(this.storyview && this.storyview.refreshStart) {
 		this.storyview.refreshStart(changedTiddlers,changedAttributes);
 	}
-	// Completely refresh if any of our attributes have changed
+
 	if(changedAttributes.filter || changedAttributes.variable || changedAttributes.counter || changedAttributes.template || changedAttributes.editTemplate || changedAttributes.join || changedAttributes.emptyMessage || changedAttributes.storyview || changedAttributes.history) {
 		this.refreshSelf();
 		result = true;
@@ -243,16 +224,13 @@ ListWidget.prototype.refresh = function(changedTiddlers) {
 			this.handleHistoryChanges();
 		}
 	}
-	// Call the storyview
+
 	if(this.storyview && this.storyview.refreshEnd) {
 		this.storyview.refreshEnd(changedTiddlers,changedAttributes);
 	}
 	return result;
 };
 
-/*
-Handle any changes to the history list
-*/
 ListWidget.prototype.handleHistoryChanges = function() {
 	// Get the history data
 	var newHistory = this.wiki.getTiddlerDataCached(this.historyTitle,[]);
@@ -261,20 +239,17 @@ ListWidget.prototype.handleHistoryChanges = function() {
 	while(entry < newHistory.length && entry < this.history.length && newHistory[entry].title === this.history[entry].title) {
 		entry++;
 	}
-	// Navigate forwards to each of the new tiddlers
+
 	while(entry < newHistory.length) {
 		if(this.storyview && this.storyview.navigateTo) {
 			this.storyview.navigateTo(newHistory[entry]);
 		}
 		entry++;
 	}
-	// Update the history
+
 	this.history = newHistory;
 };
 
-/*
-Process any changes to the list
-*/
 ListWidget.prototype.handleListChanges = function(changedTiddlers) {
 	// Get the new list
 	var prevList = this.list;
@@ -301,7 +276,7 @@ ListWidget.prototype.handleListChanges = function(changedTiddlers) {
 			this.removeChildDomNodes();
 			this.children = [];
 		}
-		// If we are providing an counter variable then we must refresh the items, otherwise we can rearrange them
+
 		var hasRefreshed = false,t;
 		if(this.counterName) {
 			var mustRefreshOldLast = false;
@@ -379,7 +354,7 @@ ListWidget.prototype.handleListChanges = function(changedTiddlers) {
 				}
 			}
 		}
-		// Remove any left over items
+
 		for(t=this.children.length-1; t>=this.list.length; t--) {
 			this.removeListItem(t);
 			hasRefreshed = true;
@@ -388,9 +363,6 @@ ListWidget.prototype.handleListChanges = function(changedTiddlers) {
 	}
 };
 
-/*
-Find the list item with a given title, starting from a specified position
-*/
 ListWidget.prototype.findListItem = function(startIndex,title) {
 	while(startIndex < this.children.length) {
 		if(this.children[startIndex].parseTreeNode.itemTitle === title) {
@@ -401,9 +373,6 @@ ListWidget.prototype.findListItem = function(startIndex,title) {
 	return undefined;
 };
 
-/*
-Insert a new list item at the specified index
-*/
 ListWidget.prototype.insertListItem = function(index,title) {
 	// Create, insert and render the new child widgets
 	var widget = this.makeChildWidget(this.makeItemTemplate(title,index));
@@ -418,9 +387,6 @@ ListWidget.prototype.insertListItem = function(index,title) {
 	return true;
 };
 
-/*
-Remove the specified list item
-*/
 ListWidget.prototype.removeListItem = function(index) {
 	var widget = this.children[index];
 	// Animate the removal if required
@@ -429,7 +395,7 @@ ListWidget.prototype.removeListItem = function(index) {
 	} else {
 		widget.removeChildDomNodes();
 	}
-	// Remove the child widget
+
 	this.children.splice(index,1);
 };
 
@@ -439,14 +405,8 @@ var ListItemWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ListItemWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ListItemWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -454,9 +414,6 @@ ListItemWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 ListItemWidget.prototype.execute = function() {
 	// Set the current list item title
 	this.setVariable(this.parseTreeNode.variableName,this.parseTreeNode.itemTitle);
@@ -465,7 +422,7 @@ ListItemWidget.prototype.execute = function() {
 		this.setVariable(this.parseTreeNode.counterName + "-first",this.parseTreeNode.isFirst ? "yes" : "no");
 		this.setVariable(this.parseTreeNode.counterName + "-last",this.parseTreeNode.isLast ? "yes" : "no");
 	}
-	// Add join if needed
+
 	var children = this.parseTreeNode.children,
 		join = this.parseTreeNode.join;
 	if(join && join.length && !this.parseTreeNode.isLast) {
@@ -474,22 +431,16 @@ ListItemWidget.prototype.execute = function() {
 			children.push(joinNode);
 		})
 	}
-	// Construct the child widgets
+
 	this.makeChildWidgets(children);
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 ListItemWidget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
 exports.listitem = ListItemWidget;
 
-/*
-Make <$list-template> and <$list-empty> widgets that do nothing
-*/
 var ListTemplateWidget = function(parseTreeNode,options) {
 	// Main initialisation inherited from widget.js
 	this.initialise(parseTreeNode,options);

--- a/core/modules/widgets/log.js
+++ b/core/modules/widgets/log.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/log.js
 type: application/javascript
 module-type: widget-subclass
-
-Widget to log debug messages
-
 \*/
 
 "use strict";

--- a/core/modules/widgets/macrocall.js
+++ b/core/modules/widgets/macrocall.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/macrocall.js
 type: application/javascript
 module-type: widget
-
-Macrocall widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var MacroCallWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 MacroCallWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 MacroCallWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -30,9 +21,6 @@ MacroCallWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 MacroCallWidget.prototype.execute = function() {
 	this.macroName = this.parseTreeNode.name || this.getAttribute("$name"),
 	this.parseType = this.getAttribute("$type","text/vnd.tiddlywiki");
@@ -69,9 +57,6 @@ MacroCallWidget.prototype.execute = function() {
 	this.makeChildWidgets(parseTreeNodes);
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 MacroCallWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0) {

--- a/core/modules/widgets/messagecatcher.js
+++ b/core/modules/widgets/messagecatcher.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/messagecatcher.js
 type: application/javascript
 module-type: widget
-
-Message catcher widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var MessageCatcherWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 MessageCatcherWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 MessageCatcherWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
 	// Remember parent

--- a/core/modules/widgets/navigator.js
+++ b/core/modules/widgets/navigator.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/navigator.js
 type: application/javascript
 module-type: widget
-
-Navigator widget
-
 \*/
 
 "use strict";
@@ -17,14 +14,8 @@ var NavigatorWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 NavigatorWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 NavigatorWidget.prototype.render = function(parent,nextSibling) {
 	this.addEventListeners([
 		{type: "tm-navigate", handler: "handleNavigateEvent"},
@@ -49,9 +40,6 @@ NavigatorWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 NavigatorWidget.prototype.execute = function() {
 	// Get our parameters
 	this.storyTitle = this.getAttribute("story");
@@ -67,9 +55,6 @@ NavigatorWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 NavigatorWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.story || changedAttributes.history) {
@@ -131,18 +116,10 @@ NavigatorWidget.prototype.addToStory = function(title,fromTitle) {
 	}
 };
 
-/*
-Add a new record to the top of the history stack
-title: a title string or an array of title strings
-fromPageRect: page coordinates of the origin of the navigation
-*/
 NavigatorWidget.prototype.addToHistory = function(title,fromPageRect) {
 	this.story.addToHistory(title,fromPageRect,this.historyTitle);
 };
 
-/*
-Handle a tm-navigate event
-*/
 NavigatorWidget.prototype.handleNavigateEvent = function(event) {
 	event = $tw.hooks.invokeHook("th-navigating",event);
 	if(event.navigateTo) {
@@ -201,7 +178,7 @@ NavigatorWidget.prototype.handleEditTiddlerEvent = function(event) {
 	if(isUnmodifiedShadow(title) && !confirmEditShadow(title)) {
 		return false;
 	}
-	// Replace the specified tiddler with a draft in edit mode
+
 	var draftTiddler = this.makeDraftTiddler(title);
 	// Update the story and history if required
 	if(!event.paramObject || event.paramObject.suppressNavigation !== "yes") {
@@ -253,7 +230,7 @@ NavigatorWidget.prototype.handleDeleteTiddlerEvent = function(event) {
 	// Invoke the hook function and delete this tiddler
 	if(tiddler) {
 		$tw.hooks.invokeHook("th-deleting-tiddler",tiddler);
-		this.wiki.deleteTiddler(title);	
+		this.wiki.deleteTiddler(title);
 	}
 	// Remove the closed tiddler from the story
 	this.removeTitleFromStory(storyList,title);
@@ -294,9 +271,6 @@ NavigatorWidget.prototype.makeDraftTiddler = function(targetTitle) {
 	return draftTiddler;
 };
 
-/*
-Generate a title for the draft of a given tiddler
-*/
 NavigatorWidget.prototype.generateDraftTitle = function(title) {
 	return this.wiki.generateDraftTitle(title);
 };
@@ -336,7 +310,7 @@ NavigatorWidget.prototype.handleSaveTiddlerEvent = function(event) {
 				if(isRename && shouldRelink && this.wiki.tiddlerExists(draftOf)) {
 					this.wiki.relinkTiddler(draftOf,draftTitle);
 				}
-				// Remove the draft tiddler
+
 				this.wiki.deleteTiddler(title);
 				// Remove the original tiddler if we're renaming it
 				if(isRename) {
@@ -449,7 +423,7 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 		draftTitle = this.generateDraftTitle(title);
 		existingTiddler = this.wiki.getTiddler(title);
 	}
-	// Merge the tags
+
 	var mergedTags = [];
 	if(existingTiddler && existingTiddler.fields.tags) {
 		$tw.utils.pushTop(mergedTags,existingTiddler.fields.tags);
@@ -464,7 +438,7 @@ NavigatorWidget.prototype.handleNewTiddlerEvent = function(event) {
 		templateHasTags = true;
 		mergedTags = $tw.utils.pushTop(mergedTags,templateTiddler.fields.tags);
 	}
-	// Save the draft tiddler
+
 	var draftTiddler = new $tw.Tiddler({
 			text: "",
 			"draft.title": title
@@ -581,7 +555,7 @@ NavigatorWidget.prototype.handlePerformImportEvent = function(event) {
 				var tiddler = new $tw.Tiddler(tiddlerFields);
 			}
 			// th-importing-tiddler doesn't allow user interaction by default
-			// If you want to use the default UI then use: $:/core/modules/upgraders/ instead
+
 			tiddler = $tw.hooks.invokeHook("th-importing-tiddler",tiddler);
 			// Add the tiddlers to the store
 			self.wiki.addTiddler(tiddler);

--- a/core/modules/widgets/parameters.js
+++ b/core/modules/widgets/parameters.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/parameters.js
 type: application/javascript
 module-type: widget
-
-Widget for definition of transclusion parameters
-
 \*/
 
 "use strict";
@@ -17,14 +14,8 @@ var ParametersWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ParametersWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ParametersWidget.prototype.render = function(parent,nextSibling) {
 	// Call the constructor
 	Widget.call(this);
@@ -34,9 +25,6 @@ ParametersWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 ParametersWidget.prototype.execute = function() {
 	var self = this;
 	this.parametersDepth = Math.max(parseInt(this.getAttribute("$depth","1"),10) || 1,1);
@@ -52,7 +40,7 @@ ParametersWidget.prototype.execute = function() {
 		}
 		pointer = pointer.parentWidget;
 	}
-	// Process each parameter
+
 	if(pointer instanceof TranscludeWidget) {
 		// Get the value for each defined parameter
 		$tw.utils.each($tw.utils.getOrderedAttributesFromParseTreeNode(self.parseTreeNode),function(attr,index) {
@@ -75,7 +63,7 @@ ParametersWidget.prototype.execute = function() {
 		});
 	} else {
 		// There is no parent transclude. i.e. direct rendering.
-		// We use default values only.
+
 		$tw.utils.each($tw.utils.getOrderedAttributesFromParseTreeNode(self.parseTreeNode),function(attr,index) {
 			var name = attr.name;
 			// If the attribute name starts with $$ then reduce to a single dollar
@@ -87,13 +75,10 @@ ParametersWidget.prototype.execute = function() {
 			self.setVariable(name,value);
 		});
 	}
-	// Construct the child widgets
+
 	this.makeChildWidgets();
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 ParametersWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(Object.keys(changedAttributes).length) {

--- a/core/modules/widgets/password.js
+++ b/core/modules/widgets/password.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/password.js
 type: application/javascript
 module-type: widget
-
-Password widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var PasswordWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 PasswordWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 PasswordWidget.prototype.render = function(parent,nextSibling) {
 	// Save the parent dom node
 	this.parentDomNode = parent;
@@ -51,9 +42,6 @@ PasswordWidget.prototype.handleChangeEvent = function(event) {
 	return $tw.utils.savePassword(this.passwordName,password);
 };
 
-/*
-Compute the internal state of the widget
-*/
 PasswordWidget.prototype.execute = function() {
 	// Get the parameters from the attributes
 	this.passwordName = this.getAttribute("name","");
@@ -61,9 +49,6 @@ PasswordWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 PasswordWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.name) {

--- a/core/modules/widgets/qualify.js
+++ b/core/modules/widgets/qualify.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/qualify.js
 type: application/javascript
 module-type: widget
-
-Qualify text to a variable 
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var QualifyWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 QualifyWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 QualifyWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -30,9 +21,6 @@ QualifyWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 QualifyWidget.prototype.execute = function() {
 	// Get our parameters
 	this.qualifyName = this.getAttribute("name");
@@ -41,13 +29,10 @@ QualifyWidget.prototype.execute = function() {
 	if(this.qualifyName) {
 		this.setVariable(this.qualifyName,this.qualifyTitle + "-" + this.getStateQualifier());
 	}
-	// Construct the child widgets
+
 	this.makeChildWidgets();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 QualifyWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.name || changedAttributes.title) {

--- a/core/modules/widgets/radio.js
+++ b/core/modules/widgets/radio.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/radio.js
 type: application/javascript
 module-type: widget
-
-Set a field or index at a given tiddler via radio buttons
-
 \*/
 
 "use strict";
@@ -14,14 +11,8 @@ var RadioWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 RadioWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 RadioWidget.prototype.render = function(parent,nextSibling) {
 	// Save the parent dom node
 	this.parentDomNode = parent;
@@ -93,15 +84,12 @@ RadioWidget.prototype.handleChangeEvent = function(event) {
 	if(this.inputDomNode.checked) {
 		this.setValue();
 	}
-	// Trigger actions
+
 	if(this.radioActions) {
 		this.invokeActionString(this.radioActions,this,event,{"actionValue": this.radioValue});
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 RadioWidget.prototype.execute = function() {
 	// Get the parameters from the attributes
 	this.radioTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
@@ -117,9 +105,6 @@ RadioWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 RadioWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(($tw.utils.count(changedAttributes) > 0)) {

--- a/core/modules/widgets/range.js
+++ b/core/modules/widgets/range.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/range.js
 type: application/javascript
 module-type: widget
-
-Range widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var RangeWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 RangeWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 RangeWidget.prototype.render = function(parent,nextSibling) {
 	// Save the parent dom node
 	this.parentDomNode = parent;
@@ -88,21 +79,19 @@ RangeWidget.prototype.getActionVariables = function(options) {
 	options = options || {};
 	var hasChanged = (this.startValue !== this.inputDomNode.value) ? "yes" : "no";
 	// Trigger actions. Use variables = {key:value, key:value ...}
-	// the "value" is needed.
+
 	return $tw.utils.extend({"actionValue": this.inputDomNode.value, "actionValueHasChanged": hasChanged}, options);
 }
 
-// actionsStart
 RangeWidget.prototype.handleMouseDownEvent = function(event) {
 	this.handleEvent(event);
 	// Trigger actions
 	if(this.actionsMouseDown) {
-		var variables = this.getActionVariables() // TODO this line will go into the function call below.
+		var variables = this.getActionVariables()
 		this.invokeActionString(this.actionsMouseDown,this,event,variables);
 	}
 }
 
-// actionsStop
 RangeWidget.prototype.handleMouseUpEvent = function(event) {
 	this.handleEvent(event);
 	// Trigger actions
@@ -121,7 +110,7 @@ RangeWidget.prototype.handleInputEvent = function(event) {
 	// Trigger actions
 	if(this.actionsInput) {
 		// "tiddler" parameter may be missing. See .execute() below
-		var variables = this.getActionVariables({"actionValueHasChanged": "yes"}) // TODO this line will go into the function call below.
+		var variables = this.getActionVariables({"actionValueHasChanged": "yes"})
 		this.invokeActionString(this.actionsInput,this,event,variables);
 	}
 };
@@ -136,9 +125,6 @@ RangeWidget.prototype.handleEvent = function(event) {
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 RangeWidget.prototype.execute = function() {
 	// Get the parameters from the attributes
 	this.tiddlerTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
@@ -152,7 +138,7 @@ RangeWidget.prototype.execute = function() {
 	this.isDisabled = this.getAttribute("disabled","no");
 	this.tabIndex = this.getAttribute("tabindex");
 	// Actions since 5.1.23
-	// Next 2 only fire once!
+
 	this.actionsMouseDown = this.getAttribute("actionsStart","");
 	this.actionsMouseUp = this.getAttribute("actionsStop","");
 	// Input fires very often!
@@ -161,9 +147,6 @@ RangeWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 RangeWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0) {

--- a/core/modules/widgets/raw.js
+++ b/core/modules/widgets/raw.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/raw.js
 type: application/javascript
 module-type: widget
-
-Raw widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var RawWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 RawWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 RawWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.execute();
@@ -32,15 +23,9 @@ RawWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(div);
 };
 
-/*
-Compute the internal state of the widget
-*/
 RawWidget.prototype.execute = function() {
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 RawWidget.prototype.refresh = function(changedTiddlers) {
 	return false;
 };

--- a/core/modules/widgets/reveal.js
+++ b/core/modules/widgets/reveal.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/reveal.js
 type: application/javascript
 module-type: widget
-
-Reveal widget
-
 \*/
 
 "use strict";
@@ -17,14 +14,8 @@ var RevealWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 RevealWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 RevealWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();

--- a/core/modules/widgets/scrollable.js
+++ b/core/modules/widgets/scrollable.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/scrollable.js
 type: application/javascript
 module-type: widget
-
-Scrollable widget
-
 \*/
 
 "use strict";
@@ -17,9 +14,6 @@ var ScrollableWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ScrollableWidget.prototype = new Widget();
 
 ScrollableWidget.prototype.cancelScroll = function() {
@@ -29,9 +23,6 @@ ScrollableWidget.prototype.cancelScroll = function() {
 	}
 };
 
-/*
-Handle a scroll event
-*/
 ScrollableWidget.prototype.handleScrollEvent = function(event) {
 	// Pass the scroll event through if our offsetsize is larger than our scrollsize
 	if(this.outerDomNode.scrollWidth <= this.outerDomNode.offsetWidth && this.outerDomNode.scrollHeight <= this.outerDomNode.offsetHeight && this.fallthrough === "yes") {
@@ -49,9 +40,6 @@ ScrollableWidget.prototype.handleScrollEvent = function(event) {
 	return false; // Handled event
 };
 
-/*
-Scroll an element into view
-*/
 ScrollableWidget.prototype.scrollIntoView = function(element,callback,options) {
 	var duration = $tw.utils.hop(options,"animationDuration") ? parseInt(options.animationDuration) : $tw.utils.getAnimationDuration(),
 		srcWindow = element ? element.ownerDocument.defaultView : window;
@@ -219,9 +207,6 @@ ScrollableWidget.prototype.updateScrollPositionFromBoundTiddler = function() {
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 ScrollableWidget.prototype.execute = function() {
 	// Get attributes
 	this.scrollableBind = this.getAttribute("bind");
@@ -231,16 +216,13 @@ ScrollableWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 ScrollableWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes["class"]) {
 		this.refreshSelf();
 		return true;
 	}
-	// If the bound tiddler has changed, update the eventListener and update scroll position
+
 	if(changedAttributes["bind"]) {
 		if(this.currentListener) {
 			this.outerDomNode.removeEventListener("scroll", this.currentListener, false);
@@ -249,7 +231,7 @@ ScrollableWidget.prototype.refresh = function(changedTiddlers) {
 		this.currentListener = this.listenerFunction.bind(this);
 		this.outerDomNode.addEventListener("scroll", this.currentListener);
 	}
-	// Refresh children
+
 	var result = this.refreshChildren(changedTiddlers);
 	// If the bound tiddler has changed, update scroll position
 	if(changedAttributes["bind"] || changedTiddlers[this.getAttribute("bind")]) {

--- a/core/modules/widgets/select.js
+++ b/core/modules/widgets/select.js
@@ -2,19 +2,6 @@
 title: $:/core/modules/widgets/select.js
 type: application/javascript
 module-type: widget
-
-Select widget:
-
-```
-<$select tiddler="MyTiddler" field="text">
-<$list filter="[tag[chapter]]">
-<option value=<<currentTiddler>>>
-<$view field="description"/>
-</option>
-</$list>
-</$select>
-```
-
 \*/
 
 "use strict";
@@ -25,14 +12,8 @@ var SelectWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 SelectWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 SelectWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -42,7 +23,7 @@ SelectWidget.prototype.render = function(parent,nextSibling) {
 	if(this.selectClass) {
 		domNode.className = this.selectClass;
 	}
-	// Assign data- attributes
+
 	this.assignAttributes(domNode,{
 		sourcePrefix: "data-",
 		destPrefix: "data-"
@@ -74,9 +55,6 @@ SelectWidget.prototype.render = function(parent,nextSibling) {
 	]);
 };
 
-/*
-Handle a change event
-*/
 SelectWidget.prototype.handleChangeEvent = function(event) {
 	// Get the new value and assign it to the tiddler
 	if(this.selectMultiple == false) {
@@ -92,9 +70,6 @@ SelectWidget.prototype.handleChangeEvent = function(event) {
 	}
 };
 
-/*
-If necessary, set the value of the select element to the current value
-*/
 SelectWidget.prototype.setSelectValue = function() {
 	var value = this.selectDefault;
 	// Get the value
@@ -117,7 +92,7 @@ SelectWidget.prototype.setSelectValue = function() {
 			}
 		}
 	}
-	// Assign it to the select element if it's different than the current value
+
 	if(this.selectMultiple) {
 		value = value === undefined ? "" : value;
 		var select = this.getSelectDomNode();
@@ -142,15 +117,12 @@ SelectWidget.prototype.setSelectValue = function() {
 	}
 };
 
-/*
-Get the DOM node of the select element
-*/
 SelectWidget.prototype.getSelectDomNode = function() {
 	return this.domNodes[0];
 };
 
 // Return an array of the selected opion values
-// select is an HTML select element
+
 SelectWidget.prototype.getSelectValues = function() {
 	var select, result, options, opt;
 	select = this.getSelectDomNode();
@@ -165,9 +137,6 @@ SelectWidget.prototype.getSelectValues = function() {
 	return result;
 };
 
-/*
-Compute the internal state of the widget
-*/
 SelectWidget.prototype.execute = function() {
 	// Get our parameters
 	this.selectActions = this.getAttribute("actions");
@@ -186,9 +155,6 @@ SelectWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 SelectWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	// If we're using a different tiddler/field/index then completely refresh ourselves
@@ -198,7 +164,7 @@ SelectWidget.prototype.refresh = function(changedTiddlers) {
 	} else {
 		if(changedAttributes.class) {
 			this.selectClass = this.getAttribute("class");
-			this.getSelectDomNode().setAttribute("class",this.selectClass); 
+			this.getSelectDomNode().setAttribute("class",this.selectClass);
 		}
 		this.assignAttributes(this.getSelectDomNode(),{
 			changedAttributes: changedAttributes,
@@ -209,7 +175,7 @@ SelectWidget.prototype.refresh = function(changedTiddlers) {
 		// If the target tiddler value has changed, just update setting and refresh the children
 		if(changedTiddlers[this.selectTitle] || childrenRefreshed) {
 			this.setSelectValue();
-		} 
+		}
 		return childrenRefreshed;
 	}
 };

--- a/core/modules/widgets/setmultiplevariables.js
+++ b/core/modules/widgets/setmultiplevariables.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/setmultiplevariables.js
 type: application/javascript
 module-type: widget
-
-Widget to set multiple variables at once from a list of names and a list of values
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var SetMultipleVariablesWidget = function(parseTreeNode,options) {
     this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 SetMultipleVariablesWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 SetMultipleVariablesWidget.prototype.render = function(parent,nextSibling) {
     this.parentDomNode = parent;
     this.computeAttributes();
@@ -30,16 +21,12 @@ SetMultipleVariablesWidget.prototype.render = function(parent,nextSibling) {
     this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 SetMultipleVariablesWidget.prototype.execute = function() {
     // Setup our variables
     this.setVariables();
     // Construct the child widgets
     this.makeChildWidgets();
 };
-
 
 SetMultipleVariablesWidget.prototype.setVariables = function() {
     // Set the variables
@@ -57,9 +44,6 @@ SetMultipleVariablesWidget.prototype.setVariables = function() {
     }
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 SetMultipleVariablesWidget.prototype.refresh = function(changedTiddlers) {
     var filterNames = this.getAttribute("$names",""),
         filterValues = this.getAttribute("$values",""),

--- a/core/modules/widgets/setvariable.js
+++ b/core/modules/widgets/setvariable.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/set.js
 type: application/javascript
 module-type: widget
-
-Set variable widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var SetWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 SetWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 SetWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -30,9 +21,6 @@ SetWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 SetWidget.prototype.execute = function() {
 	// Get our parameters
 	this.setName = this.getAttribute("name","currentTiddler");
@@ -56,13 +44,10 @@ SetWidget.prototype.execute = function() {
 	} else {
 		this.setVariable(this.setName,this.getValue());
 	}
-	// Construct the child widgets
+
 	this.makeChildWidgets();
 };
 
-/*
-Get the value to be assigned
-*/
 SetWidget.prototype.getValue = function() {
 	var value = this.setValue;
 	if(this.setTiddler) {
@@ -103,9 +88,6 @@ SetWidget.prototype.getValue = function() {
 	return value || "";
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 SetWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.name || changedAttributes.filter || changedAttributes.select || changedAttributes.tiddler || (this.setTiddler && changedTiddlers[this.setTiddler]) || changedAttributes.field || changedAttributes.index || changedAttributes.value || changedAttributes.emptyValue ||

--- a/core/modules/widgets/slot.js
+++ b/core/modules/widgets/slot.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/slot.js
 type: application/javascript
 module-type: widget
-
-Widget for definition of slots within transcluded content. The values provided by the translusion are passed to the slot.
-
 \*/
 
 "use strict";
@@ -17,14 +14,8 @@ var SlotWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 SlotWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 SlotWidget.prototype.render = function(parent,nextSibling) {
 	// Call the constructor
 	Widget.call(this);
@@ -34,9 +25,6 @@ SlotWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 SlotWidget.prototype.execute = function() {
 	var self = this;
 	this.slotName = this.getAttribute("$name");
@@ -58,13 +46,10 @@ SlotWidget.prototype.execute = function() {
 		// Get the parse tree nodes comprising the slot contents
 		parseTreeNodes = pointer.getTransclusionSlotFill(this.slotName,this.parseTreeNode.children);
 	}
-	// Construct the child widgets
+
 	this.makeChildWidgets(parseTreeNodes);
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 SlotWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes["$name"] || changedAttributes["$depth"]) {

--- a/core/modules/widgets/testcase.js
+++ b/core/modules/widgets/testcase.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/testcase.js
 type: application/javascript
 module-type: widget
-
-Widget to display a test case
-
 \*/
 "use strict";
 
@@ -14,14 +11,8 @@ var TestCaseWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 TestCaseWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 TestCaseWidget.prototype.render = function(parent,nextSibling) {
 	var self = this;
 	this.parentDomNode = parent;
@@ -79,7 +70,7 @@ TestCaseWidget.prototype.render = function(parent,nextSibling) {
 	if(this.testcaseTestOutput && this.testcaseWiki.tiddlerExists(this.testcaseTestOutput) && this.testcaseTestExpectedResult && this.testcaseWiki.tiddlerExists(this.testcaseTestExpectedResult)) {
 		shouldRunTests = true;
 	}
-	// Render the test rendering if required
+
 	if(shouldRunTests) {
 		var testcaseOutputContainer = $tw.fakeDocument.createElement("div");
 		var testcaseOutputWidget = this.testcaseWiki.makeTranscludeWidget(this.testcaseTestOutput,{
@@ -92,14 +83,14 @@ TestCaseWidget.prototype.render = function(parent,nextSibling) {
 		});
 		testcaseOutputWidget.render(testcaseOutputContainer);
 	}
-	// Clear changes queue
+
 	this.testcaseWiki.clearTiddlerEventQueue();
 	// Run the actions if provided
 	if(this.testcaseWiki.tiddlerExists(this.testcaseTestActions)) {
 		testcaseOutputWidget.invokeActionString(this.testcaseWiki.getTiddlerText(this.testcaseTestActions));
 		testcaseOutputWidget.refresh(this.testcaseWiki.changedTiddlers,testcaseOutputContainer);
 	}
-	// Set up the test result variables
+
 	var testResult = "",
 		outputHTML = "",
 		expectedHTML = "";
@@ -116,11 +107,11 @@ TestCaseWidget.prototype.render = function(parent,nextSibling) {
 		this.setVariable("testResult",testResult);
 		this.setVariable("currentTiddler",this.testcaseTestOutput);
 	}
-	// Don't display anything if testHideIfPass is "yes" and the tests have passed
+
 	if(this.testcaseHideIfPass === "yes" && testResult !== "fail") {
 		return;
 	}
-	// Render the page root template of the subwiki
+
 	var rootWidget = this.testcaseWiki.makeTranscludeWidget(this.testcaseTemplate,{
 		document: this.document,
 		parseAsInline: false,
@@ -133,9 +124,6 @@ TestCaseWidget.prototype.render = function(parent,nextSibling) {
 	});
 };
 
-/*
-Compute the internal state of the widget
-*/
 TestCaseWidget.prototype.execute = function() {
 	this.testcaseTemplate = this.getAttribute("template","$:/core/ui/testcases/DefaultTemplate");
 	this.testcaseTestOutput = this.getAttribute("testOutput");
@@ -145,9 +133,6 @@ TestCaseWidget.prototype.execute = function() {
 	this.testcaseClass = this.getAttribute("class","");
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 TestCaseWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0) {

--- a/core/modules/widgets/text.js
+++ b/core/modules/widgets/text.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/text.js
 type: application/javascript
 module-type: widget
-
-Text node widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var TextNodeWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 TextNodeWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 TextNodeWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -34,16 +25,10 @@ TextNodeWidget.prototype.render = function(parent,nextSibling) {
 	this.domNodes.push(textNode);
 };
 
-/*
-Compute the internal state of the widget
-*/
 TextNodeWidget.prototype.execute = function() {
 	// Nothing to do for a text node
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 TextNodeWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.text) {

--- a/core/modules/widgets/tiddler.js
+++ b/core/modules/widgets/tiddler.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/tiddler.js
 type: application/javascript
 module-type: widget
-
-Tiddler widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var TiddlerWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 TiddlerWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 TiddlerWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -30,9 +21,6 @@ TiddlerWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 TiddlerWidget.prototype.execute = function() {
 	this.tiddlerState = this.computeTiddlerState();
 	this.setVariable("currentTiddler",this.tiddlerState.currentTiddler);
@@ -44,9 +32,6 @@ TiddlerWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Compute the tiddler state flags
-*/
 TiddlerWidget.prototype.computeTiddlerState = function() {
 	// Get our parameters
 	this.tiddlerTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
@@ -63,9 +48,6 @@ TiddlerWidget.prototype.computeTiddlerState = function() {
 	return state;
 };
 
-/*
-Create a string of CSS classes derived from the tags of the current tiddler
-*/
 TiddlerWidget.prototype.getTagClasses = function() {
 	var tiddler = this.wiki.getTiddler(this.tiddlerTitle);
 	if(tiddler) {
@@ -79,9 +61,6 @@ TiddlerWidget.prototype.getTagClasses = function() {
 	}
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 TiddlerWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes(),
 		newTiddlerState = this.computeTiddlerState();

--- a/core/modules/widgets/transclude.js
+++ b/core/modules/widgets/transclude.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/transclude.js
 type: application/javascript
 module-type: widget
-
-Transclude widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var TranscludeWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 TranscludeWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 TranscludeWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes({asList: true});
@@ -32,24 +23,24 @@ TranscludeWidget.prototype.render = function(parent,nextSibling) {
 	} catch(error) {
 		if(error instanceof $tw.utils.TranscludeRecursionError) {
 			// We were infinite looping.
-			// We need to try and abort as much of the loop as we
+
 			// can, so we will keep "throwing" upward until we find
-			// a transclusion that has a different signature.
+
 			// Hopefully that will land us just outside where the
-			// loop began. That's where we want to issue an error.
+
 			// Rendering widgets beneath this point may result in a
-			// freezing browser if they explode exponentially.
+
 			var transcludeSignature = this.getVariable("transclusion");
 			if(this.getAncestorCount() > $tw.utils.TranscludeRecursionError.MAX_WIDGET_TREE_DEPTH - 50) {
 				// For the first fifty transcludes we climb up,
 				// we simply collect signatures.
-				// We're assuming those first 50 will likely
+
 				// include all transcludes involved in the loop.
 				error.signatures[transcludeSignature] = true;
 			} else if(!error.signatures[transcludeSignature]) {
 				// Now that we're past the first 50, look for
 				// the first signature that wasn't in that loop.
-				// That's where we print the error and resume
+
 				// rendering.
 				this.removeChildDomNodes();
 				this.children = [this.makeChildWidget({type: "error", attributes: {
@@ -63,9 +54,6 @@ TranscludeWidget.prototype.render = function(parent,nextSibling) {
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 TranscludeWidget.prototype.execute = function() {
 	// Get our attributes, string parameters, and slot values into properties of the widget object
 	this.collectAttributes();
@@ -114,13 +102,10 @@ TranscludeWidget.prototype.execute = function() {
 		var recursionMarker = this.makeRecursionMarker();
 		this.setVariable("transclusion",recursionMarker);
 	}
-	// Construct the child widgets
+
 	this.makeChildWidgets(parseTreeNodes);
 };
 
-/*
-Collect the attributes we need, in the process determining whether we're being used in legacy mode
-*/
 TranscludeWidget.prototype.collectAttributes = function() {
 	var self = this;
 	// Detect legacy mode
@@ -152,9 +137,6 @@ TranscludeWidget.prototype.collectAttributes = function() {
 	}
 };
 
-/*
-Collect string parameters
-*/
 TranscludeWidget.prototype.collectStringParameters = function() {
 	var self = this;
 	this.stringParametersByName = Object.create(null);
@@ -179,9 +161,6 @@ TranscludeWidget.prototype.collectStringParameters = function() {
 	}
 };
 
-/*
-Collect slot value parameters
-*/
 TranscludeWidget.prototype.collectSlotFillParameters = function() {
 	var self = this;
 	this.slotFillParseTrees = Object.create(null);
@@ -210,9 +189,6 @@ TranscludeWidget.prototype.collectSlotFillParameters = function() {
 	}
 };
 
-/*
-Get transcluded details as an object {text:,type:}
-*/
 TranscludeWidget.prototype.getTransclusionTarget = function() {
 	var self = this;
 	var text;
@@ -247,9 +223,6 @@ TranscludeWidget.prototype.getTransclusionTarget = function() {
 	}
 };
 
-/*
-Get transcluded parse tree nodes as an object {text:,type:,parseTreeNodes:,parseAsInline:}
-*/
 TranscludeWidget.prototype.parseTransclusionTarget = function(parseAsInline) {
 	var self = this;
 	var parser;
@@ -360,7 +333,7 @@ TranscludeWidget.prototype.parseTransclusionTarget = function(parseAsInline) {
 							defaultType: this.transcludeType
 						});
 	}
-	// Return the parse tree
+
 	return {
 		parser: parser,
 		parseTreeNodes: parser ? parser.tree : (this.slotFillParseTrees["ts-missing"] || []),
@@ -370,9 +343,6 @@ TranscludeWidget.prototype.parseTransclusionTarget = function(parseAsInline) {
 	};
 };
 
-/*
-Fetch all the string parameters as an ordered array of {name:, value:} where the name is optional
-*/
 TranscludeWidget.prototype.getOrderedTransclusionParameters = function() {
 	var result = [];
 	// Collect the parameters
@@ -384,7 +354,7 @@ TranscludeWidget.prototype.getOrderedTransclusionParameters = function() {
 		}
 		result.push(param);
 	}
-	// Sort numerical parameter names first
+
 	result.sort(function(a,b) {
 		var aIsNumeric = !isNaN(a.name),
 			bIsNumeric = !isNaN(b.name);
@@ -407,9 +377,6 @@ TranscludeWidget.prototype.getOrderedTransclusionParameters = function() {
 	return result;
 };
 
-/*
-Fetch the value of a parameter
-*/
 TranscludeWidget.prototype.getTransclusionParameter = function(name,index,defaultValue) {
 	if(name in this.stringParametersByName) {
 		if(this.multiValuedParametersByName[name]) {
@@ -428,9 +395,6 @@ TranscludeWidget.prototype.getTransclusionParameter = function(name,index,defaul
 	return defaultValue;
 };
 
-/*
-Get one of the special parameters to be provided by the parameters widget
-*/
 TranscludeWidget.prototype.getTransclusionMetaParameters = function() {
 	var self = this;
 	return {
@@ -449,9 +413,6 @@ TranscludeWidget.prototype.getTransclusionMetaParameters = function() {
 	};
 };
 
-/*
-Fetch the value of a slot
-*/
 TranscludeWidget.prototype.getTransclusionSlotFill = function(name,defaultParseTreeNodes) {
 	if(name && this.slotFillParseTrees[name] && this.slotFillParseTrees[name].length > 0) {
 		return this.slotFillParseTrees[name];
@@ -460,16 +421,10 @@ TranscludeWidget.prototype.getTransclusionSlotFill = function(name,defaultParseT
 	}
 };
 
-/*
-Return whether this transclusion should be visible to the slot widget
-*/
 TranscludeWidget.prototype.hasVisibleSlots = function() {
 	return this.getAttribute("$fillignore","no") === "no";
 }
 
-/*
-Compose a string comprising the title, field and/or index to identify this transclusion for recursion detection
-*/
 TranscludeWidget.prototype.makeRecursionMarker = function() {
 	var output = [];
 	output.push("{");
@@ -502,9 +457,6 @@ TranscludeWidget.prototype.functionNeedsRefresh = function() {
 	return oldResult !== newResult;
 }
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 TranscludeWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(($tw.utils.count(changedAttributes) > 0) || (this.transcludeVariableIsFunction && this.functionNeedsRefresh()) || (!this.transcludeVariable && changedTiddlers[this.transcludeTitle] && this.parserNeedsRefresh())) {

--- a/core/modules/widgets/vars.js
+++ b/core/modules/widgets/vars.js
@@ -2,16 +2,6 @@
 title: $:/core/modules/widgets/vars.js
 type: application/javascript
 module-type: widget
-
-This widget allows multiple variables to be set in one go:
-
-```
-\define helloworld() Hello world!
-<$vars greeting="Hi" me={{!!title}} sentence=<<helloworld>>>
-  <<greeting>>! I am <<me>> and I say: <<sentence>>
-</$vars>
-```
-
 \*/
 
 "use strict";
@@ -23,14 +13,8 @@ var VarsWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 VarsWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 VarsWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -38,9 +22,6 @@ VarsWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 VarsWidget.prototype.execute = function() {
 	// Parse variables
 	var self = this;
@@ -53,9 +34,6 @@ VarsWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Refresh the widget by ensuring our attributes are up to date
-*/
 VarsWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if($tw.utils.count(changedAttributes) > 0) {

--- a/core/modules/widgets/view.js
+++ b/core/modules/widgets/view.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/view.js
 type: application/javascript
 module-type: widget
-
-View widget
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var ViewWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 ViewWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 ViewWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -37,9 +28,6 @@ ViewWidget.prototype.render = function(parent,nextSibling) {
 	}
 };
 
-/*
-Compute the internal state of the widget
-*/
 ViewWidget.prototype.execute = function() {
 	// Get parameters from our attributes
 	this.viewTitle = this.getAttribute("tiddler",this.getVariable("currentTiddler"));
@@ -89,14 +77,6 @@ ViewWidget.prototype.execute = function() {
 	}
 };
 
-/*
-The various formatter functions are baked into this widget for the moment. Eventually they will be replaced by macro functions
-*/
-
-/*
-Retrieve the value of the widget. Options are:
-asString: Optionally return the value as a string
-*/
 ViewWidget.prototype.getValue = function(options) {
 	options = options || {};
 	var value = options.asString ? "" : undefined;
@@ -207,9 +187,6 @@ ViewWidget.prototype.getValueAsJsEncoded = function() {
 	return $tw.utils.stringify(this.getValueAsText());
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 ViewWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	if(changedAttributes.tiddler || changedAttributes.field || changedAttributes.index || changedAttributes.template || changedAttributes.format || changedTiddlers[this.viewTitle]) {

--- a/core/modules/widgets/void.js
+++ b/core/modules/widgets/void.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/void.js
 type: application/javascript
 module-type: widget
-
-Void widget that corresponds to pragma and comment AST nodes, etc. It does not render itself but renders all its children.
-
 \*/
 
 "use strict";
@@ -15,9 +12,6 @@ var VoidNodeWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 VoidNodeWidget.prototype = new Widget();
 
 exports.void = VoidNodeWidget;

--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -2,29 +2,14 @@
 title: $:/core/modules/widgets/widget.js
 type: application/javascript
 module-type: widget
-
-Widget base class
-
 \*/
 
 "use strict";
 
-/*
-Create a widget object for a parse tree node
-	parseTreeNode: reference to the parse tree node to be rendered
-	options: see below
-Options include:
-	wiki: mandatory reference to wiki associated with this render tree
-	parentWidget: optional reference to a parent renderer node for the context chain
-	document: optional document object to use instead of global document
-*/
 var Widget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Initialise widget properties. These steps are pulled out of the constructor so that we can reuse them in subclasses
-*/
 Widget.prototype.initialise = function(parseTreeNode,options) {
 	// Bail if parseTreeNode is undefined, meaning  that the widget constructor was called without any arguments so that it can be subclassed
 	if(parseTreeNode === undefined) {
@@ -61,33 +46,16 @@ Widget.prototype.initialise = function(parseTreeNode,options) {
 	}
 };
 
-/*
-Render this widget into the DOM
-*/
 Widget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.execute();
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 Widget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Set the value of a context variable
-name: name of the variable
-value: value of the variable, can be a string or an array
-params: array of {name:, default:} for each parameter
-isMacroDefinition: true if the variable is set via a \define macro pragma (and hence should have variable substitution performed)
-options includes:
-	isProcedureDefinition: true if the variable is set via a \procedure pragma (and hence should not have variable substitution performed)
-	isFunctionDefinition: true if the variable is set via a \function pragma (and hence should not have variable substitution performed)
-	isWidgetDefinition: true if the variable is set via a \widget pragma (and hence should not have variable substitution performed)
-*/
 Widget.prototype.setVariable = function(name,value,params,isMacroDefinition,options) {
 	options = options || {};
 	var valueIsArray = $tw.utils.isArray(value);
@@ -103,24 +71,6 @@ Widget.prototype.setVariable = function(name,value,params,isMacroDefinition,opti
 	};
 };
 
-/*
-Get the prevailing value of a context variable
-name: name of variable
-options: see below
-Options include
-
-params: array of {name:, value:} for each parameter
-defaultValue: default value if the variable is not defined
-source: optional source iterator for evaluating function invocations
-allowSelfAssigned: if true, includes the current widget in the context chain instead of just the parent
-
-Returns an object with the following fields:
-
-params: array of {name:,value:,multiValue:} of parameters to be applied (name is optional)
-text: text of variable, with parameters properly substituted
-resultList: result of variable evaluation as an array
-srcVariable: reference to the object defining the variable
-*/
 Widget.prototype.getVariableInfo = function(name,options) {
 	options = options || {};
 	var self = this,
@@ -131,7 +81,7 @@ Widget.prototype.getVariableInfo = function(name,options) {
 	} else {
 		variable = this.parentWidget && this.parentWidget.variables[name];
 	}
-	// Check for the variable defined in the parent widget (or an ancestor in the prototype chain)
+
 	if(variable) {
 		var originalValue = variable.value,
 			value = originalValue,
@@ -182,7 +132,7 @@ Widget.prototype.getVariableInfo = function(name,options) {
 			isCacheable: originalValue === value
 		};
 	}
-	// If the variable doesn't exist in the parent widget then look for a macro module
+
 	var text = this.evaluateMacroModule(name,actualParams);
 	if(text === undefined) {
 		text = options.defaultValue;
@@ -193,18 +143,10 @@ Widget.prototype.getVariableInfo = function(name,options) {
 	};
 };
 
-/*
-Simplified version of getVariableInfo() that just returns the text
-*/
 Widget.prototype.getVariable = function(name,options) {
 	return this.getVariableInfo(name,options).text;
 };
 
-/*
-Maps actual parameters onto formal parameters, returning an array of {name:,value:} objects
-formalParams - Array of {name:,default:} (default value is optional)
-actualParams - Array of string values or {name:,value:,multiValue} (name and multiValue is optional)
-*/
 Widget.prototype.resolveVariableParameters = function(formalParams,actualParams) {
 	formalParams = formalParams || [];
 	actualParams = actualParams || [];
@@ -237,7 +179,7 @@ Widget.prototype.resolveVariableParameters = function(formalParams,actualParams)
 			paramValue = paramInfo["default"] || "";
 			paramMultiValue = [paramValue];
 		}
-		// Store the parameter name and value
+
 		results.push({name: paramInfo.name, value: paramValue, multiValue: paramMultiValue});
 	}
 	return results;
@@ -289,9 +231,6 @@ Widget.prototype.evaluateMacroModule = function(name,actualParams,defaultValue) 
 	}
 };
 
-/*
-Check whether a given context variable value exists in the parent chain
-*/
 Widget.prototype.hasVariable = function(name,value) {
 	var node = this;
 	while(node) {
@@ -303,9 +242,6 @@ Widget.prototype.hasVariable = function(name,value) {
 	return false;
 };
 
-/*
-Construct a qualifying string based on a hash of concatenating the values of a given variable in the parent chain
-*/
 Widget.prototype.getStateQualifier = function(name) {
 	this.qualifiers = this.qualifiers || Object.create(null);
 	name = name || "transclusion";
@@ -326,9 +262,6 @@ Widget.prototype.getStateQualifier = function(name) {
 	}
 };
 
-/*
-Make a fake widget with specified variables, suitable for variable lookup in filters. Each variable can be a string or an array of strings
-*/
 Widget.prototype.makeFakeWidgetWithVariables = function(vars = {}) {
 	const self = this;
 
@@ -345,7 +278,6 @@ Widget.prototype.makeFakeWidgetWithVariables = function(vars = {}) {
 			return self.getVariableInfo(name, opts);
 		},
 
-
 		getVariable(name,opts) {
 			return this.getVariableInfo(name, opts).text;
 		},
@@ -356,7 +288,7 @@ Widget.prototype.makeFakeWidgetWithVariables = function(vars = {}) {
 
 		get variables() {
 			// Merge parent vars via prototype-like delegation
-			return Object.create(self.variables || {}, 
+			return Object.create(self.variables || {},
 				Object.keys(vars).reduce((acc, key) => {
 					acc[key] = { value: vars[key], enumerable: true, configurable: true };
 					return acc;
@@ -368,12 +300,6 @@ Widget.prototype.makeFakeWidgetWithVariables = function(vars = {}) {
 	return fakeWidget;
 };
 
-/*
-Compute the current values of the attributes of the widget. Returns a hashmap of the names of the attributes that have changed.
-Options include:
-filterFn: only include attributes where filterFn(name) returns true
-asList: boolean if true returns results as an array instead of a single value
-*/
 Widget.prototype.computeAttributes = function(options) {
 	options = options || {};
 	var changedAttributes = {},
@@ -405,10 +331,6 @@ Widget.prototype.computeAttributes = function(options) {
 	return changedAttributes;
 };
 
-/*
-Compute the value of a single attribute. Options include:
-asList: boolean if true returns results as an array instead of a single value
-*/
 Widget.prototype.computeAttribute = function(attribute,options) {
 	options = options || {};
 	var self = this,
@@ -462,23 +384,14 @@ Widget.prototype.computeAttribute = function(attribute,options) {
 	return value;
 };
 
-/*
-Check for the presence of an evaluated attribute on the widget. Note that attributes set to a missing variable (ie attr=<<missing>>) will be treated as missing
-*/
 Widget.prototype.hasAttribute = function(name) {
 	return $tw.utils.hop(this.attributes,name);
 };
 
-/*
-Check for the presence of a raw attribute on the widget parse tree node. Note that attributes set to a missing variable (ie attr=<<missing>>) will NOT be treated as missing
-*/
 Widget.prototype.hasParseTreeNodeAttribute = function(name) {
 	return $tw.utils.hop(this.parseTreeNode.attributes,name);
 };
 
-/*
-Get the value of an attribute
-*/
 Widget.prototype.getAttribute = function(name,defaultText) {
 	if($tw.utils.hop(this.attributes,name)) {
 		return this.attributes[name];
@@ -487,14 +400,6 @@ Widget.prototype.getAttribute = function(name,defaultText) {
 	}
 };
 
-/*
-Assign the common attributes of the widget to a domNode
-options include:
-sourcePrefix: prefix of attributes that are to be directly assigned (defaults to the empty string meaning all attributes)
-destPrefix: prefix to be applied to attribute names that are to be directly assigned (defaults to the emtpy string which means no prefix is added)
-changedAttributes: hashmap by attribute name of attributes to process (if missing, process all attributes)
-excludeEventAttributes: ignores attributes whose name would begin with "on"
-*/
 Widget.prototype.assignAttributes = function(domNode,options) {
 	options = options || {};
 	var self = this,
@@ -508,18 +413,18 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 			domNode.style.setProperty(name,value);
 			return;
 		}
-		// Process any style attributes before considering sourcePrefix and destPrefix
+
 		if(name.substr(0,6) === "style." && name.length > 6) {
 			domNode.style[$tw.utils.unHyphenateCss(name.substr(6))] = value;
 			return;
 		}
-		// Check if the sourcePrefix is a match
+
 		if(name.substr(0,sourcePrefix.length) === sourcePrefix) {
 			name = destPrefix + name.substr(sourcePrefix.length);
 		} else {
 			value = undefined;
 		}
-		// Check for excluded attribute names
+
 		if(options.excludeEventAttributes && name.substr(0,2).toLowerCase() === EVENT_ATTRIBUTE_PREFIX) {
 			value = undefined;
 		}
@@ -530,7 +435,7 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 				namespace = "http://www.w3.org/1999/xlink";
 				name = name.substr(6);
 			}
-			// Setting certain attributes can cause a DOM error (eg xmlns on the svg element)
+
 			try {
 				domNode.setAttributeNS(namespace,name,value);
 			} catch(e) {
@@ -548,13 +453,10 @@ Widget.prototype.assignAttributes = function(domNode,options) {
 	} else {
 		$tw.utils.each(changedAttributes,function(value,name) {
 			assignAttribute(name,self.getAttribute(name));
-		});	
+		});
 	}
 };
 
-/*
-Get the number of ancestor widgets for this widget
-*/
 Widget.prototype.getAncestorCount = function() {
 	if(this.ancestorCount === undefined) {
 		if(this.parentWidget) {
@@ -566,9 +468,6 @@ Widget.prototype.getAncestorCount = function() {
 	return this.ancestorCount;
 };
 
-/*
-Make child widgets correspondng to specified parseTreeNodes
-*/
 Widget.prototype.makeChildWidgets = function(parseTreeNodes,options) {
 	options = options || {};
 	this.children = [];
@@ -596,11 +495,6 @@ Widget.prototype.makeChildWidgets = function(parseTreeNodes,options) {
 	}
 };
 
-/*
-Construct the widget object for a parse tree node
-options include:
-	variables: optional hashmap of variables to wrap around the widget
-*/
 Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 	var self = this;
 	options = options || {};
@@ -611,7 +505,7 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 				// Widget is overrideable if its name contains a period, or if it is an existing JS widget and we're not in safe mode
 				return parseTreeNode.type.indexOf(".") !== -1 || (!!self.widgetClasses[parseTreeNode.type] && !$tw.safeMode);
 			};
-		if(!parseTreeNode.isNotRemappable && isOverrideable()) { 
+		if(!parseTreeNode.isNotRemappable && isOverrideable()) {
 			var variableInfo = this.getVariableInfo(variableDefinitionName,{allowSelfAssigned: true});
 			if(variableInfo && variableInfo.srcVariable && variableInfo.srcVariable.value && variableInfo.srcVariable.isWidgetDefinition) {
 				var newParseTreeNode = {
@@ -629,13 +523,13 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 			}
 		}
 	}
-	// Get the widget class for this node type
+
 	var WidgetClass = this.widgetClasses[parseTreeNode.type];
 	if(!WidgetClass) {
 		WidgetClass = this.widgetClasses.text;
 		parseTreeNode = {type: "text", text: "Undefined widget '" + parseTreeNode.type + "'"};
 	}
-	// Create set variable widgets for each variable
+
 	$tw.utils.each(options.variables,function(value,name) {
 		var setVariableWidget = {
 			type: "set",
@@ -656,9 +550,6 @@ Widget.prototype.makeChildWidget = function(parseTreeNode,options) {
 	});
 };
 
-/*
-Get the next sibling of this widget
-*/
 Widget.prototype.nextSibling = function() {
 	if(this.parentWidget) {
 		var index = this.parentWidget.children.indexOf(this);
@@ -669,9 +560,6 @@ Widget.prototype.nextSibling = function() {
 	return null;
 };
 
-/*
-Get the previous sibling of this widget
-*/
 Widget.prototype.previousSibling = function() {
 	if(this.parentWidget) {
 		var index = this.parentWidget.children.indexOf(this);
@@ -682,9 +570,6 @@ Widget.prototype.previousSibling = function() {
 	return null;
 };
 
-/*
-Render the children of this widget into the DOM
-*/
 Widget.prototype.renderChildren = function(parent,nextSibling) {
 	var children = this.children;
 	for(var i = 0; i < children.length; i++) {
@@ -692,9 +577,6 @@ Widget.prototype.renderChildren = function(parent,nextSibling) {
 	};
 };
 
-/*
-Add a list of event listeners from an array [{type:,handler:},...]
-*/
 Widget.prototype.addEventListeners = function(listeners) {
 	var self = this;
 	$tw.utils.each(listeners,function(listenerInfo) {
@@ -702,11 +584,6 @@ Widget.prototype.addEventListeners = function(listeners) {
 	});
 };
 
-/*
-Add an event listener.
-
-Listener could return a boolean indicating whether to further propagation or not, default to `false`.
-*/
 Widget.prototype.addEventListener = function(type,handler) {
 	this.eventListeners[type] = this.eventListeners[type] || [];
 	if(this.eventListeners[type].indexOf(handler) === -1) {
@@ -714,9 +591,6 @@ Widget.prototype.addEventListener = function(type,handler) {
 	}
 };
 
-/*
-Remove an event listener
-*/
 Widget.prototype.removeEventListener = function(type,handler) {
 	if(!this.eventListeners[type]) return;
 	var index = this.eventListeners[type].indexOf(handler);
@@ -725,11 +599,6 @@ Widget.prototype.removeEventListener = function(type,handler) {
 	}
 };
 
-/*
-Dispatch an event to a widget.
-
-If the widget doesn't handle the event then it is also dispatched to the parent widget
-*/
 Widget.prototype.dispatchEvent = function(event) {
 	event.widget = event.widget || this;
 	var listeners = this.eventListeners[event.type];
@@ -753,32 +622,23 @@ Widget.prototype.dispatchEvent = function(event) {
 			return false;
 		}
 	}
-	// Dispatch the event to the parent widget
+
 	if(this.parentWidget) {
 		return this.parentWidget.dispatchEvent(event);
 	}
 	return true;
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 Widget.prototype.refresh = function(changedTiddlers) {
 	return this.refreshChildren(changedTiddlers);
 };
 
-/*
-Rebuild a previously rendered widget
-*/
 Widget.prototype.refreshSelf = function() {
 	var nextSibling = this.findNextSiblingDomNode();
 	this.removeChildDomNodes();
 	this.render(this.parentDomNode,nextSibling);
 };
 
-/*
-Refresh all the children of a widget
-*/
 Widget.prototype.refreshChildren = function(changedTiddlers) {
 	var children = this.children,
 		refreshed = false;
@@ -788,9 +648,6 @@ Widget.prototype.refreshChildren = function(changedTiddlers) {
 	return refreshed;
 };
 
-/*
-Find the next sibling in the DOM to this widget. This is done by scanning the widget tree through all next siblings and their descendents that share the same parent DOM node
-*/
 Widget.prototype.findNextSiblingDomNode = function(startIndex) {
 	// Refer to this widget by its index within its parents children
 	var parent = this.parentWidget,
@@ -798,14 +655,14 @@ Widget.prototype.findNextSiblingDomNode = function(startIndex) {
 	if(index === -1) {
 		throw "node not found in parents children";
 	}
-	// Look for a DOM node in the later siblings
+
 	while(++index < parent.children.length) {
 		var domNode = parent.children[index].findFirstDomNode();
 		if(domNode) {
 			return domNode;
 		}
 	}
-	// Go back and look for later siblings of our parent if it has the same parent dom node
+
 	var grandParent = parent.parentWidget;
 	if(grandParent && parent.parentDomNode === this.parentDomNode) {
 		index = grandParent.children.indexOf(parent);
@@ -816,9 +673,6 @@ Widget.prototype.findNextSiblingDomNode = function(startIndex) {
 	return null;
 };
 
-/*
-Find the first DOM node generated by a widget or its children
-*/
 Widget.prototype.findFirstDomNode = function() {
 	// Return the first dom node of this widget, if we've got one
 	if(this.domNodes.length > 0) {
@@ -867,20 +721,20 @@ Widget.prototype.destroy = function(options) {
 	// Destroy children first
 	this.destroyChildren({removeDOMNodes: removeChildDOMNodes});
 	this.children = [];
-	
+
 	// Call custom cleanup method if implemented
 	if(typeof this.onDestroy === "function") {
 		this.onDestroy();
 	}
-	
+
 	// Remove our DOM nodes if needed
 	if(removeDOMNodes) {
-		this.removeLocalDomNodes();	
+		this.removeLocalDomNodes();
 	}
 };
 
 /*
-Remove any DOM nodes created by this widget 
+Remove any DOM nodes created by this widget
 */
 Widget.prototype.removeLocalDomNodes = function() {
 	for(const domNode of this.domNodes) {

--- a/core/modules/widgets/wikify.js
+++ b/core/modules/widgets/wikify.js
@@ -2,9 +2,6 @@
 title: $:/core/modules/widgets/wikify.js
 type: application/javascript
 module-type: widget
-
-Widget to wikify text into a variable
-
 \*/
 
 "use strict";
@@ -15,14 +12,8 @@ var WikifyWidget = function(parseTreeNode,options) {
 	this.initialise(parseTreeNode,options);
 };
 
-/*
-Inherit from the base widget class
-*/
 WikifyWidget.prototype = new Widget();
 
-/*
-Render this widget into the DOM
-*/
 WikifyWidget.prototype.render = function(parent,nextSibling) {
 	this.parentDomNode = parent;
 	this.computeAttributes();
@@ -30,9 +21,6 @@ WikifyWidget.prototype.render = function(parent,nextSibling) {
 	this.renderChildren(parent,nextSibling);
 };
 
-/*
-Compute the internal state of the widget
-*/
 WikifyWidget.prototype.execute = function() {
 	// Get our parameters
 	this.wikifyName = this.getAttribute("name");
@@ -44,7 +32,7 @@ WikifyWidget.prototype.execute = function() {
 	this.wikifyParser = this.wiki.parseText(this.wikifyType,this.wikifyText,{
 			parseAsInline: this.wikifyMode === "inline"
 		});
-	// Create the widget tree 
+	// Create the widget tree
 	this.wikifyWidgetNode = this.wiki.makeWidget(this.wikifyParser,{
 			document: $tw.fakeDocument,
 			parentWidget: this
@@ -59,9 +47,6 @@ WikifyWidget.prototype.execute = function() {
 	this.makeChildWidgets();
 };
 
-/*
-Return the result string
-*/
 WikifyWidget.prototype.getResult = function() {
 	var result;
 	switch(this.wikifyOutput) {
@@ -84,9 +69,6 @@ WikifyWidget.prototype.getResult = function() {
 	return result;
 };
 
-/*
-Return a string of the widget tree
-*/
 WikifyWidget.prototype.getWidgetTree = function() {
 	var copyNode = function(widgetNode,resultNode) {
 			var type = widgetNode.parseTreeNode.type;
@@ -119,9 +101,6 @@ WikifyWidget.prototype.getWidgetTree = function() {
 	return results;
 };
 
-/*
-Selectively refreshes the widget if needed. Returns true if the widget or any of its children needed re-rendering
-*/
 WikifyWidget.prototype.refresh = function(changedTiddlers) {
 	var changedAttributes = this.computeAttributes();
 	// Refresh ourselves entirely if any of our attributes have changed
@@ -144,7 +123,7 @@ WikifyWidget.prototype.refresh = function(changedTiddlers) {
 				return true;
 			}
 		}
-		// Just refresh the children
+
 		return this.refreshChildren(changedTiddlers);
 	}
 };

--- a/core/modules/wiki-bulkops.js
+++ b/core/modules/wiki-bulkops.js
@@ -2,16 +2,10 @@
 title: $:/core/modules/wiki-bulkops.js
 type: application/javascript
 module-type: wikimethod
-
-Bulk tiddler operations such as rename.
-
 \*/
 
 "use strict";
 
-/*
-Rename a tiddler, and relink any tags or lists that reference it.
-*/
 function renameTiddler(fromTitle,toTitle,options) {
 	fromTitle = (fromTitle || "").trim();
 	toTitle = (toTitle || "").trim();
@@ -28,9 +22,6 @@ function renameTiddler(fromTitle,toTitle,options) {
 	}
 }
 
-/*
-Relink any tags or lists that reference a given tiddler
-*/
 function relinkTiddler(fromTitle,toTitle,options) {
 	var self = this;
 	fromTitle = (fromTitle || "").trim();

--- a/core/modules/wiki.js
+++ b/core/modules/wiki.js
@@ -2,19 +2,6 @@
 title: $:/core/modules/wiki.js
 type: application/javascript
 module-type: wikimethod
-
-Extension methods for the $tw.Wiki object
-
-Adds the following properties to the wiki object:
-
-* `eventListeners` is a hashmap by type of arrays of listener functions
-* `changedTiddlers` is a hashmap describing changes to named tiddlers since wiki change events were last dispatched. Each entry is a hashmap containing two fields:
-	modified: true/false
-	deleted: true/false
-* `changeCount` is a hashmap by tiddler title containing a numerical index that starts at zero and is incremented each time a tiddler is created changed or deleted
-* `caches` is a hashmap by tiddler title containing a further hashmap of named cache objects. Caches are automatically cleared when a tiddler is modified or deleted
-* `globalCache` is a hashmap by cache name of cache objects that are cleared whenever any tiddler change occurs
-
 \*/
 
 "use strict";
@@ -24,9 +11,6 @@ var widget = require("$:/core/modules/widgets/widget.js");
 var USER_NAME_TITLE = "$:/status/UserName",
 	TIMESTAMP_DISABLE_TITLE = "$:/config/TimestampDisable";
 
-/*
-Add available indexers to this wiki
-*/
 exports.addIndexersToWiki = function() {
 	var self = this;
 	$tw.utils.each($tw.modules.applyMethods("indexer"),function(Indexer,name) {
@@ -34,13 +18,6 @@ exports.addIndexersToWiki = function() {
 	});
 };
 
-/*
-Get the value of a text reference. Text references can have any of these forms:
-	<tiddlertitle>
-	<tiddlertitle>!!<fieldname>
-	!!<fieldname> - specifies a field of the current tiddlers
-	<tiddlertitle>##<index>
-*/
 exports.getTextReference = function(textRef,defaultText,currTiddlerTitle) {
 	var tr = $tw.utils.parseTextReference(textRef),
 		title = tr.title || currTiddlerTitle;
@@ -121,7 +98,7 @@ exports.removeEventListener = function(type,listener) {
 	}
 };
 
-exports.dispatchEvent = function(type /*, args */) {
+exports.dispatchEvent = function(type) {
 	var args = Array.prototype.slice.call(arguments,1),
 		listeners = this.eventListeners[type];
 	if(listeners) {
@@ -132,15 +109,6 @@ exports.dispatchEvent = function(type /*, args */) {
 	}
 };
 
-/*
-Causes a tiddler to be marked as changed, incrementing the change count, and triggers event handlers.
-This method should be called after the changes it describes have been made to the wiki.tiddlers[] array.
-	title: Title of tiddler
-	isDeleted: defaults to false (meaning the tiddler has been created or modified),
-		true if the tiddler has been deleted
-	isShadow: defaults to false (meaning the change applies to the normal tiddler),
-		true if the tiddler being changed is a shadow tiddler
-*/
 exports.enqueueTiddlerEvent = function(title,isDeleted,isShadow) {
 	// Record the touch in the list of changed tiddlers
 	this.changedTiddlers = this.changedTiddlers || Object.create(null);
@@ -154,7 +122,7 @@ exports.enqueueTiddlerEvent = function(title,isDeleted,isShadow) {
 	} else {
 		this.changeCount[title] = 1;
 	}
-	// Trigger events
+
 	this.eventListeners = this.eventListeners || {};
 	if(!this.eventsTriggered) {
 		var self = this;
@@ -188,10 +156,6 @@ exports.getChangeCount = function(title) {
 	}
 };
 
-/*
-Generate an unused title from the specified base
-options.prefix must be a string
-*/
 exports.generateNewTitle = function(baseTitle,options) {
 	options = options || {};
 	var title = baseTitle,
@@ -251,9 +215,6 @@ exports.isBinaryTiddler = function(title) {
 	}
 };
 
-/*
-Like addTiddler() except it will silently reject any plugin tiddlers that are older than the currently loaded version. Returns true if the tiddler was imported
-*/
 exports.importTiddler = function(tiddler) {
 	var existingTiddler = this.getTiddler(tiddler.fields.title);
 	// Check if we're dealing with a plugin
@@ -378,7 +339,7 @@ exports.sortTiddlers = function(titles,sortField,isDescending,isCaseSensitive,is
 				titles.sort((a,b) => sorter.compare(b, a));
 			} else {
 				titles.sort((a,b) => sorter.compare(a, b));
-			}	
+			}
 		} else {
 			titles.sort(function(a,b) {
 				var x,y;
@@ -508,9 +469,6 @@ exports.getTiddlerLinks = function(title) {
 	}).slice(0);
 };
 
-/*
-Return an array of tiddler titles that link to the specified tiddler
-*/
 exports.getTiddlerBacklinks = function(targetTitle) {
 	var self = this,
 		backIndexer = this.getIndexer("BackIndexer"),
@@ -529,10 +487,6 @@ exports.getTiddlerBacklinks = function(targetTitle) {
 	return backlinks.slice(0);
 };
 
-
-/*
-Return an array of tiddler titles that are directly transcluded within the given parse tree. `title` is the tiddler being parsed, we will ignore its self-referential transclusions, only return
- */
 exports.extractTranscludes = function(parseTreeRoot, title) {
 	// Count up the transcludes
 	var transcludes = [],
@@ -557,13 +511,13 @@ exports.extractTranscludes = function(parseTreeRoot, title) {
 							value = parseTreeNode.attributes.tiddler.value;
 						}
 					} else if(parseTreeNode.attributes.$field && parseTreeNode.attributes.$field.type === "string") {
-						// Empty value (like `<$transclude $field='created'/>`) means self-referential transclusion. 
+						// Empty value (like `<$transclude $field='created'/>`) means self-referential transclusion.
 						value = title;
 					} else if(parseTreeNode.attributes.field && parseTreeNode.attributes.field.type === "string") {
 						// Old usage with Empty value (like `<$transclude field='created'/>`)
 						value = title;
 					}
-					// Deduplicate the result.
+
 					if(value && transcludes.indexOf(value) === -1) {
 						$tw.utils.pushTop(transcludes,value);
 					}
@@ -577,10 +531,6 @@ exports.extractTranscludes = function(parseTreeRoot, title) {
 	return transcludes;
 };
 
-
-/*
-Return an array of tiddler titles that are transcluded from the specified tiddler
-*/
 exports.getTiddlerTranscludes = function(title) {
 	var self = this;
 	// We'll cache the transcludes so they only get computed if the tiddler changes
@@ -758,9 +708,9 @@ exports.sortByList = function(array,listTitle) {
 				// If a new position is specified, let's move it
 				if(newPos !== -1) {
 					// get its current Pos, and make sure
-					// sure that it's _actually_ in the list
+
 					// and that it would _actually_ move
-					// (#4275) We don't bother calling
+
 					//         indexOf unless we have a new
 					//         position to work with
 					var currPos = titles.indexOf(title);
@@ -788,14 +738,14 @@ exports.sortByList = function(array,listTitle) {
 				titles.push(title);
 			}
 		}
-		// Then place any remaining entries
+
 		for(t=0; t<array.length; t++) {
 			title = array[t];
 			if(list.indexOf(title) === -1) {
 				titles.push(title);
 			}
 		}
-		// Finally obey the list-before and list-after fields of each tiddler in turn
+
 		var sortedTitles = titles.slice(0);
 		for(t=0; t<sortedTitles.length; t++) {
 			title = sortedTitles[t];
@@ -816,9 +766,6 @@ exports.getSubTiddler = function(title,subTiddlerTitle) {
 	return null;
 };
 
-/*
-Retrieve a tiddler as a JSON string of the fields
-*/
 exports.getTiddlerAsJson = function(title) {
 	var tiddler = this.getTiddler(title);
 	if(tiddler) {
@@ -849,19 +796,6 @@ exports.getTiddlersAsJson = function(filter,spaces) {
 	return JSON.stringify(data,null,spaces);
 };
 
-/*
-Get the content of a tiddler as a JavaScript object. How this is done depends on the type of the tiddler:
-
-application/json: the tiddler JSON is parsed into an object
-application/x-tiddler-dictionary: the tiddler is parsed as sequence of name:value pairs
-
-Other types currently just return null.
-
-titleOrTiddler: string tiddler title or a tiddler object
-defaultData: default data to be returned if the tiddler is missing or doesn't contain data
-
-Note that the same value is returned for repeated calls for the same tiddler data. The value is frozen to prevent modification; otherwise modifications would be visible to all callers
-*/
 exports.getTiddlerDataCached = function(titleOrTiddler,defaultData) {
 	var self = this,
 		tiddler = titleOrTiddler;
@@ -880,9 +814,6 @@ exports.getTiddlerDataCached = function(titleOrTiddler,defaultData) {
 	}
 };
 
-/*
-Alternative, uncached version of getTiddlerDataCached(). The return value can be mutated freely and reused
-*/
 exports.getTiddlerData = function(titleOrTiddler,defaultData) {
 	var tiddler = titleOrTiddler,
 		data;
@@ -901,9 +832,6 @@ exports.getTiddlerData = function(titleOrTiddler,defaultData) {
 	return defaultData;
 };
 
-/*
-Extract an indexed field from within a data tiddler
-*/
 exports.extractTiddlerDataItem = function(titleOrTiddler,index,defaultText) {
 	var data = this.getTiddlerDataCached(titleOrTiddler,Object.create(null)),
 		text;
@@ -917,14 +845,6 @@ exports.extractTiddlerDataItem = function(titleOrTiddler,index,defaultText) {
 	}
 };
 
-/*
-Set a tiddlers content to a JavaScript object. Currently this is done by setting the tiddler's type to "application/json" and setting the text to the JSON text of the data.
-title: title of tiddler
-data: object that can be serialised to JSON
-fields: optional hashmap of additional tiddler fields to be set
-options: optional hashmap of options including:
-	suppressTimestamp: if true, don't set the creation/modification timestamps
-*/
 exports.setTiddlerData = function(title,data,fields,options) {
 	options = options || {};
 	var existingTiddler = this.getTiddler(title),
@@ -942,9 +862,6 @@ exports.setTiddlerData = function(title,data,fields,options) {
 	this.addTiddler(new $tw.Tiddler(creationFields,existingTiddler,fields,newFields,modificationFields));
 };
 
-/*
-Return the content of a tiddler as an array containing each line
-*/
 exports.getTiddlerList = function(title,field,index) {
 	if(index) {
 		return $tw.utils.parseStringArray(this.extractTiddlerDataItem(title,index,""));
@@ -1069,7 +986,7 @@ exports.parseTextReference = function(title,field,index,options) {
 			this.getTiddlerText(title); // Force the tiddler to be lazily loaded
 			return this.parseTiddler(title,options);
 		}
-	} 
+	}
 	parserInfo = this.getTextReferenceParserInfo(title,field,index,options);
 	if(parserInfo.sourceText !== null) {
 		return this.parseText(parserInfo.parserType,parserInfo.sourceText,options);
@@ -1303,7 +1220,7 @@ Options available:
 		literal: searches for literal string
 		whitespace: same as literal except runs of whitespace are treated as a single space
 		regexp: treats the search term as a regular expression
-		words: (default) treats search string as a list of tokens, and matches if all tokens are found, 
+		words: (default) treats search string as a list of tokens, and matches if all tokens are found,
 			regardless of adjacency or ordering
 		some: treats search string as a list of tokens, and matches if at least ONE token is found
 */
@@ -1379,7 +1296,7 @@ exports.search = function(text,options) {
 		fields.push("tags");
 		fields.push("text");
 	}
-	// Function to check a given tiddler for the search term
+
 	var searchTiddler = function(title) {
 		if(!searchTermsRegExps) {
 			return true;
@@ -1459,9 +1376,6 @@ exports.search = function(text,options) {
 	return results;
 };
 
-/*
-Trigger a load for a tiddler if it is skinny. Returns the text, or undefined if the tiddler is missing, null if the tiddler is being lazily loaded.
-*/
 exports.getTiddlerText = function(title,defaultText) {
 	var tiddler = this.getTiddler(title);
 	// Return undefined if the tiddler isn't found
@@ -1479,9 +1393,6 @@ exports.getTiddlerText = function(title,defaultText) {
 	}
 };
 
-/*
-Check whether the text of a tiddler matches a given value. By default, the comparison is case insensitive, and any spaces at either end of the tiddler text is trimmed
-*/
 exports.checkTiddlerText = function(title,targetText,options) {
 	options = options || {};
 	var text = this.getTiddlerText(title,"");
@@ -1495,17 +1406,11 @@ exports.checkTiddlerText = function(title,targetText,options) {
 	return text === targetText;
 };
 
-/*
-Execute an action string without an associated context widget
-*/
 exports.invokeActionString = function(actions,event,variables,options) {
 	var widget = this.makeWidget(null,{parentWidget: options.parentWidget});
 	widget.invokeActionString(actions,null,event,variables);
 };
 
-/*
-Read an array of browser File objects, invoking callback(tiddlerFieldsArray) once they're all read
-*/
 exports.readFiles = function(files,options) {
 	var callback;
 	if(typeof options === "function") {
@@ -1528,9 +1433,6 @@ exports.readFiles = function(files,options) {
 	return files.length;
 };
 
-/*
-Read a browser File object, invoking callback(tiddlerFieldsArray) with an array of tiddler fields objects
-*/
 exports.readFile = function(file,options) {
 	var callback;
 	if(typeof options === "function") {
@@ -1539,7 +1441,7 @@ exports.readFile = function(file,options) {
 	} else {
 		callback = options.callback;
 	}
-	// Get the type, falling back to the filename extension
+
 	var self = this,
 		type = file.type;
 	if(type === "" || !type) {
@@ -1551,14 +1453,14 @@ exports.readFile = function(file,options) {
 			}
 		}
 	}
-	// Figure out if we're reading a binary file
+
 	var contentTypeInfo = $tw.config.contentTypeInfo[type],
 		isBinary = contentTypeInfo ? contentTypeInfo.encoding === "base64" : false;
 	// Log some debugging information
 	if($tw.log.IMPORT) {
 		console.log("Importing file '" + file.name + "', type: '" + type + "', isBinary: " + isBinary);
 	}
-	// Give the hook a chance to process the drag
+
 	if($tw.hooks.invokeHook("th-importing-file",{
 		file: file,
 		type: type,
@@ -1569,9 +1471,6 @@ exports.readFile = function(file,options) {
 	}
 };
 
-/*
-Lower level utility to read the content of a browser File object, invoking callback(tiddlerFieldsArray) with an array of tiddler fields objects
-*/
 exports.readFileContent = function(file,type,isBinary,deserializer,callback) {
 	var self = this;
 	// Create the FileReader
@@ -1586,7 +1485,7 @@ exports.readFileContent = function(file,type,isBinary,deserializer,callback) {
 				text = text.substr(commaPos + 1);
 			}
 		}
-		// Check whether this is an encrypted TiddlyWiki file
+
 		var encryptedJson = $tw.utils.extractEncryptedStoreArea(text);
 		if(encryptedJson) {
 			// If so, attempt to decrypt it with the current password
@@ -1606,9 +1505,6 @@ exports.readFileContent = function(file,type,isBinary,deserializer,callback) {
 	}
 };
 
-/*
-Find any existing draft of a specified tiddler
-*/
 exports.findDraft = function(targetTitle) {
 	var draftTitle = undefined;
 	this.forEachTiddler({includeSystem: true},function(title,tiddler) {
@@ -1619,11 +1515,6 @@ exports.findDraft = function(targetTitle) {
 	return draftTitle;
 };
 
-/*
-Check whether the specified draft tiddler has been modified.
-If the original tiddler doesn't exist, create  a vanilla tiddler variable,
-to check if additional fields have been added.
-*/
 exports.isDraftModified = function(title) {
 	var tiddler = this.getTiddler(title);
 	if(!tiddler.isDraft()) {
@@ -1635,34 +1526,18 @@ exports.isDraftModified = function(title) {
 	return titleModified || !tiddler.isEqual(origTiddler,ignoredFields);
 };
 
-/*
-Add a new record to the top of the history stack
-title: a title string or an array of title strings
-fromPageRect: page coordinates of the origin of the navigation
-historyTitle: title of history tiddler (defaults to $:/HistoryList)
-*/
 exports.addToHistory = function(title,fromPageRect,historyTitle) {
 	var story = new $tw.Story({wiki: this, historyTitle: historyTitle});
 	story.addToHistory(title,fromPageRect);
 	console.log("$tw.wiki.addToHistory() is deprecated since V5.1.23! Use the this.story.addToHistory() from the story-object!");
 };
 
-/*
-Add a new tiddler to the story river
-title: a title string or an array of title strings
-fromTitle: the title of the tiddler from which the navigation originated
-storyTitle: title of story tiddler (defaults to $:/StoryList)
-options: see story.js
-*/
 exports.addToStory = function(title,fromTitle,storyTitle,options) {
 	var story = new $tw.Story({wiki: this, storyTitle: storyTitle});
 	story.addToStory(title,fromTitle,options);
 	console.log("$tw.wiki.addToStory() is deprecated since V5.1.23! Use the this.story.addToStory() from the story-object!");
 };
 
-/*
-Generate a title for the draft of a given tiddler
-*/
 exports.generateDraftTitle = function(title) {
 	let c = 0,
 		draftTitle;
@@ -1677,12 +1552,6 @@ exports.generateDraftTitle = function(title) {
 	return draftTitle;
 };
 
-/*
-Invoke the available upgrader modules
-titles: array of tiddler titles to be processed
-tiddlers: hashmap by title of tiddler fields of pending import tiddlers. These can be modified by the upgraders. An entry with no fields indicates a tiddler that was pending import has been suppressed. When entries are added to the pending import the tiddlers hashmap may have entries that are not present in the titles array
-Returns a hashmap of messages keyed by tiddler title.
-*/
 exports.invokeUpgraders = function(titles,tiddlers) {
 	// Collect up the available upgrader modules
 	var self = this;
@@ -1694,7 +1563,7 @@ exports.invokeUpgraders = function(titles,tiddlers) {
 			}
 		});
 	}
-	// Invoke each upgrader in turn
+
 	var messages = {};
 	for(var t=0; t<this.upgraderModules.length; t++) {
 		var upgrader = this.upgraderModules[t],
@@ -1737,14 +1606,14 @@ exports.slugify = function(title,options) {
 	if(tiddler && tiddler.fields.slug) {
 		slug = tiddler.fields.slug;
 	} else {
-		slug = $tw.utils.transliterate(title.toString().toLowerCase()) // Replace diacritics with basic lowercase ASCII
-			.replace(/\s+/g,"-")                                       // Replace spaces with -
-			.replace(/[^\w\-\.]+/g,"")                                 // Remove all non-word chars except dash and dot
-			.replace(/\-\-+/g,"-")                                     // Replace multiple - with single -
-			.replace(/^-+/,"")                                         // Trim - from start of text
+		slug = $tw.utils.transliterate(title.toString().toLowerCase())
+			.replace(/\s+/g,"-")
+			.replace(/[^\w\-\.]+/g,"")
+			.replace(/\-\-+/g,"-")
+			.replace(/^-+/,"")
 			.replace(/-+$/,"");                                        // Trim - from end of text
 	}
-	// If the resulting slug is blank (eg because the title is just punctuation characters)
+
 	if(!slug) {
 		// ...then just use the character codes of the title
 		var result = [];


### PR DESCRIPTION
This PR explores the impact of removing all of the comments from the core JavaScript files. The goal is to achieve a substantial reduction in the size of the core. It's a big job, so I used Claude to do the work. It turns out to gain us a 4.8% reduction, which is undoubtedly significant.

The rationale for doing this includes:

* Existing comments are poor quality and repetitive (eg widgets all having the same comments)
* Nowadays an LLM can easily answer questions about the code
* If we're not doing all that we can to manage the size of the core then it is discouraging for contributors to have their submission rejected due to impact on the size of the core

I've experimented with having Claude write code documentation, and the results are not bad. If we were to adopt that documentation we could use diffs to communicate any future API changes.