### PR TITLE
Fixes filtered widget attributes when filter result is empty

### DIFF
--- a/core/modules/widgets/widget.js
+++ b/core/modules/widgets/widget.js
@@ -390,7 +390,7 @@ Widget.prototype.computeAttributes = function(options) {
 		if($tw.utils.isArray(value)) {
 			multiValue = value;
 			newMultiValuedAttributes[name] = multiValue;
-			value = value[0];
+			value = value[0] || "";
 		}
 		var changed = (self.attributes[name] !== value);
 		if(!changed && multiValue && self.multiValuedAttributes) {
@@ -452,9 +452,7 @@ Widget.prototype.computeAttribute = function(attribute,options) {
 	} else { // String attribute
 		value = attribute.value;
 		if(options.asList) {
-			if(value === undefined) {
-				value = [];
-			} else {
+			if(value !== undefined) {
 				value = [value];
 			}
 		}

--- a/editions/test/tiddlers/tests/data/transclude/MissingTiddlerAttribute.tid
+++ b/editions/test/tiddlers/tests/data/transclude/MissingTiddlerAttribute.tid
@@ -5,11 +5,6 @@ tags: [[$:/tags/wiki-test-spec]]
 
 title: Output
 
-\procedure testproc()
-This is ''wikitext''
-\end
-
-
 <$tiddler tiddler="Data">
 <$transclude $index="testindex"/>
 -

--- a/editions/test/tiddlers/tests/data/transclude/MissingTiddlerAttributeFiltered.tid
+++ b/editions/test/tiddlers/tests/data/transclude/MissingTiddlerAttributeFiltered.tid
@@ -1,0 +1,20 @@
+title: Transclude/MissingTiddlerAttributeFiltered
+description: Missing Tiddler Attribute Filtered
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+<$transclude tiddler={{{ [[sometiddler]get[nosuchfield]] }}}/>
+-
+<$transclude tiddler="">fallback content</$transclude>
+-
+<$transclude tiddler={{{ [[sometiddler]get[nosuchfield]] }}}>fallback content</$transclude>
++
+title: ExpectedResult
+
+<p>
+-
+fallback content
+-
+fallback content</p>


### PR DESCRIPTION
- As a single value, filtered attributes must resolve to an empty string when the filter returns no results
-  As an MVV, a missing attribute should return as `undefined` and not as an empty array. This ensures disambiguation between an `undefined` attribute and one that is `""`, as the first member of an empty array is treated as a single value of `""`.

Fixes #9684 

Added a test and removed some erroneously copied text from another test.