### PR TITLE
fix: limit macro call parser to need >> to work, prevent > in regex

### DIFF
--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -327,7 +327,7 @@ exports.parseMacroParameterAsAttribute = function(source,pos) {
 	// Define our regexps
 	var reAttributeName = /([^\/\s>"'`=:]+)/y,
 		reStrictIdentifier = /^[A-Za-z0-9\-_]+$/,
-		reUnquotedAttribute = /(?!<<)((?:(?:>(?!>))|[^\s>"'])+)/y,
+		reUnquotedAttribute = /((?:(?:>(?!>))|[^\s>"'])+)/y,
 		reFilteredValue = /\{\{\{([\S\s]+?)\}\}\}/y,
 		reIndirectValue = /\{\{([^\}]+)\}\}/y,
 		reSubstitutedValue = /(?:```([\s\S]*?)```|`([^`]|[\S\s]*?)`)/y;

--- a/core/modules/parsers/parseutils.js
+++ b/core/modules/parsers/parseutils.js
@@ -327,7 +327,7 @@ exports.parseMacroParameterAsAttribute = function(source,pos) {
 	// Define our regexps
 	var reAttributeName = /([^\/\s>"'`=:]+)/y,
 		reStrictIdentifier = /^[A-Za-z0-9\-_]+$/,
-		reUnquotedAttribute = /((?:(?:>(?!>))|[^\s>"'])+)/y,
+		reUnquotedAttribute = /(?!<<)((?:(?:>(?!>))|[^\s>"'])+)/y,
 		reFilteredValue = /\{\{\{([\S\s]+?)\}\}\}/y,
 		reIndirectValue = /\{\{([^\}]+)\}\}/y,
 		reSubstitutedValue = /(?:```([\s\S]*?)```|`([^`]|[\S\s]*?)`)/y;

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -468,5 +468,9 @@ describe("WikiText parser tests", function() {
 
 		expect(parse(wikitext)).toEqual(expectedParseTree);
 	});
-});
 
+	it("should reject unquoted macro parameter values that start with <<", function() {
+		var attribute = $tw.utils.parseMacroParameterAsAttribute('d=<<d> />',0);
+		expect(attribute).toBeNull();
+	});
+});

--- a/editions/test/tiddlers/tests/test-wikitext-parser.js
+++ b/editions/test/tiddlers/tests/test-wikitext-parser.js
@@ -470,7 +470,7 @@ describe("WikiText parser tests", function() {
 	});
 
 	it("should reject unquoted macro parameter values that start with <<", function() {
-		var attribute = $tw.utils.parseMacroParameterAsAttribute('d=<<d> />',0);
+		var attribute = $tw.utils.parseMacroParameterAsAttribute("d=<<d> />",0);
 		expect(attribute).toBeNull();
 	});
 });


### PR DESCRIPTION
```
(()=>{const n=20,s=Array.from({length:n},()=>'<$macrocall $name="x" a=<<a>> b=<<b>> c=<<c>> d=<<d> />').join('\n'),t=performance.now();$tw.wiki.parseText('text/vnd.tiddlywiki',s,{});console.log('bad ms',Math.round(performance.now()-t));})();
```

from 9248 ms back to 6 ms

But this only fix the problem I run into. I'm not sure if #9812 's solution is fixing a more fundermental cause. Maybe both could be merged?