### PR TITLE
Fixes a bug in zoomin storyview

### DIFF
--- a/core/modules/storyviews/zoomin.js
+++ b/core/modules/storyviews/zoomin.js
@@ -212,8 +212,8 @@ ZoominListView.prototype.remove = function(widget) {
 	]);
 	setTimeout(function() {
 		$tw.utils.removeStyles(toWidgetDomNode, ["transformOrigin", "transform", "transition", "opacity", "zIndex"]);
+		removeElement();
 	}, duration);	
-	setTimeout(removeElement,duration);
 	// Now the tiddler we're going back to
 	if(toWidgetDomNode) {
 		$tw.utils.setStyle(toWidgetDomNode,[

--- a/core/modules/utils/dom/browser.js
+++ b/core/modules/utils/dom/browser.js
@@ -30,8 +30,10 @@ Remove style properties of an element
 	styleProperties: ordered array of string property names
 */
 exports.removeStyles = function(element, styleProperties) {
-	for(var i=0; i<styleProperties.length; i++) {
-		element.style.removeProperty($tw.utils.convertStyleNameToPropertyName(styleProperties[i]));
+	if(element) {
+		for(var i=0; i<styleProperties.length; i++) {
+			element.style.removeProperty($tw.utils.convertStyleNameToPropertyName(styleProperties[i]));
+		}
 	}
 };
 


### PR DESCRIPTION
Fixes a bug in zoomin storyview where the code attempted to remove CSS properties from an element that had already been removed.