### PR TITLE
Fix flaky test runner

### DIFF
--- a/editions/test/tiddlers/tests/test-backlinks.js
+++ b/editions/test/tiddlers/tests/test-backlinks.js
@@ -28,7 +28,7 @@ describe("Backlinks tests", function() {
 	}
 
 	describe("a tiddler with no links to it", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestIncoming",

--- a/editions/test/tiddlers/tests/test-backtranscludes.js
+++ b/editions/test/tiddlers/tests/test-backtranscludes.js
@@ -10,7 +10,7 @@ Tests the backtranscludes mechanism.
 
 describe("Backtranscludes and transclude filter tests", function() {
 	describe("a tiddler with no transcludes to it", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestIncoming",
@@ -25,7 +25,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("A tiddler added to the wiki with a transclude to it", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestIncoming",
@@ -44,7 +44,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("A tiddler transclude with template will still use the tiddler as result.", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestIncoming",
@@ -60,7 +60,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("A data tiddler transclude will still use the tiddler as result.", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestIncoming",
@@ -81,7 +81,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 
 	describe("A tiddler that has a transclude added to it later", function() {
 		it("should have an additional backtransclude", function() {
-			var wiki = new $tw.Wiki();
+			var wiki = $tw.test.wiki();
 
 			wiki.addTiddler({
 				title: "TestIncoming",
@@ -106,7 +106,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("A tiddler that has a transclude remove from it later", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestIncoming",
@@ -128,7 +128,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("A tiddler transcludeing to another that gets renamed", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestIncoming",
@@ -148,7 +148,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("A tiddler transcludeing to another that gets deleted", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestIncoming",
@@ -168,7 +168,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("a tiddler with some transcludes on it in order", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestOutgoing",
@@ -186,7 +186,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("include implicit self transclusion", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestOutgoing",
@@ -202,7 +202,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("include explicit self transclusion", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestOutgoing",
@@ -218,7 +218,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("exclude self when target tiddler is not string", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestOutgoing",
@@ -234,7 +234,7 @@ describe("Backtranscludes and transclude filter tests", function() {
 	});
 
 	describe("recognize transclusion defined by widget", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 
 		wiki.addTiddler({
 			title: "TestOutgoing",

--- a/editions/test/tiddlers/tests/test-checkbox-widget.js
+++ b/editions/test/tiddlers/tests/test-checkbox-widget.js
@@ -534,7 +534,7 @@ describe("Checkbox widget", function() {
 		it("checkbox widget test: " + data.testName, function() {
 			// Setup
     
-			var wiki = new $tw.Wiki();
+			var wiki = $tw.test.wiki();
 			wiki.addTiddlers(data.tiddlers);
 			var widgetNode = createWidgetNode(parseText(data.widgetText,wiki),wiki);
 			renderWidgetNode(widgetNode);

--- a/editions/test/tiddlers/tests/test-compare-filter.js
+++ b/editions/test/tiddlers/tests/test-compare-filter.js
@@ -13,7 +13,7 @@ Tests the compare filter.
 
 describe("'compare' filter tests", function() {
 
-	var wiki = new $tw.Wiki();
+	var wiki = $tw.test.wiki();
 
 	it("should compare numerical equality", function() {
 		expect(wiki.filterTiddlers("[[2]compare:number:eq[0003]]").join(",")).toBe("");

--- a/editions/test/tiddlers/tests/test-filters.js
+++ b/editions/test/tiddlers/tests/test-filters.js
@@ -583,7 +583,7 @@ describe("Filter tests", function() {
 			});
 
 			it("should handle the '[is[draft]]' operator", function() {
-				var wiki = new $tw.Wiki();
+				var wiki = $tw.test.wiki();
 				wiki.addTiddlers([
 					{title: "A"},
 					{title: "Draft of 'A'", "draft.of": "A", "draft.title": "A"},

--- a/editions/test/tiddlers/tests/test-json-filters.js
+++ b/editions/test/tiddlers/tests/test-json-filters.js
@@ -13,7 +13,7 @@ Tests the JSON filters and the format:json operator
 
 describe("json filter tests", function() {
 
-	var wiki = new $tw.Wiki();
+	var wiki = $tw.test.wiki();
 	var tiddlers = [{
 		title: "First",
 		text: '{"a":"one","b":"","c":1.618,"d": {"e": "four","f": ["five","six",true,false,null]}}',

--- a/editions/test/tiddlers/tests/test-parsetextreference.js
+++ b/editions/test/tiddlers/tests/test-parsetextreference.js
@@ -12,7 +12,7 @@ Tests for source attribute in parser returned from wiki.parseTextReference
 describe("Wiki.parseTextReference tests", function() {
 
 	// Create a wiki
-	var wiki = new $tw.Wiki();
+	var wiki = $tw.test.wiki();
 	wiki.addTiddler({
 		title: "TiddlerOne",
 		text: "The quick brown fox in $:/TiddlerTwo",

--- a/editions/test/tiddlers/tests/test-prefixes-filter.js
+++ b/editions/test/tiddlers/tests/test-prefixes-filter.js
@@ -14,7 +14,7 @@ Tests the reduce prefix and filter.
 
 describe("general filter prefix tests", function() {
 	it("should handle nonexistent prefixes gracefully", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var results = wiki.filterTiddlers("[tag[A]] :nonexistent[tag[B]]");
 		expect(results).toEqual(["Filter Error: Unknown prefix for filter run"]);
 	});
@@ -215,7 +215,7 @@ describe("general filter prefix tests", function() {
 
 describe("'reduce' and 'intersection' filter prefix tests", function() {
 
-	var wiki = new $tw.Wiki();
+	var wiki = $tw.test.wiki();
 
 	wiki.addTiddler({
 		title: "Brownies",

--- a/editions/test/tiddlers/tests/test-utils.js
+++ b/editions/test/tiddlers/tests/test-utils.js
@@ -82,7 +82,7 @@ describe("Utility tests", function() {
 	});
 
 	it("stringifyList shouldn't interfere with setting variables to negative numbers", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		wiki.addTiddler({title: "test", text: "<$set name=X filter='\"-7\"'>{{{ [<X>add[2]] }}}</$set>"});
 		// X shouldn't be wrapped in brackets. If it is, math filters will treat it as zero.
 		expect(wiki.renderTiddler("text/plain","test")).toBe("-5");

--- a/editions/test/tiddlers/tests/test-widget-event.js
+++ b/editions/test/tiddlers/tests/test-widget-event.js
@@ -19,7 +19,7 @@ describe("Widget Event Listeners", function() {
 
 	it("should call all added event listeners on dispatchEvent", function() {
 		var calls = [];
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var widget = createWidgetNode({type:"widget", text:"text"}, wiki);
 
 		// Add a function listener.
@@ -44,7 +44,7 @@ describe("Widget Event Listeners", function() {
 
 	it("should remove an event listener correctly", function() {
 		var calls = [];
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var widget = createWidgetNode({type:"widget", text:"text"}, wiki);
 
 		function listener(e) {
@@ -70,7 +70,7 @@ describe("Widget Event Listeners", function() {
 
 	it("stop further propagation by returns false won't block other listeners on the same level.", function() {
 		var calls = [];
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var widget = createWidgetNode({type:"widget", text:"text"}, wiki);
 
 		widget.addEventListener("stopEvent", function(e) {
@@ -92,7 +92,7 @@ describe("Widget Event Listeners", function() {
 
 	it("should dispatch event to parent widget if not handled on child", function() {
 		var parentCalls = [];
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var parentWidget = createWidgetNode({type:"widget", text:"text"}, wiki);
 		parentWidget.addEventListener("parentEvent", function(e) {
 			parentCalls.push("parentListener");
@@ -110,7 +110,7 @@ describe("Widget Event Listeners", function() {
 
 	it("should not dispatch event to parent if child's listener stops propagation", function() {
 		var parentCalls = [];
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var parentWidget = createWidgetNode({type:"widget", text:"text"}, wiki);
 		parentWidget.addEventListener("bubbleTest", function(e) {
 			parentCalls.push("parentListener");
@@ -128,7 +128,7 @@ describe("Widget Event Listeners", function() {
 
 	it("should call multiple listeners in proper order across child and parent", function() {
 		var calls = [];
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var parentWidget = createWidgetNode({type:"widget", text:"text"}, wiki);
 		parentWidget.addEventListener("chainEvent", function(e) {
 			calls.push("parentListener");
@@ -152,7 +152,7 @@ describe("Widget Event Listeners", function() {
 	it("should handle events of different types separately", function() {
 		var callsA = [];
 		var callsB = [];
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var widget = createWidgetNode({type:"widget", text:"text"}, wiki);
 		widget.addEventListener("eventA", function(e) {
 			callsA.push("A1");
@@ -171,7 +171,7 @@ describe("Widget Event Listeners", function() {
 	// Test using $tw.utils.each in removeEventListener internally (behavior verified via dispatch)
 	it("should remove listeners using $tw.utils.each without affecting other listeners", function() {
 		var calls = [];
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var widget = createWidgetNode({type:"widget", text:"text"}, wiki);
 		function listener1(e) {
 			calls.push("listener1");
@@ -192,7 +192,7 @@ describe("Widget Event Listeners", function() {
 
 	it("should prevent adding the same event listener multiple times", function() {
 		var calls = 0;
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var widget = createWidgetNode({type:"widget", text:"text"}, wiki);
 		
 		function listener(e) {

--- a/editions/test/tiddlers/tests/test-widget.js
+++ b/editions/test/tiddlers/tests/test-widget.js
@@ -45,7 +45,7 @@ describe("Widget module", function() {
 	}
 
 	it("should deal with text nodes and HTML elements", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Test parse tree
 		var parseTreeNode = {type: "widget", children: [
 			{type: "text", text: "A text node"},
@@ -77,7 +77,7 @@ describe("Widget module", function() {
 	});
 
 	it("should deal with transclude widgets and indirect attributes", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add a tiddler
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "the quick brown fox"}
@@ -137,7 +137,7 @@ describe("Widget module", function() {
 	});
 
 	it("should detect recursion of the transclude macro", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add a tiddler
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "<$transclude tiddler='TiddlerTwo'/>"},
@@ -158,7 +158,7 @@ describe("Widget module", function() {
 	});
 
 	it("should handle single-tiddler recursion with branching nodes", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add a tiddler
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "<$tiddler tiddler='TiddlerOne'><$transclude /> <$transclude /></$tiddler>"},
@@ -182,7 +182,7 @@ describe("Widget module", function() {
 	// end up being the same value for all iterations of the test. 
 	$tw.utils.each(["div","$button","$checkbox","$diff-text","$draggable","$droppable","dropzone","$eventcatcher","$keyboard","$link","$list filter=x variable=x","$radio","$reveal type=nomatch","$scrollable","$select","$view field=x"],function(tag) {
 		it(`${tag} cleans itself up if children rendering fails`, function() {
-			var wiki = new $tw.Wiki();
+			var wiki = $tw.test.wiki();
 			wiki.addTiddler({title: "TiddlerOne", text: `<$tiddler tiddler='TiddlerOne'><${tag}><$transclude />`});
 			var parseTreeNode = {type: "widget", children: [
 				{type: "transclude", attributes: {
@@ -204,7 +204,7 @@ describe("Widget module", function() {
 	});
 
 	it("should handle many-tiddler recursion with branching nodes", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add a tiddler
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "<$transclude tiddler='TiddlerTwo'/> <$transclude tiddler='TiddlerTwo'/>"},
@@ -225,7 +225,7 @@ describe("Widget module", function() {
 	});
 
 	it("should deal with SVG elements", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Construct the widget node
 		var text = "<svg class=\"tv-image-new-button\" viewBox=\"83 81 50 50\" width=\"22pt\" height=\"22pt\"><path d=\"M 101.25 112.5 L 101.25 127.5 C 101.25 127.5 101.25 127.5 101.25 127.5 L 101.25 127.5 C 101.25 129.156855 102.593146 130.5 104.25 130.5 L 111.75 130.5 C 113.406854 130.5 114.75 129.156854 114.75 127.5 L 114.75 112.5 L 129.75 112.5 C 131.406854 112.5 132.75 111.156854 132.75 109.5 L 132.75 102 C 132.75 100.343146 131.406854 99 129.75 99 L 114.75 99 L 114.75 84 C 114.75 82.343146 113.406854 81 111.75 81 L 104.25 81 C 104.25 81 104.25 81 104.25 81 C 102.593146 81 101.25 82.343146 101.25 84 L 101.25 99 L 86.25 99 C 86.25 99 86.25 99 86.25 99 C 84.593146 99 83.25 100.343146 83.25 102 L 83.25 109.5 C 83.25 109.5 83.25 109.5 83.25 109.5 L 83.25 109.5 C 83.25 111.156855 84.593146 112.5 86.25 112.5 Z\"/></svg>\n";
 		var widgetNode = createWidgetNode(parseText(text,wiki,{parseAsInline:true}),wiki);
@@ -237,7 +237,7 @@ describe("Widget module", function() {
 	});
 
 	it("should parse and render transclusions", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add a tiddler
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "Jolly Old World"},
@@ -254,7 +254,7 @@ describe("Widget module", function() {
 	});
 
 	it("should render the view widget", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add a tiddler
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "Jolly Old World"}
@@ -283,7 +283,7 @@ describe("Widget module", function() {
 	});
 
 	it("should deal with the set widget", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "Jolly Old World"},
@@ -313,7 +313,7 @@ describe("Widget module", function() {
 	});
 
 	it("should deal with the let widget", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "lookup"},
 			{title: "TiddlerTwo", lookup: "value", newlookup: "value", wrong: "wrong"},
@@ -347,7 +347,7 @@ describe("Widget module", function() {
 	});
 
 	it("should deal with attributes specified as macro invocations", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Construct the widget node
 		var text = "\\define myMacro(one:\"paramOne\",two,three:\"paramTwo\")\nMy something $one$, $two$ or other $three$\n\\end\n<div class=<<myMacro 'something' three:'thing'>>>Content</div>";
 		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
@@ -358,7 +358,7 @@ describe("Widget module", function() {
 	});
 
 	it("should deal with built-in macros", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "Jolly Old World", type: "text/vnd.tiddlywiki"}
@@ -374,7 +374,7 @@ describe("Widget module", function() {
 
 	/* This test reproduces issue #4693. */
 	it("should render the entity widget", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Construct the widget node
 		var text = "\n\n<$entity entity='&nbsp;' />\n\n<$entity entity='&#x2713;' />\n";
 		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
@@ -391,7 +391,7 @@ describe("Widget module", function() {
 	});
 
 	it("should deal with the list widget", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "Jolly Old World"},
@@ -451,7 +451,7 @@ describe("Widget module", function() {
 
 
 	it("should deal with the list widget using a counter variable", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "Jolly Old World"},
@@ -593,7 +593,7 @@ describe("Widget module", function() {
 
 	var testListJoin = function(oldList, newList) {
 		return function() {
-			var wiki = new $tw.Wiki();
+			var wiki = $tw.test.wiki();
 			// Add some tiddlers
 			wiki.addTiddler({title: "Numbers", text: "", list: oldList});
 			var text = "<$list filter='[list[Numbers]]' variable='item' join=', '><<item>></$list>";
@@ -632,7 +632,7 @@ describe("Widget module", function() {
 
 	var testCounterLast = function(oldList, newList) {
 		return function() {
-			var wiki = new $tw.Wiki();
+			var wiki = $tw.test.wiki();
 			// Add some tiddlers
 			wiki.addTiddler({title: "Numbers", text: "", list: oldList});
 			var text = "<$list filter='[list[Numbers]]' variable='item' counter='c'><<item>><$text text={{{ [<c-last>match[no]then[, ]] }}} /></$list>";
@@ -654,7 +654,7 @@ describe("Widget module", function() {
 	it("the list widget with counter-last should update correctly when first item is removed", testCounterLast("1 2 3 4", "2 3 4"));
 
 	it("should deal with the list widget followed by other widgets", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "Jolly Old World"},
@@ -727,7 +727,7 @@ describe("Widget module", function() {
 	});
 
 	it("should deal with the list widget and external templates", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "$:/myTemplate", text: "(<$view field='title'/>)"},
@@ -747,7 +747,7 @@ describe("Widget module", function() {
 	});
 
 	it("should deal with the list widget and empty lists", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Construct the widget node
 		var text = "<$list emptyMessage='nothing'><$view field='title'/></$list>";
 		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
@@ -758,7 +758,7 @@ describe("Widget module", function() {
 	});
 
 	it("should refresh lists that become empty", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "TiddlerOne", text: "Jolly Old World"},
@@ -788,7 +788,7 @@ describe("Widget module", function() {
 	 * if they use transclusion for their value. This relates to PR #4108.
 	 */
 	it("should refresh imported <$set> widgets", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "Raw", text: "Initial value"},
@@ -808,7 +808,7 @@ describe("Widget module", function() {
 	});
 
 	it("should support mixed setWidgets and macros when importing", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "A", text: "\\define A() Aval"},
@@ -824,7 +824,7 @@ describe("Widget module", function() {
 	});
 
 	it("should skip parameters widgets when importing", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		// Add some tiddlers
 		wiki.addTiddlers([
 			{title: "B", text: "<$parameters bee=nothing><$set name='B' value='Bval'>\n\ndummy text</$set></$parameters>"},
@@ -838,7 +838,7 @@ describe("Widget module", function() {
 	});
 
 	it("should use default $parameters if directly rendered", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var text = "<$parameters bee=default $$dollar=bill nothing empty=''>bee=<<bee>>, $dollar=<<$dollar>>, nothing=<<nothing>>, empty=<<empty>></$parameters>";
 		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
 		// Render the widget node to the DOM
@@ -848,7 +848,7 @@ describe("Widget module", function() {
 	});
 
 	it("should use default \\parameters if directly rendered", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var text = "\\parameters(bee:default $$dollar:bill nothing)\nbee=<<bee>>, $$dollar=<<$$dollar>>, nothing=<<nothing>>";
 		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
 		// Render the widget node to the DOM
@@ -858,7 +858,7 @@ describe("Widget module", function() {
 	});
 
 	it("can have more than one macroDef variable imported", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		wiki.addTiddlers([
 			{title: "ABC", text: "<$set name=A value=A>\n\n<$set name=B value=B>\n\n<$set name=C value=C>\n\ndummy text</$set></$set></$set>"},
 			{title: "D", text: "\\define D() D"}]);
@@ -911,7 +911,7 @@ describe("Widget module", function() {
 	 *  doesn't forget its childrenNodes.
 	 */
 	it("should work when import widget imports nothing", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var text = "\\import [prefix[XXX]]\nDon't forget me.";
 		var widgetNode = createWidgetNode(parseText(text,wiki),wiki);
 		// Render the widget node to the DOM
@@ -925,7 +925,7 @@ describe("Widget module", function() {
 	 *  visual difference, but may affect plugins if it doesn't.
 	 */
 	it("should work when import pragma is standalone", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		var text = "\\import [prefix[XXX]]";
 		var parseTreeNode = parseText(text,wiki);
 		// Test the resulting parse tree node, since there is no
@@ -944,7 +944,7 @@ describe("Widget module", function() {
 	 * at least ONE variable.
 	 */
 	it("adding imported variables doesn't change qualifyers", function() {
-		var wiki = new $tw.Wiki();
+		var wiki = $tw.test.wiki();
 		function wikiparse(text) {
 			var tree = parseText(text,wiki);
 			var widgetNode = createWidgetNode(tree,wiki);

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -12,7 +12,7 @@ Tests for wikitext parser
 describe("WikiText parser tests", function() {
 
 	// Create a wiki
-	var wiki = new $tw.Wiki();
+	var wiki = $tw.test.wiki();
 
 	// Define a parsing shortcut
 	var parse = function(text) {

--- a/editions/test/tiddlers/tests/test-wikitext.js
+++ b/editions/test/tiddlers/tests/test-wikitext.js
@@ -12,7 +12,7 @@ Tests the wikitext rendering pipeline end-to-end. We also need tests that indivi
 describe("WikiText tests", function() {
 
 	// Create a wiki
-	var wiki = new $tw.Wiki();
+	var wiki = $tw.test.wiki();
 	// Add a couple of tiddlers
 	wiki.addTiddler({title: "TiddlerOne", text: "The quick brown fox"});
 	wiki.addTiddler({title: "TiddlerTwo", text: "The rain in Spain\nfalls mainly on the plain"});

--- a/plugins/tiddlywiki/jasmine/jasmine-plugin.js
+++ b/plugins/tiddlywiki/jasmine/jasmine-plugin.js
@@ -143,6 +143,16 @@ exports.runTests = function(callback,specFilter) {
 	var env = jasmine.getEnv();
 	var jasmineInterface = jasmineCore.interface(jasmine,env);
 	context = $tw.utils.extend({},jasmineInterface,context);
+	// Initialise the WikiParser prototype with the correct rule config
+	// from the main wiki, before any test can trigger it from an empty wiki
+	$tw.wiki.parseText("text/vnd.tiddlywiki","");
+	// Set up test utilities available to all test specs
+	$tw.test = {
+		/** Create a test wiki instance, pre-configured with core settings */
+		wiki: function() {
+			return new $tw.Wiki();
+		}
+	};
 	// Iterate through all the test modules
 	var tests = $tw.wiki.filterTiddlers(TEST_TIDDLER_FILTER);
 	$tw.utils.each(tests,evalInContext);

--- a/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js
+++ b/plugins/tiddlywiki/jasmine/run-wiki-based-tests.js
@@ -19,7 +19,7 @@ describe("Wiki-based tests", function() {
 		var tiddler = $tw.wiki.getTiddler(title);
 		it(tiddler.fields.title + ": " + tiddler.fields.description, function() {
 			// Add our tiddlers
-			var wiki = new $tw.Wiki(),
+			var wiki = $tw.test.wiki(),
 				coreTiddler = $tw.wiki.getTiddler("$:/core");
 			if(coreTiddler) {
 				wiki.addTiddler(coreTiddler);


### PR DESCRIPTION
# Fix: Flaky test failures caused by WikiParser prototype pollution

The problem is tricky, so read carefully. The problem was introduced when we disabled automatic CamelCase linking by default. 

## Problem

- To reliably reproduce the problem see: #9716

Running `node tiddlywiki.js ./editions/test --test` produces 4 intermittent test failures. The failures depend on test execution order (Jasmine uses random seeds), so they appear in most runs but not all.

### Affected tests

1. `Widgets/ElementWidgetCSSCustomProps`
2. `Widgets/ElementWidgetStyleAttributes`
3. `Widgets/ElementWidgetEventAttributes`
4. `Tabs-macro HTML tests` (horizontal-all)

All four expect plain text for CamelCase words like `TiddlyWiki` or `TabTwo`, but the actual output wraps them in `<a class="tc-tiddlylink">` links.

## Root cause

`WikiParser.prototype.inlineRuleClasses` is a **shared, one-time initialisation** cached on the prototype. The first `parseText()` call in the process sets up the parser rules for **all** subsequent parses across **all** wiki instances.

The rule setup reads `$:/config/WikiParserRules/Inline/wikilink` from whichever wiki triggers the first parse. Since CamelCase linking was globally disabled in the core (`wikilink.tid` = `disable`, commit `0095ea60d`), the main `$tw.wiki` correctly disables the wikilink rule.

However, several test files create **empty wikis** via `new $tw.Wiki()` without the core config tiddlers. When Jasmine's random test ordering causes one of these tests to run first (e.g. `test-wikitext-parser.js` or `test-widget.js`), the empty wiki initialises the prototype. Since `getTiddlerText("$:/config/WikiParserRules/Inline/wikilink", "enable")` returns the default `"enable"` on an empty wiki, the wikilink rule is **kept**, and all subsequent tests produce CamelCase links.

## Fix

Two changes, applied together:

### 1. Force prototype initialisation before tests run

In `jasmine-plugin.js`, a dummy `$tw.wiki.parseText("text/vnd.tiddlywiki", "")` call is added before test specs are loaded. This ensures the `WikiParser.prototype` is initialised using the main wiki (which has the core config), making the outcome independent of test execution order.

### 2. Introduce `$tw.test.wiki()` helper

All `new $tw.Wiki()` calls in test files (14 files, 60+ occurrences) are replaced with `$tw.test.wiki()`, a factory function defined in `jasmine-plugin.js`. This provides a single point of control for test wiki initialisation, so future configuration requirements can be applied in one place rather than scattered across every test file.

