### PR TITLE
Ensures missing attributes are undefined

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -390,7 +390,7 @@ Widget.prototype.computeAttributes = function(options) {
 		if($tw.utils.isArray(value)) {
 			multiValue = value;
 			newMultiValuedAttributes[name] = multiValue;
-			value = value[0] || "";
+			value = value[0];
 		}
 		var changed = (self.attributes[name] !== value);
 		if(!changed && multiValue && self.multiValuedAttributes) {

--- a/editions/test/tiddlers/tests/data/transclude/MissingTiddlerAttribute.tid
+++ b/editions/test/tiddlers/tests/data/transclude/MissingTiddlerAttribute.tid
@@ -1,0 +1,39 @@
+title: Transclude/MissingTiddlerAttribute
+description: Missing Tiddler Attribute
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\procedure testproc()
+This is ''wikitext''
+\end
+
+
+<$tiddler tiddler="Data">
+<$transclude $index="testindex"/>
+-
+{{##testindex}}
+-
+<$transclude $field="custom"/>
+-
+{{!!custom}}
+</$tiddler>
++
+title: Data
+type: application/x-tiddler-dictionary
+custom: This is ''wikitext''
+
+testindex: This is ''wikitext''
++
+title: ExpectedResult
+
+<p>
+This is <strong>wikitext</strong>
+-
+This is <strong>wikitext</strong>
+-
+This is <strong>wikitext</strong>
+-
+This is <strong>wikitext</strong>
+</p>


### PR DESCRIPTION
Fixes #9675 

Missing widget attributes must remain undefined in the widget tree.