### PR TITLE
Add tests/examples for transclusion shortcut syntax

### DIFF
--- a/editions/tw5.com/tiddlers/procedures/calls/Calls.tid
+++ b/editions/tw5.com/tiddlers/procedures/calls/Calls.tid
@@ -1,6 +1,6 @@
 caption: Calls
 created: 20221007130006705
-modified: 20260125212303316
+modified: 20260301030947969
 tags: WikiText Procedures Functions Macros
 title: Calls
 type: text/vnd.tiddlywiki
@@ -24,6 +24,12 @@ If no value is specified for a parameter, the default value given for that param
 Each parameter value can be enclosed in `'`single quotes`'`, `"`double quotes`"`, `"""`triple double quotes`"""` or `[[`double square brackets`]]`. Triple double quotes allow a value to contain almost anything. If a value contains no spaces or single or double quotes, it requires no delimiters. [[Substituted Attribute Values]] enclosed in single or triple back quotes are also supported.
 
 See the discussion about [[parser modes|WikiText parser mode: macro examples]]
+
+!!! Examples
+
+<<testcase TestCases/Calls/ProcedureStaticAttributes>>
+
+<<testcase TestCases/Calls/ProcedureDynamicAttributes>>
 
 !! Calls with <<.wlink TranscludeWidget>> Widget
 

--- a/editions/tw5.com/tiddlers/testcases/Calls/ProcedureDynamicAttributes.tid
+++ b/editions/tw5.com/tiddlers/testcases/Calls/ProcedureDynamicAttributes.tid
@@ -1,0 +1,40 @@
+created: 20260301005951330
+description: Procedure calls with dynamic attributes
+modified: 20260301013907635
+tags: $:/tags/wiki-test-spec
+title: TestCases/Calls/ProcedureDynamicAttributes
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+New-style equals sign named parameters support dynamic values
++
+title: Output
+
+\function f(a) foo [<a>] :and[join[ ]]
+\procedure p(a1) <$text text=<<a1>>/>
+
+<$let v="foo 1" v2="foo 3">
+<<p a1=<<v>>>> -
+<<p a1=<<f 2>>>> -
+<<p a1=`$(v2)$`>> -
+<<p a1={{my tiddler}}>> -
+<<p a1={{my tiddler!!myfield}}>> -
+<<p a1={{{ foo 6 :and[join[ ]] }}}>>
+</$let>
++
+title: my tiddler
+myfield: foo 5
+
+foo 4
++
+title: ExpectedResult
+
+<p>
+foo 1 -
+foo 2 -
+foo 3 -
+foo 4 -
+foo 5 -
+foo 6
+</p>

--- a/editions/tw5.com/tiddlers/testcases/Calls/ProcedureStaticAttributes.tid
+++ b/editions/tw5.com/tiddlers/testcases/Calls/ProcedureStaticAttributes.tid
@@ -1,0 +1,48 @@
+created: 20260301000418824
+description: Procedure calls with static attributes
+modified: 20260301031128810
+tags: $:/tags/wiki-test-spec
+title: TestCases/Calls/ProcedureStaticAttributes
+type: text/vnd.tiddlywiki-multiple
+
+title: Narrative
+
+Positional, old style colon named parameters, and new-style equals sign named parameters support static values
++
+title: Output
+
+\procedure p(a1) <$text text=<<a1>>/>
+
+<<p foo1>> -
+<<p a1:foo2>> -
+<<p a1=foo3>>
+
+<<p "foo 4">> -
+<<p a1:"foo 5">> -
+<<p a1="foo 6">>
+
+<<p 'foo 7'>> -
+<<p a1:'foo 8'>> -
+<<p a1='foo 9'>>
+
+<<p """foo 10""">> -
+<<p a1:"""foo 11""">> -
+<<p a1="""foo 12""">>
+
+<<p [[foo 13]]>> -
+<<p a1:[[foo 14]]>> -
+<<p a1=[[foo 15]]>>
++
+title: ExpectedResult
+
+<p>foo1 -
+foo2 -
+foo3</p><p>foo 4 -
+foo 5 -
+foo 6</p><p>foo 7 -
+foo 8 -
+foo 9</p><p>foo 10 -
+foo 11 -
+foo 12</p><p>foo 13 -
+foo 14 -
+foo 15</p>


### PR DESCRIPTION
Added testcases and examples illustrating the new 5.4.0 dynamic parameter feature for procedure call short-cut syntax