### PR TITLE
[DOCS] Fix MWS Banner image display

### DIFF
--- a/editions/tw5.com/tiddlers/roadmap/multiwikiserver/MultiWikiServer.tid
+++ b/editions/tw5.com/tiddlers/roadmap/multiwikiserver/MultiWikiServer.tid
@@ -3,7 +3,7 @@ tags: Definitions
 modified: 20241105133737778
 created: 20241105133737778
 
-<span class="tc-float-right tc-bordered-image">[img width=200 [MWS Banner.png]]</span>
+<span class="tc-float-right tc-bordered-image">[img width=200 [MWS Banner]]</span>
 ~MultiWikiServer is a new development that drastically improves ~TiddlyWiki's capabilities when running as a server under Node.js. It brings ~TiddlyWiki up to par with common web-based tools like ~WordPress or ~MediaWiki by supporting multiple wikis and multiple users at the same time.
 
 Planned features include:


### PR DESCRIPTION
The banner has been broken since all the PNGs were converted to WebP.

**Before**
![before](https://github.com/user-attachments/assets/5fa93210-bd2f-4970-a03c-613ddba4ddd4)

**After**
![after](https://github.com/user-attachments/assets/42d9685a-175d-4dc3-997e-fd86157e51ca)