### PR TITLE
Restore v5.3.8 handling of malformed attribute syntax

### DIFF
--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -576,6 +576,9 @@ exports.parseAttribute = function(source,pos) {
 									pos = unquotedValue.end;
 									node.type = "string";
 									node.value = unquotedValue.match[1];
+								} else if(source.charAt(pos) === "<" && source.charAt(pos + 1) === "<" && source.indexOf(">>",pos) !== -1) {
+									// Value looks like a macro invocation (starts with << with a closing >> ahead) but does not parse as one. Return null so the enclosing tag fails to parse rather than silently binding the attribute to "true" and treating the remainder as further attributes (restores v5.3.8 behaviour)
+									return null;
 								} else {
 									node.type = "string";
 									node.value = "true";

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-named.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-named.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/MacrocallColonNamed
+description: Macrocall named-parameter syntax using colon continues to work
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<<x d:"hi">>
++
+title: ExpectedResult
+
+<p>got=hi</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-non-strict.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-colon-non-strict.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/MacrocallColonNonStrict
+description: Colon-separator requires a strict identifier name; otherwise value is treated as positional (fix #9788)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<<x $:/a:"v">>
++
+title: ExpectedResult
+
+<p>got=<a class="tc-tiddlylink tc-tiddlylink-missing" href="#%24%3A%2Fa">$:/a</a>:</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-equals-no-value.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-equals-no-value.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/MacrocallEqualsNoValue
+description: Macrocall named parameter with =-separator but no value fails to parse the macro call
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<<x d=>>
++
+title: ExpectedResult
+
+<p>&lt;<x d="true">&gt;</x></p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-equals.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-equals.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/MacrocallNamedEquals
+description: Macrocall attribute with =-separator (restored compact call syntax, v5.3.9+)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<<x d="hello">>
++
+title: ExpectedResult
+
+<p>got=hello</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-filtered-value.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-filtered-value.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/MacrocallFilteredValue
+description: Macrocall attribute value can be a filtered value {{{...}}}
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<<x d={{{[[hi]]}}}>>
++
+title: ExpectedResult
+
+<p>got=hi</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-indirect-value.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-indirect-value.tid
@@ -1,0 +1,17 @@
+title: Parse/BackCompat/MacrocallIndirectValue
+description: Macrocall attribute value can be an indirect value {{tid!!field}}
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<<x d={{Other!!foo}}>>
++
+title: ExpectedResult
+
+<p>got=FROM-OTHER</p>
++
+title: Other
+foo: FROM-OTHER
+

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-mvv-value.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-mvv-value.tid
@@ -1,0 +1,14 @@
+title: Parse/BackCompat/MacrocallMvvValue
+description: Macrocall attribute value can be an MVV reference ((v))
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define d() DEFD
+\define x(d) got=$d$
+<<x d=((d))>>
++
+title: ExpectedResult
+
+<p>got=DEFD</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-nested-macro.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-nested-macro.tid
@@ -1,0 +1,14 @@
+title: Parse/BackCompat/MacrocallNestedMacroValue
+description: Macrocall attribute value can be a nested macro invocation
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define d() DEFD
+\define x(d) got=$d$
+<<x d=<<d>>>>
++
+title: ExpectedResult
+
+<p>got=DEFD</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-substituted-value.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-named-substituted-value.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/MacrocallSubstitutedValue
+description: Macrocall attribute value can be a substituted value `...`
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<<x d=`hi`>>
++
+title: ExpectedResult
+
+<p>got=hi</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-positional-gt.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/macrocall-positional-gt.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/MacrocallPositionalGt
+description: Bare > (not followed by >) is permitted in unquoted macrocall positional params
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<<x foo>val>>
++
+title: ExpectedResult
+
+<p>got=foo&gt;val</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/parse-backcompat-multiline.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/parse-backcompat-multiline.tid
@@ -1,0 +1,17 @@
+title: Parse/BackCompat/MalformedMultiLineTerminator
+description: When << value looks like a macro invocation but fails to parse, the enclosing widget tag must fail cleanly so the remainder of the document is not silently reinterpreted (the v5.4 strict parser previously collapsed to attribute="true" and swallowed subsequent lines as stray attributes)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define d() DEFD
+\define x(d) got=$d$
+<$macrocall $name="x" d=<<d> />
+<$macrocall $name="x" d=<<d> />
+>>
++
+title: ExpectedResult
+
+<p>&lt;$macrocall $name="x" d=&lt;<d> /&gt;
+&lt;$macrocall $name="x" d=DEFD</d></p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/parse-backcompat-quoted-gt.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/parse-backcompat-quoted-gt.tid
@@ -1,0 +1,14 @@
+title: Parse/BackCompat/QuotedGtInNestedMacro
+description: Nested macro invocation in widget attribute can contain > in quoted inner attribute values
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define d() DEFD
+\define x(d) got=$d$
+<$macrocall $name="x" d=<<d b="x>y">> />
++
+title: ExpectedResult
+
+<p>got=DEFD</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/parse-backcompat-single-line.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/parse-backcompat-single-line.tid
@@ -1,0 +1,14 @@
+title: Parse/BackCompat/MalformedNoTerminator
+description: Widget attribute value starting with << but with no >> ahead falls through to "true" (matches v5.3.8)
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define d() DEFD
+\define x(d) got=$d$
+<$macrocall $name="x" d=<<d> />
++
+title: ExpectedResult
+
+<p>got=true</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/parse-backcompat.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/parse-backcompat.tid
@@ -1,0 +1,14 @@
+title: Parse/BackCompat/ValidNestedMacro
+description: Widget attribute value with well-formed nested macro invocation
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define d() DEFD
+\define x(d) got=$d$
+<$macrocall $name="x" d=<<d>> />
++
+title: ExpectedResult
+
+<p>got=DEFD</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-equals-noval.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-equals-noval.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/WidgetAttrEqualsNoValue
+description: Widget attribute with trailing equals and no value falls through to "true"
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<$macrocall $name="x" d= />
++
+title: ExpectedResult
+
+<p>got=true</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-malformed-mvv.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-malformed-mvv.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/WidgetAttrMalformedMvv
+description: Widget attribute value with unclosed ((v) falls through to a string literal
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<$macrocall $name="x" d=((d) />
++
+title: ExpectedResult
+
+<p>got=((d)</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-mvv-value.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-mvv-value.tid
@@ -1,0 +1,14 @@
+title: Parse/BackCompat/WidgetAttrMvvValue
+description: Widget attribute value can be an MVV reference ((v))
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define d() DEFD
+\define x(d) got=$d$
+<$macrocall $name="x" d=((d)) />
++
+title: ExpectedResult
+
+<p>got=DEFD</p>

--- a/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-substituted-value.tid
+++ b/editions/test/tiddlers/tests/data/parse-backcompat/widget-attr-substituted-value.tid
@@ -1,0 +1,13 @@
+title: Parse/BackCompat/WidgetAttrSubstitutedValue
+description: Widget attribute value can be a substituted value `...`
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+
+title: Output
+
+\define x(d) got=$d$
+<$macrocall $name="x" d=`hi` />
++
+title: ExpectedResult
+
+<p>got=hi</p>


### PR DESCRIPTION
Also adds a number of new tests to prevent future compatibility drift

Fixes #9808