### PR TITLE
Fix: restore mhchem require for \ce and \pu macro support

### DIFF
--- a/plugins/tiddlywiki/katex/wrapper.js
+++ b/plugins/tiddlywiki/katex/wrapper.js
@@ -11,6 +11,7 @@ Wrapper for `katex.min.js` that provides a `<$latex>` widget. It is also availab
 
 var katex = require("$:/plugins/tiddlywiki/katex/katex.min.js"),
 	Widget = require("$:/core/modules/widgets/widget.js").widget;
+require("$:/plugins/tiddlywiki/katex/mhchem.min.js");
 
 katex.macros = {};
 katex.updateMacros = function() {


### PR DESCRIPTION
Commit https://github.com/TiddlyWiki/TiddlyWiki5/commit/785086e0a5d60d13c76a6f7527639eefcbb052b8 removed the `require()` call for `mhchem.min.js` from `plugins/tiddlywiki/katex/wrapper.js` as an ESLint unused-variable fix. However, the side effect of the `require` was needed to register `\ce` and `\pu` macros with KaTeX.

This restores the require without an assignment, so ESLint won't flag it again.