### PR TITLE
Tabs examples dynamically setting default tab

### DIFF
--- a/editions/tw5.com/tiddlers/macros/examples/tabs.tid
+++ b/editions/tw5.com/tiddlers/macros/examples/tabs.tid
@@ -12,3 +12,15 @@ eg="""<<tabs "[tag[sampletab]]" "SampleTabTwo" "$:/state/tab2" "tc-vertical">>""
 
 <$macrocall $name=".example" n="3"
 eg="""<<tabs "[tag[sampletab]nsort[order]]" "SampleTabThree" "$:/state/tab3" "tc-vertical">>"""/>
+
+The following example sets the default tab to be the first tiddler selected in the filter and makes the saved state non-persistent (by using "~$:/temp/"):
+
+<$macrocall $name=".example" n="4"
+eg="""<$set name=tl filter="[tag[sampletab]nsort[order]]">
+<$transclude $variable=tabs tabsList=<<tl>> default={{{[enlist<tl>]}}} state="$:/temp/state/tab" class="tc-vertical"/>
+</$set>"""/>
+
+<<.from-version "5.4.0">> Dynamic parameters can be used to specify the default tab:
+
+<$macrocall $name=".example" n="5"
+eg="""<<tabs "[tag[sampletab]nsort[order]]" default={{{[tag[sampletab]nsort[order]]}}} state="$:/temp/state/tab" class="tc-vertical">>"""/>


### PR DESCRIPTION
Where tabs have been selected using a filter it is sometimes useful to set the default tab dynamically from the filter results. In most of these cases it is also desirable that the state not be persistent.

I also think it's important to have a pre-5.4.0 example.